### PR TITLE
fix: Field system validation and cleanup (closes #50, #56)

### DIFF
--- a/jbom-new/src/jbom/cli/bom.py
+++ b/jbom-new/src/jbom/cli/bom.py
@@ -97,6 +97,25 @@ def register_command(subparsers) -> None:
 def handle_bom(args: argparse.Namespace) -> int:
     """Handle BOM command with project-centric input resolution."""
     try:
+        # Determine effective fabricator early (needed for --list-fields)
+        fabricator = args.fabricator
+        if not fabricator:
+            if args.jlc:
+                fabricator = "jlc"
+            elif args.pcbway:
+                fabricator = "pcbway"
+            elif args.seeed:
+                fabricator = "seeed"
+            elif args.generic:
+                fabricator = "generic"
+        if not fabricator:
+            fabricator = "generic"
+
+        # Handle --list-fields before input resolution (no project needed)
+        if args.list_fields:
+            _list_available_fields(fabricator)
+            return 0
+
         # Create options
         options = GeneratorOptions(verbose=args.verbose) if args.verbose else None
 
@@ -172,25 +191,6 @@ def handle_bom(args: argparse.Namespace) -> int:
         else:
             # Load components from single schematic
             components = reader.load_components(schematic_file)
-
-        # Determine effective fabricator (default generic)
-        fabricator = args.fabricator
-        if not fabricator:
-            if args.jlc:
-                fabricator = "jlc"
-            elif args.pcbway:
-                fabricator = "pcbway"
-            elif args.seeed:
-                fabricator = "seeed"
-            elif args.generic:
-                fabricator = "generic"
-        if not fabricator:
-            fabricator = "generic"
-
-        # Handle --list-fields before processing
-        if args.list_fields:
-            _list_available_fields(fabricator)
-            return 0
 
         # Parse field selection
         fabricator_presets = get_fabricator_presets(fabricator)
@@ -433,11 +433,11 @@ def _write_csv(
 ) -> None:
     """Write BOM as CSV to file with dynamic fields."""
     with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
-        # Use the same logic as stdout
-        old_stdout = sys.stdout
-        sys.stdout = csvfile
-        _print_csv(bom_data, selected_fields, headers)
-        sys.stdout = old_stdout
+        writer = csv.writer(csvfile)
+        writer.writerow(headers)
+        for entry in bom_data.entries:
+            row = [_get_field_value(entry, field) for field in selected_fields]
+            writer.writerow(row)
 
 
 def _get_field_value(entry, field: str) -> str:
@@ -475,7 +475,5 @@ def _get_field_value(entry, field: str) -> str:
     if field in field_mapping:
         return field_mapping[field](entry)
 
-    # Fall back to attribute lookup for unknown fields
-    return entry.attributes.get(field, "")
     # Fall back to attribute lookup for unknown fields
     return entry.attributes.get(field, "")

--- a/jbom-new/src/jbom/cli/formatting.py
+++ b/jbom-new/src/jbom/cli/formatting.py
@@ -20,12 +20,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    TYPE_CHECKING,
 )
-
-
-if TYPE_CHECKING:
-    from jbom.services.bom_generator import BOMData
 
 
 @dataclass(frozen=True)
@@ -244,80 +239,6 @@ def print_tabular_data(
         print(summary_line)
 
 
-def print_bom_table(bom_data: "BOMData") -> None:
-    """Pretty-print BOM as a formatted table to stdout."""
-
-    print(f"\n{bom_data.project_name} - Bill of Materials")
-    print("=" * 60)
-
-    if not bom_data.entries:
-        print("No components found.")
-        return
-
-    print(f"{'References':<15} {'Value':<12} {'Footprint':<20} {'Qty':<4}")
-    print("-" * 60)
-
-    for entry in bom_data.entries:
-        refs = entry.references_string
-        if len(refs) > 14:
-            refs = refs[:14] + "..."
-        value = entry.value
-        if len(value) > 11:
-            value = value[:11] + "..."
-        footprint = entry.footprint
-        if len(footprint) > 19:
-            footprint = footprint[:19] + "..."
-        print(f"{refs:<15} {value:<12} {footprint:<20} {entry.quantity:<4}")
-
-    print(
-        f"\nTotal: {bom_data.total_components} components, {bom_data.total_line_items} unique items"
-    )
-
-    if "matched_entries" in bom_data.metadata:
-        matched = bom_data.metadata["matched_entries"]
-        print(
-            f"Inventory enhanced: {matched}/{bom_data.total_line_items} items matched"
-        )
-
-
-def print_pos_table(pos_data: List[dict]) -> None:
-    """Pretty-print POS data as a formatted table to stdout (always mm units)."""
-
-    print(f"\nComponent Placement Data ({len(pos_data)} components)")
-    print("=" * 80)
-
-    if not pos_data:
-        print("No components found.")
-        return
-
-    print(
-        f"{'Ref':<10} {'X(mm)':<12} {'Y(mm)':<12} {'Rot':<6} {'Side':<6} {'Package':<15}"
-    )
-    print("-" * 80)
-
-    for e in pos_data:
-        # Use raw tokens if available, otherwise format mm values
-        if e.get("x_raw"):
-            x = str(e["x_raw"])
-        else:
-            x = f"{e['x_mm']:.3f}"
-        if e.get("y_raw"):
-            y = str(e["y_raw"])
-        else:
-            y = f"{e['y_mm']:.3f}"
-        ref = e["reference"]
-        if len(ref) > 9:
-            ref = ref[:9] + "..."
-        pkg = e["package"]
-        if len(pkg) > 14:
-            pkg = pkg[:14] + "..."
-        print(
-            f"{ref:<10} {x:<12} {y:<12} {e['rotation']:<6.1f} {e['side']:<6} {pkg:<15}"
-        )
-
-    print(f"\nTotal: {len(pos_data)} components")
-
-
 def print_inventory_table(items: Iterable[dict], fieldnames: List[str]) -> None:
     """Pretty-print inventory rows as a compact table to stdout.
 
@@ -364,7 +285,5 @@ __all__ = [
     "Column",
     "print_table",
     "print_tabular_data",
-    "print_bom_table",
-    "print_pos_table",
     "print_inventory_table",
 ]

--- a/jbom-new/tests/integration/test_target_inventory_contract.py
+++ b/jbom-new/tests/integration/test_target_inventory_contract.py
@@ -301,8 +301,8 @@ class TestTargetInventoryContract:
     ) -> None:
         sentinel_ipns = {
             "RES_5%_100mW_0603_10k",
-            "CAP_0.1uF_X7R_0603",
-            "LED_Red _0603",
+            "CAP_0.1uF_X5R_0603_25V",
+            "LED_Red_0603_20mA",
         }
 
         missing = {
@@ -345,8 +345,8 @@ class TestTargetInventoryContract:
                     value="100nF",
                     footprint="C_0603_1608Metric",
                 ),
-                # The contract says 100nF should match the existing 0.1uF X7R option.
-                expected_ipn="CAP_0.1uF_X7R_0603",
+                # The contract says 100nF should match the 0.1uF X5R 25V option (priority 1).
+                expected_ipn="CAP_0.1uF_X5R_0603_25V",
                 expected_package="0603",
             ),
             ExpectedMatch(
@@ -357,7 +357,7 @@ class TestTargetInventoryContract:
                     value="Red",
                     footprint="LED_0603_1608Metric",
                 ),
-                expected_ipn="LED_Red _0603",
+                expected_ipn="LED_Red_0603_20mA",
                 expected_package="0603",
             ),
         ]


### PR DESCRIPTION
# Field System Validation & Cleanup

## Issues Addressed
Closes #50 (Inconsistent field names between console and CSV output formats)
Closes #56 (Research: Fabricator field system completeness)

## Validation Results
Tested against real KiCad projects (Core-wt32-eth0, LEDStripDriver) with all fabricator × output format combinations:

- **Issue #50 resolved**: Console and CSV headers are consistent for all fabricators (jlc, pcbway, generic)
- **Issue #56 resolved**: Field system is complete and working:
  - `-f/--fields` with `+preset` syntax works (+minimal, +all, +jlc, custom fields)
  - `--list-fields` now works standalone (no project required)
  - Fabricator presets resolve correctly from YAML configs
  - `fabricator_part_number` correctly maps to LCSC codes (JLC), MPNs (PCBWay), supplier PNs (generic)

## Code Changes

### Fixes
- **`--list-fields` ordering**: Moved fabricator resolution and `--list-fields` check before input resolution in `bom.py` so it works without a project directory
- **`_write_csv` fragility**: Replaced `sys.stdout` redirect hack with proper `csv.writer(csvfile)` in `bom.py`
- **Duplicate return**: Removed duplicate `return entry.attributes.get(field, "")` in `_get_field_value()`

### Dead Code Removal
- Removed `print_bom_table()` and `print_pos_table()` from `formatting.py` — hardcoded-header formatters superseded by fabricator-aware output in `bom.py`/`pos.py`
- Removed unused `BOMData` TYPE_CHECKING import

### Contract Test Updates
- Updated inventory sentinel IPNs to match user's inventory cleanup (voltage-specific cap IPNs, LED naming fixes)

## Testing
- 231 pytest passed
- 192 BDD scenarios passed
- All pre-commit hooks pass

Co-Authored-By: Oz <oz-agent@warp.dev>