### PR TITLE
feat: Phase 6 catalog search + inventory-search

### DIFF
--- a/jbom-new/features/cli/basics.feature
+++ b/jbom-new/features/cli/basics.feature
@@ -13,6 +13,7 @@ Feature: CLI Basics
     And the output should contain "bom"
     And the output should contain "pos"
     And the output should contain "inventory"
+    And the output should contain "search"
 
   Scenario: Show version
     When I run jbom command "--version"

--- a/jbom-new/features/cli/basics.feature
+++ b/jbom-new/features/cli/basics.feature
@@ -14,6 +14,7 @@ Feature: CLI Basics
     And the output should contain "pos"
     And the output should contain "inventory"
     And the output should contain "search"
+    And the output should contain "inventory-search"
 
   Scenario: Show version
     When I run jbom command "--version"

--- a/jbom-new/features/search/inventory_search.feature
+++ b/jbom-new/features/search/inventory_search.feature
@@ -1,0 +1,19 @@
+Feature: Inventory Search (Dry Run)
+  As a jBOM user
+  I want to validate inventory-search inputs without hitting the network
+  So that I can safely test workflows without API calls
+
+  Scenario: Dry run with a simple inventory
+    Given an inventory file "inventory.csv" that contains:
+      | IPN     | Category | Value | Description   | Package |
+      | RES_10K | RES      | 10K   | Resistor 10K  | 0603    |
+      | CAP_1U  | CAP      | 1uF   | Capacitor 1uF | 0603    |
+    When I run jbom command "inventory-search inventory.csv --dry-run"
+    Then the command should succeed
+    And the output should contain "DRY RUN"
+    And the output should contain "Searchable items: 2"
+
+  Scenario: Missing inventory file
+    When I run jbom command "inventory-search missing.csv --dry-run"
+    Then the command should fail
+    And the output should contain "Inventory file not found"

--- a/jbom-new/src/jbom/cli/inventory_search.py
+++ b/jbom-new/src/jbom/cli/inventory_search.py
@@ -1,0 +1,174 @@
+"""inventory-search command - bulk catalog search for inventory backfill (Phase 6.3)."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+from jbom.services.inventory_reader import InventoryReader
+from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.inventory_search_service import InventorySearchService
+from jbom.services.search.mouser_provider import MouserProvider
+
+
+def register_command(subparsers) -> None:
+    """Register inventory-search command with argument parser."""
+
+    parser = subparsers.add_parser(
+        "inventory-search",
+        help="Search distributor catalogs based on an inventory file",
+        description="Bulk catalog search to find candidate supplier part numbers for inventory items.",
+    )
+
+    parser.add_argument(
+        "inventory_file",
+        help="Path to inventory file (CSV, Excel, or Numbers)",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file for enhanced inventory with search candidates (CSV)",
+    )
+
+    parser.add_argument(
+        "--report",
+        help="Output file for analysis report (default: stdout)",
+    )
+
+    parser.add_argument(
+        "--provider",
+        choices=["mouser"],
+        default="mouser",
+        help="Search provider to use (default: mouser)",
+    )
+
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=3,
+        help="Maximum number of candidates per inventory item (default: 3)",
+    )
+
+    parser.add_argument(
+        "--api-key",
+        help="API key for the provider (overrides env vars)",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate input and compute searchable items without performing API calls",
+    )
+
+    parser.add_argument(
+        "--categories",
+        help="Comma-separated list of categories to search (e.g. 'RES,CAP,IC')",
+    )
+
+    parser.set_defaults(handler=handle_inventory_search)
+
+
+def handle_inventory_search(args: argparse.Namespace) -> int:
+    try:
+        inventory_path = Path(args.inventory_file)
+        if not inventory_path.exists():
+            print(f"Error: Inventory file not found: {inventory_path}", file=sys.stderr)
+            return 1
+
+        reader = InventoryReader(inventory_path)
+        items, _fields = reader.load()
+        if not items:
+            print("Error: No inventory items found in file", file=sys.stderr)
+            return 1
+
+        cache = InMemorySearchCache()
+
+        provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
+        service = InventorySearchService(
+            provider,
+            candidate_limit=args.limit,
+            request_delay_seconds=0.2,
+        )
+
+        searchable = service.filter_searchable_items(items, categories=args.categories)
+
+        if args.dry_run:
+            _print_dry_run_summary(searchable)
+            return 0
+
+        records = service.search(searchable)
+
+        report = service.generate_report(records)
+        if args.report:
+            Path(args.report).write_text(report, encoding="utf-8")
+        else:
+            print(report)
+
+        if args.output:
+            header_order = _load_header_order(inventory_path)
+            enhanced_rows = service.enhance_inventory_rows(
+                items,
+                original_field_order=header_order,
+                records=records,
+            )
+            out_fields = header_order + service.enhanced_csv_columns()
+
+            out_path = Path(args.output)
+            with open(out_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=out_fields)
+                writer.writeheader()
+                for row in enhanced_rows:
+                    writer.writerow(row)
+
+            print(f"Enhanced inventory written to {out_path}")
+
+        return 0
+
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _create_provider(provider_id: str, *, api_key: str | None, cache) -> MouserProvider:
+    pid = (provider_id or "").strip().lower()
+    if pid == "mouser":
+        return MouserProvider(api_key=api_key, cache=cache)
+
+    raise ValueError(f"Unknown provider: {provider_id}")
+
+
+def _print_dry_run_summary(items) -> None:
+    print("DRY RUN")
+    print(f"Searchable items: {len(items)}")
+
+    by_cat: dict[str, int] = {}
+    for item in items:
+        cat = (item.category or "").strip().upper() or "(missing)"
+        by_cat[cat] = by_cat.get(cat, 0) + 1
+
+    if by_cat:
+        print("By category:")
+        for cat, count in sorted(by_cat.items()):
+            print(f"  {cat}: {count}")
+
+
+def _load_header_order(path: Path) -> list[str]:
+    # Best effort: preserve original CSV header order.
+    if path.suffix.lower() == ".csv":
+        with open(path, "r", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            return next(reader)
+
+    # For non-CSV, fall back to a stable default.
+    return [
+        "IPN",
+        "Category",
+        "Value",
+        "Description",
+        "Package",
+        "Manufacturer",
+        "MFGPN",
+    ]

--- a/jbom-new/src/jbom/cli/main.py
+++ b/jbom-new/src/jbom/cli/main.py
@@ -5,7 +5,7 @@ import sys
 from typing import List, Optional
 
 from jbom import __version__
-from jbom.cli import bom, inventory, pos, parts, search
+from jbom.cli import bom, inventory, pos, parts, search, inventory_search
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -41,6 +41,7 @@ def create_parser() -> argparse.ArgumentParser:
     pos.register_command(subparsers)
     parts.register_command(subparsers)
     search.register_command(subparsers)
+    inventory_search.register_command(subparsers)
 
     return parser
 

--- a/jbom-new/src/jbom/cli/main.py
+++ b/jbom-new/src/jbom/cli/main.py
@@ -5,7 +5,7 @@ import sys
 from typing import List, Optional
 
 from jbom import __version__
-from jbom.cli import bom, inventory, pos, parts
+from jbom.cli import bom, inventory, pos, parts, search
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -40,6 +40,7 @@ def create_parser() -> argparse.ArgumentParser:
     inventory.register_command(subparsers)
     pos.register_command(subparsers)
     parts.register_command(subparsers)
+    search.register_command(subparsers)
 
     return parser
 

--- a/jbom-new/src/jbom/cli/search.py
+++ b/jbom-new/src/jbom/cli/search.py
@@ -1,0 +1,210 @@
+"""Search command - catalog lookup via external distributors (Phase 6)."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import Optional
+
+from jbom.cli.formatting import Column, print_table
+from jbom.services.search.cache import InMemorySearchCache, SearchCache
+from jbom.services.search.filtering import (
+    SearchFilter,
+    SearchSorter,
+    apply_default_filters,
+)
+from jbom.services.search.mouser_provider import MouserProvider
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+
+
+def register_command(subparsers) -> None:
+    """Register search command with argument parser."""
+
+    parser = subparsers.add_parser(
+        "search",
+        help="Search distributor catalogs (e.g. Mouser)",
+        description="Search distributor catalogs and print results.",
+    )
+
+    parser.add_argument(
+        "query", help="Search query (keyword, part number, description)"
+    )
+
+    parser.add_argument(
+        "--provider",
+        choices=["mouser"],
+        default="mouser",
+        help="Search provider to use (default: mouser)",
+    )
+
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of results to display (default: 10)",
+    )
+
+    parser.add_argument("--api-key", help="API key (overrides env vars)")
+
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Disable default filters (show out-of-stock/obsolete results)",
+    )
+
+    parser.add_argument(
+        "--no-parametric",
+        action="store_true",
+        help="Disable parametric filtering derived from the query text",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output destination: 'console' for table, '-' for CSV to stdout, or a file path",
+    )
+
+    parser.set_defaults(handler=handle_search)
+
+
+def handle_search(args: argparse.Namespace) -> int:
+    """Handle `jbom search` command."""
+
+    cache = InMemorySearchCache()
+
+    try:
+        provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
+    except (ValueError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # Pull extra results to allow client-side filtering.
+    display_limit = max(1, int(args.limit))
+    fetch_limit = min(100, max(50, display_limit * 3))
+
+    try:
+        results = provider.search(args.query, limit=fetch_limit)
+    except Exception as exc:
+        print(f"Error: search failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.all:
+        results = apply_default_filters(results)
+
+    # Parametric filtering is optional.
+    if not args.no_parametric:
+        results = SearchFilter.filter_by_query(results, args.query)
+
+    results = SearchSorter.rank(results)
+    results = results[:display_limit]
+
+    return _output_results(results, output=args.output)
+
+
+def _create_provider(
+    provider_id: str, *, api_key: Optional[str], cache: SearchCache
+) -> SearchProvider:
+    pid = (provider_id or "").strip().lower()
+    if pid == "mouser":
+        return MouserProvider(api_key=api_key, cache=cache)
+
+    raise ValueError(f"Unknown provider: {provider_id}")
+
+
+def _output_results(results: list[SearchResult], *, output: Optional[str]) -> int:
+    if output is None or output == "console":
+        _print_console(results)
+        return 0
+
+    if output == "-":
+        _print_csv(results)
+        return 0
+
+    path = Path(output)
+    _write_csv(results, path)
+    print(f"Search results written to {path}")
+    return 0
+
+
+def _print_console(results: list[SearchResult]) -> None:
+    if not results:
+        print("No results found.")
+        return
+
+    rows = [_row_for_result(r) for r in results]
+    cols = [
+        Column(
+            header="Manufacturer", key="manufacturer", preferred_width=18, wrap=True
+        ),
+        Column(header="MPN", key="mpn", preferred_width=28, wrap=True),
+        Column(
+            header="Distributor PN",
+            key="distributor_part_number",
+            preferred_width=22,
+            wrap=True,
+        ),
+        Column(
+            header="Price", key="price", preferred_width=10, fixed=True, align="right"
+        ),
+        Column(
+            header="Stock",
+            key="stock_quantity",
+            preferred_width=8,
+            fixed=True,
+            align="right",
+        ),
+        Column(
+            header="Lifecycle", key="lifecycle_status", preferred_width=10, wrap=True
+        ),
+    ]
+
+    print("")
+    print_table(rows, cols, terminal_width=120)
+    print("")
+    print(f"Found {len(results)} results.")
+
+
+def _print_csv(results: list[SearchResult]) -> None:
+    writer = csv.DictWriter(sys.stdout, fieldnames=_csv_headers())
+    writer.writeheader()
+    for r in results:
+        writer.writerow(_row_for_result(r))
+
+
+def _write_csv(results: list[SearchResult], path: Path) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=_csv_headers())
+        writer.writeheader()
+        for r in results:
+            writer.writerow(_row_for_result(r))
+
+
+def _csv_headers() -> list[str]:
+    return [
+        "manufacturer",
+        "mpn",
+        "distributor",
+        "distributor_part_number",
+        "availability",
+        "stock_quantity",
+        "price",
+        "lifecycle_status",
+        "details_url",
+    ]
+
+
+def _row_for_result(r: SearchResult) -> dict[str, str]:
+    return {
+        "manufacturer": r.manufacturer,
+        "mpn": r.mpn,
+        "distributor": r.distributor,
+        "distributor_part_number": r.distributor_part_number,
+        "availability": r.availability,
+        "stock_quantity": str(r.stock_quantity),
+        "price": r.price,
+        "lifecycle_status": r.lifecycle_status,
+        "details_url": r.details_url,
+    }

--- a/jbom-new/src/jbom/cli/search.py
+++ b/jbom-new/src/jbom/cli/search.py
@@ -171,7 +171,7 @@ def _print_csv(results: list[SearchResult]) -> None:
     writer = csv.DictWriter(sys.stdout, fieldnames=_csv_headers())
     writer.writeheader()
     for r in results:
-        writer.writerow(_row_for_result(r))
+        writer.writerow(_csv_row_for_result(r))
 
 
 def _write_csv(results: list[SearchResult], path: Path) -> None:
@@ -179,24 +179,41 @@ def _write_csv(results: list[SearchResult], path: Path) -> None:
         writer = csv.DictWriter(f, fieldnames=_csv_headers())
         writer.writeheader()
         for r in results:
-            writer.writerow(_row_for_result(r))
+            writer.writerow(_csv_row_for_result(r))
 
 
 def _csv_headers() -> list[str]:
+    # House style: human-readable headers (Title Case / abbreviations) similar to
+    # other jbom-new CSV outputs.
     return [
-        "manufacturer",
-        "mpn",
-        "distributor",
-        "distributor_part_number",
-        "availability",
-        "stock_quantity",
-        "price",
-        "lifecycle_status",
-        "details_url",
+        "Manufacturer",
+        "MPN",
+        "Distributor",
+        "Distributor PN",
+        "Availability",
+        "Stock",
+        "Price",
+        "Lifecycle",
+        "Details URL",
     ]
 
 
+def _csv_row_for_result(r: SearchResult) -> dict[str, str]:
+    return {
+        "Manufacturer": r.manufacturer,
+        "MPN": r.mpn,
+        "Distributor": r.distributor,
+        "Distributor PN": r.distributor_part_number,
+        "Availability": r.availability,
+        "Stock": str(r.stock_quantity),
+        "Price": r.price,
+        "Lifecycle": r.lifecycle_status,
+        "Details URL": r.details_url,
+    }
+
+
 def _row_for_result(r: SearchResult) -> dict[str, str]:
+    # Internal row mapping used by console output.
     return {
         "manufacturer": r.manufacturer,
         "mpn": r.mpn,

--- a/jbom-new/src/jbom/common/value_parsing.py
+++ b/jbom-new/src/jbom/common/value_parsing.py
@@ -50,7 +50,8 @@ def parse_res_to_ohms(value: str) -> Optional[float]:
         return None
 
     t = value.strip()
-    t = t.replace("Ω", "").replace("ω", "").replace("ohm", "").replace("OHM", "")
+    t = t.replace("Ω", "").replace("ω", "")
+    t = re.sub(r"(?i)ohms?", "", t)
     t = t.replace(" ", "")
     t = t.upper()
 

--- a/jbom-new/src/jbom/services/search/__init__.py
+++ b/jbom-new/src/jbom/services/search/__init__.py
@@ -1,0 +1,12 @@
+"""Search services.
+
+Phase 6 harvest: external catalog search providers (starting with Mouser),
+plus filtering/sorting/caching helpers.
+
+This package is intentionally provider-agnostic.
+"""
+
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+
+__all__ = ["SearchProvider", "SearchResult"]

--- a/jbom-new/src/jbom/services/search/cache.py
+++ b/jbom-new/src/jbom/services/search/cache.py
@@ -1,0 +1,67 @@
+"""Search caching helpers.
+
+Phase 6 constraint: keep web API usage low (rate limits / bandwidth). For now we
+use in-memory caching, but the interface is designed so we can later add a
+persistent user-level cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from jbom.services.search.models import SearchResult
+
+
+def normalize_query(query: str) -> str:
+    """Normalize a query string for caching keys."""
+
+    return " ".join((query or "").strip().lower().split())
+
+
+@dataclass(frozen=True)
+class SearchCacheKey:
+    """Cache key for a provider search."""
+
+    provider_id: str
+    query: str
+    limit: int
+
+    @staticmethod
+    def create(*, provider_id: str, query: str, limit: int) -> "SearchCacheKey":
+        return SearchCacheKey(
+            provider_id=(provider_id or "").strip().lower(),
+            query=normalize_query(query),
+            limit=int(limit),
+        )
+
+
+class SearchCache(Protocol):
+    """Cache interface for search results."""
+
+    def get(self, key: SearchCacheKey) -> Optional[list[SearchResult]]:
+        """Return cached results, or None if absent."""
+
+    def set(self, key: SearchCacheKey, value: list[SearchResult]) -> None:
+        """Store results for later reuse."""
+
+
+class InMemorySearchCache:
+    """Simple in-memory cache keyed by provider/query/limit."""
+
+    def __init__(self) -> None:
+        self._data: dict[SearchCacheKey, list[SearchResult]] = {}
+
+    def get(self, key: SearchCacheKey) -> Optional[list[SearchResult]]:
+        return self._data.get(key)
+
+    def set(self, key: SearchCacheKey, value: list[SearchResult]) -> None:
+        self._data[key] = list(value)
+
+
+__all__ = [
+    "InMemorySearchCache",
+    "SearchCache",
+    "SearchCacheKey",
+    "normalize_query",
+]

--- a/jbom-new/src/jbom/services/search/filtering.py
+++ b/jbom-new/src/jbom/services/search/filtering.py
@@ -1,0 +1,143 @@
+"""Search filtering and sorting.
+
+This module contains pure client-side helpers:
+- Parametric filtering (query-driven)
+- Default availability/lifecycle filtering
+- Sorting/ranking
+
+All functions are side-effect free.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from jbom.common.value_parsing import parse_res_to_ohms
+from jbom.services.search.models import SearchResult
+
+
+class SearchFilter:
+    """Client-side filtering helpers."""
+
+    @staticmethod
+    def filter_by_query(results: list[SearchResult], query: str) -> list[SearchResult]:
+        """Filter results based on query terms matching parametric attributes.
+
+        Current behavior mirrors legacy jBOM's implementation for resistors:
+        - If the query contains a parseable resistance, keep only results whose
+          "Resistance" attribute matches.
+        - If the query contains a tolerance percentage, keep only exact matches
+          when the result includes "Tolerance".
+
+        Filtering is "fail open" when a result lacks parametric attributes.
+        """
+
+        filtered: list[SearchResult] = []
+
+        # Resistance target.
+        # Queries are usually multi-token (e.g. "10K resistor 0603"), while the
+        # value parser expects a single value token.
+        target_ohms = None
+        for token in re.split(r"[\s,]+", query or ""):
+            if not token:
+                continue
+            target_ohms = parse_res_to_ohms(token)
+            if target_ohms is not None:
+                break
+
+        # Tolerance target (e.g. "1%", "5%")
+        target_tol: float | None = None
+        tol_match = re.search(r"(\d+(?:\.\d+)?)%", query)
+        if tol_match:
+            try:
+                target_tol = float(tol_match.group(1))
+            except ValueError:
+                target_tol = None
+
+        for r in results:
+            if not r.attributes:
+                filtered.append(r)
+                continue
+
+            keep = True
+
+            if target_ohms is not None:
+                res_attr = r.attributes.get("Resistance", "")
+                if res_attr:
+                    attr_ohms = parse_res_to_ohms(res_attr)
+                    if attr_ohms is None or abs(attr_ohms - target_ohms) > (
+                        target_ohms * 0.001
+                    ):
+                        keep = False
+
+            if keep and target_tol is not None:
+                tol_attr = r.attributes.get("Tolerance", "")
+                if tol_attr:
+                    clean_tol = tol_attr.replace("%", "").replace("+/-", "").strip()
+                    try:
+                        attr_tol = float(clean_tol)
+                        if attr_tol != target_tol:
+                            keep = False
+                    except ValueError:
+                        # If the result tolerance is unparsable, fail open.
+                        pass
+
+            if keep:
+                filtered.append(r)
+
+        return filtered
+
+
+def apply_default_filters(results: Iterable[SearchResult]) -> list[SearchResult]:
+    """Apply conservative default filters (in-stock, avoid obsolete/NRND).
+
+    This is intended for interactive `jbom search` usage.
+
+    Providers are encouraged to return raw results; these filters are applied
+    by the CLI/service layer so `--all` can bypass them.
+    """
+
+    filtered: list[SearchResult] = []
+    for r in results:
+        if r.stock_quantity <= 0:
+            continue
+
+        status = (r.lifecycle_status or "").lower()
+        if "obsolete" in status or "not recommended" in status:
+            continue
+
+        if "factory order" in (r.availability or "").lower():
+            continue
+
+        filtered.append(r)
+
+    return filtered
+
+
+class SearchSorter:
+    """Sorting utilities."""
+
+    @staticmethod
+    def rank(results: list[SearchResult]) -> list[SearchResult]:
+        """Rank by stock (desc) then price (asc)."""
+
+        def sort_key(r: SearchResult) -> tuple[int, float]:
+            stock = r.stock_quantity
+            try:
+                price_clean = (
+                    (r.price or "")
+                    .replace("$", "")
+                    .replace("€", "")
+                    .replace("£", "")
+                    .strip()
+                )
+                price_value = float(price_clean)
+            except ValueError:
+                price_value = float("inf")
+            return (-stock, price_value)
+
+        return sorted(results, key=sort_key)
+
+
+__all__ = ["SearchFilter", "SearchSorter", "apply_default_filters"]

--- a/jbom-new/src/jbom/services/search/inventory_search_service.py
+++ b/jbom-new/src/jbom/services/search/inventory_search_service.py
@@ -1,0 +1,453 @@
+"""Inventory search (Phase 6.3).
+
+This service searches an external catalog (starting with Mouser) for candidates
+that could fill gaps in an inventory file.
+
+Design goals:
+- No file I/O (CLI handles reading/writing)
+- Deterministic, testable behavior
+- No API calls required in unit tests (provider can be mocked)
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+
+from jbom.common.component_classification import normalize_component_type
+from jbom.common.types import Component, InventoryItem
+from jbom.services.search.filtering import SearchSorter, apply_default_filters
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+from jbom.services.sophisticated_inventory_matcher import (
+    MatchingOptions,
+    SophisticatedInventoryMatcher,
+)
+
+
+@dataclass(frozen=True)
+class InventorySearchCandidate:
+    """One scored candidate for an inventory item."""
+
+    result: SearchResult
+    match_score: int
+
+
+@dataclass(frozen=True)
+class InventorySearchRecord:
+    """Search outcomes for one inventory item."""
+
+    inventory_item: InventoryItem
+    query: str
+    candidates: list[InventorySearchCandidate]
+    error: str | None = None
+
+
+def _normalize_ascii_value(text: str) -> str:
+    """Normalize value strings to ASCII-friendly equivalents."""
+
+    if not text:
+        return ""
+
+    t = str(text)
+    t = t.replace("Ω", "")
+    t = t.replace("ω", "")
+    t = t.replace("μ", "u")
+    t = t.replace("µ", "u")
+    return " ".join(t.split()).strip()
+
+
+def _category_token(category: str) -> str:
+    """Return a normalized category token usable for comparisons."""
+
+    return normalize_component_type(category or "")
+
+
+def _category_matches(item_category: str, selector: str) -> bool:
+    """Return True if an inventory category matches a selector token."""
+
+    cat = (item_category or "").strip().upper()
+    sel = (selector or "").strip().upper()
+    if not cat or not sel:
+        return False
+
+    return cat == sel or cat.startswith(sel) or (sel in cat)
+
+
+class InventorySearchService:
+    """Service that searches external catalogs for inventory backfill candidates."""
+
+    def __init__(
+        self,
+        provider: SearchProvider,
+        *,
+        candidate_limit: int = 3,
+        request_delay_seconds: float = 0.0,
+    ) -> None:
+        self._provider = provider
+        self._candidate_limit = max(1, int(candidate_limit))
+        self._request_delay_seconds = max(0.0, float(request_delay_seconds))
+        self._matcher = SophisticatedInventoryMatcher(MatchingOptions())
+
+    def filter_searchable_items(
+        self, items: list[InventoryItem], *, categories: str | None
+    ) -> list[InventoryItem]:
+        """Filter to items suitable for catalog search."""
+
+        default_searchable = {
+            "RES",
+            "CAP",
+            "IND",
+            "LED",
+            "DIO",
+            "IC",
+            "Q",
+            "REG",
+            "OSC",
+            "CONN",
+            "CON",
+        }
+
+        excluded = {"SLK", "BOARD", "DOC", "MECH"}
+
+        if categories:
+            selectors = {
+                _category_token(t) for t in re.split(r"[\s,]+", categories) if t.strip()
+            }
+        else:
+            selectors = default_searchable
+
+        out: list[InventoryItem] = []
+        for item in items:
+            cat_raw = (item.category or "").strip()
+            if not cat_raw:
+                continue
+
+            cat_norm = _category_token(cat_raw)
+            if cat_norm in excluded:
+                continue
+
+            if not item.value or len(str(item.value).strip()) < 2:
+                continue
+
+            if any(_category_matches(cat_raw, s) for s in selectors):
+                out.append(item)
+
+        return out
+
+    def build_query(self, item: InventoryItem) -> str:
+        """Build a Mouser-friendly keyword query string."""
+
+        parts: list[str] = []
+
+        if item.value:
+            parts.append(_normalize_ascii_value(item.value))
+
+        cat = _category_token(item.category)
+        type_keywords = {
+            "RES": "resistor",
+            "CAP": "capacitor",
+            "IND": "inductor",
+            "LED": "LED",
+            "DIO": "diode",
+            "IC": "IC",
+            "Q": "transistor",
+            "REG": "regulator",
+            "CON": "connector",
+            "CONN": "connector",
+        }
+        if cat in type_keywords:
+            parts.append(type_keywords[cat])
+
+        if item.package:
+            parts.append(_normalize_ascii_value(item.package))
+
+        if (
+            item.tolerance
+            and item.tolerance.strip()
+            and item.tolerance.strip().upper() != "N/A"
+        ):
+            parts.append(_normalize_ascii_value(item.tolerance))
+
+        return " ".join(p for p in parts if p).strip()
+
+    def search(self, items: list[InventoryItem]) -> list[InventorySearchRecord]:
+        """Search for candidates for each inventory item."""
+
+        records: list[InventorySearchRecord] = []
+
+        for item in items:
+            query = self.build_query(item)
+            if not query:
+                records.append(
+                    InventorySearchRecord(
+                        inventory_item=item,
+                        query=query,
+                        candidates=[],
+                        error="empty query",
+                    )
+                )
+                continue
+
+            try:
+                raw_results = self._provider.search(
+                    query,
+                    limit=max(10, self._candidate_limit * 3),
+                )
+            except Exception as exc:
+                records.append(
+                    InventorySearchRecord(
+                        inventory_item=item,
+                        query=query,
+                        candidates=[],
+                        error=str(exc),
+                    )
+                )
+                continue
+
+            filtered = apply_default_filters(raw_results)
+            ranked = SearchSorter.rank(filtered)
+
+            candidates = self._score_candidates(item, ranked)
+            records.append(
+                InventorySearchRecord(
+                    inventory_item=item,
+                    query=query,
+                    candidates=candidates[: self._candidate_limit],
+                )
+            )
+
+            # Be conservative with public APIs (configurable for tests).
+            if self._request_delay_seconds > 0:
+                time.sleep(self._request_delay_seconds)
+
+        return records
+
+    def _score_candidates(
+        self, base_item: InventoryItem, results: list[SearchResult]
+    ) -> list[InventorySearchCandidate]:
+        comp = self._inventory_item_to_component(base_item)
+
+        scored: list[InventorySearchCandidate] = []
+        for r in results:
+            candidate_item = self._search_result_to_inventory_item(r, base_item)
+            matches = self._matcher.find_matches(comp, [candidate_item])
+            score = matches[0].score if matches else 0
+            if score <= 0:
+                continue
+            scored.append(InventorySearchCandidate(result=r, match_score=score))
+
+        scored.sort(
+            key=lambda c: (
+                -c.match_score,
+                -c.result.stock_quantity,
+                _price_to_float(c.result.price),
+            )
+        )
+        return scored
+
+    @staticmethod
+    def _inventory_item_to_component(item: InventoryItem) -> Component:
+        cat = _category_token(item.category)
+        # Choose a lib_id that makes get_component_type return the correct type.
+        lib_id_map = {
+            "RES": "Device:R",
+            "CAP": "Device:C",
+            "IND": "Device:L",
+            "DIO": "Device:D",
+            "LED": "Device:LED",
+            "Q": "Device:Q",
+            "IC": "Device:U",
+            "REG": "Device:U",
+            "OSC": "Device:U",
+            "CON": "Connector:Conn",
+            "CONN": "Connector:Conn",
+        }
+        lib_id = lib_id_map.get(cat, f"{cat}:{item.ipn}" if cat else "Device:Generic")
+
+        props: dict[str, str] = {}
+        if item.tolerance:
+            props["Tolerance"] = item.tolerance
+        if item.voltage:
+            props["Voltage"] = item.voltage
+        if item.wattage:
+            props["Wattage"] = item.wattage
+
+        return Component(
+            reference=item.ipn or "",
+            lib_id=lib_id,
+            value=item.value or "",
+            footprint=item.package or "",
+            properties=props,
+        )
+
+    @staticmethod
+    def _search_result_to_inventory_item(
+        result: SearchResult, base_item: InventoryItem
+    ) -> InventoryItem:
+        # For scoring we only need a subset of fields used by SophisticatedInventoryMatcher.
+        # Category/value/package are the most important.
+        return InventoryItem(
+            ipn="",
+            keywords="",
+            category=base_item.category or "",
+            description=result.description,
+            smd="",
+            value=_value_from_search_result(result, base_item),
+            type="",
+            tolerance=result.attributes.get("Tolerance", "") or base_item.tolerance,
+            voltage=result.attributes.get("Voltage", "") or base_item.voltage,
+            amperage="",
+            wattage=result.attributes.get("Power", "") or base_item.wattage,
+            lcsc="",
+            manufacturer=result.manufacturer,
+            mfgpn=result.mpn,
+            datasheet=result.datasheet,
+            package=_package_from_search_result(result, base_item),
+            distributor=result.distributor,
+            distributor_part_number=result.distributor_part_number,
+            raw_data={},
+        )
+
+    def generate_report(self, records: list[InventorySearchRecord]) -> str:
+        total = len(records)
+        successes = sum(1 for r in records if r.candidates)
+        failures = total - successes
+
+        by_cat: dict[str, dict[str, int]] = {}
+        for r in records:
+            cat = (r.inventory_item.category or "").strip().upper() or "(missing)"
+            stats = by_cat.setdefault(cat, {"total": 0, "success": 0})
+            stats["total"] += 1
+            if r.candidates:
+                stats["success"] += 1
+
+        lines: list[str] = []
+        lines.append("INVENTORY SEARCH REPORT")
+        lines.append(f"Generated: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append("")
+        lines.append(f"Total searchable items: {total}")
+        if total:
+            lines.append(
+                f"Successful searches: {successes} ({successes/total*100:.1f}%)"
+            )
+            lines.append(f"Failed searches: {failures} ({failures/total*100:.1f}%)")
+        lines.append("")
+        lines.append("By category:")
+        for cat, stats in sorted(by_cat.items()):
+            rate = (
+                (stats["success"] / stats["total"] * 100.0) if stats["total"] else 0.0
+            )
+            lines.append(f"  {cat}: {stats['success']}/{stats['total']} ({rate:.1f}%)")
+
+        return "\n".join(lines) + "\n"
+
+    def enhanced_csv_columns(self) -> list[str]:
+        cols: list[str] = ["Search Query", "Search Success"]
+        for idx in range(1, self._candidate_limit + 1):
+            cols.extend(
+                [
+                    f"Candidate {idx} Manufacturer",
+                    f"Candidate {idx} MPN",
+                    f"Candidate {idx} Distributor PN",
+                    f"Candidate {idx} Availability",
+                    f"Candidate {idx} Stock",
+                    f"Candidate {idx} Price",
+                    f"Candidate {idx} Lifecycle",
+                    f"Candidate {idx} Match Score",
+                ]
+            )
+        return cols
+
+    def enhance_inventory_rows(
+        self,
+        original_items: list[InventoryItem],
+        *,
+        original_field_order: list[str],
+        records: list[InventorySearchRecord],
+    ) -> list[dict[str, str]]:
+        by_ipn = {r.inventory_item.ipn: r for r in records if r.inventory_item.ipn}
+
+        enhanced: list[dict[str, str]] = []
+        for item in original_items:
+            row = dict(item.raw_data or {})
+
+            # Ensure all original fields exist.
+            for f in original_field_order:
+                row.setdefault(f, "")
+
+            rec = by_ipn.get(item.ipn)
+            if rec is None:
+                # Not searched / filtered out.
+                row["Search Query"] = ""
+                row["Search Success"] = ""
+                for col in self.enhanced_csv_columns()[2:]:
+                    row[col] = ""
+                enhanced.append(row)
+                continue
+
+            row["Search Query"] = rec.query
+            row["Search Success"] = "Yes" if rec.candidates else "No"
+
+            # Fill candidate columns.
+            for i in range(1, self._candidate_limit + 1):
+                prefix = f"Candidate {i} "
+                if i <= len(rec.candidates):
+                    c = rec.candidates[i - 1]
+                    row[prefix + "Manufacturer"] = c.result.manufacturer
+                    row[prefix + "MPN"] = c.result.mpn
+                    row[prefix + "Distributor PN"] = c.result.distributor_part_number
+                    row[prefix + "Availability"] = c.result.availability
+                    row[prefix + "Stock"] = str(c.result.stock_quantity)
+                    row[prefix + "Price"] = c.result.price
+                    row[prefix + "Lifecycle"] = c.result.lifecycle_status
+                    row[prefix + "Match Score"] = str(c.match_score)
+                else:
+                    row[prefix + "Manufacturer"] = ""
+                    row[prefix + "MPN"] = ""
+                    row[prefix + "Distributor PN"] = ""
+                    row[prefix + "Availability"] = ""
+                    row[prefix + "Stock"] = ""
+                    row[prefix + "Price"] = ""
+                    row[prefix + "Lifecycle"] = ""
+                    row[prefix + "Match Score"] = ""
+
+            enhanced.append(row)
+
+        return enhanced
+
+
+def _price_to_float(price: str) -> float:
+    try:
+        t = re.sub(r"[^0-9\.]", "", price or "")
+        return float(t)
+    except ValueError:
+        return float("inf")
+
+
+def _value_from_search_result(result: SearchResult, base_item: InventoryItem) -> str:
+    # Attempt to preserve semantic value for passives.
+    cat = _category_token(base_item.category)
+
+    if cat == "RES":
+        return result.attributes.get("Resistance", "") or base_item.value
+
+    if cat == "CAP":
+        return result.attributes.get("Capacitance", "") or base_item.value
+
+    if cat == "IND":
+        return result.attributes.get("Inductance", "") or base_item.value
+
+    return base_item.value
+
+
+def _package_from_search_result(result: SearchResult, base_item: InventoryItem) -> str:
+    return result.attributes.get("Package", "") or base_item.package
+
+
+__all__ = [
+    "InventorySearchCandidate",
+    "InventorySearchRecord",
+    "InventorySearchService",
+]

--- a/jbom-new/src/jbom/services/search/models.py
+++ b/jbom-new/src/jbom/services/search/models.py
@@ -1,0 +1,42 @@
+"""Search domain models.
+
+These dataclasses normalize data returned by distributor APIs so the rest of the
+application can stay provider-agnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """A single normalized distributor catalog result."""
+
+    manufacturer: str
+    mpn: str
+    description: str
+    datasheet: str
+
+    distributor: str
+    distributor_part_number: str
+
+    availability: str
+    price: str
+    details_url: str
+
+    raw_data: dict[str, Any]
+
+    lifecycle_status: str = "Unknown"
+    min_order_qty: int = 1
+    category: str = ""
+
+    # Parametric attributes (e.g. Resistance, Tolerance, Technology)
+    attributes: dict[str, str] = field(default_factory=dict)
+
+    # Numeric stock quantity extracted from availability, when possible.
+    stock_quantity: int = 0
+
+
+__all__ = ["SearchResult"]

--- a/jbom-new/src/jbom/services/search/mouser_provider.py
+++ b/jbom-new/src/jbom/services/search/mouser_provider.py
@@ -1,0 +1,200 @@
+"""Mouser Search API provider."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from jbom.services.search.cache import SearchCache, SearchCacheKey
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+
+logger = logging.getLogger(__name__)
+
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+
+class MouserProvider(SearchProvider):
+    """Mouser keyword search API integration."""
+
+    BASE_URL = "https://api.mouser.com/api/v1/search"
+
+    def __init__(
+        self, *, api_key: Optional[str] = None, cache: Optional[SearchCache] = None
+    ):
+        """Create a provider.
+
+        Args:
+            api_key: Mouser API key. Defaults to MOUSER_API_KEY environment variable.
+            cache: Optional cache used to reduce repeated API calls.
+
+        Raises:
+            ValueError: When api_key is not provided and MOUSER_API_KEY is not set.
+        """
+
+        self._api_key = api_key or os.environ.get("MOUSER_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "Mouser API Key is required. Set MOUSER_API_KEY or pass --api-key."
+            )
+
+        self._cache = cache
+
+    @property
+    def provider_id(self) -> str:
+        return "mouser"
+
+    @property
+    def name(self) -> str:
+        return "Mouser"
+
+    def search(self, query: str, *, limit: int = 10) -> list[SearchResult]:
+        if requests is None:  # pragma: no cover
+            raise RuntimeError(
+                "Search support requires the 'requests' package. Install it with: pip install requests"
+            )
+
+        cache_key = None
+        if self._cache is not None:
+            cache_key = SearchCacheKey.create(
+                provider_id=self.provider_id, query=query, limit=limit
+            )
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                return list(cached)
+
+        # Fetch more than requested to allow client-side filtering.
+        records = min(100, max(50, int(limit) * 2))
+
+        url = f"{self.BASE_URL}/keyword"
+        payload = {
+            "SearchByKeywordRequest": {
+                "keyword": query,
+                "records": records,
+                "startingRecord": 0,
+                "searchOptions": "None",
+                "searchWithYourSignUpLanguage": "English",
+            }
+        }
+
+        try:
+            response = requests.post(
+                url,
+                params={"apiKey": self._api_key},
+                json=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:
+            logger.error("Mouser API request failed: %s", exc)
+            return []
+
+        # Mouser embeds error strings inside the JSON body.
+        errors = data.get("Errors")
+        if isinstance(errors, list) and errors:
+            msgs = [
+                str(e.get("Message", "Unknown Error"))
+                for e in errors
+                if isinstance(e, dict)
+            ]
+            logger.error("Mouser API error(s): %s", ", ".join(msgs) if msgs else errors)
+            return []
+
+        results = self._parse_results(data)
+        results = results[: max(0, int(limit))]
+
+        if cache_key is not None and self._cache is not None:
+            self._cache.set(cache_key, results)
+
+        return results
+
+    @staticmethod
+    def _parse_stock_quantity(availability: str) -> int:
+        if not availability:
+            return 0
+
+        # Common format: "6,609 In Stock".
+        parts = availability.split()
+        if not parts:
+            return 0
+
+        head = parts[0].replace(",", "")
+        if not head.isdigit():
+            return 0
+
+        try:
+            return int(head)
+        except ValueError:
+            return 0
+
+    def _parse_results(self, data: dict[str, Any]) -> list[SearchResult]:
+        search_results = data.get("SearchResults", {})
+        parts = search_results.get("Parts", [])
+        if not isinstance(parts, list):
+            return []
+
+        results: list[SearchResult] = []
+
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+
+            availability = str(part.get("Availability", ""))
+            stock_qty = self._parse_stock_quantity(availability)
+
+            price = "N/A"
+            price_breaks = part.get("PriceBreaks", [])
+            if isinstance(price_breaks, list) and price_breaks:
+                first = price_breaks[0] if isinstance(price_breaks[0], dict) else {}
+                if isinstance(first, dict):
+                    price = str(first.get("Price", "N/A"))
+
+            attributes: dict[str, str] = {}
+            for attr in part.get("ProductAttributes", []) or []:
+                if not isinstance(attr, dict):
+                    continue
+                name = str(attr.get("AttributeName", "") or "").strip()
+                value = str(attr.get("AttributeValue", "") or "").strip()
+                if name and value:
+                    attributes[name] = value
+
+            lifecycle = str(part.get("LifecycleStatus", "Unknown"))
+            min_order_raw = str(part.get("Min", "1"))
+            try:
+                min_order = int(min_order_raw)
+            except ValueError:
+                min_order = 1
+
+            results.append(
+                SearchResult(
+                    manufacturer=str(part.get("Manufacturer", "")),
+                    mpn=str(part.get("ManufacturerPartNumber", "")),
+                    description=str(part.get("Description", "")),
+                    datasheet=str(part.get("DataSheetUrl", "")),
+                    distributor=self.provider_id,
+                    distributor_part_number=str(part.get("MouserPartNumber", "")),
+                    availability=availability,
+                    price=price,
+                    details_url=str(part.get("ProductDetailUrl", "")),
+                    raw_data=part,
+                    lifecycle_status=lifecycle,
+                    min_order_qty=min_order,
+                    category=str(part.get("Category", "")),
+                    attributes=attributes,
+                    stock_quantity=stock_qty,
+                )
+            )
+
+        return results
+
+
+__all__ = ["MouserProvider"]

--- a/jbom-new/src/jbom/services/search/provider.py
+++ b/jbom-new/src/jbom/services/search/provider.py
@@ -1,0 +1,36 @@
+"""Search provider abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from jbom.services.search.models import SearchResult
+
+
+class SearchProvider(ABC):
+    """Abstract base class for distributor catalog search providers."""
+
+    @property
+    @abstractmethod
+    def provider_id(self) -> str:
+        """Stable provider identifier (e.g. "mouser")."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable provider name (e.g. "Mouser")."""
+
+    @abstractmethod
+    def search(self, query: str, *, limit: int = 10) -> list[SearchResult]:
+        """Search by keyword / part number.
+
+        Args:
+            query: Search query.
+            limit: Max number of results to return.
+
+        Returns:
+            List of normalized results.
+        """
+
+
+__all__ = ["SearchProvider"]

--- a/jbom-new/tests/services/search/__init__.py
+++ b/jbom-new/tests/services/search/__init__.py
@@ -1,0 +1,1 @@
+"""Search service unit tests."""

--- a/jbom-new/tests/services/search/test_filtering.py
+++ b/jbom-new/tests/services/search/test_filtering.py
@@ -1,0 +1,65 @@
+from jbom.services.search.filtering import (
+    SearchFilter,
+    SearchSorter,
+    apply_default_filters,
+)
+from jbom.services.search.models import SearchResult
+
+
+def _sr(**kw):
+    base = dict(
+        manufacturer="Mfg",
+        mpn="MPN",
+        description="desc",
+        datasheet="",
+        distributor="mouser",
+        distributor_part_number="123",
+        availability="100 In Stock",
+        price="$0.10",
+        details_url="",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        category="",
+        attributes={},
+        stock_quantity=100,
+    )
+    base.update(kw)
+    return SearchResult(**base)
+
+
+def test_apply_default_filters_removes_out_of_stock_and_obsolete():
+    results = [
+        _sr(stock_quantity=0),
+        _sr(lifecycle_status="Obsolete", stock_quantity=10),
+        _sr(availability="Factory Order", stock_quantity=10),
+        _sr(stock_quantity=10),
+    ]
+    filtered = apply_default_filters(results)
+    assert len(filtered) == 1
+    assert filtered[0].stock_quantity == 10
+
+
+def test_filter_by_query_resistance_strict_matches_when_attribute_present():
+    results = [
+        _sr(attributes={"Resistance": "10 kOhms"}, mpn="A"),
+        _sr(attributes={"Resistance": "22 kOhms"}, mpn="B"),
+        _sr(attributes={}, mpn="C"),  # fail-open
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10K 0603")
+    mpns = {r.mpn for r in filtered}
+    assert "A" in mpns
+    assert "B" not in mpns
+    assert "C" in mpns
+
+
+def test_sorter_prefers_higher_stock_then_lower_price():
+    results = [
+        _sr(stock_quantity=10, price="$0.20", mpn="A"),
+        _sr(stock_quantity=10, price="$0.10", mpn="B"),
+        _sr(stock_quantity=100, price="$1.00", mpn="C"),
+    ]
+
+    ranked = SearchSorter.rank(results)
+    assert [r.mpn for r in ranked] == ["C", "B", "A"]

--- a/jbom-new/tests/services/search/test_mouser_provider.py
+++ b/jbom-new/tests/services/search/test_mouser_provider.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.mouser_provider import MouserProvider
+
+
+def _mock_response(payload: dict):
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.json = Mock(return_value=payload)
+    return resp
+
+
+def test_mouser_provider_requires_api_key(monkeypatch):
+    monkeypatch.delenv("MOUSER_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        MouserProvider()
+
+
+def test_mouser_provider_parses_basic_result(monkeypatch):
+    cache = InMemorySearchCache()
+
+    # Provide env key so constructor succeeds.
+    monkeypatch.setenv("MOUSER_API_KEY", "dummy")
+
+    import jbom.services.search.mouser_provider as mp
+
+    post = Mock(
+        return_value=_mock_response(
+            {
+                "SearchResults": {
+                    "Parts": [
+                        {
+                            "Manufacturer": "Yageo",
+                            "ManufacturerPartNumber": "RC0603FR-0710KL",
+                            "Description": "RES 10K",
+                            "DataSheetUrl": "http://example",
+                            "MouserPartNumber": "123-ABC",
+                            "Availability": "6,609 In Stock",
+                            "PriceBreaks": [{"Price": "$0.10"}],
+                            "ProductDetailUrl": "http://detail",
+                            "LifecycleStatus": "Active",
+                            "Min": "1",
+                            "Category": "Resistors",
+                            "ProductAttributes": [
+                                {
+                                    "AttributeName": "Resistance",
+                                    "AttributeValue": "10 kOhms",
+                                },
+                                {"AttributeName": "Tolerance", "AttributeValue": "1%"},
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(mp, "requests", Mock(post=post))
+
+    provider = MouserProvider(cache=cache)
+    results = provider.search("10K resistor", limit=5)
+    assert len(results) == 1
+
+    r = results[0]
+    assert r.manufacturer == "Yageo"
+    assert r.distributor == "mouser"
+    assert r.stock_quantity == 6609
+    assert r.attributes.get("Resistance") == "10 kOhms"
+
+
+def test_mouser_provider_uses_cache(monkeypatch):
+    cache = InMemorySearchCache()
+    monkeypatch.setenv("MOUSER_API_KEY", "dummy")
+
+    import jbom.services.search.mouser_provider as mp
+
+    post = Mock(return_value=_mock_response({"SearchResults": {"Parts": []}}))
+    monkeypatch.setattr(mp, "requests", Mock(post=post))
+
+    provider = MouserProvider(cache=cache)
+
+    provider.search("abc", limit=10)
+    provider.search("abc", limit=10)
+
+    assert post.call_count == 1

--- a/jbom-new/tests/services/search/test_search_cli.py
+++ b/jbom-new/tests/services/search/test_search_cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+
+from jbom.cli.search import handle_search
+from jbom.services.search.models import SearchResult
+
+
+def _sr(**kw) -> SearchResult:
+    base = dict(
+        manufacturer="Yageo",
+        mpn="RC0603FR-0710KL",
+        description="RES 10K",
+        datasheet="http://example",
+        distributor="mouser",
+        distributor_part_number="123-ABC",
+        availability="6,609 In Stock",
+        price="$0.10",
+        details_url="http://detail",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        category="Resistors",
+        attributes={"Resistance": "10 kOhms"},
+        stock_quantity=6609,
+    )
+    base.update(kw)
+    return SearchResult(**base)
+
+
+def test_search_console_output(monkeypatch, capsys):
+    # Avoid any network calls.
+    from jbom.services.search import mouser_provider
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [_sr()],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        provider="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="console",
+    )
+
+    rc = handle_search(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "Manufacturer" in out
+    assert "Yageo" in out
+
+
+def test_search_csv_stdout(monkeypatch, capsys):
+    from jbom.services.search import mouser_provider
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [_sr()],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        provider="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+    )
+
+    rc = handle_search(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out.splitlines()
+    assert out[0].startswith("manufacturer,mpn,distributor")
+    assert any("Yageo" in line for line in out[1:])
+
+
+def test_search_csv_file(monkeypatch, tmp_path):
+    from jbom.services.search import mouser_provider
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [_sr()],
+    )
+
+    outpath = tmp_path / "out.csv"
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        provider="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output=str(outpath),
+    )
+
+    rc = handle_search(args)
+    assert rc == 0
+
+    text = outpath.read_text(encoding="utf-8")
+    assert text.splitlines()[0].startswith("manufacturer,mpn,distributor")
+    assert "Yageo" in text

--- a/jbom-new/tests/services/search/test_search_cli.py
+++ b/jbom-new/tests/services/search/test_search_cli.py
@@ -79,7 +79,7 @@ def test_search_csv_stdout(monkeypatch, capsys):
     assert rc == 0
 
     out = capsys.readouterr().out.splitlines()
-    assert out[0].startswith("manufacturer,mpn,distributor")
+    assert out[0].startswith("Manufacturer,MPN,Distributor")
     assert any("Yageo" in line for line in out[1:])
 
 
@@ -108,5 +108,5 @@ def test_search_csv_file(monkeypatch, tmp_path):
     assert rc == 0
 
     text = outpath.read_text(encoding="utf-8")
-    assert text.splitlines()[0].startswith("manufacturer,mpn,distributor")
+    assert text.splitlines()[0].startswith("Manufacturer,MPN,Distributor")
     assert "Yageo" in text

--- a/jbom-new/tests/unit/test_cli_help.py
+++ b/jbom-new/tests/unit/test_cli_help.py
@@ -61,3 +61,8 @@ def test_inventory_help_shows_inventory_interface_tokens():
     tokens_current = ["--inventory", "--filter-matches", "-o", "--output"]
     for token in tokens_current:
         assert token in out
+
+
+def test_root_help_includes_search_command():
+    out = run_help([]).lower()
+    assert "search" in out

--- a/jbom-new/tests/unit/test_cli_help.py
+++ b/jbom-new/tests/unit/test_cli_help.py
@@ -66,3 +66,8 @@ def test_inventory_help_shows_inventory_interface_tokens():
 def test_root_help_includes_search_command():
     out = run_help([]).lower()
     assert "search" in out
+
+
+def test_root_help_includes_inventory_search_command():
+    out = run_help([]).lower()
+    assert "inventory-search" in out


### PR DESCRIPTION
Implements Phase 6 catalog search harvest from legacy jBOM.

What’s included
- Search provider infrastructure under `jbom-new/src/jbom/services/search/`:
  - `SearchProvider` abstraction + `SearchResult` model
  - in-memory caching interface (`InMemorySearchCache`) designed to allow a future user-level on-disk cache
  - query filtering + sorting
  - Mouser keyword search provider (`MOUSER_API_KEY` / `--api-key`)
- New CLI commands:
  - `jbom search` (console table by default; CSV via `-o -` or `-o <file>`)
  - `jbom inventory-search` (supports `--dry-run`; optional enhanced inventory CSV + analysis report)
- Tests
  - pytest unit tests for providers/filtering/CLI behavior (no API key required; requests is mocked)
  - behave scenarios for non-network behavior (`inventory-search --dry-run`) and CLI help

Notes
- Live API usage requires a Mouser API key.
- This PR intentionally keeps BDD focused on non-network behavior for stability.

Related
- #68 (parts output house-style consistency)
- #69 (DRY opportunities in CLI output plumbing)

Co-Authored-By: Oz <oz-agent@warp.dev>
