### PR TITLE
fix: align parts output semantics with house style (closes #68)

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -162,7 +162,7 @@ Generates an unaggregated parts list — one row per component reference — fro
 : Path to .kicad_sch file, project directory, or base name.
 
 **-o, --output FILE**
-: Output path. Default: stdout CSV. Special values: `console`, `-`.
+: Output destination. Default: `console` (formatted table). Use `-` for CSV to stdout, or provide a file path.
 
 **--inventory FILE**
 : Optional. Enhance the parts list with inventory data.
@@ -257,8 +257,8 @@ Bulk-searches distributor catalogs using items from an existing inventory file t
 **Inventory CSV**
 : Default name `part-inventory.csv`. Template with IPN, Category, Value, Package, and related columns.
 
-**Parts CSV**
-: Default: stdout. One row per component reference, not aggregated.
+**Parts**
+: Default: console table. One row per component reference, not aggregated. Use `-o -` for CSV to stdout.
 
 **Exit Codes**
 : 0 — success

--- a/features/cli/parts_output.feature
+++ b/features/cli/parts_output.feature
@@ -1,0 +1,54 @@
+Feature: CLI Parts Output Semantics
+  As a jBOM user
+  I want consistent output handling for the parts command
+  So that the CLI is predictable for both humans and automation
+
+  Background:
+    Given the generic fabricator is selected
+    And a schematic that contains:
+      | Reference | Value | Footprint         |
+      | R1        | 10K   | R_0805_2012       |
+      | R2        | 10K   | R_0805_2012       |
+      | R10       | 10K   | R_0805_2012       |
+      | C1        | 100nF | C_0603_1608       |
+      | C20       | 100nF | C_0603_1608       |
+      | U1        | LM358 | SOIC-8_3.9x4.9mm |
+
+  Scenario: Default output is console table (human-first)
+    When I run jbom command "parts"
+    Then the command should succeed
+    And the output should contain "Parts List"
+    And the output should contain "R1"
+
+  Scenario: CSV to stdout uses -o -
+    When I run jbom command "parts -o -"
+    Then the command should succeed
+    And the output should contain these fields:
+      | Reference | Value | Footprint |
+    And the CSV output has rows where:
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+      | C1        | 100nF | C_0603_1608 |
+
+  Scenario: Explicit console output uses -o console
+    When I run jbom command "parts -o console"
+    Then the command should succeed
+    And the output should contain "Parts List"
+
+  Scenario: Custom output filename writes a CSV file
+    When I run jbom command "parts -o TestProject.parts.csv"
+    Then the command should succeed
+    And a file named "TestProject.parts.csv" should exist
+
+  Scenario: Reject legacy -o stdout option
+    When I run jbom command "parts -o stdout"
+    Then the command should fail
+    And the output should contain "no longer supported"
+    And the output should contain "Use -o -"
+
+  Scenario: Handle empty schematic with console output
+    Given a schematic that contains:
+      | Reference | Value | Footprint |
+    When I run jbom command "parts -o console"
+    Then the command should succeed
+    And the output should contain "No components found"

--- a/features/cli/parts_output.feature
+++ b/features/cli/parts_output.feature
@@ -40,11 +40,11 @@ Feature: CLI Parts Output Semantics
     Then the command should succeed
     And a file named "TestProject.parts.csv" should exist
 
-  Scenario: Reject legacy -o stdout option
+  Scenario: Output file named stdout is treated as a literal filename
     When I run jbom command "parts -o stdout"
-    Then the command should fail
-    And the output should contain "no longer supported"
-    And the output should contain "Use -o -"
+    Then the command should succeed
+    And a file named "stdout" should exist
+    And the file "stdout" should contain "R1"
 
   Scenario: Handle empty schematic with console output
     Given a schematic that contains:

--- a/features/parts/core.feature
+++ b/features/parts/core.feature
@@ -4,7 +4,8 @@ Feature: Parts List Generation (Core Functionality)
   So that I can see every component instance for PCB assembly
 
   Background:
-    Given the generic fabricator is selected
+    Given a jBOM CSV sandbox
+    And the generic fabricator is selected
     And a schematic that contains:
       | Reference | Value | Footprint         |
       | R1        | 10K   | R_0805_2012       |
@@ -14,15 +15,15 @@ Feature: Parts List Generation (Core Functionality)
       | C20       | 100nF | C_0603_1608       |
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
-  Scenario: Generate basic parts list to stdout (CSV format)
+  Scenario: Generate basic parts list (CSV output)
     When I run jbom command "parts"
     Then the command should succeed
-    And the output should contain "R1"
-    And the output should contain "10K"
-    And the output should contain "C1"
-    And the output should contain "100nF"
-    And the output should contain "U1"
-    And the output should contain "LM358"
+    And the output should contain these fields:
+      | Reference | Value | Footprint |
+    And the CSV output has rows where:
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+      | C1        | 100nF | C_0603_1608 |
 
   Scenario: Parts list shows individual components (no aggregation)
     When I run jbom command "parts"
@@ -39,22 +40,3 @@ Feature: Parts List Generation (Core Functionality)
     And R1 appears before R2 in the output
     And R2 appears before R10 in the output
     And C1 appears before C20 in the output
-
-  Scenario: Generate parts list with console table output
-    When I run jbom command "parts -o console"
-    Then the command should succeed
-    And the output should contain "Parts List"
-    And the output should contain "R1"
-    And the output should contain "C1"
-
-  Scenario: Custom output filename with project-based default
-    When I run jbom command "parts -o TestProject.parts.csv"
-    Then the command should succeed
-    And a file named "TestProject.parts.csv" should exist
-
-  Scenario: Handle empty schematic
-    Given a schematic that contains:
-      | Reference | Value | Footprint |
-    When I run jbom command "parts -o console"
-    Then the command should succeed
-    And the output should contain "No components found"

--- a/features/parts/filtering.feature
+++ b/features/parts/filtering.feature
@@ -4,7 +4,8 @@ Feature: Parts List Filtering
   So that I can customize the parts list for different assembly scenarios
 
   Background:
-    Given the generic fabricator is selected
+    Given a jBOM CSV sandbox
+    And the generic fabricator is selected
 
   Scenario: Exclude DNP components by default
     Given a schematic that contains:
@@ -12,7 +13,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No    |
       | R2        | 10K   | R_0805_2012 | Yes   |
       | C1        | 100nF | C_0603_1608 | No    |
-    When I run jbom command "parts -o -"
+    When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -28,7 +29,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No    |
       | R2        | 10K   | R_0805_2012 | Yes   |
       | C1        | 100nF | C_0603_1608 | No    |
-    When I run jbom command "parts --include-dnp -o -"
+    When I run jbom command "parts --include-dnp"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -42,7 +43,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No             |
       | R2        | 10K   | R_0805_2012 | Yes            |
       | C1        | 100nF | C_0603_1608 | No             |
-    When I run jbom command "parts -o -"
+    When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -58,7 +59,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No             |
       | R2        | 10K   | R_0805_2012 | Yes            |
       | C1        | 100nF | C_0603_1608 | No             |
-    When I run jbom command "parts --include-excluded -o -"
+    When I run jbom command "parts --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -73,7 +74,7 @@ Feature: Parts List Filtering
       | #PWR01    | GND   |             |
       | #PWR02    | VCC   |             |
       | C1        | 100nF | C_0603_1608 |
-    When I run jbom command "parts -o -"
+    When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -91,7 +92,7 @@ Feature: Parts List Filtering
       | #PWR01    | GND   |             |
       | #PWR02    | VCC   |             |
       | C1        | 100nF | C_0603_1608 |
-    When I run jbom command "parts --include-all -o -"
+    When I run jbom command "parts --include-all"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -107,7 +108,7 @@ Feature: Parts List Filtering
       | R2        | 10K   | R_0805_2012 | Yes   | No             |
       | R3        | 10K   | R_0805_2012 | No    | Yes            |
       | C1        | 100nF | C_0603_1608 | No    | No             |
-    When I run jbom command "parts --include-dnp --include-excluded -o -"
+    When I run jbom command "parts --include-dnp --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -122,7 +123,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No    | No             |
       | R2        | 10K   | R_0805_2012 | Yes   | No             |
       | R3        | 10K   | R_0805_2012 | No    | Yes            |
-    When I run jbom command "parts --include-dnp -o -"
+    When I run jbom command "parts --include-dnp"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |
@@ -138,7 +139,7 @@ Feature: Parts List Filtering
       | R1        | 10K   | R_0805_2012 | No    | No             |
       | R2        | 10K   | R_0805_2012 | Yes   | No             |
       | R3        | 10K   | R_0805_2012 | No    | Yes            |
-    When I run jbom command "parts --include-excluded -o -"
+    When I run jbom command "parts --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
       | Reference | Value |

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -35,7 +35,7 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help='Output file path, "stdout" for stdout, or "console" for formatted table',
+        help='Output destination: omit for console table, use "console" for table, "-" for CSV to stdout, or a file path',
     )
 
     # Enhancement options
@@ -196,20 +196,30 @@ def _output_parts(
 ) -> int:
     """Output Parts List data in the requested format.
 
-    Special cases:
-    - output in {None, "stdout", "-"} => CSV to stdout
-    - output == "console" => formatted table to stdout
+    Human-first defaults (UX consistency with bom/pos/inventory):
+    - output is None or "console" => formatted table to stdout
+    - output == "-" => CSV to stdout
+    - output == "stdout" => error (use "-" instead)
     - otherwise => treat as file path
     """
-    if output == "console":
+    if output is None or output == "console":
         _print_console_table(parts_data)
-    elif output in (None, "stdout", "-"):
-        _print_csv(parts_data)
-    else:
-        output_path = Path(output)
-        _write_csv(parts_data, output_path)
-        print(f"Parts list written to {output_path}")
+        return 0
 
+    if output == "-":
+        _print_csv(parts_data)
+        return 0
+
+    if output == "stdout":
+        print(
+            "Error: -o stdout is no longer supported. Use -o - for CSV to stdout.",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_path = Path(output)
+    _write_csv(parts_data, output_path)
+    print(f"Parts list written to {output_path}")
     return 0
 
 

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -199,8 +199,10 @@ def _output_parts(
     Human-first defaults (UX consistency with bom/pos/inventory):
     - output is None or "console" => formatted table to stdout
     - output == "-" => CSV to stdout
-    - output == "stdout" => error (use "-" instead)
     - otherwise => treat as file path
+
+    Note: "stdout" is not a special value. If provided (e.g. `-o stdout`), it is treated
+    as a literal filename.
     """
     if output is None or output == "console":
         _print_console_table(parts_data)
@@ -209,13 +211,6 @@ def _output_parts(
     if output == "-":
         _print_csv(parts_data)
         return 0
-
-    if output == "stdout":
-        print(
-            "Error: -o stdout is no longer supported. Use -o - for CSV to stdout.",
-            file=sys.stderr,
-        )
-        return 1
 
     output_path = Path(output)
     _write_csv(parts_data, output_path)


### PR DESCRIPTION
Closes #68

## Summary
- Align `jbom parts` output semantics with the house style used by `bom`/`pos`/`inventory`:
  - default (no `-o`) and `-o console` => console table
  - `-o -` => CSV to stdout
  - other values => write CSV to a file path (including `-o stdout` which creates a file literally named `stdout`)
- Update Behave coverage to keep domain tests CSV-first via the CSV sandbox, and move CLI output edge cases to a dedicated CLI feature.
- Update `docs/README.man1.md` to document the new parts defaults.

## Testing
- `python -m pytest`
- `python -m behave --format progress`

Co-Authored-By: Oz <oz-agent@warp.dev>