### PR TITLE
Fix CLI output defaults; unify -o semantics and force overwrite

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -48,13 +48,20 @@ jbom bom [PROJECT] [--inventory FILE ...] [-o OUTPUT] [OPTIONS]
 Generates a Bill of Materials aggregated by value+package for procurement. Matches schematic components against an inventory file to produce fabrication-ready output.
 
 **PROJECT** (optional, default: current directory)
-: Path to .kicad_sch file, project directory, or base name. Hierarchical schematics are processed automatically when a project directory is given.
+: Path to a KiCad project directory, `.kicad_pro`, `.kicad_sch`, or a base name. The project directory must contain exactly one `*.kicad_pro` file. Hierarchical schematics are processed automatically when a project directory is given.
 
 **--inventory FILE**
 : Inventory file for BOM matching. Supported: .csv, .xlsx, .xls, .numbers. May be repeated to load from multiple sources: `--inventory project.csv --inventory jlc_export.xlsx`
 
-**-o, --output FILE**
-: Output CSV path. Default: `<project>_bom.csv`. Special values: `-`, `stdout`, `console` (formatted table).
+**-o, --output OUTPUT**
+: Output destination.
+  - Omit `-o` to write `${project}.bom.csv` in the discovered project directory.
+  - Use `-o console` for a formatted table.
+  - Use `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
 
 **--fabricator NAME**
 : PCB fabricator for field presets and part number lookup. Choices: `jlc`, `pcbway`, `seeed`, `generic`. Default: `generic`.
@@ -91,8 +98,15 @@ Generates a component placement file (CPL/POS) from a KiCad PCB for pick-and-pla
 **PROJECT** (optional, default: current directory)
 : Path to .kicad_pcb file, project directory, or base name. If a .kicad_sch file is given, jBOM looks for the matching .kicad_pcb.
 
-**-o, --output FILE**
-: Output CSV path. Default: `<project>_pos.csv`. Special values: `-`, `stdout`, `console`.
+**-o, --output OUTPUT**
+: Output destination.
+  - Omit `-o` to write `${project}.pos.csv` in the discovered project directory.
+  - Use `-o console` for a formatted table.
+  - Use `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
 
 **--fabricator NAME**
 : Target fabricator for field preset selection. Choices: `jlc`, `pcbway`, `seeed`, `generic`.
@@ -135,8 +149,15 @@ Generates an initial inventory template from schematic components. The output is
 **PROJECT** (optional, default: current directory)
 : Path to .kicad_sch file, project directory, or base name.
 
-**-o, --output FILE**
-: Output path. Default: `part-inventory.csv`. Special values: `console`, `-`.
+**-o, --output OUTPUT**
+: Output destination.
+  - Omit `-o` to write `part-inventory.csv` in the current working directory.
+  - Use `-o console` for a formatted table.
+  - Use `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file (also creates a timestamped backup if the file exists).
 
 **--inventory FILE**
 : Existing inventory file for merge operations. May be repeated.
@@ -144,8 +165,6 @@ Generates an initial inventory template from schematic components. The output is
 **--filter-matches**
 : When used with `--inventory`, exclude components that already match items in the existing inventory (show only new/unmatched components).
 
-**--force**
-: Overwrite an existing output file without confirmation.
 
 **-v, --verbose**
 : Show loading and processing diagnostics.
@@ -161,8 +180,15 @@ Generates an unaggregated parts list — one row per component reference — fro
 **PROJECT** (optional, default: current directory)
 : Path to .kicad_sch file, project directory, or base name.
 
-**-o, --output FILE**
-: Output destination. Default: `console` (formatted table). Use `-` for CSV to stdout, or provide a file path.
+**-o, --output OUTPUT**
+: Output destination.
+  - Omit `-o` to write `${project}.parts.csv` in the discovered project directory.
+  - Use `-o console` for a formatted table.
+  - Use `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
 
 **--inventory FILE**
 : Optional. Enhance the parts list with inventory data.
@@ -211,8 +237,14 @@ Searches distributor catalogs for parts matching a keyword or part number.
 **--no-parametric**
 : Disable smart parametric filtering derived from the query text.
 
-**-o, --output FILE**
-: Output destination. Default: `console` (formatted table). Use `-` for CSV to stdout or a file path.
+**-o, --output OUTPUT**
+: Output destination. Default: `console` (formatted table).
+  - Use `-o console` (or omit `-o`) for a formatted table.
+  - Use `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
 
 ## INVENTORY-SEARCH COMMAND
 
@@ -225,8 +257,14 @@ Bulk-searches distributor catalogs using items from an existing inventory file t
 **INVENTORY_FILE**
 : Path to inventory file (.csv, .xlsx, .numbers). Required.
 
-**-o, --output FILE**
-: Write enhanced inventory CSV (original columns plus search candidates) to this file.
+**-o, --output OUTPUT**
+: Enhanced inventory CSV output destination.
+  - Omit `-o` (or use `-o console`) to skip writing the enhanced CSV.
+  - Use `-o -` to write the enhanced CSV to stdout (the human report is written to stderr unless `--report` is provided).
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
 
 **--report FILE**
 : Write analysis report to this file. Default: stdout.
@@ -249,16 +287,16 @@ Bulk-searches distributor catalogs using items from an existing inventory file t
 ## OUTPUT
 
 **BOM CSV**
-: Default name `<ProjectName>_bom.csv`. Aggregated by value+package. Columns depend on `-f` and fabricator preset.
+: Default name `${ProjectName}.bom.csv` (written in the project directory when `-o` is omitted). Aggregated by value+package. Columns depend on `-f` and fabricator preset.
 
 **POS CSV**
-: Default name `<ProjectName>_pos.csv`. One row per component. Coordinates in mm.
+: Default name `${ProjectName}.pos.csv` (written in the project directory when `-o` is omitted). One row per component. Coordinates in mm.
 
 **Inventory CSV**
-: Default name `part-inventory.csv`. Template with IPN, Category, Value, Package, and related columns.
+: Default name `part-inventory.csv` (written in the current working directory when `-o` is omitted). Template with IPN, Category, Value, Package, and related columns.
 
-**Parts**
-: Default: console table. One row per component reference, not aggregated. Use `-o -` for CSV to stdout.
+**Parts CSV**
+: Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per component reference, not aggregated. Use `-o -` for CSV to stdout.
 
 **Exit Codes**
 : 0 — success

--- a/features/bom/core.feature
+++ b/features/bom/core.feature
@@ -11,8 +11,8 @@ Feature: BOM Generation (Core Functionality)
       | C1        | 100nF | C_0603_1608       |
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
-  Scenario: Generate basic BOM with default console output (human-first)
-    When I run jbom command "bom"
+  Scenario: Generate basic BOM with console output (human-first)
+    When I run jbom command "bom -o console"
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "10K"

--- a/features/bom/fabricator_compatibility.feature
+++ b/features/bom/fabricator_compatibility.feature
@@ -11,9 +11,9 @@ Feature: BOM Fabricator Compatibility
       | C1        | 100nF | C_0603_1608 |
 
   Scenario: BOM generation works with all configured fabricators
-    When I run jbom command "bom"
+    When I run jbom command "bom -o -"
     Then the BOM works with all configured fabricators
 
   Scenario: All configured fabricators work without errors
-    When I run jbom command "bom"
+    When I run jbom command "bom -o -"
     Then the BOM works with all configured fabricators

--- a/features/bom/field_system_regression.feature
+++ b/features/bom/field_system_regression.feature
@@ -93,7 +93,7 @@ Feature: BOM Field System and Output Customization
 
   @regression @current-broken
   Scenario: Console table respects field selection
-    When I run jbom command "bom -f Reference,Value,LCSC"
+    When I run jbom command "bom -f Reference,Value,LCSC -o console"
     Then the command should succeed
     And the console table headers should be "Reference Value LCSC"
     And the console table should not contain "Footprint"

--- a/features/bom/generation.feature
+++ b/features/bom/generation.feature
@@ -12,7 +12,7 @@ Feature: BOM Generation
       | R1        | 10K   | R_0805_2012   |
       | C1        | 100nF | C_0603_1608   |
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
-    When I run jbom command "bom"
+    When I run jbom command "bom -o console"
     Then the command should succeed
     And the output should contain "Bill of Materials"
     And the output should contain "R1"

--- a/features/bom/inventory.feature
+++ b/features/bom/inventory.feature
@@ -15,7 +15,7 @@ Feature: BOM Inventory Enhancement
       | IPN     | Category  | Value | Package | Manufacturer | MFGPN           | LCSC   |
       | RES_10K | RESISTOR  | 10K   | 0805    | Yageo        | RC0805FR-0710KL | C17414 |
       | CAP_100N| CAPACITOR | 100nF | 0603    | Samsung      | CL10B104KB8NNNC | C1591  |
-    When I run jbom command "bom --inventory components.csv"
+    When I run jbom command "bom --inventory components.csv -o console"
     Then the command should succeed
     And the output should contain "Inventory enhanced"
 

--- a/features/bom/output.feature
+++ b/features/bom/output.feature
@@ -13,6 +13,13 @@ Feature: BOM Output Options
       | C1        | 100nF | C_0603_1608       |
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
+  Scenario: Default output writes a project-named CSV file
+    When I run jbom command "bom"
+    Then the command should succeed
+    And a file named "project.bom.csv" should exist
+    And the file "project.bom.csv" should contain "R1"
+    And the file "project.bom.csv" should contain "10K"
+
   Scenario: Console table output with default options (human-first)
     When I run jbom command "bom -o console"
     Then the command should succeed

--- a/features/bom/output.feature
+++ b/features/bom/output.feature
@@ -14,7 +14,7 @@ Feature: BOM Output Options
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
   Scenario: Console table output with default options (human-first)
-    When I run jbom command "bom"
+    When I run jbom command "bom -o console"
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "10K"
@@ -24,7 +24,7 @@ Feature: BOM Output Options
     And the output should contain "LM358"
 
   Scenario: BOM with aggregated components
-    When I run jbom command "bom"
+    When I run jbom command "bom -o console"
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "R2"
@@ -39,7 +39,7 @@ Feature: BOM Output Options
     And the output should contain "C1"
 
   Scenario: Verbose output
-    When I run jbom command "bom -v"
+    When I run jbom command "bom -v -o console"
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "10K"

--- a/features/cli/parts_output.feature
+++ b/features/cli/parts_output.feature
@@ -15,7 +15,7 @@ Feature: CLI Parts Output Semantics
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
   Scenario: Default output is console table (human-first)
-    When I run jbom command "parts"
+    When I run jbom command "parts -o console"
     Then the command should succeed
     And the output should contain "Parts List"
     And the output should contain "R1"

--- a/features/cli/parts_output.feature
+++ b/features/cli/parts_output.feature
@@ -14,6 +14,12 @@ Feature: CLI Parts Output Semantics
       | C20       | 100nF | C_0603_1608       |
       | U1        | LM358 | SOIC-8_3.9x4.9mm |
 
+  Scenario: Default output writes a project-named CSV file
+    When I run jbom command "parts"
+    Then the command should succeed
+    And a file named "project.parts.csv" should exist
+    And the file "project.parts.csv" should contain "R1"
+
   Scenario: Default output is console table (human-first)
     When I run jbom command "parts -o console"
     Then the command should succeed

--- a/features/pos/core.feature
+++ b/features/pos/core.feature
@@ -12,7 +12,7 @@ Feature: POS Generation (Core Functionality)
       | R1        | 10| 5 | 0        | TOP  | R_0805_2012       |
       | C1        | 15| 8 | 90       | TOP  | C_0603_1608       |
       | U1        | 25|12 | 180      | TOP  | SOIC-8_3.9x4.9mm |
-    When I run jbom command "pos"
+    When I run jbom command "pos -o console"
     Then the command should succeed
     And the output should contain "Component Placement Data"
     And the output should contain "R1"

--- a/features/pos/core.feature
+++ b/features/pos/core.feature
@@ -6,7 +6,18 @@ Feature: POS Generation (Core Functionality)
   Background:
     Given the generic fabricator is selected
 
-  Scenario: Generate basic POS with default console output (human-first)
+  Scenario: Default output writes a project-named CSV file
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint         |
+      | R1        | 10| 5 | 0        | TOP  | R_0805_2012       |
+      | C1        | 15| 8 | 90       | TOP  | C_0603_1608       |
+      | U1        | 25|12 | 180      | TOP  | SOIC-8_3.9x4.9mm |
+    When I run jbom command "pos"
+    Then the command should succeed
+    And a file named "project.pos.csv" should exist
+    And the file "project.pos.csv" should contain "R1"
+
+  Scenario: Generate basic POS with console output (human-first)
     Given a PCB that contains:
       | Reference | X | Y | Rotation | Side | Footprint         |
       | R1        | 10| 5 | 0        | TOP  | R_0805_2012       |

--- a/features/pos/rotation_orientation.feature
+++ b/features/pos/rotation_orientation.feature
@@ -22,6 +22,6 @@ Feature: POS Rotation and Orientation
     Given a PCB that contains:
       | Reference | X | Y | Rotation | Side   | Footprint   |
       | R1        | 5 | 5 | 0        | BOTTOM | R_0805_2012 |
-    When I run jbom command "pos"
+    When I run jbom command "pos -o console"
     Then the command should succeed
     And the output should contain "R1"

--- a/features/pos/units_origin.feature
+++ b/features/pos/units_origin.feature
@@ -11,7 +11,7 @@ Feature: POS Units and Origin
       | Reference | X | Y | Side | Footprint   |
       | R1        | 10| 5 | TOP  | R_0805_2012 |
       | C1        | 15| 8 | TOP  | C_0603_1608 |
-    When I run jbom command "pos --origin aux"
+    When I run jbom command "pos --origin aux -o console"
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "C1"

--- a/features/regression/issue_21_conceptual_problem.feature
+++ b/features/regression/issue_21_conceptual_problem.feature
@@ -25,7 +25,7 @@ Feature: Issue #21 Conceptual Problem - BOM vs Parts List Distinction
       | R1        | 10K   | R_0805_2012 |
       | R2        | 10K   | R_0805_2012 |
       | R3        | 10K   | R_0603_1608 |
-    When I run jbom command "parts"
+    When I run jbom command "parts -o -"
     Then the command should succeed
     # Problem solved: Parts command gives you individual component listing for assembly
     And the output should contain "R1"
@@ -58,7 +58,7 @@ Feature: Issue #21 Conceptual Problem - BOM vs Parts List Distinction
       | R1        | 10K   | R_0805_2012 |
       | R2        | 10K   | R_0805_2012 |
       | R3        | 10K   | R_0603_1608 |
-    When I run jbom command "parts"
+    When I run jbom command "parts -o -"
     Then the command should succeed
     # Parts list shows every individual component for assembly
     And the output should contain "R1"

--- a/features/ux_consistency.feature
+++ b/features/ux_consistency.feature
@@ -22,7 +22,7 @@ Feature: UX Consistency Across Commands
       | CAP_100nF | CAP      | 100nF | 100nF capacitor  | 0603    |
       | IC_LM358  | IC       | LM358 | Op-amp           | SOIC-8  |
 
-  Scenario: bom/pos/inventory default to file output
+  Scenario: bom/pos/parts/inventory default to file output
     When I run jbom command "bom"
     Then the command should succeed
     And a file named "project.bom.csv" should exist
@@ -30,6 +30,10 @@ Feature: UX Consistency Across Commands
     When I run jbom command "pos"
     Then the command should succeed
     And a file named "project.pos.csv" should exist
+
+    When I run jbom command "parts"
+    Then the command should succeed
+    And a file named "project.parts.csv" should exist
 
     When I run jbom command "inventory"
     Then the command should succeed

--- a/features/ux_consistency.feature
+++ b/features/ux_consistency.feature
@@ -22,23 +22,18 @@ Feature: UX Consistency Across Commands
       | CAP_100nF | CAP      | 100nF | 100nF capacitor  | 0603    |
       | IC_LM358  | IC       | LM358 | Op-amp           | SOIC-8  |
 
-  Scenario: All commands default to human-readable console output
+  Scenario: bom/pos/inventory default to file output
     When I run jbom command "bom"
     Then the command should succeed
-    And the output should contain "Bill of Materials"
-    And the output should contain "R1"
-    And the output should contain "10k"
+    And a file named "project.bom.csv" should exist
 
     When I run jbom command "pos"
     Then the command should succeed
-    And the output should contain "Component Placement Data"
-    And the output should contain "R1"
-    And the output should contain "5"
+    And a file named "project.pos.csv" should exist
 
-    When I run jbom command "inventory --inventory test_inventory.csv"
+    When I run jbom command "inventory"
     Then the command should succeed
-    And the output should contain "Generated inventory"
-    And the IPN for component "R1" should be consistent
+    And a file named "part-inventory.csv" should exist
 
   Scenario: All commands support -o - for CSV stdout
     When I run jbom command "bom -o -"
@@ -115,11 +110,11 @@ Feature: UX Consistency Across Commands
       | Reference | X | Y | Side |
     And an inventory file "test_inventory.csv" that contains:
       | IPN       | Category | Value | Description      | Package |
-    When I run jbom command "bom"
+    When I run jbom command "bom -o console"
     Then the command should succeed
     And the output should contain "No components found"
 
-    When I run jbom command "pos"
+    When I run jbom command "pos -o console"
     Then the command should succeed
     And the output should contain "No components found"
 

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -6,6 +6,14 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.services.schematic_reader import SchematicReader
 from jbom.services.bom_generator import BOMGenerator, BOMData
 from jbom.services.inventory_matcher import InventoryMatcher
@@ -48,8 +56,9 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help='Output file path, "stdout" for stdout, or "console" for formatted table',
+        help='Output destination: omit for default file output, use "console" for table, "-" for CSV to stdout, or a file path',
     )
+    add_force_argument(parser)
 
     # Enhancement options
     parser.add_argument(
@@ -159,11 +168,14 @@ def handle_bom(args: argparse.Namespace) -> int:
 
         schematic_file = resolved_input.resolved_path
 
-        # Determine project name from context or file
-        if resolved_input.project_context:
-            project_name = resolved_input.project_context.project_base_name
-        else:
-            project_name = schematic_file.stem
+        if not resolved_input.project_context:
+            raise ValueError("No project context available")
+
+        project_context = resolved_input.project_context
+        project_name = project_context.project_base_name
+        default_output_path = (
+            project_context.project_directory / f"{project_name}.bom.csv"
+        )
 
         # Use services directly - no workflow abstraction needed
         reader = SchematicReader(options)
@@ -253,7 +265,14 @@ def handle_bom(args: argparse.Namespace) -> int:
             )
 
         # Handle output
-        return _output_bom(bom_data, args.output, selected_fields, fabricator)
+        return _output_bom(
+            bom_data,
+            args.output,
+            selected_fields,
+            fabricator,
+            default_output_path=default_output_path,
+            force=args.force,
+        )
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -338,30 +357,47 @@ def _output_bom(
     output: Optional[str],
     selected_fields: list[str],
     fabricator: str,
+    *,
+    default_output_path: Path,
+    force: bool,
 ) -> int:
-    """Output BOM data in the requested format with field customization.
+    """Output BOM data in the requested format with field customization."""
 
-    Args:
-        bom_data: BOM data to output
-        output: Output destination (None/"console" for table, "-" for CSV, path for file)
-        selected_fields: List of fields to include in output
-        fabricator: Fabricator ID for column mapping
-
-    Returns:
-        Exit code (0 for success)
-    """
-    # Apply fabricator-specific column mapping to get headers
     headers = apply_fabricator_column_mapping(fabricator, "bom", selected_fields)
 
-    if output is None or output == "console":
-        _print_console_table(bom_data, selected_fields, headers)
-    elif output == "-":
-        _print_csv(bom_data, selected_fields, headers)
-    else:
-        output_path = Path(output)
-        _write_csv(bom_data, output_path, selected_fields, headers)
-        print(f"BOM written to {output_path}")
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(
+            OutputKind.FILE, path=default_output_path
+        ),
+    )
 
+    if dest.kind == OutputKind.CONSOLE:
+        _print_console_table(bom_data, selected_fields, headers)
+        return 0
+
+    if dest.kind == OutputKind.STDOUT:
+        _print_csv(bom_data, selected_fields, headers)
+        return 0
+
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
+
+    output_path = dest.path
+    refused = f"Error: Output file '{output_path}' already exists. Use -F/--force to overwrite."
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+        ) as f:
+            _write_csv_handle(bom_data, f, selected_fields, headers)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"BOM written to {output_path}")
     return 0
 
 
@@ -413,31 +449,23 @@ def _print_csv(
     bom_data: BOMData, selected_fields: list[str], headers: list[str]
 ) -> None:
     """Print BOM as CSV to stdout with dynamic fields."""
-    writer = csv.writer(sys.stdout)
 
-    # Write dynamic headers
-    writer.writerow(headers)
-
-    # Write data rows
-    for entry in bom_data.entries:
-        row = []
-        for field in selected_fields:
-            value = _get_field_value(entry, field)
-            row.append(value)
-
-        writer.writerow(row)
+    _write_csv_handle(bom_data, sys.stdout, selected_fields, headers)
 
 
-def _write_csv(
-    bom_data: BOMData, output_path: Path, selected_fields: list[str], headers: list[str]
+def _write_csv_handle(
+    bom_data: BOMData,
+    f,
+    selected_fields: list[str],
+    headers: list[str],
 ) -> None:
-    """Write BOM as CSV to file with dynamic fields."""
-    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerow(headers)
-        for entry in bom_data.entries:
-            row = [_get_field_value(entry, field) for field in selected_fields]
-            writer.writerow(row)
+    """Write BOM as CSV to a file-like object."""
+
+    writer = csv.writer(f)
+    writer.writerow(headers)
+    for entry in bom_data.entries:
+        row = [_get_field_value(entry, field) for field in selected_fields]
+        writer.writerow(row)
 
 
 def _get_field_value(entry, field: str) -> str:

--- a/src/jbom/cli/discovery.py
+++ b/src/jbom/cli/discovery.py
@@ -1,7 +1,7 @@
 """CLI discovery functions for KiCad project files.
 
-Provides functions to find KiCad project files (.kicad_pro, .pro),
-schematic files (.kicad_sch), and PCB files (.kicad_pcb) in directories.
+Provides functions to find KiCad v6+ project files (`*.kicad_pro`),
+schematic files (`*.kicad_sch`), and PCB files (`*.kicad_pcb`) in directories.
 Handles autosave files and directory name matching preferences.
 """
 
@@ -19,37 +19,32 @@ __all__ = [
 
 
 def find_project(search_dir: Path) -> Optional[Path]:
-    """Find the best KiCad project file in a directory.
+    """Find the single KiCad v6+ project file in a directory.
+
+    Returns the project file only if exactly one `*.kicad_pro` exists.
 
     Args:
         search_dir: Directory to search in
 
     Returns:
-        Path to .kicad_pro or .pro file, or None if not found
+        Path to the single `*.kicad_pro` file, or None if not found.
+
+    Raises:
+        ValueError: If multiple `*.kicad_pro` files are found.
     """
     if not search_dir.is_dir():
         return None
 
-    # Find project files (prefer .kicad_pro over legacy .pro)
-    kicad_pro_files = list(search_dir.glob("*.kicad_pro"))
-    if kicad_pro_files:
-        # Prefer files matching directory name
-        dir_name = search_dir.name
-        matching = [f for f in kicad_pro_files if f.stem == dir_name]
-        if matching:
-            return matching[0]
-        return sorted(kicad_pro_files)[0]
+    kicad_pro_files = sorted(search_dir.glob("*.kicad_pro"))
+    if not kicad_pro_files:
+        return None
 
-    # Fall back to legacy .pro files
-    pro_files = list(search_dir.glob("*.pro"))
-    if pro_files:
-        dir_name = search_dir.name
-        matching = [f for f in pro_files if f.stem == dir_name]
-        if matching:
-            return matching[0]
-        return sorted(pro_files)[0]
+    if len(kicad_pro_files) > 1:
+        raise ValueError(
+            f"Multiple project files found in {search_dir}: {len(kicad_pro_files)}"
+        )
 
-    return None
+    return kicad_pro_files[0]
 
 
 def find_pcb(search_dir: Path) -> Optional[Path]:

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -3,10 +3,20 @@
 import argparse
 import csv
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import TextIO
+
 import shutil
 
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.common.types import Component, InventoryItem
 from jbom.common.options import GeneratorOptions
 from jbom.cli.formatting import print_inventory_table
@@ -40,7 +50,10 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help="Output destination: file path, 'console', or '-' for stdout (default: part-inventory.csv)",
+        help=(
+            "Output destination: omit for default file output (part-inventory.csv), "
+            "use 'console' for table, '-' for stdout, or a file path"
+        ),
         default=None,
     )
 
@@ -60,11 +73,7 @@ def register_command(subparsers) -> None:
     )
 
     # Safety options
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Overwrite existing output files without confirmation",
-    )
+    add_force_argument(parser)
 
     # Verbose mode
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
@@ -302,42 +311,60 @@ def _filter_components_by_existing_inventory(
 
 
 def _output_inventory(
-    inventory_items, field_names, output, force=False, verbose=False
+    inventory_items, field_names, output, force: bool = False, verbose: bool = False
 ) -> int:
     """Output inventory data in the requested format.
 
-    Human-first defaults (BREAKING CHANGE for UX consistency):
-    - output is None => formatted table to stdout (human exploration)
-    - output == "console" => formatted table to stdout (explicit)
-    - output == "-" => CSV to stdout (machine readable)
+    Defaults:
+    - output omitted => write to part-inventory.csv in the current working directory
+    - output == "console" => formatted table to stdout
+    - output == "-" => CSV to stdout
     - otherwise => treat as file path with safety checks
     """
-    if output is None or output == "console":
+    default_path = Path("part-inventory.csv")
+
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(OutputKind.FILE, path=default_path),
+    )
+
+    if dest.kind == OutputKind.CONSOLE:
         _print_console_table(inventory_items, field_names)
-    elif output == "-":
-        _print_csv(inventory_items, field_names)
-    else:
-        output_path = Path(output)
+        return 0
 
-        # File existence and backup handling
-        if output_path.exists():
-            if not force:
-                print(
-                    f"Error: Output file '{output_path}' already exists. Use --force to overwrite.",
-                    file=sys.stderr,
-                )
-                return 1
+    if dest.kind == OutputKind.STDOUT:
+        _print_csv(inventory_items, field_names, out=sys.stdout)
+        return 0
 
-            # Create timestamped backup
-            backup_path = _create_backup(output_path, verbose)
-            if backup_path and verbose:
-                print(f"Created backup: {backup_path}", file=sys.stderr)
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
 
-        _write_csv(inventory_items, field_names, output_path)
-        print(
-            f"Generated inventory with {len(inventory_items)} items written to {output_path}"
-        )
+    output_path = dest.path
+    refused = (
+        f"Error: Output file '{output_path}' already exists. Use --force to overwrite."
+    )
 
+    def _backup(p: Path) -> Path | None:
+        backup_path = _create_backup(p, verbose)
+        if backup_path and verbose:
+            print(f"Created backup: {backup_path}", file=sys.stderr)
+        return backup_path
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+            make_backup=_backup,
+        ) as f:
+            _write_csv(inventory_items, field_names, out=f)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(
+        f"Generated inventory with {len(inventory_items)} items written to {output_path}"
+    )
     return 0
 
 
@@ -401,9 +428,10 @@ def _print_console_table(inventory_items, field_names) -> None:
     print(f"\nGenerated inventory with {len(inventory_items)} items")
 
 
-def _print_csv(inventory_items, field_names) -> None:
-    """Print inventory as CSV to stdout."""
-    writer = csv.DictWriter(sys.stdout, fieldnames=field_names)
+def _print_csv(inventory_items, field_names, *, out: TextIO) -> None:
+    """Print inventory as CSV to a file-like object."""
+
+    writer = csv.DictWriter(out, fieldnames=field_names)
     writer.writeheader()
 
     for item in inventory_items:
@@ -430,31 +458,31 @@ def _print_csv(inventory_items, field_names) -> None:
         writer.writerow(row)
 
 
-def _write_csv(inventory_items, field_names, output_path: Path) -> None:
-    """Write inventory as CSV to file."""
-    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=field_names)
-        writer.writeheader()
+def _write_csv(inventory_items, field_names, *, out: TextIO) -> None:
+    """Write inventory as CSV to a file-like object."""
 
-        for item in inventory_items:
-            row = {
-                "IPN": item.ipn,
-                "Category": item.category,
-                "Value": item.value,
-                "Description": item.description,
-                "Package": item.package,
-                "Manufacturer": item.manufacturer,
-                "MFGPN": item.mfgpn,
-                "LCSC": item.lcsc,
-                "Datasheet": item.datasheet,
-                "UUID": item.uuid,
-            }
-            # Add any extra fields from component properties
-            for field in field_names:
-                if (
-                    field not in row
-                    and hasattr(item, "raw_data")
-                    and field in item.raw_data
-                ):
-                    row[field] = item.raw_data[field]
-            writer.writerow(row)
+    writer = csv.DictWriter(out, fieldnames=field_names)
+    writer.writeheader()
+
+    for item in inventory_items:
+        row = {
+            "IPN": item.ipn,
+            "Category": item.category,
+            "Value": item.value,
+            "Description": item.description,
+            "Package": item.package,
+            "Manufacturer": item.manufacturer,
+            "MFGPN": item.mfgpn,
+            "LCSC": item.lcsc,
+            "Datasheet": item.datasheet,
+            "UUID": item.uuid,
+        }
+        # Add any extra fields from component properties
+        for field in field_names:
+            if (
+                field not in row
+                and hasattr(item, "raw_data")
+                and field in item.raw_data
+            ):
+                row[field] = item.raw_data[field]
+        writer.writerow(row)

--- a/src/jbom/cli/inventory_search.py
+++ b/src/jbom/cli/inventory_search.py
@@ -6,7 +6,16 @@ import argparse
 import csv
 import sys
 from pathlib import Path
+from typing import TextIO
 
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.services.inventory_reader import InventoryReader
 from jbom.services.search.cache import InMemorySearchCache
 from jbom.services.search.inventory_search_service import InventorySearchService
@@ -30,8 +39,9 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help="Output file for enhanced inventory with search candidates (CSV)",
+        help="Output destination for enhanced inventory CSV: omit/console for none, '-' for stdout, or a file path",
     )
+    add_force_argument(parser)
 
     parser.add_argument(
         "--report",
@@ -103,13 +113,21 @@ def handle_inventory_search(args: argparse.Namespace) -> int:
 
         records = service.search(searchable)
 
+        dest = resolve_output_destination(
+            args.output,
+            default_destination=OutputDestination(OutputKind.CONSOLE),
+        )
+
         report = service.generate_report(records)
         if args.report:
             Path(args.report).write_text(report, encoding="utf-8")
         else:
-            print(report)
+            # If the user asked for CSV to stdout, keep stdout machine-readable by
+            # emitting the human report to stderr.
+            report_stream = sys.stderr if dest.kind == OutputKind.STDOUT else sys.stdout
+            print(report, file=report_stream)
 
-        if args.output:
+        if dest.kind == OutputKind.FILE or dest.kind == OutputKind.STDOUT:
             header_order = _load_header_order(inventory_path)
             enhanced_rows = service.enhance_inventory_rows(
                 items,
@@ -118,14 +136,29 @@ def handle_inventory_search(args: argparse.Namespace) -> int:
             )
             out_fields = header_order + service.enhanced_csv_columns()
 
-            out_path = Path(args.output)
-            with open(out_path, "w", newline="", encoding="utf-8") as f:
-                writer = csv.DictWriter(f, fieldnames=out_fields)
-                writer.writeheader()
-                for row in enhanced_rows:
-                    writer.writerow(row)
+            if dest.kind == OutputKind.STDOUT:
+                _write_enhanced_csv(enhanced_rows, out_fields, out=sys.stdout)
+            else:
+                if not dest.path:
+                    raise ValueError(
+                        "Internal error: file output selected but no path provided"
+                    )
 
-            print(f"Enhanced inventory written to {out_path}")
+                out_path = dest.path
+                refused = f"Error: Output file '{out_path}' already exists. Use -F/--force to overwrite."
+
+                try:
+                    with open_output_text_file(
+                        out_path,
+                        force=args.force,
+                        refused_message=refused,
+                    ) as f:
+                        _write_enhanced_csv(enhanced_rows, out_fields, out=f)
+                except OutputRefusedError as exc:
+                    print(str(exc), file=sys.stderr)
+                    return 1
+
+                print(f"Enhanced inventory written to {out_path}")
 
         return 0
 
@@ -155,6 +188,13 @@ def _print_dry_run_summary(items) -> None:
         print("By category:")
         for cat, count in sorted(by_cat.items()):
             print(f"  {cat}: {count}")
+
+
+def _write_enhanced_csv(rows: list[dict], fields: list[str], *, out: TextIO) -> None:
+    writer = csv.DictWriter(out, fieldnames=fields)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
 
 
 def _load_header_order(path: Path) -> list[str]:

--- a/src/jbom/cli/output.py
+++ b/src/jbom/cli/output.py
@@ -1,0 +1,113 @@
+"""Shared CLI output helpers.
+
+Centralizes `-o/--output` semantics across subcommands:
+- `-o console` => console output
+- `-o -` => CSV to stdout
+- `-o <path>` => write CSV to file
+- omitted `-o` => command-specific default (console or file path)
+
+Also centralizes overwrite protection via `-F/--force/--Force`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, TextIO
+
+
+class OutputKind(str, Enum):
+    """High-level output destination kind."""
+
+    CONSOLE = "console"
+    STDOUT = "stdout"
+    FILE = "file"
+
+
+@dataclass(frozen=True)
+class OutputDestination:
+    """Resolved output destination."""
+
+    kind: OutputKind
+    path: Path | None = None
+
+
+def add_force_argument(parser: argparse.ArgumentParser) -> None:
+    """Add a common overwrite flag.
+
+    Uses `-F/--force/--Force` as requested.
+    """
+
+    parser.add_argument(
+        "-F",
+        "--force",
+        "--Force",
+        action="store_true",
+        help="Overwrite existing output files",
+    )
+
+
+def resolve_output_destination(
+    output: str | None,
+    *,
+    default_destination: OutputDestination,
+) -> OutputDestination:
+    """Resolve CLI output argument into a normalized OutputDestination.
+
+    Args:
+        output: Raw CLI `-o/--output` value.
+        default_destination: Destination to use when `output` is omitted.
+
+    Returns:
+        Resolved destination.
+    """
+
+    if output is None:
+        return default_destination
+
+    out = (output or "").strip()
+    if out == "console":
+        return OutputDestination(OutputKind.CONSOLE)
+
+    if out == "-":
+        return OutputDestination(OutputKind.STDOUT)
+
+    return OutputDestination(OutputKind.FILE, path=Path(out))
+
+
+class OutputRefusedError(RuntimeError):
+    """Raised when output cannot be written (e.g. overwrite protection)."""
+
+
+def open_output_text_file(
+    path: Path,
+    *,
+    force: bool,
+    refused_message: str,
+    make_backup: Callable[[Path], Path | None] | None = None,
+) -> TextIO:
+    """Open an output file for writing with overwrite protection.
+
+    Args:
+        path: Output path.
+        force: If True, allow overwriting an existing file.
+        refused_message: Message to use if overwriting is refused.
+        make_backup: Optional function invoked when overwriting an existing file.
+
+    Raises:
+        OutputRefusedError: If the file exists and force is False.
+
+    Returns:
+        Open file handle.
+    """
+
+    if path.exists() and not force:
+        raise OutputRefusedError(refused_message)
+
+    if path.exists() and force and make_backup is not None:
+        make_backup(path)
+
+    # Always overwrite when force is True or the file does not exist.
+    return path.open("w", newline="", encoding="utf-8")

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -4,8 +4,16 @@ import argparse
 import csv
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.services.schematic_reader import SchematicReader
 from jbom.services.parts_list_generator import PartsListGenerator, PartsListData
 from jbom.services.project_file_resolver import ProjectFileResolver
@@ -35,8 +43,9 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help='Output destination: omit for console table, use "console" for table, "-" for CSV to stdout, or a file path',
+        help='Output destination: omit for default file output, use "console" for table, "-" for CSV to stdout, or a file path',
     )
+    add_force_argument(parser)
 
     # Enhancement options
     parser.add_argument(
@@ -109,11 +118,14 @@ def handle_parts(args: argparse.Namespace) -> int:
 
         schematic_file = resolved_input.resolved_path
 
-        # Determine project name from context or file
-        if resolved_input.project_context:
-            project_name = resolved_input.project_context.project_base_name
-        else:
-            project_name = schematic_file.stem
+        if not resolved_input.project_context:
+            raise ValueError("No project context available")
+
+        project_context = resolved_input.project_context
+        project_name = project_context.project_base_name
+        default_output_path = (
+            project_context.project_directory / f"{project_name}.parts.csv"
+        )
 
         # Use services directly - no workflow abstraction needed
         reader = SchematicReader(options)
@@ -174,7 +186,13 @@ def handle_parts(args: argparse.Namespace) -> int:
             parts_data = _enhance_parts_with_inventory(parts_data, inventory_file)
 
         # Handle output
-        return _output_parts(parts_data, args.output, project_name)
+        return _output_parts(
+            parts_data,
+            args.output,
+            project_name,
+            default_output_path=default_output_path,
+            force=args.force,
+        )
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -192,28 +210,46 @@ def _enhance_parts_with_inventory(
 
 
 def _output_parts(
-    parts_data: PartsListData, output: Optional[str], project_name: str
+    parts_data: PartsListData,
+    output: Optional[str],
+    project_name: str,
+    *,
+    default_output_path: Path,
+    force: bool,
 ) -> int:
-    """Output Parts List data in the requested format.
+    """Output Parts List data in the requested format."""
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(
+            OutputKind.FILE, path=default_output_path
+        ),
+    )
 
-    Human-first defaults (UX consistency with bom/pos/inventory):
-    - output is None or "console" => formatted table to stdout
-    - output == "-" => CSV to stdout
-    - otherwise => treat as file path
-
-    Note: "stdout" is not a special value. If provided (e.g. `-o stdout`), it is treated
-    as a literal filename.
-    """
-    if output is None or output == "console":
+    if dest.kind == OutputKind.CONSOLE:
         _print_console_table(parts_data)
         return 0
 
-    if output == "-":
-        _print_csv(parts_data)
+    if dest.kind == OutputKind.STDOUT:
+        _print_csv(parts_data, out=sys.stdout)
         return 0
 
-    output_path = Path(output)
-    _write_csv(parts_data, output_path)
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
+
+    output_path = dest.path
+    refused = f"Error: Output file '{output_path}' already exists. Use -F/--force to overwrite."
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+        ) as f:
+            _print_csv(parts_data, out=f)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
     print(f"Parts list written to {output_path}")
     return 0
 
@@ -252,9 +288,10 @@ def _print_console_table(parts_data: PartsListData) -> None:
         )
 
 
-def _print_csv(parts_data: PartsListData) -> None:
-    """Print Parts List as CSV to stdout."""
-    writer = csv.writer(sys.stdout)
+def _print_csv(parts_data: PartsListData, *, out: TextIO) -> None:
+    """Print Parts List as CSV to a file-like object."""
+
+    writer = csv.writer(out)
 
     # Headers
     headers = ["Reference", "Value", "Footprint"]
@@ -281,13 +318,3 @@ def _print_csv(parts_data: PartsListData) -> None:
             )
 
         writer.writerow(row)
-
-
-def _write_csv(parts_data: PartsListData, output_path: Path) -> None:
-    """Write Parts List as CSV to file."""
-    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
-        # Use the same logic as stdout
-        old_stdout = sys.stdout
-        sys.stdout = csvfile
-        _print_csv(parts_data)
-        sys.stdout = old_stdout

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -4,7 +4,16 @@ import argparse
 import csv
 import sys
 from pathlib import Path
+from typing import TextIO
 
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.services.pcb_reader import DefaultKiCadReaderService
 from jbom.services.pos_generator import POSGenerator
 from jbom.services.project_file_resolver import ProjectFileResolver
@@ -46,8 +55,9 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help='Output file path, "stdout" for stdout, or "console" for formatted table',
+        help='Output destination: omit for default file output, use "console" for table, "-" for CSV to stdout, or a file path',
     )
+    add_force_argument(parser)
 
     # Filtering options
     parser.add_argument(
@@ -151,6 +161,15 @@ def handle_pos(args: argparse.Namespace) -> int:
 
         pcb_file = resolved_input.resolved_path
 
+        if not resolved_input.project_context:
+            raise ValueError("No project context available")
+
+        project_context = resolved_input.project_context
+        project_name = project_context.project_base_name
+        default_output_path = (
+            project_context.project_directory / f"{project_name}.pos.csv"
+        )
+
         # If project has hierarchical schematics, emit a helpful diagnostic (tests expect this)
         if resolved_input.project_context:
             try:
@@ -239,7 +258,13 @@ def handle_pos(args: argparse.Namespace) -> int:
 
         # Handle output
         return _output_pos(
-            pos_data, args.output, fabricator, selected_fields, user_specified_fields
+            pos_data,
+            args.output,
+            fabricator,
+            selected_fields,
+            user_specified_fields,
+            default_output_path=default_output_path,
+            force=args.force,
         )
 
     except Exception as e:
@@ -293,27 +318,15 @@ def _list_available_pos_fields(fabricator: str) -> None:
 
 def _output_pos(
     pos_data: list,
-    output: str,
+    output: str | None,
     fabricator: str = "generic",
-    selected_fields: list = None,
+    selected_fields: list | None = None,
     user_specified_fields: bool = False,
+    *,
+    default_output_path: Path,
+    force: bool,
 ) -> int:
-    """Output position data in the requested format.
-
-    Human-first defaults (BREAKING CHANGE for UX consistency):
-    - output is None => formatted table to stdout (human exploration)
-    - output == "console" => formatted table to stdout (explicit)
-    - output == "-" => CSV to stdout (machine readable)
-    - "stdout" removed (legacy compatibility)
-    - otherwise => treat as file path
-
-    Args:
-        pos_data: List of position data dictionaries
-        output: Output destination
-        fabricator: Fabricator ID for column mapping
-        selected_fields: List of selected field names to include
-        user_specified_fields: Whether fields were explicitly specified by user
-    """
+    """Output position data in the requested format."""
     # Use default fields if none selected
     if not selected_fields:
         # Try to get fabricator default fields, fall back to standard set
@@ -339,15 +352,39 @@ def _output_pos(
         # Fabricator preset - use fabricator-specific column names
         headers = apply_fabricator_column_mapping(fabricator, "pos", selected_fields)
 
-    if output is None or output == "console":
-        _print_console_table(pos_data, selected_fields, headers)
-    elif output == "-":
-        _print_csv(pos_data, selected_fields, headers)
-    else:
-        output_path = Path(output)
-        _write_csv(pos_data, output_path, selected_fields, headers)
-        print(f"Position file written to {output_path}")
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(
+            OutputKind.FILE, path=default_output_path
+        ),
+    )
 
+    if dest.kind == OutputKind.CONSOLE:
+        _print_console_table(pos_data, selected_fields, headers)
+        return 0
+
+    if dest.kind == OutputKind.STDOUT:
+        _print_csv(pos_data, selected_fields, headers, out=sys.stdout)
+        return 0
+
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
+
+    output_path = dest.path
+    refused = f"Error: Output file '{output_path}' already exists. Use -F/--force to overwrite."
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+        ) as f:
+            _print_csv(pos_data, selected_fields, headers, out=f)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Position file written to {output_path}")
     return 0
 
 
@@ -401,9 +438,16 @@ def _print_console_table(pos_data: list, selected_fields: list, headers: list) -
     print(f"\nTotal: {len(pos_data)} components")
 
 
-def _print_csv(pos_data: list, selected_fields: list, headers: list) -> None:
-    """Print position data as CSV to stdout."""
-    writer = csv.writer(sys.stdout)
+def _print_csv(
+    pos_data: list,
+    selected_fields: list,
+    headers: list,
+    *,
+    out: TextIO,
+) -> None:
+    """Print position data as CSV to a file-like object."""
+
+    writer = csv.writer(out)
 
     # Use headers exactly as provided by fabricator column mapping
     writer.writerow(headers)
@@ -457,18 +501,3 @@ def _get_pos_field_value(entry: dict, field: str) -> str:
 
     # Fallback for unknown fields
     return str(entry.get(field, ""))
-
-
-def _write_csv(
-    pos_data: list,
-    output_path: Path,
-    selected_fields: list = None,
-    headers: list = None,
-) -> None:
-    """Write position data as CSV to file."""
-    with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
-        # Use the same logic as stdout
-        old_stdout = sys.stdout
-        sys.stdout = csvfile
-        _print_csv(pos_data, selected_fields, headers)
-        sys.stdout = old_stdout

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -109,7 +109,8 @@ def handle_search(args: argparse.Namespace) -> int:
     results = SearchSorter.rank(results)
     results = results[:display_limit]
 
-    return _output_results(results, output=args.output, force=args.force)
+    force = bool(getattr(args, "force", False))
+    return _output_results(results, output=args.output, force=force)
 
 
 def _create_provider(

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import argparse
 import csv
 import sys
-from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 from jbom.cli.formatting import Column, print_table
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
 from jbom.services.search.cache import InMemorySearchCache, SearchCache
 from jbom.services.search.filtering import (
     SearchFilter,
@@ -64,8 +71,9 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "-o",
         "--output",
-        help="Output destination: 'console' for table, '-' for CSV to stdout, or a file path",
+        help="Output destination: omit for console, use 'console' for table, '-' for CSV to stdout, or a file path",
     )
+    add_force_argument(parser)
 
     parser.set_defaults(handler=handle_search)
 
@@ -101,7 +109,7 @@ def handle_search(args: argparse.Namespace) -> int:
     results = SearchSorter.rank(results)
     results = results[:display_limit]
 
-    return _output_results(results, output=args.output)
+    return _output_results(results, output=args.output, force=args.force)
 
 
 def _create_provider(
@@ -114,17 +122,41 @@ def _create_provider(
     raise ValueError(f"Unknown provider: {provider_id}")
 
 
-def _output_results(results: list[SearchResult], *, output: Optional[str]) -> int:
-    if output is None or output == "console":
+def _output_results(
+    results: list[SearchResult], *, output: Optional[str], force: bool
+) -> int:
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(OutputKind.CONSOLE),
+    )
+
+    if dest.kind == OutputKind.CONSOLE:
         _print_console(results)
         return 0
 
-    if output == "-":
-        _print_csv(results)
+    if dest.kind == OutputKind.STDOUT:
+        _print_csv(results, out=sys.stdout)
         return 0
 
-    path = Path(output)
-    _write_csv(results, path)
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
+
+    path = dest.path
+    refused = (
+        f"Error: Output file '{path}' already exists. Use -F/--force to overwrite."
+    )
+
+    try:
+        with open_output_text_file(
+            path,
+            force=force,
+            refused_message=refused,
+        ) as f:
+            _print_csv(results, out=f)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
     print(f"Search results written to {path}")
     return 0
 
@@ -167,19 +199,11 @@ def _print_console(results: list[SearchResult]) -> None:
     print(f"Found {len(results)} results.")
 
 
-def _print_csv(results: list[SearchResult]) -> None:
-    writer = csv.DictWriter(sys.stdout, fieldnames=_csv_headers())
+def _print_csv(results: list[SearchResult], *, out: TextIO) -> None:
+    writer = csv.DictWriter(out, fieldnames=_csv_headers())
     writer.writeheader()
     for r in results:
         writer.writerow(_csv_row_for_result(r))
-
-
-def _write_csv(results: list[SearchResult], path: Path) -> None:
-    with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=_csv_headers())
-        writer.writeheader()
-        for r in results:
-            writer.writerow(_csv_row_for_result(r))
 
 
 def _csv_headers() -> list[str]:

--- a/src/jbom/services/project_context.py
+++ b/src/jbom/services/project_context.py
@@ -38,22 +38,14 @@ class ProjectContext:
         self.options = options or GeneratorOptions()
 
         # Discover project files using ProjectDiscovery service
-        discovery = ProjectDiscovery(strict_mode=False, options=self.options)
+        discovery = ProjectDiscovery(options=self.options)
         self.project_files = discovery.discover_project_files(project_directory)
 
-        # Validate that we found at least some project files
-        if (
-            not self.project_files.project_file
-            and not self.project_files.schematic_file
-            and not self.project_files.pcb_file
-        ):
-            raise ValueError(
-                f"No project files found in {project_directory}. "
-                f"Expected at least one of: .kicad_pro, .kicad_sch, or .kicad_pcb files."
-            )
+        # KiCad 6+ projects always have exactly one *.kicad_pro
+        # ProjectDiscovery enforces this and will raise a ValueError if missing/ambiguous.
 
     @property
-    def project_file(self) -> Optional[Path]:
+    def project_file(self) -> Path:
         """Get the project file path."""
         return self.project_files.project_file
 

--- a/src/jbom/services/project_discovery.py
+++ b/src/jbom/services/project_discovery.py
@@ -1,14 +1,15 @@
-"""ProjectDiscovery service for finding KiCad project files.
+"""ProjectDiscovery service for finding KiCad v6+ project files.
 
-Stateful service that discovers KiCad project files (.kicad_pro, .pro),
-schematic files (.kicad_sch), and PCB files (.kicad_pcb) in directories.
-Follows domain service architecture with constructor-configured behavior.
+jBOM v7 targets KiCad 6+ projects, which always include exactly one
+`*.kicad_pro` project file in the project directory.
+
+This service discovers the project file (`*.kicad_pro`), schematic file
+(`*.kicad_sch`), and PCB file (`*.kicad_pcb`) in directories.
 """
 
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from jbom.common.options import GeneratorOptions
 
@@ -19,98 +20,45 @@ __all__ = ["ProjectDiscovery", "ProjectFiles"]
 class ProjectFiles:
     """Data structure holding discovered project files."""
 
-    project_file: Optional[Path] = None
-    schematic_file: Optional[Path] = None
-    pcb_file: Optional[Path] = None
+    project_file: Path
+    schematic_file: Path | None = None
+    pcb_file: Path | None = None
 
 
 class ProjectDiscovery:
-    """Service for discovering KiCad project files in directories.
+    """Service for discovering KiCad v6+ project files in directories."""
 
-    Stateful service with constructor-configured search behavior.
-    Handles autosave files, directory name matching, and multiple project scenarios.
-    """
-
-    def __init__(
-        self, strict_mode: bool = False, options: Optional[GeneratorOptions] = None
-    ):
-        """Initialize ProjectDiscovery service.
-
-        Args:
-            strict_mode: If True, raise exception when multiple project files found.
-                        If False, pick the first one alphabetically.
-            options: Optional GeneratorOptions for verbose output etc.
-        """
-        self.strict_mode = strict_mode
+    def __init__(self, options: GeneratorOptions | None = None):
         self.options = options or GeneratorOptions()
 
-    def find_project_file(self, search_dir: Path) -> Optional[Path]:
-        """Find the best KiCad project file in a directory.
+    def find_project_file(self, search_dir: Path) -> Path:
+        """Find the single KiCad v6+ project file in a directory.
 
-        Args:
-            search_dir: Directory to search in
-
-        Returns:
-            Path to .kicad_pro or .pro file, or None if not found
+        KiCad projects must contain exactly one `*.kicad_pro` file.
 
         Raises:
-            ValueError: If strict_mode=True and multiple projects found
+            ValueError: If zero or multiple `*.kicad_pro` files are found.
         """
         if not search_dir.is_dir():
-            return None
+            raise ValueError(f"Project directory does not exist: {search_dir}")
 
-        # Find project files (prefer .kicad_pro over legacy .pro)
-        kicad_pro_files = list(search_dir.glob("*.kicad_pro"))
-        pro_files = list(search_dir.glob("*.pro"))
-
-        # Check for multiple projects in strict mode
-        total_projects = len(kicad_pro_files) + len(pro_files)
-        if self.strict_mode and total_projects > 1:
+        kicad_pro_files = sorted(search_dir.glob("*.kicad_pro"))
+        if not kicad_pro_files:
+            # Preserve the "No project files found" substring for existing error mapping/tests.
             raise ValueError(
-                f"Multiple project files found in {search_dir}. "
-                f"Found {len(kicad_pro_files)} .kicad_pro and {len(pro_files)} .pro files. "
-                f"Please specify a specific project file."
+                f"No project files found (expected exactly one *.kicad_pro in {search_dir})"
             )
 
-        # Prefer .kicad_pro files
-        if kicad_pro_files:
-            # If legacy also present, emit UX note selecting modern file
-            try:
-                import sys as _sys
+        if len(kicad_pro_files) > 1:
+            raise ValueError(
+                f"Multiple project files found in {search_dir} "
+                f"({len(kicad_pro_files)} *.kicad_pro files)"
+            )
 
-                if pro_files:
-                    print(
-                        f"using modern project file {sorted(kicad_pro_files)[0].name}",
-                        file=_sys.stderr,
-                    )
-            except Exception:
-                pass
-            return self._select_best_file(kicad_pro_files, search_dir.name)
+        return kicad_pro_files[0]
 
-        # Fall back to legacy .pro files
-        if pro_files:
-            try:
-                import sys as _sys
-
-                print(
-                    f"using legacy project file {sorted(pro_files)[0].name}",
-                    file=_sys.stderr,
-                )
-            except Exception:
-                pass
-            return self._select_best_file(pro_files, search_dir.name)
-
-        return None
-
-    def find_schematic_file(self, search_dir: Path) -> Optional[Path]:
-        """Find the best schematic file in a directory.
-
-        Args:
-            search_dir: Directory to search in
-
-        Returns:
-            Path to .kicad_sch file, or None if not found
-        """
+    def find_schematic_file(self, search_dir: Path) -> Path | None:
+        """Find the best schematic file in a directory."""
         if not search_dir.is_dir():
             return None
 
@@ -122,15 +70,8 @@ class ProjectDiscovery:
             schematic_files, search_dir.name, "schematic"
         )
 
-    def find_pcb_file(self, search_dir: Path) -> Optional[Path]:
-        """Find the best PCB file in a directory.
-
-        Args:
-            search_dir: Directory to search in
-
-        Returns:
-            Path to .kicad_pcb file, or None if not found
-        """
+    def find_pcb_file(self, search_dir: Path) -> Path | None:
+        """Find the best PCB file in a directory."""
         if not search_dir.is_dir():
             return None
 
@@ -141,14 +82,7 @@ class ProjectDiscovery:
         return self._select_best_file_with_autosave(pcb_files, search_dir.name, "PCB")
 
     def discover_project_files(self, search_dir: Path) -> ProjectFiles:
-        """Discover all project files in a directory.
-
-        Args:
-            search_dir: Directory to search in
-
-        Returns:
-            ProjectFiles object with discovered file paths
-        """
+        """Discover all project files in a directory."""
         return ProjectFiles(
             project_file=self.find_project_file(search_dir),
             schematic_file=self.find_schematic_file(search_dir),
@@ -156,50 +90,27 @@ class ProjectDiscovery:
         )
 
     def _select_best_file(self, files: list[Path], dir_name: str) -> Path:
-        """Select best file from list, preferring directory name matches.
-
-        Args:
-            files: List of file paths
-            dir_name: Directory name to match against
-
-        Returns:
-            Best file path
-        """
-        # Prefer files matching directory name
+        """Select best file from list, preferring directory name matches."""
         matching = [f for f in files if f.stem == dir_name]
         if matching:
             return matching[0]
 
-        # Return first file alphabetically
         return sorted(files)[0]
 
     def _select_best_file_with_autosave(
         self, files: list[Path], dir_name: str, file_type: str
     ) -> Path:
-        """Select best file handling autosave files with warnings.
-
-        Args:
-            files: List of file paths
-            dir_name: Directory name to match against
-            file_type: Type of file for warning messages
-
-        Returns:
-            Best file path
-        """
-        # Separate autosave and normal files
+        """Select best file handling autosave files with warnings."""
         normal_files = [f for f in files if not f.name.startswith("_autosave-")]
         autosave_files = [f for f in files if f.name.startswith("_autosave-")]
 
-        # Prefer normal files that match directory name
         matching_normal = [f for f in normal_files if f.stem == dir_name]
         if matching_normal:
             return matching_normal[0]
 
-        # Use any normal file
         if normal_files:
             return sorted(normal_files)[0]
 
-        # Fall back to autosave files with warning
         if autosave_files:
             print(
                 f"WARNING: Only autosave {file_type} files found in {files[0].parent}. "
@@ -213,5 +124,4 @@ class ProjectDiscovery:
                 return matching_autosave[0]
             return sorted(autosave_files)[0]
 
-        # Should not reach here given our input filtering
         return files[0]

--- a/src/jbom/services/project_file_resolver.py
+++ b/src/jbom/services/project_file_resolver.py
@@ -132,7 +132,7 @@ class ProjectFileResolver:
                 raise FileNotFoundError(
                     f"No PCB file found (File not found: {resolved_path})"
                 )
-            if input_path.suffix in (".kicad_pro", ".pro"):
+            if input_path.suffix == ".kicad_pro":
                 raise FileNotFoundError(
                     f"Project file not found (File not found: {resolved_path})"
                 )
@@ -200,7 +200,7 @@ class ProjectFileResolver:
                 raise FileNotFoundError("No schematic file found")
             if file_path.suffix == ".kicad_pcb":
                 raise FileNotFoundError("No PCB file found")
-            if file_path.suffix in (".kicad_pro", ".pro"):
+            if file_path.suffix == ".kicad_pro":
                 raise FileNotFoundError("Project file not found")
             raise FileNotFoundError(f"File not found: {file_path}")
 

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -43,10 +43,10 @@ class TestDiscovery(unittest.TestCase):
         out = default_output_name(self.tmpdir, project, pcb, "pos.csv")
         self.assertEqual(out.name, "proj.pos.csv")
 
-    def test_legacy_project(self):
+    def test_legacy_project_is_not_supported(self):
         legacy = self.tmpdir / "legacy.pro"
         legacy.write_text("legacy\n")
-        self.assertEqual(find_project(self.tmpdir), legacy)
+        self.assertIsNone(find_project(self.tmpdir))
 
     def test_directory_matching_preferred(self):
         # Create two pcb files, prefer one whose stem matches directory name

--- a/tests/test_project_context.py
+++ b/tests/test_project_context.py
@@ -52,6 +52,9 @@ class TestProjectContext(unittest.TestCase):
 
     def test_resolve_hierarchical_schematics(self):
         """Test finding hierarchical schematic files."""
+        # KiCad 6+ projects require a .kicad_pro
+        (self.tmpdir / "main.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         # Create main schematic with hierarchical references
         main_sch = self.tmpdir / "main.kicad_sch"
         main_sch_content = """(kicad_sch (version 20211123)
@@ -131,6 +134,8 @@ class TestProjectContext(unittest.TestCase):
 
     def test_suggest_missing_files(self):
         """Test suggesting missing related files."""
+        (self.tmpdir / "test.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         # Only create schematic, missing PCB
         schematic_file = self.tmpdir / "test.kicad_sch"
         schematic_file.write_text("(kicad_sch (version 20211123))")

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -21,11 +21,14 @@ class TestProjectDiscovery(unittest.TestCase):
             if p.is_file():
                 p.unlink()
 
-    def test_empty_directory_returns_none(self):
-        """Test that empty directory returns None for all file types."""
+    def test_empty_directory_requires_project_file(self):
+        """KiCad 6+ projects must contain exactly one *.kicad_pro."""
         discovery = ProjectDiscovery()
 
-        self.assertIsNone(discovery.find_project_file(self.tmpdir))
+        with self.assertRaises(ValueError) as cm:
+            discovery.find_project_file(self.tmpdir)
+        self.assertIn("No project files found", str(cm.exception))
+
         self.assertIsNone(discovery.find_schematic_file(self.tmpdir))
         self.assertIsNone(discovery.find_pcb_file(self.tmpdir))
 
@@ -39,40 +42,39 @@ class TestProjectDiscovery(unittest.TestCase):
 
         self.assertEqual(found, project_file)
 
-    def test_find_legacy_pro_project_file(self):
-        """Test finding legacy .pro project files."""
-        legacy_file = self.tmpdir / "legacy.pro"
-        legacy_file.write_text("legacy project file content")
+    def test_multiple_projects_raises_exception(self):
+        """Test that multiple project files raise an exception."""
+        (self.tmpdir / "project1.kicad_pro").write_text(
+            "(kicad_pro (version 20211014))"
+        )
+        (self.tmpdir / "project2.kicad_pro").write_text(
+            "(kicad_pro (version 20211014))"
+        )
 
         discovery = ProjectDiscovery()
-        found = discovery.find_project_file(self.tmpdir)
 
-        self.assertEqual(found, legacy_file)
+        with self.assertRaises(ValueError) as cm:
+            discovery.find_project_file(self.tmpdir)
 
-    def test_prefer_kicad_pro_over_legacy_pro(self):
-        """Test that .kicad_pro files are preferred over .pro files."""
-        legacy_file = self.tmpdir / "legacy.pro"
-        legacy_file.write_text("legacy project file content")
+        self.assertIn("Multiple project files found", str(cm.exception))
 
-        kicad_pro_file = self.tmpdir / "modern.kicad_pro"
-        kicad_pro_file.write_text("(kicad_pro (version 20211014))")
+    def test_discover_project_files_returns_all(self):
+        """Test discovering all project files at once."""
+        project = self.tmpdir / "test.kicad_pro"
+        project.write_text("(kicad_pro (version 20211014))")
 
-        discovery = ProjectDiscovery()
-        found = discovery.find_project_file(self.tmpdir)
+        schematic = self.tmpdir / "test.kicad_sch"
+        schematic.write_text("(kicad_sch (version 20211123))")
 
-        self.assertEqual(found, kicad_pro_file)
-
-    def test_prefer_directory_name_matching(self):
-        """Test that files matching directory name are preferred."""
-        # Create two project files, prefer one that matches directory name
-        (self.tmpdir / "other.kicad_pro").write_text("(kicad_pro (version 20211014))")
-        expected = self.tmpdir / f"{self.tmpdir.name}.kicad_pro"
-        expected.write_text("(kicad_pro (version 20211014))")
+        pcb = self.tmpdir / "test.kicad_pcb"
+        pcb.write_text("(kicad_pcb (version 20211014))")
 
         discovery = ProjectDiscovery()
-        found = discovery.find_project_file(self.tmpdir)
+        result = discovery.discover_project_files(self.tmpdir)
 
-        self.assertEqual(found, expected)
+        self.assertEqual(result.project_file, project)
+        self.assertEqual(result.schematic_file, schematic)
+        self.assertEqual(result.pcb_file, pcb)
 
     def test_find_schematic_file(self):
         """Test finding schematic files."""
@@ -116,53 +118,6 @@ class TestProjectDiscovery(unittest.TestCase):
         found = discovery.find_schematic_file(self.tmpdir)
 
         self.assertEqual(found, normal)
-
-    def test_discover_project_files_returns_all(self):
-        """Test discovering all project files at once."""
-        project = self.tmpdir / "test.kicad_pro"
-        project.write_text("(kicad_pro (version 20211014))")
-
-        schematic = self.tmpdir / "test.kicad_sch"
-        schematic.write_text("(kicad_sch (version 20211123))")
-
-        pcb = self.tmpdir / "test.kicad_pcb"
-        pcb.write_text("(kicad_pcb (version 20211014))")
-
-        discovery = ProjectDiscovery()
-        result = discovery.discover_project_files(self.tmpdir)
-
-        self.assertEqual(result.project_file, project)
-        self.assertEqual(result.schematic_file, schematic)
-        self.assertEqual(result.pcb_file, pcb)
-
-    def test_multiple_projects_raises_exception(self):
-        """Test that multiple project files raise an exception."""
-        (self.tmpdir / "project1.kicad_pro").write_text(
-            "(kicad_pro (version 20211014))"
-        )
-        (self.tmpdir / "project2.kicad_pro").write_text(
-            "(kicad_pro (version 20211014))"
-        )
-
-        discovery = ProjectDiscovery(strict_mode=True)
-
-        with self.assertRaises(ValueError) as cm:
-            discovery.find_project_file(self.tmpdir)
-
-        self.assertIn("Multiple project files found", str(cm.exception))
-
-    def test_multiple_projects_in_lenient_mode(self):
-        """Test that multiple project files in lenient mode picks first."""
-        project1 = self.tmpdir / "a_first.kicad_pro"
-        project1.write_text("(kicad_pro (version 20211014))")
-        (self.tmpdir / "b_second.kicad_pro").write_text(
-            "(kicad_pro (version 20211014))"
-        )
-
-        discovery = ProjectDiscovery(strict_mode=False)
-        found = discovery.find_project_file(self.tmpdir)
-
-        self.assertEqual(found, project1)
 
 
 if __name__ == "__main__":

--- a/tests/test_project_file_resolver.py
+++ b/tests/test_project_file_resolver.py
@@ -22,7 +22,9 @@ class TestProjectFileResolver(unittest.TestCase):
                 p.unlink()
 
     def test_resolve_explicit_schematic_file(self):
-        """Test resolving explicit .kicad_sch file paths (backward compatibility)."""
+        """Test resolving explicit .kicad_sch file paths."""
+        (self.tmpdir / "board.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         schematic = self.tmpdir / "board.kicad_sch"
         schematic.write_text("(kicad_sch (version 20211123))")
 
@@ -37,6 +39,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_resolve_explicit_pcb_file(self):
         """Test resolving explicit .kicad_pcb file paths."""
+        (self.tmpdir / "board.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         pcb = self.tmpdir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb (version 20211014))")
 
@@ -50,6 +54,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_resolve_current_directory(self):
         """Test resolving current directory '.' input."""
+        (self.tmpdir / "project.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         schematic = self.tmpdir / "project.kicad_sch"
         schematic.write_text("(kicad_sch (version 20211123))")
 
@@ -114,6 +120,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_resolve_pcb_input_returns_pcb(self):
         """Test that resolver can return PCB files when appropriate."""
+        (self.tmpdir / "test.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         pcb = self.tmpdir / "test.kicad_pcb"
         pcb.write_text("(kicad_pcb (version 20211014))")
 
@@ -126,6 +134,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_resolve_cross_file_intelligence(self):
         """Test cross-file intelligence (sch -> pcb, pcb -> sch)."""
+        (self.tmpdir / "board.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         schematic = self.tmpdir / "board.kicad_sch"
         schematic.write_text("(kicad_sch (version 20211123))")
 
@@ -161,6 +171,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_helpful_suggestions(self):
         """Test that resolver provides helpful suggestions for common mistakes."""
+        (self.tmpdir / "board.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         # Create PCB file but user asks for schematic
         pcb = self.tmpdir / "board.kicad_pcb"
         pcb.write_text("(kicad_pcb (version 20211014))")
@@ -177,6 +189,8 @@ class TestProjectFileResolver(unittest.TestCase):
 
     def test_hierarchical_schematic_resolution(self):
         """Test resolution of hierarchical schematics."""
+        (self.tmpdir / "main.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
         # Create main schematic with hierarchical sheets
         main_sch = self.tmpdir / "main.kicad_sch"
         main_sch_content = """(kicad_sch (version 20211123)


### PR DESCRIPTION
Closes #69
Closes #77

Summary
- Enforce KiCad 6+ project rule: exactly one `*.kicad_pro` per project directory (no legacy `.pro` support).
- Add shared CLI output helper to DRY output resolution and safe file writes.
- Change default output contract for `bom`, `pos`, `parts` (omit `-o`): write `${project}.bom.csv|.pos.csv|.parts.csv` in the discovered project directory.
- Add `-F/--force/--Force` across commands that write files; refuse overwrites by default.
- Fix `inventory-search -o console` being treated as a filename; now it behaves as console mode (no enhanced CSV output).
- Update Behave scenarios and manpage docs to match the corrected defaults.

Verification
- `pre-commit run`
- `PYTHONPATH=src python -m behave --format progress`
- `PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py' -v`

Notes
- For `inventory-search -o -`, the enhanced CSV is written to stdout; the human report is written to stderr unless `--report` is provided.

Co-Authored-By: Oz <oz-agent@warp.dev>