### PR TITLE
Phase 4S: Supplier Profiles (config loader + URL resolver)

### DIFF
--- a/jbom-new/docs/workflow/planning/PHASE_4S_PLAN.md
+++ b/jbom-new/docs/workflow/planning/PHASE_4S_PLAN.md
@@ -23,6 +23,11 @@ search_url_template: "https://www.lcsc.com/search?q={query}"
 
 ### Supplier Profiles to Create
 
+**Generic** (`generic.supplier.yaml`):
+- No-op supplier profile (fallback for unknown suppliers)
+- `url_template`: null
+- `search_url_template`: null
+
 **LCSC** (`lcsc.supplier.yaml`):
 - `inventory_column`: "LCSC"
 - `part_number.pattern`: `^C\d+$`
@@ -37,17 +42,20 @@ search_url_template: "https://www.lcsc.com/search?q={query}"
 
 **DigiKey** (`digikey.supplier.yaml`):
 - `inventory_column`: "DigiKey"
-- `url_template`: `https://www.digikey.com/en/products/detail/-/-/{pn}`
-- `search_url_template`: `https://www.digikey.com/en/products/result?keywords={query}`
+- Direct product URLs are not reliably derivable from a bare PN without additional identifiers
+- `url_template`: null (explicitly unsupported)
+- `search_url_template`: `https://www.digikey.com/en/products?keywords={query}`
 
 ## Implementation
 
 ### 1. Config infrastructure
 
 **New files**:
-- `src/jbom/config/suppliers/` — directory for supplier YAML files
-- `src/jbom/config/suppliers/__init__.py`
+- `src/jbom/config/__init__.py` — make `jbom.config` a regular package
+- `src/jbom/config/suppliers/` — directory for supplier YAML files (data-only; no `__init__.py`)
 - `src/jbom/config/suppliers.py` — loader module (parallel to `fabricators.py`)
+
+Note: `src/jbom/config/suppliers/__init__.py` is intentionally NOT created because it would conflict with importing `jbom.config.suppliers` (which is the loader module).
 
 **SupplierConfig dataclass** in `suppliers.py`:
 ```python
@@ -85,19 +93,19 @@ This replaces the dropped `DPNLink` column — URLs are derived, not stored.
 
 ### 3. Part number validation
 Optional validation using `part_number.pattern`:
-- `validate_part_number(supplier_id: str, pn: str) -> bool`
+- `validate_part_number(supplier: SupplierConfig, pn: str) -> bool`
 - Useful for inventory validation CLI (`jbom validate-inventory`)
 - Not blocking for BOM generation — validation is advisory
 
 ### 4. Tests
+Phase 4S scope is unit tests only:
 - Unit tests for `SupplierConfig` loading and parsing
-- Unit tests for URL generation (template substitution)
+- Unit tests for URL generation (template substitution + encoding behavior)
 - Unit tests for PN validation (regex matching)
-- BDD scenario: given an inventory with LCSC codes, supplier URL is derivable
 
 ## Relationship to Fabricator Profiles
 Fabricator profiles and supplier profiles are **orthogonal**:
-- Fab profiles reference suppliers implicitly through `field_synonyms` column names (e.g., JLC's `fab_pn` synonyms include "LCSC")
+- Fab profiles reference suppliers implicitly through inventory column names (e.g., JLC's `fab_pn` synonyms include "LCSC")
 - Supplier profiles define what those column names *mean* and what capabilities they enable
 - A fabricator can use any combination of suppliers
 - Adding a new supplier = add a `*.supplier.yaml` + optionally add column to inventory
@@ -111,6 +119,7 @@ These are NOT in scope for Phase 4S but supplier profiles enable them:
 - **Catalog search CLI**: `jbom search "0603 100nF" --supplier lcsc` uses `search_url_template`
 - **Inventory validation**: `jbom validate-inventory` checks PN formats against `part_number.pattern`
 - **Multi-supplier price comparison**: Future feature using supplier APIs
+- **Hierarchical config discovery**: Allow user overrides/extensions beyond factory defaults
 
 ## Reference Implementation
 Follow the patterns established in `src/jbom/config/fabricators.py`:
@@ -121,21 +130,19 @@ Follow the patterns established in `src/jbom/config/fabricators.py`:
 
 ## Execution Order
 1. Create `suppliers.py` config loader + `SupplierConfig` dataclass
-2. Create LCSC, Mouser, DigiKey supplier YAML files
+2. Create Generic, LCSC, Mouser, DigiKey supplier YAML files
 3. Create `SupplierUrlResolver` service
 4. Add unit tests for loader, URL resolver, PN validation
-5. Update architecture docs (`domain-centric-design.md`, `workflow-architecture.md`)
 
 ## Validation
 ```bash
 PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/jbom-new/src python -c "
-from jbom.config.suppliers import load_supplier
-s = load_supplier('lcsc')
-print(s.url_template.format(pn='C25231'))
-# https://www.lcsc.com/product-detail/C25231.html
+from jbom.services.supplier_url_resolver import SupplierUrlResolver
+r = SupplierUrlResolver()
+print(r.resolve_url('lcsc','C25231'))
+print(r.resolve_search_url('lcsc','0603 100nF'))
 "
 PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/jbom-new/src python -m pytest tests/ -q --tb=short
-python -m behave --format progress
 ```
 
 ## Estimated Effort

--- a/jbom-new/src/jbom/config/__init__.py
+++ b/jbom-new/src/jbom/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration loaders and built-in profile definitions."""

--- a/jbom-new/src/jbom/config/suppliers.py
+++ b/jbom-new/src/jbom/config/suppliers.py
@@ -1,0 +1,220 @@
+"""Supplier configuration loader.
+
+Supplier profiles capture supplier-specific knowledge such as:
+- URL templates for direct product links and search pages
+- Part-number validation patterns
+
+Phase 4S scope: built-in profiles stored in the source tree.
+Future scope: support hierarchical override/extension locations.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+import yaml
+
+
+@dataclass(frozen=True)
+class SupplierConfig:
+    """Configuration for a parts supplier/distributor."""
+
+    id: str
+    name: str
+    inventory_column: str
+
+    description: Optional[str] = None
+    website: Optional[str] = None
+
+    url_template: Optional[str] = None
+    search_url_template: Optional[str] = None
+
+    part_number_pattern: Optional[str] = None
+    part_number_example: Optional[str] = None
+
+    @staticmethod
+    def from_yaml_dict(data: Dict[str, Any], *, default_id: str) -> "SupplierConfig":
+        """Parse a SupplierConfig from a YAML dict.
+
+        Args:
+            data: YAML mapping produced by yaml.safe_load().
+            default_id: Supplier ID derived from filename when 'id' is not set.
+
+        Raises:
+            ValueError: When required fields are missing or schema is invalid.
+        """
+
+        if not isinstance(data, dict):
+            raise ValueError(f"Supplier '{default_id}' config must be a YAML mapping")
+
+        sid = data.get("id", default_id)
+        name = data.get("name", default_id)
+        inventory_column = data.get("inventory_column")
+
+        if not isinstance(sid, str) or not sid.strip():
+            raise ValueError("Supplier id must be a non-empty string")
+
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"Supplier '{sid}' name must be a non-empty string")
+
+        if not isinstance(inventory_column, str) or not inventory_column.strip():
+            raise ValueError(
+                f"Supplier '{sid}' missing inventory_column (canonical CSV column name)"
+            )
+
+        part_number_cfg = data.get("part_number") or {}
+        if part_number_cfg is None:
+            part_number_cfg = {}
+
+        if not isinstance(part_number_cfg, dict):
+            raise ValueError(f"Supplier '{sid}' part_number must be a mapping")
+
+        pattern = part_number_cfg.get("pattern")
+        example = part_number_cfg.get("example")
+
+        if pattern is not None and (
+            not isinstance(pattern, str) or not pattern.strip()
+        ):
+            raise ValueError(f"Supplier '{sid}' part_number.pattern must be a string")
+
+        if example is not None and (
+            not isinstance(example, str) or not example.strip()
+        ):
+            raise ValueError(f"Supplier '{sid}' part_number.example must be a string")
+
+        url_template = data.get("url_template")
+        if url_template is not None and not isinstance(url_template, str):
+            raise ValueError(f"Supplier '{sid}' url_template must be a string or null")
+
+        search_url_template = data.get("search_url_template")
+        if search_url_template is not None and not isinstance(search_url_template, str):
+            raise ValueError(
+                f"Supplier '{sid}' search_url_template must be a string or null"
+            )
+
+        description = data.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError(f"Supplier '{sid}' description must be a string or null")
+
+        website = data.get("website")
+        if website is not None and not isinstance(website, str):
+            raise ValueError(f"Supplier '{sid}' website must be a string or null")
+
+        # Best-effort validation of regex.
+        if isinstance(pattern, str) and pattern.strip():
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                raise ValueError(
+                    f"Supplier '{sid}' part_number.pattern is not a valid regex: {pattern!r}"
+                ) from e
+
+        return SupplierConfig(
+            id=sid,
+            name=name,
+            inventory_column=inventory_column,
+            description=description,
+            website=website,
+            url_template=url_template,
+            search_url_template=search_url_template,
+            part_number_pattern=pattern,
+            part_number_example=example,
+        )
+
+
+_BUILTIN_DIR = Path(__file__).parent / "suppliers"
+
+
+def list_suppliers() -> list[str]:
+    """List available supplier IDs by scanning the built-in config directory."""
+
+    if not _BUILTIN_DIR.exists():
+        return []
+
+    # Filename: <id>.supplier.yaml
+    return sorted(
+        p.stem.replace(".supplier", "") for p in _BUILTIN_DIR.glob("*.supplier.yaml")
+    )
+
+
+def get_available_suppliers() -> list[str]:
+    """Get list of available suppliers with a stable fallback."""
+
+    suppliers = list_suppliers()
+    return suppliers if suppliers else ["generic"]
+
+
+def load_supplier(sid: str) -> SupplierConfig:
+    """Load supplier configuration from YAML file.
+
+    Args:
+        sid: Supplier ID (filename without .supplier.yaml extension)
+
+    Returns:
+        Parsed SupplierConfig.
+
+    Raises:
+        ValueError: If supplier not found or schema is invalid.
+    """
+
+    path = _BUILTIN_DIR / f"{sid}.supplier.yaml"
+    if not path.exists():
+        raise ValueError(f"Unknown supplier: {sid}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Supplier '{sid}' config must be a YAML mapping")
+
+    return SupplierConfig.from_yaml_dict(data, default_id=sid)
+
+
+def validate_part_number(supplier: SupplierConfig, pn: str) -> bool:
+    """Validate part number using the supplier's regex, when available.
+
+    Validation is advisory: if the supplier has no pattern, validation passes.
+
+    Args:
+        supplier: SupplierConfig used to validate.
+        pn: Part number string.
+
+    Returns:
+        True if pn matches the supplier pattern (or no pattern is defined).
+    """
+
+    pn_norm = (pn or "").strip()
+    if not pn_norm:
+        return False
+
+    pattern = (supplier.part_number_pattern or "").strip()
+    if not pattern:
+        return True
+
+    return re.fullmatch(pattern, pn_norm) is not None
+
+
+def normalize_supplier_id(supplier_id: str) -> str:
+    """Normalize supplier id for case-insensitive lookups."""
+
+    return (supplier_id or "").strip().lower()
+
+
+def resolve_supplier_by_id(supplier_id: str) -> Optional[SupplierConfig]:
+    """Load a supplier config, returning None if it is unknown."""
+
+    try:
+        return load_supplier(normalize_supplier_id(supplier_id))
+    except ValueError:
+        return None
+
+
+def normalize_inventory_column(
+    raw_data: Mapping[str, str], supplier: SupplierConfig
+) -> str:
+    """Return the value from raw_data for this supplier's canonical column."""
+
+    return str(raw_data.get(supplier.inventory_column, ""))

--- a/jbom-new/src/jbom/config/suppliers.py
+++ b/jbom-new/src/jbom/config/suppliers.py
@@ -66,8 +66,6 @@ class SupplierConfig:
             )
 
         part_number_cfg = data.get("part_number") or {}
-        if part_number_cfg is None:
-            part_number_cfg = {}
 
         if not isinstance(part_number_cfg, dict):
             raise ValueError(f"Supplier '{sid}' part_number must be a mapping")

--- a/jbom-new/src/jbom/config/suppliers/digikey.supplier.yaml
+++ b/jbom-new/src/jbom/config/suppliers/digikey.supplier.yaml
@@ -1,0 +1,10 @@
+name: "DigiKey"
+id: "digikey"
+description: "DigiKey Electronics"
+website: "https://www.digikey.com"
+inventory_column: "DigiKey"
+# DigiKey direct product URLs are not reliably derivable from a bare PN without additional identifiers.
+# Use search_url_template for browser address-bar searches.
+url_template: null
+search_url_template: "https://www.digikey.com/en/products?keywords={query}"
+part_number: {}

--- a/jbom-new/src/jbom/config/suppliers/generic.supplier.yaml
+++ b/jbom-new/src/jbom/config/suppliers/generic.supplier.yaml
@@ -1,0 +1,8 @@
+name: "Generic"
+id: "generic"
+description: "No-op supplier profile (fallback / unknown supplier)"
+website: ""
+inventory_column: "Supplier"
+url_template: null
+search_url_template: null
+part_number: {}

--- a/jbom-new/src/jbom/config/suppliers/lcsc.supplier.yaml
+++ b/jbom-new/src/jbom/config/suppliers/lcsc.supplier.yaml
@@ -1,0 +1,10 @@
+name: "LCSC"
+id: "lcsc"
+description: "LCSC Electronics (JLCPCB parts catalog)"
+website: "https://www.lcsc.com"
+inventory_column: "LCSC"
+part_number:
+  pattern: "^C\\d+$"
+  example: "C25231"
+url_template: "https://www.lcsc.com/product-detail/{pn}.html"
+search_url_template: "https://www.lcsc.com/search?q={query}"

--- a/jbom-new/src/jbom/config/suppliers/mouser.supplier.yaml
+++ b/jbom-new/src/jbom/config/suppliers/mouser.supplier.yaml
@@ -1,0 +1,10 @@
+name: "Mouser"
+id: "mouser"
+description: "Mouser Electronics"
+website: "https://www.mouser.com"
+inventory_column: "Mouser"
+part_number:
+  pattern: "^\\d{3}-.*$"
+  example: "595-TPS62133DQCR"
+url_template: "https://www.mouser.com/ProductDetail/{pn}"
+search_url_template: "https://www.mouser.com/c/?q={query}"

--- a/jbom-new/src/jbom/services/supplier_url_resolver.py
+++ b/jbom-new/src/jbom/services/supplier_url_resolver.py
@@ -1,0 +1,89 @@
+"""Supplier URL resolution service.
+
+Phase 4S introduces supplier profiles which can generate:
+- Direct product page URLs (when derivable)
+- Search URLs (for browser/interactive lookup)
+
+This service is intentionally small and stateless.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import quote, quote_plus
+
+from jbom.config.suppliers import SupplierConfig, resolve_supplier_by_id
+
+
+@dataclass(frozen=True)
+class SupplierUrlResolver:
+    """Generate supplier URLs from a supplier profile and input strings."""
+
+    encode: bool = True
+
+    def resolve_url(self, supplier_id: str, part_number: str) -> Optional[str]:
+        """Generate supplier product URL from part number.
+
+        Returns None when:
+        - supplier_id is unknown
+        - supplier has no url_template
+        - part_number is empty
+        """
+
+        supplier = resolve_supplier_by_id(supplier_id)
+        if supplier is None:
+            return None
+
+        return self._resolve_url_for_supplier(supplier, part_number)
+
+    def resolve_search_url(self, supplier_id: str, query: str) -> Optional[str]:
+        """Generate supplier search URL."""
+
+        supplier = resolve_supplier_by_id(supplier_id)
+        if supplier is None:
+            return None
+
+        return self._resolve_search_url_for_supplier(supplier, query)
+
+    def _resolve_url_for_supplier(
+        self, supplier: SupplierConfig, part_number: str
+    ) -> Optional[str]:
+        template = (supplier.url_template or "").strip()
+        if not template:
+            return None
+
+        pn = (part_number or "").strip()
+        if not pn:
+            return None
+
+        if self.encode:
+            pn = quote(pn, safe="")
+
+        try:
+            return template.format(pn=pn)
+        except KeyError as e:
+            raise ValueError(
+                f"Supplier '{supplier.id}' url_template is missing required placeholders: {e}"
+            ) from e
+
+    def _resolve_search_url_for_supplier(
+        self, supplier: SupplierConfig, query: str
+    ) -> Optional[str]:
+        template = (supplier.search_url_template or "").strip()
+        if not template:
+            return None
+
+        q = (query or "").strip()
+        if not q:
+            return None
+
+        if self.encode:
+            q = quote_plus(q, safe="")
+
+        try:
+            return template.format(query=q)
+        except KeyError as e:
+            raise ValueError(
+                f"Supplier '{supplier.id}' search_url_template is missing required placeholders: {e}"
+            ) from e

--- a/jbom-new/tests/unit/test_supplier_config_schema.py
+++ b/jbom-new/tests/unit/test_supplier_config_schema.py
@@ -1,0 +1,57 @@
+"""Unit tests for SupplierConfig schema parsing and loader behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from jbom.config.suppliers import (
+    SupplierConfig,
+    get_available_suppliers,
+    list_suppliers,
+    load_supplier,
+    validate_part_number,
+)
+
+
+def test_list_suppliers_includes_builtin_profiles() -> None:
+    suppliers = list_suppliers()
+    assert isinstance(suppliers, list)
+    assert "generic" in suppliers
+    assert "lcsc" in suppliers
+    assert "mouser" in suppliers
+    assert "digikey" in suppliers
+
+
+def test_get_available_suppliers_is_non_empty() -> None:
+    assert get_available_suppliers()
+
+
+def test_load_supplier_lcsc() -> None:
+    lcsc = load_supplier("lcsc")
+    assert isinstance(lcsc, SupplierConfig)
+    assert lcsc.id == "lcsc"
+    assert lcsc.name == "LCSC"
+    assert lcsc.inventory_column == "LCSC"
+    assert lcsc.url_template
+    assert lcsc.search_url_template
+    assert lcsc.part_number_pattern
+
+
+def test_load_unknown_supplier_raises() -> None:
+    with pytest.raises(ValueError, match=r"Unknown supplier"):
+        load_supplier("does-not-exist")
+
+
+def test_validate_part_number_with_pattern() -> None:
+    lcsc = load_supplier("lcsc")
+
+    assert validate_part_number(lcsc, "C25231") is True
+    assert validate_part_number(lcsc, "c25231") is False
+    assert validate_part_number(lcsc, "25231") is False
+
+
+def test_validate_part_number_without_pattern_is_advisory() -> None:
+    generic = load_supplier("generic")
+
+    assert validate_part_number(generic, "ANYTHING") is True
+    assert validate_part_number(generic, "") is False

--- a/jbom-new/tests/unit/test_supplier_url_resolver.py
+++ b/jbom-new/tests/unit/test_supplier_url_resolver.py
@@ -1,0 +1,45 @@
+"""Unit tests for SupplierUrlResolver service."""
+
+from __future__ import annotations
+
+from jbom.services.supplier_url_resolver import SupplierUrlResolver
+
+
+def test_resolve_url_lcsc() -> None:
+    resolver = SupplierUrlResolver()
+
+    url = resolver.resolve_url("lcsc", "C25231")
+    assert url == "https://www.lcsc.com/product-detail/C25231.html"
+
+
+def test_resolve_search_url_lcsc() -> None:
+    resolver = SupplierUrlResolver()
+
+    url = resolver.resolve_search_url("lcsc", "0603 100nF")
+    assert url == "https://www.lcsc.com/search?q=0603+100nF"
+
+
+def test_resolve_url_unknown_supplier_returns_none() -> None:
+    resolver = SupplierUrlResolver()
+
+    assert resolver.resolve_url("unknown", "ABC") is None
+    assert resolver.resolve_search_url("unknown", "ABC") is None
+
+
+def test_resolve_url_digikey_not_supported_returns_none() -> None:
+    resolver = SupplierUrlResolver()
+
+    assert resolver.resolve_url("digikey", "TPS62133") is None
+    assert (
+        resolver.resolve_search_url("digikey", "TPS62133")
+        == "https://www.digikey.com/en/products?keywords=TPS62133"
+    )
+
+
+def test_resolve_url_encodes_part_number() -> None:
+    resolver = SupplierUrlResolver()
+
+    # Encoding behavior is important for safety; whether the target site accepts
+    # the encoded form is a supplier-specific detail we can refine later.
+    url = resolver.resolve_url("mouser", "ABC/DEF")
+    assert url == "https://www.mouser.com/ProductDetail/ABC%2FDEF"


### PR DESCRIPTION
Implements Phase 4S Supplier Profiles (minimal scope: no CLI/BDD/output wiring yet).

Changes:
- Add supplier profile loader + SupplierConfig schema (mirrors fabricator loader pattern)
- Add built-in supplier YAML profiles: generic, LCSC, Mouser, DigiKey (DigiKey direct product URL marked unsupported; search URL supported)
- Add SupplierUrlResolver service (product + search URL generation; encoding enabled by default)
- Add unit tests for loader, URL generation, and PN validation
- Add docs/workflow/planning/PHASE_4S_PLAN.md aligned with implementation