### PR TITLE
Fix BOM output issues: console formatting, debug messages, and JLC field mapping

### DIFF
--- a/src/jbom/cli/formatting.py
+++ b/src/jbom/cli/formatting.py
@@ -100,7 +100,7 @@ def print_bom_table(
         elif header == "SMD":
             return "Yes" if entry.smd else "No"
         elif header == "Match_Quality":
-            return f"{entry.match_quality:.1f}" if entry.match_quality else ""
+            return entry.match_quality if entry.match_quality else ""
         elif header == "Priority":
             return str(entry.priority) if entry.priority else ""
         elif header == "Notes":

--- a/src/jbom/config/fabricators/jlc.fab.yaml
+++ b/src/jbom/config/fabricators/jlc.fab.yaml
@@ -20,6 +20,8 @@ part_number:
     - "JLC PCB"
     - "JLC PCB Part"
     - "JLC_PCB Part #"
+    - "DPN"  # Distributor Part Number (common abbreviation)
+    - "Distributor Part Number"
     - "MPN"
     - "MFGPN"
 

--- a/src/jbom/generators/bom.py
+++ b/src/jbom/generators/bom.py
@@ -1009,12 +1009,35 @@ class BOMGenerator(Generator):
     def _get_inventory_field_value(
         self, field: str, inventory_item: Optional[InventoryItem]
     ) -> str:
-        """Get a value from inventory item's raw data, handling cleaned field names.
+        """Get a value from inventory item, checking both attributes and raw data.
 
         Field should be in normalized snake_case format.
         """
         if not inventory_item:
             return ""
+
+        # Check first-class InventoryItem attributes first
+        if field == "package" and inventory_item.package:
+            return inventory_item.package
+        elif field == "lcsc" and inventory_item.lcsc:
+            return inventory_item.lcsc
+        elif field == "manufacturer" and inventory_item.manufacturer:
+            return inventory_item.manufacturer
+        elif field in ["mfgpn", "mpn"] and inventory_item.mfgpn:
+            return inventory_item.mfgpn
+        elif field == "distributor" and inventory_item.distributor:
+            return inventory_item.distributor
+        elif (
+            field == "distributor_part_number"
+            and inventory_item.distributor_part_number
+        ):
+            return inventory_item.distributor_part_number
+        elif field == "smd" and inventory_item.smd:
+            return inventory_item.smd
+        elif field == "datasheet" and inventory_item.datasheet:
+            return inventory_item.datasheet
+        elif field == "description" and inventory_item.description:
+            return inventory_item.description
 
         # Try to find a raw field that matches when normalized
         for raw_field, value in inventory_item.raw_data.items():
@@ -1037,6 +1060,26 @@ class BOMGenerator(Generator):
         """
         if not inventory_item:
             return False
+
+        # Check first-class InventoryItem attributes
+        first_class_fields = [
+            "package",
+            "lcsc",
+            "manufacturer",
+            "mfgpn",
+            "mpn",
+            "distributor",
+            "distributor_part_number",
+            "smd",
+            "datasheet",
+            "description",
+        ]
+        if field in first_class_fields:
+            # Check if the attribute exists and has a value
+            attr_value = getattr(
+                inventory_item, field if field != "mpn" else "mfgpn", None
+            )
+            return bool(attr_value)
 
         # Check if a raw field matches when normalized
         for raw_field in inventory_item.raw_data.keys():

--- a/src/jbom/loaders/inventory.py
+++ b/src/jbom/loaders/inventory.py
@@ -297,7 +297,9 @@ class InventoryLoader:
                 voltage=row.get("V", ""),
                 amperage=row.get("A", ""),
                 wattage=row.get("W", ""),
-                lcsc=row.get("LCSC", ""),
+                lcsc=self._get_first_value(
+                    row, ["LCSC", "LCSC Part", "LCSC Part #", "DPN"]
+                ),
                 manufacturer=row.get("Manufacturer", ""),
                 mfgpn=row.get("MFGPN", ""),
                 datasheet=row.get("Datasheet", ""),

--- a/src/jbom/loaders/schematic.py
+++ b/src/jbom/loaders/schematic.py
@@ -52,9 +52,9 @@ class SchematicLoader:
                 exclude_reason = "Reference starts with #"
 
             # Debug logging if enabled
+            is_debug = self.options.debug
+            is_sch_debug = "schematic" in self.options.debug_categories
             if is_excluded:
-                is_debug = self.options.debug
-                is_sch_debug = "schematic" in self.options.debug_categories
                 if is_debug or is_sch_debug:
                     print(
                         f"DEBUG[schematic]: Excluded component {comp.reference} ({comp.value}): {exclude_reason}",
@@ -62,6 +62,20 @@ class SchematicLoader:
                     )
             else:
                 self.components.append(comp)
+                if is_debug or is_sch_debug:
+                    print(
+                        f"DEBUG[schematic]: Added component {comp.reference} ({comp.value}) - {comp.footprint}",
+                        file=sys.stderr,
+                    )
+
+        # Print summary if debug enabled
+        is_debug = self.options.debug
+        is_sch_debug = "schematic" in self.options.debug_categories
+        if is_debug or is_sch_debug:
+            print(
+                f"DEBUG[schematic]: Parsing complete - found {len(self.components)} components in BOM",
+                file=sys.stderr,
+            )
 
         return self.components
 
@@ -121,15 +135,8 @@ class SchematicLoader:
         # But for compatibility with simple/older files, we allow missing instances if reference is valid
         # AND it has a position (placed on sheet).
         if not has_instances and not has_position:
-            # Likely a library definition or unannotated symbol
-            is_debug = self.options.debug
-            is_sch_debug = "schematic" in self.options.debug_categories
-            if (is_debug or is_sch_debug) and reference:
-                print(
-                    f"DEBUG[schematic]: Ignored symbol {reference} ({value}): "
-                    f"No instances/position found (likely library definition)",
-                    file=sys.stderr,
-                )
+            # Likely a library definition or unannotated symbol - skip without debug noise
+            # These are template symbols, not actual placed components
             return None
 
         return Component(


### PR DESCRIPTION
## Summary

Fixes multiple issues with BOM generation output, debug logging, and JLC fabricator field mapping.

## Issues Fixed

1. **Format error in console output** - Fixed TypeError when outputting BOM to console
2. **Confusing debug messages** - Removed noisy library symbol messages  
3. **Missing component logging** - Added debug output for included components
4. **Empty LCSC column** - Fixed JLC BOM to populate LCSC part numbers from DPN
5. **Empty Footprint column** - Fixed inventory package field lookup

## Changes

- Remove float formatting from match_quality (already formatted string)
- Remove confusing "Ignored symbol" debug messages for library definitions
- Add debug output when components are added to BOM + summary count
- Add DPN support to JLC fabricator config priority fields
- Add LCSC field aliases (LCSC, LCSC Part, LCSC Part #, DPN) in inventory loader  
- Add first-class InventoryItem attribute checks to field lookup methods

## Testing

✅ Console output renders without errors
✅ Debug shows added components and summary  
✅ JLC BOM populates LCSC column (C2843785, C4118381, C25231)
✅ JLC BOM populates Footprint/package column (SMD5050, 0603)

Co-Authored-By: Warp <agent@warp.dev>