### PR TITLE
fix: deduplicate multi-unit component references in BOM and parts list

### DIFF
--- a/jbom-new/src/jbom/services/bom_generator.py
+++ b/jbom-new/src/jbom/services/bom_generator.py
@@ -125,8 +125,9 @@ class BOMGenerator:
         # Use the first component as the base
         base_component = components[0]
 
-        # Collect all references
-        references = [comp.reference for comp in components]
+        # Collect unique references (multi-unit components like dual op-amps
+        # produce multiple symbol instances with the same reference)
+        references = list(dict.fromkeys(comp.reference for comp in components))
 
         # Merge properties from all components
         merged_attributes = {}

--- a/jbom-new/src/jbom/services/parts_list_generator.py
+++ b/jbom-new/src/jbom/services/parts_list_generator.py
@@ -76,10 +76,19 @@ class PartsListGenerator:
     def _create_individual_entries(
         self, components: List[Component]
     ) -> List[PartsListEntry]:
-        """Create individual PartsListEntry objects (1:1 with components)."""
+        """Create individual PartsListEntry objects (1:1 with unique components).
+
+        Multi-unit components (e.g. dual op-amps) produce multiple symbol
+        instances with the same reference. We deduplicate by reference so
+        each physical component appears only once.
+        """
+        seen_refs: set[str] = set()
         entries = []
 
         for component in components:
+            if component.reference in seen_refs:
+                continue
+            seen_refs.add(component.reference)
             entry = PartsListEntry(
                 reference=component.reference,
                 value=component.value,

--- a/jbom-new/tests/services/generators/test_bom_generator.py
+++ b/jbom-new/tests/services/generators/test_bom_generator.py
@@ -242,6 +242,79 @@ class TestBOMGenerator:
         assert len(bom_data.entries) == 1
         assert bom_data.entries[0].references == ["R1"]
 
+    def test_multiunit_component_deduplication(self):
+        """Test that multi-unit components (e.g. dual op-amps) are deduplicated.
+
+        A dual op-amp like LM6132A has 3 symbol instances in KiCad (unit A,
+        unit B, power unit) all with reference IC1. The BOM should show IC1
+        once with quantity 1, not IC1 three times.
+        """
+        generator = BOMGenerator()
+        # Simulate a dual op-amp: 3 symbol instances, same reference
+        components = [
+            Component(
+                reference="IC1",
+                lib_id="Amplifier_Operational:LM6132",
+                value="LM6132A",
+                footprint="Package_SO:SO-8",
+                uuid="uuid-ic1a",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="IC1",
+                lib_id="Amplifier_Operational:LM6132",
+                value="LM6132A",
+                footprint="Package_SO:SO-8",
+                uuid="uuid-ic1b",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="IC1",
+                lib_id="Amplifier_Operational:LM6132",
+                value="LM6132A",
+                footprint="Package_SO:SO-8",
+                uuid="uuid-ic1c",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="R1",
+                lib_id="Device:R",
+                value="10K",
+                footprint="R_0603_1608Metric",
+                uuid="uuid-r1",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+        ]
+
+        bom_data = generator.generate_bom_data(components)
+
+        # IC1 should appear once with quantity 1
+        ic_entries = [e for e in bom_data.entries if "IC1" in e.references]
+        assert len(ic_entries) == 1
+        assert ic_entries[0].references == ["IC1"]
+        assert ic_entries[0].quantity == 1
+
+        # R1 should appear once with quantity 1
+        r_entries = [e for e in bom_data.entries if "R1" in e.references]
+        assert len(r_entries) == 1
+        assert r_entries[0].quantity == 1
+
+        # Total: 2 line items, 2 components
+        assert bom_data.total_line_items == 2
+        assert bom_data.total_components == 2
+
     def test_aggregation_strategy_value_only(self):
         """Test aggregation by value only (ignoring footprint)."""
         generator = BOMGenerator("value_only")


### PR DESCRIPTION
## Summary

Fixes incorrect quantity counting for multi-unit KiCad components (e.g. dual op-amps, multi-pin connectors).

## Problem

Multi-unit components like the LM6132A dual op-amp have multiple symbol instances in KiCad schematics that share the same reference designator. The BOM generator was counting each unit as a separate component, resulting in inflated quantities:
- IC1 (dual op-amp, 3 units) showed as `IC1, IC1, IC1` with quantity 3 instead of quantity 1
- J1 (5-pin connector) showed as `J1, J1, J1, J1, J1` with quantity 5 instead of quantity 1

The parts list generator had the same bug, listing each unit as a separate entry.

## Changes

- **`bom_generator.py`**: Deduplicate references in `_create_bom_entry()` using `dict.fromkeys()` to preserve order while removing duplicates from multi-unit symbols
- **`parts_list_generator.py`**: Skip already-seen references in `_create_individual_entries()` so each physical component appears only once
- **`test_bom_generator.py`**: Added `test_multiunit_component_deduplication` test simulating a dual op-amp with 3 symbol instances

## Validation

Ran jbom against 11 real KiCad production projects comparing BOM output:
- **5 exact matches**: AltmillSwitchRemote, Brakeman-BLUE, Brakeman-RED, Core-ESP32, Core-wt32-eth0
- **6 expected differences**: schematic changes since production BOMs were generated, DNP filtering, footprint naming conventions (KiCad standard vs SPCoast library)
- **Multi-unit bug confirmed fixed** in cpOD and cpOD-updated projects

## Test Results

- 243 pytest tests passing
- 192 BDD scenarios passing (36 features)

Co-Authored-By: Oz <oz-agent@warp.dev>