### PR TITLE
Search fixtures + Mouser contract/integration tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to jBOM are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Mouser search fixtures and offline contract/integration test scaffolding.
+
 ## [7.0.0] - 2026-02-27
 
 ### Breaking Changes

--- a/scripts/record_mouser_fixture.py
+++ b/scripts/record_mouser_fixture.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Record raw Mouser keyword search responses as JSON fixtures.
+
+This script is a developer tool intended to be run manually (not by pytest).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+
+BASE_URL = "https://api.mouser.com/api/v1/search"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Record a raw Mouser keyword search response to a fixture JSON file."
+    )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="Keyword search query to send to Mouser (e.g. '10K resistor 0603').",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output JSON path (e.g. tests/fixtures/mouser/keyword_resistor_10k_0603.json).",
+    )
+    return parser
+
+
+def _fetch_keyword_search(*, api_key: str, query: str) -> dict[str, Any]:
+    try:
+        import requests  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "This script requires 'requests'. Install it with: pip install requests"
+        ) from exc
+
+    url = f"{BASE_URL}/keyword"
+    payload = {
+        "SearchByKeywordRequest": {
+            "keyword": query,
+            "records": 100,
+            "startingRecord": 0,
+            "searchOptions": "None",
+            "searchWithYourSignUpLanguage": "English",
+        }
+    }
+
+    response = requests.post(
+        url,
+        params={"apiKey": api_key},
+        json=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected JSON object response, got {type(data).__name__}")
+
+    return data
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("MOUSER_API_KEY")
+    if not api_key:
+        parser.error(
+            "MOUSER_API_KEY environment variable is required to record fixtures"
+        )
+
+    try:
+        data = _fetch_keyword_search(api_key=api_key, query=args.query)
+    except Exception as exc:
+        print(f"Failed to record Mouser fixture: {exc}", file=sys.stderr)
+        return 1
+
+    output_path: Path = args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Pytest configuration for jbom-new.
+"""Pytest configuration for jBOM.
 
 This repo expects imports from the local `src/` tree (e.g. `import jbom`).
 In many developer workflows this is provided via PYTHONPATH, but tests should be
@@ -7,10 +7,32 @@ runnable without external environment configuration.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from typing import Any
 
 
 _SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_FIXTURES_DIR = _TESTS_DIR / "fixtures"
+
+
+def load_mouser_fixture(name: str) -> dict[str, Any]:
+    """Load a named fixture from tests/fixtures/mouser/."""
+
+    filename = name if name.endswith(".json") else f"{name}.json"
+    fixture_path = _FIXTURES_DIR / "mouser" / filename
+    if not fixture_path.exists():
+        raise FileNotFoundError(f"Fixture not found: {fixture_path}")
+
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Fixture {fixture_path} must contain a JSON object, got {type(data).__name__}"
+        )
+
+    return data

--- a/tests/fixtures/mouser/empty_results.json
+++ b/tests/fixtures/mouser/empty_results.json
@@ -1,0 +1,5 @@
+{
+  "SearchResults": {
+    "Parts": []
+  }
+}

--- a/tests/fixtures/mouser/error_response.json
+++ b/tests/fixtures/mouser/error_response.json
@@ -1,0 +1,7 @@
+{
+  "Errors": [
+    {
+      "Message": "Example error fixture"
+    }
+  ]
+}

--- a/tests/fixtures/mouser/keyword_capacitor_1uf_0805.json
+++ b/tests/fixtures/mouser/keyword_capacitor_1uf_0805.json
@@ -1,0 +1,6128 @@
+{
+  "Errors": [],
+  "SearchResults": {
+    "NumberOfResult": 763,
+    "Parts": [
+      {
+        "Availability": "25981 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR71H105JU NEW GLOBAL PN 50V 1uF X7 A 581-KGM21AR71H105JU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08055C105JAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08055C105JAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.59",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.582",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.582",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08055C105JAT2A?qs=tIBUQlZETBw4JiKO8J7C1w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KGM21AR71H105JU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "25981",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 15000,
+            "Date": "2026-06-15T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2475 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 6.3V 1uF X5R 0805 10 % A 581-08056D105KAT4A",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08056D105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08056D105KAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.137",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.083",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.066",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.056",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.048",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.044",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "08056D105KAT4A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08056D105KAT2A?qs=ykEKLGTiBcwM6Pzmu5POiw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-08056D105KAT4A",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "2475",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 6000,
+            "Date": "2026-06-09T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "187298 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR71C105KU NEW GLOBAL PN 16V 1uF X7 A 581-KGM21AR71C105KU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "0805YC105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-0805YC105KAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.049",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.043",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.036",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.033",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.025",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 9000,
+            "Price": "$0.022",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "0805YC105KAT4A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/0805YC105KAT2A?qs=Ppq%252BQS%252B9qgKbltvIecMi5g%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "581-KGM21AR71C105KU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "187298",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6112 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/catalog/specsheets/avx_04122018_part number explanation.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF Y5V 0805 20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08053G105MAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08053G105MAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.137",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.071",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.057",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.046",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.037",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.036",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08053G105MAT2A?qs=%252BdQmOuGyFcFhHccwoblzEQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "6112",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 8000,
+            "Date": "2026-06-29T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532400000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "87287 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 0805 1uF 10volts X7R 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/VJ_W1BC_series.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "126 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Vitramon",
+        "ManufacturerPartNumber": "VJ0805Y105KXQTW1BC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "77-VJ0805Y105KXQTBC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.066",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.057",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.043",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 9000,
+            "Price": "$0.026",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "VJ0805Y105KXQRW1BC"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Vitramon/VJ0805Y105KXQTW1BC?qs=F2lBERbFaaHnNHh23%2Flzkg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "87287",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 41 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6169 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 6.3V 1uF X7R 0805 20 %",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08056C105MAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08056C105MAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.206",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.134",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.108",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.099",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.08",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08056C105MAT2A?qs=ykEKLGTiBczQmPFL2Pr3Kg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "6169",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3976 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805T105K4RACTU.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "364 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805T105K4RACTU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805T105K4RACTU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$1.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.909",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.831",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.769",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.729",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.714",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805T105K4RACTU?qs=MdyXZ7FdW%2F5TQ%2FwGkCt4PQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "3976",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "462 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 6.3V 1uF X7R 0805 5% Tol FLEX",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08056C105JAZ2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08056C105JAZ2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.73",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.889",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.753",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.705",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.617",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.609",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.607",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08056C105JAZ2A?qs=G2E3TvrFun38e5oIaHmBpQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "462",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "14071 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805C105J4RAC7210.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 5%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105J4RAC7210",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105J4RACLR",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.159",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.094",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.075",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.068",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.063",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.055",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.054",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.05",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105J4RAC7210?qs=7zB%252BIQS%2FKOJG%252BUtduyFhHw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "14071",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "21679 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/508/1/KEM_C1002_X7R_SMD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X7R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105K3RACTM",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105K3RACTM",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.095",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.058",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.053",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.049",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.023",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105K3RACTM?qs=2uRfZzjKWaneMR%2FyjdUOBQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "21679",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1394 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X7R 0805 5% Tol FLEX",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08053C105JAZ2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08053C105JAZ2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.44",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.93",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.75",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.745",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08053C105JAZ2A?qs=bb%252B1MDm7h6L%2FlQm5NeIcJA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "1394",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "184 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/KEM_C1008_X8L_150C_SMD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 10V 1uF X8L 0805 10% AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105K8NACAUTO",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105K8NAUTO",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.686",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.495",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.408",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.379",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.33",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105K8NACAUTO?qs=KosDah%252BIqW9fFjto7gIw4Q%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "184",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 2500,
+            "Date": "2026-08-11T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "413 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 10V 1uF X7R 0805 10% TOL",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "0805ZC105K4Z2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-0805ZC105K4Z2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.617",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.436",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.413",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.314",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.313",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.309",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/0805ZC105K4Z2A?qs=Xu68utgrSJ%252B9PdUnrILYTQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "413",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 2000,
+            "Date": "2026-05-20T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "4757 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KAM21KR71E105JU NEW GLOBAL PN 25V 1uF X7 A 581-KAM21KR71E105JU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08053C105J4T2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08053C105J4T2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.756",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.652",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.566",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.532",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.494",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.466",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08053C105J4T2A?qs=6N9RIo5FA54sS8G6gtoDaA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KAM21KR71E105JU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "4757",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8600 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/508/1/KEM_C1090_X7R_ESD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105M4REC7210",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105M4RECLR",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.147",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.089",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.071",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.053",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.042",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105M4REC7210?qs=55YtniHzbhBUNgNmKPKUmg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "8600",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5576 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR51E105MU NEW GLOBAL PN 25V 1uF X5 A 581-KGM21AR51E105MU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08053D105MAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08053D105MAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.224",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.182",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.169",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.123",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08053D105MAT2A?qs=ZsCFEZsLLL0uU7AQ31HnTw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KGM21AR51E105MU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "5576",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1885 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/KEM_C1008_X8L_150C_SMD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 10V 1uF X8L 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "105 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805X105K8NACTU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805X105K8NACTU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.13",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.763",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.555",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.428",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.362",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805X105K8NACTU?qs=d7up6SOEJDNM0%252BIw4nFXgA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "1885",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2106 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/317/1/WTC_MLCC_General_Purpose.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 0805 MLCC X7R 1 uF, +/- 5% 16 V T&R GP",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kamaya/images/MLCC.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "120 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Walsin",
+        "ManufacturerPartNumber": "0805B105J160CT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "791-0805B105J160CT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.061",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.037",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.026",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.018",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Walsin/0805B105J160CT?qs=fIkAfuXiAQJryshggw2bXw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "2106",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 6000,
+            "Date": "2026-06-25T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5950 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/317/1/WTC_MLCC_General_Purpose.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 0805 MLCC X7R 1 uF, +/- 20% 50 V T&R GP",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kamaya/images/MLCC.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "114 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Walsin",
+        "ManufacturerPartNumber": "0805B105M500CT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "791-0805B105M500CT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.057",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.034",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.027",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.024",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.016",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Walsin/0805B105M500CT?qs=u16ybLDytRa2ocGSmaywWg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "5950",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 9000,
+            "Date": "2026-05-04T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "221 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/KEM_C1078_X7R_FT_CAP_AUTO_SMD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 5% Flex AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "105 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805X105J4RACAUTO",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805X105J4RAUTO",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.843",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.613",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.509",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.473",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.44",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.407",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805X105J4RACAUTO?qs=Mv7BduZupUicclHcCfiTew%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "221",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5006 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 50V 1uF X5R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR51H105KU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR51H105KU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.367",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.229",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.184",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.128",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR51H105KU?qs=Jm2GQyTW%2FbhaiLr0BvUsEA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "5006",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 3000,
+            "Date": "2026-06-09T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6568 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805C105M4RACAUTO.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 20% AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105M4RACAUTO",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105M4RAUTO",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.126",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.076",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.061",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.046",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.043",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105M4RACAUTO?qs=zDkSFN9STR%2FQblumrygq6Q%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "6568",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 8000,
+            "Date": "2026-04-21T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9627 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X7R 0805 5%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR71E105JU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR71E105JU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.277",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.167",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.134",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.097",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.093",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.085",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR71E105JU?qs=Jm2GQyTW%2FbgnlYTD8j%2FQ8g%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "9627",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9304 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 0805 MLCC X5R 1 uF, +/- 20% 16 V T&R GP",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kamaya/images/MLCC.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "128 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Walsin",
+        "ManufacturerPartNumber": "0805X105M160CT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "791-0805X105M160CT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.025",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.022",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.018",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Walsin/0805X105M160CT?qs=u16ybLDytRZ8ct%2FwMvsviw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "9304",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8310 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 1.0uF +-10% 25V",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kamaya/images/MLCC.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "131 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Walsin",
+        "ManufacturerPartNumber": "0805X105K250CT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "791-0805X105K250CT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.025",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.022",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.018",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Walsin/0805X105K250CT?qs=ZrPdAQfJ6DNIatdME91eIw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "8310",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3344 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X5R 0805 20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR51E105MU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR51E105MU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.408",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.278",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.227",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.191",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.178",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR51E105MU?qs=OcgtsXO%252B3gtm958g9lYdiA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "3344",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "15929 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/508/1/KEM_C1090_X7R_ESD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X7R 0805 5% AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105J3RECAUTO7210",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105J3REAULR",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.39",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.225",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.136",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.109",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.092",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.091",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.075",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.065",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "C0805C105J3RECAUTO"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105J3RECAUTO7210?qs=55YtniHzbhAOX3yRELGunA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "15929",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3800 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/KEM_C1013_X7R_FT_CAP_SMD.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 6.3V 1uF X7R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "105 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805X105K9RACTU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805X105K9R",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.346",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.161",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.08",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805X105K9RACTU?qs=BMjR8U9V8eZo8EloG%2FM4ng%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "3800",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8864 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/317/1/WTC_MLCC_General_Purpose.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 0805 MLCC X7R 1 uF, +/- 5% 25 V T&R GP",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kamaya/images/MLCC.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "120 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Walsin",
+        "ManufacturerPartNumber": "0805B105J250CT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "791-0805B105J250CT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.061",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.037",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.026",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.022",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.018",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Walsin/0805B105J250CT?qs=fIkAfuXiAQInwtoPwtp3Vg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "8864",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5747 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805X105K8RACTU.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 10V 1uF X7R 0805 10% Flex Soft",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "105 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805X105K8RACTU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805X105K8R",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.71",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.453",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.377",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.216",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.215",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "C0805X105K8RAC"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805X105K8RACTU?qs=p6yRp5s%252B%2FXRBx6%252BCsmrxtg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "5747",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "18152 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KAF21KR71H105KL NW G LOB PN 50V 1uF X7R 0 A 581-KAF21KR71H105KL",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08055C105K4Z4A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08055C105K4Z4A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.144",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.128",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.101",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.092",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.084",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.078",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.077",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.071",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "08055C105K4Z2A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08055C105K4Z4A?qs=%252BdQmOuGyFcEU%252Bou2MKEfDQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KAF21KR71H105KL",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.168762004e-06
+        },
+        "AvailabilityInStock": "18152",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5837 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/2614/1/Comm_Chip_X7R_16V_10kVdc.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 1uF25V10%Tol X7R0805",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/knowlescorporation/images/1825_DSL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "119 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Knowles Novacap",
+        "ManufacturerPartNumber": "0805B104K250NT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "767-0805B104K250NT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.67",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$1.35",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Knowles-Novacap/0805B104K250NT?qs=W2iVYWQZWNBvd1Qhwur%2Fiw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "5837",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "7352 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 5%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR71C105JU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR71C105JU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.165",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.098",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.078",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.071",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.064",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.056",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR71C105JU?qs=Jm2GQyTW%2FbgRn%252Bi87%2FZsQQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "7352",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "42286 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X5R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR51E105KU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR51E105KU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.134",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.069",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.055",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.035",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.032",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR51E105KU?qs=Jm2GQyTW%2FbiM5gP12t4YVA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "42286",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2520 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT R102 HIGH CV",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGF21KR71H105KU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGF21KR71H105KU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.657",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.594",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.583",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGF21KR71H105KU?qs=Jm2GQyTW%2FbgpIvuKLmoCtg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2520",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 3000,
+            "Date": "2026-03-10T00:00:00"
+          },
+          {
+            "Quantity": 3000,
+            "Date": "2026-06-09T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5838 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805F105K4RACAUTO.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 10% Open Mode AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "77 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805F105K4RACAUTO",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805F105K4RAUTO",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.132",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.117",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.092",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.084",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.075",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.074",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805F105K4RACAUTO?qs=yc9RBI4tIAK03YGbagZsnA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.605e-05
+        },
+        "AvailabilityInStock": "5838",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1909 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 10% AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KAM21KR71C105KU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KAM21KR71C105KU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.77",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.504",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.361",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.296",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.283",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.234",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KAM21KR71C105KU?qs=Jm2GQyTW%2FbhXd2hn%252BVAs5w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1909",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5838 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805J105K4RACAUTO.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 10% Open Mode AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805J105K4RACAUTO",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805J105K4RAUTO",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.152",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.121",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.111",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.099",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805J105K4RACAUTO?qs=yc9RBI4tIALjaJ4YcDiHlg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.605e-05
+        },
+        "AvailabilityInStock": "5838",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6816 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT Automotive MLCC 1uF, 10%, X7R, 50VDC",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KAM21KR71H105KL",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KAM21KR71H105KL",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.209",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.119",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.092",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.085",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.078",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.069",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.061",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KAM21KR71H105KL?qs=Jm2GQyTW%2FbhahfzttUK9QA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "6816",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 10000,
+            "Date": "2026-05-26T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "15385 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 25V 1uF X7R 0805 10% AEC-Q200 FLEXITERM",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KAF21KR71E105KL",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KAF21KR71E105KL",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.219",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.132",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.106",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.089",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.078",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.073",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.063",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KAF21KR71E105KL?qs=Jm2GQyTW%2FbjzDmXmrHnoLQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "15385",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1728 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 50V 1uF Y5V 0805 +80 -20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AV51H105ZU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AV51H105ZU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.126",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.076",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.061",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.044",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AV51H105ZU?qs=Jm2GQyTW%2FbgC6k4YwVndlA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1728",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 6000,
+            "Date": "2026-03-11T00:00:00"
+          },
+          {
+            "Quantity": 9000,
+            "Date": "2026-06-09T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2000 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X5R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "KGM21AR51C105KU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-KGM21AR51C105KU",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.134",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.081",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.064",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.058",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.047",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/KGM21AR51C105KU?qs=OcgtsXO%252B3gthj5jOmIx2Xw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2000",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "477 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805K105K8RML.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 10V 1 uF X7R 0805 10% SMD MIL X7R PRF32535",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "434 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "M3253504E2X105KZMB",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-M325354E2X105KZMB",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Waffle"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "130"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$13.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$10.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$9.60",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/M3253504E2X105KZMB?qs=F5EMLAvA7ICi%252B2CbVGuHMA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "No",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "477",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "133254 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/508/1/UPY_GPHC_X7R_6_3V_TO_250V.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 16V 1uF X7R 0805 10% HI CV",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/AC_capacitor_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "YAGEO",
+        "ManufacturerPartNumber": "CC0805KKX7R7BB105",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "603-CC805KKX7R7BB105",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.13",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.044",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.033",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "CC0805KFX7R7BB105"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/YAGEO/CC0805KKX7R7BB105?qs=AgBp2OyFlx%2FM8WCHgVQGuw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "133254",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 20 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "102857 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/508/1/UPY_GPHC_X7R_6_3V_TO_250V.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 50V 1uF X7R 0805 10% HI CV",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/AC_capacitor_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "YAGEO",
+        "ManufacturerPartNumber": "CC0805KKX7R9BB105",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "603-CC805KKX7R9BB105",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.095",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.084",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.059",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.042",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "CC0805KFX7R9BB105"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/YAGEO/CC0805KKX7R9BB105?qs=57cj7OiSijnrKSvL75vdbQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.4e-06
+        },
+        "AvailabilityInStock": "102857",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 126000,
+            "Date": "2026-04-01T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 20 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "251363 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR71E105KU NEW GLOBAL PN 25V 1uF X7 A 581-KGM21AR71E105KU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08053C105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08053C105KAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.084",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.047",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.034",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.033",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "08053C105KAT4A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08053C105KAT2A?qs=85uWm5%252BqJhX0Bt9byAHA4A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "581-KGM21AR71E105KU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.4e-06
+        },
+        "AvailabilityInStock": "251363",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "49403 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR51H105KU NEW GLOBAL PN 50V 1uF X5 A 581-KGM21AR51H105KU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08055D105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08055D105K",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.47",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.196",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.128",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.113",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.088",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.083",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.077",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08055D105KAT2A?qs=0ZUpllj3bsbqxjCAZGkcjQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "581-KGM21AR51H105KU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "49403",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "213770 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR71A105KU NEW GLOBAL PN 10V 1uF X7 A 581-KGM21AR71A105KU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC-SnPb_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "0805ZC105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-0805ZC105K",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.063",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.055",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.041",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.037",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.027",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "0805ZC105KAT4A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/0805ZC105KAT2A?qs=xgF8L8qeT4CdIRVv939gnA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KGM21AR71A105KU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.5e-06
+        },
+        "AvailabilityInStock": "213770",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 81000,
+            "Date": "2026-04-13T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "76848 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT KGM21AR71H105KU NEW GLOBAL PN 50V 1uF X7 A 581-KGM21AR71H105KU",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/kyoceraelectronicdevices/images/MLCC_SPL.jpg",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KYOCERA AVX",
+        "ManufacturerPartNumber": "08055C105KAT2A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "581-08055C105KAT2A",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.128",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.106",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.088",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.081",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.062",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.058",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 9000,
+            "Price": "$0.056",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.049",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "08055C105KAT4A"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KYOCERA-AVX/08055C105KAT2A?qs=2ujN4bDBNE9BNQHBgLvfKA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "581-KGM21AR71H105KU",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.4e-06
+        },
+        "AvailabilityInStock": "76848",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 54000,
+            "Date": "2026-05-12T00:00:00"
+          },
+          {
+            "Quantity": 41500,
+            "Date": "2026-06-01T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "139915 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/72/1/C0805C105K5RACTU.pdf",
+        "Description": "Multilayer Ceramic Capacitors MLCC - SMD/SMT 50V 1uF X7R 0805 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/yageo/images/SMD_MLCC_series_SPL.JPG",
+        "Category": "Multilayer Ceramic Capacitors MLCC - SMD/SMT",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "KEMET",
+        "ManufacturerPartNumber": "C0805C105K5RACTU",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "80-C0805C105K5R",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.211",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.153",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.125",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.088",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/KEMET/C0805C105K5RACTU?qs=iP0bYSAMAFrBrUflcErrLQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.4e-06
+        },
+        "AvailabilityInStock": "139915",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 272500,
+            "Date": "2026-06-04T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8532240020"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8532241000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8532240010"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853224000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8532240000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8532240400"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85322410"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/mouser/keyword_connector_header.json
+++ b/tests/fixtures/mouser/keyword_connector_header.json
@@ -1,0 +1,5193 @@
+{
+  "Errors": [],
+  "SearchResults": {
+    "NumberOfResult": 908941,
+    "Parts": [
+      {
+        "Availability": "1598 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Phone Connectors 1/4\"Phone jack hor CHASSIS CONN PLSTC",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/amphenol/images/ITP_523-ACJM-HHDR_t.jpg",
+        "Category": "Phone Connectors",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Amphenol Audio",
+        "ManufacturerPartNumber": "ACJM-HHDR",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "523-ACJM-HHDR",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Bulk"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "100"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.13",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$0.978",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.934",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.817",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.805",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.792",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Amphenol-Audio/ACJM-HHDR?qs=t8%2F5FiDdxGZR4gBVKrXjqA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0082
+        },
+        "AvailabilityInStock": "1598",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8536901100"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "85369099"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/710/1/conga_JC370.pdf",
+        "Description": "Computer Cables Cable for LVDS Panel with JST SHDR-40V connector, 50 cm, Open End, matches also with conga-JC370.",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Computer Cables",
+        "LeadTime": "34 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "congatec",
+        "ManufacturerPartNumber": "cab-LVDS SHDR-40V, Open End",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "787-CAB-LVDSR40VONED",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$21.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$18.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$17.27",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$16.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$16.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$15.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$14.29",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/congatec/cab-LVDS-SHDR-40V-Open-End?qs=A6eO%252BMLsxmSTHb6ovdlN0A%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8544429090"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8544420090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536699099"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85444200"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "64 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/85/1/qms_ra.pdf",
+        "Description": "Headers & Wire Housings 0.635 mm Q2 High-Speed Rugged Ground Plane Terminal Strip",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/samtec/images/qms-016-01-h-d-dp-em2_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "36 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Samtec",
+        "ManufacturerPartNumber": "QMS-026-01-H-D-RA-MG",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "200-QMS02601HDRAMG",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "40"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$23.77",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$22.50",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$21.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 120,
+            "Price": "$16.81",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$14.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 520,
+            "Price": "$12.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$10.20",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Samtec/QMS-026-01-H-D-RA-MG?qs=PB6%2FjmICvI0X83Lp8XDdvQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0005408
+        },
+        "AvailabilityInStock": "64",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8538900000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8536699999"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "940 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Headers & Wire Housings GHD HOUSING",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "JST Commercial",
+        "ManufacturerPartNumber": "GHDR-24V-S-1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "306-GHDR-24V-S-1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.343",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.302",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.267",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.195",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.182",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.174",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.165",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/JST-Commercial/GHDR-24V-S-1?qs=CoAU%2FpHVZXxdfRZmfzWOTA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "940",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 12 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8538908180"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853890000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2247 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/1070/1/eGHD_AU.pdf",
+        "Description": "Headers & Wire Housings GHD HOUSING",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/jstcommercial/images/GHDR-series_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "JST Commercial",
+        "ManufacturerPartNumber": "GHDR-20V-S-1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "306-GHDR-20V-S-1F",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.337",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.297",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.262",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.236",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.191",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.179",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.171",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.167",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/JST-Commercial/GHDR-20V-S-1?qs=IKkN%2F947nfCMyJuk7NGt8Q%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2247",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 12 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8538908180"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8538900000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853890000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8538907080"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "849 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Headers & Wire Housings GHD HOUSING",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "JST Commercial",
+        "ManufacturerPartNumber": "GHDR-28V-S-1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "306-GHDR-28V-S-1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.354",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.311",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.275",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.247",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.201",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.188",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.17",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/JST-Commercial/GHDR-28V-S-1?qs=CoAU%2FpHVZXxAQq%252Bnc7nAcQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "849",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8538908180"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853890000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "650 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Headers & Wire Housings GHD HOUSING",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "JST Commercial",
+        "ManufacturerPartNumber": "GHDR-16V-S-1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "306-GHDR-16V-S-1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.337",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.296",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.262",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.235",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.172",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.171",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.166",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/JST-Commercial/GHDR-16V-S-1?qs=IKkN%2F947nfBQTiYhIo8sNQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "650",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": []
+      },
+      {
+        "Availability": "1855 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/506/1/100866606.pdf",
+        "Description": "Terminals HRNG-TRM 16-12 #10     VYL YEL",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/panduit/images/pv12-10hdrb-2k_SPL.jpg",
+        "Category": "Terminals",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Panduit",
+        "ManufacturerPartNumber": "PV12-10HDRB-2K",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "644-PV12-10HDRB-2K",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.722",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.654",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.637",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.585",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.441",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Panduit/PV12-10HDRB-2K?qs=yEyEXwUbCumTYUYE6A2FwQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.002696885
+        },
+        "AvailabilityInStock": "1855",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536904000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8538900000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536900020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853690000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536909010"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536901000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8536902800"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85369090"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "139 In Stock",
+        "DataSheetUrl": "",
+        "Description": "HDMI, Displayport & DVI Connectors Latch lock, HDMI, receptacle, with dust cover",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/amphenol/images/MRHDR01A1300035_SPL.jpg",
+        "Category": "HDMI, Displayport & DVI Connectors",
+        "LeadTime": "56 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "Amphenol Commercial Products",
+        "ManufacturerPartNumber": "MRHDR01A13000",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "523-MRHDR01A13000",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Bag"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "192"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$18.47",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$15.70",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$14.72",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$14.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$13.12",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Amphenol-Commercial-Products/MRHDR01A13000?qs=jcD%2FCkGBYeOFZqEAHVHykQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "139",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694030"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536699099"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "896 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 8 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2508-6002-SH 08P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2508-600208ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "896"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.904",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.774",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 896,
+            "Price": "$0.737",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$0.731",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5376,
+            "Price": "$0.682",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2508-6002-SH-08P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYeMzOyxvjvv5gg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "896",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "811 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 6 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2506-6002-SH 06P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2506-600206ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1064"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.987",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.839",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.749",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1064,
+            "Price": "$0.709",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2128,
+            "Price": "$0.698",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5320,
+            "Price": "$0.633",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2506-6002-SH-06P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePsP568TfIASA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "811",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "279 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 40 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2540-5003-SH 40P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2540-500340RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.88",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.20",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2540-5003-SH-40P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYeOKCOUOj595XQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "279",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "279 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 34 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2534-5003-SH 34P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2534-500334RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.67",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.07",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2534-5003-SH-34P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYePdpHGvqbtuQA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "279",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 60 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2560-5002-SH 60P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2560-500260RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.78",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2560-5002-SH-60P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeMRQRpuQxthyQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "774 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 10 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2510-5002-SH 10P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2510-500210RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "784"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.845",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.719",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.622",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 784,
+            "Price": "$0.591",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2352,
+            "Price": "$0.583",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5488,
+            "Price": "$0.541",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2510-5002-SH-10P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeNB4CpHwFYjbQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "774",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "179 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 40 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2540-5002-SH 40P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2540-500240RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.88",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.20",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2540-5002-SH-40P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYePjdUKZj%2Frl6A%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "179",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1063 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 6 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2506-5002-SH 06P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2506-500206RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1064"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.748",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.718",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.672",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.611",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.55",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1064,
+            "Price": "$0.498",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2128,
+            "Price": "$0.488",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5320,
+            "Price": "$0.444",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2506-5002-SH-06P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYePPTw160j%2F%252BOQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1063",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 30 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2530-5003-SH 30P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2530-500330RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.76",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.50",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$1.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.963",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2530-5003-SH-30P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYePfTob5hNRDLQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1990 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/506/1/100866606.pdf",
+        "Description": "Terminals Ring Terminal, heavy duty, vinyl insulated, 16 - 12 AWG, 1/4\" stud size, funnel entry",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/panduit/images/pv12-10hdrb-2k_SPL.jpg",
+        "Category": "Terminals",
+        "LeadTime": "115 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Panduit",
+        "ManufacturerPartNumber": "PV12-14HDRB-2K",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "644-PV12-14HDRB-2K",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.87",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.845",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.765",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.745",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.684",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.664",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.638",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.616",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Panduit/PV12-14HDRB-2K?qs=yEyEXwUbCukUFLAeF5sjJw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00341875
+        },
+        "AvailabilityInStock": "1990",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 20 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536904000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8538900000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536900020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "8536900002"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536901000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85369090"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "266 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 40 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2540-6003-SH 40P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2540-600340ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.86",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.19",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2540-6003-SH-40P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYePhH9nSDDzvWA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "266",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "392 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 26 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2526-6003-SH 26P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2526-600326ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "392"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.58",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 392,
+            "Price": "$0.985",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1176,
+            "Price": "$0.957",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2744,
+            "Price": "$0.931",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5096,
+            "Price": "$0.863",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2526-6003-SH-26P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeP15B67Lig5Ew%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "392",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 30 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2530-6003-SH 30P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2530-600330ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.75",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$1.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.956",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2530-6003-SH-30P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeOQRLr1o6Iodw%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 64 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2564-5003-SH 64P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2564-500364RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.59",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.50",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$2.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$2.13",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.96",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2564-5003-SH-64P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYePQIxniBEiksw%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1063 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 6 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2506-5003-SH 06P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2506-500306RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1064"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.995",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.846",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.755",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1064,
+            "Price": "$0.715",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2128,
+            "Price": "$0.704",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5320,
+            "Price": "$0.638",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2506-5003-SH-06P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYePTyMN8XPNhzA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1063",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "280 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 36 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2536-5003-SH 36P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2536-500336RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.12",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2536-5003-SH-36P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYeOzO77LNt43fg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "280",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1053 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 6 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2506-6003-SH 06P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2506-600306ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1064"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.987",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.839",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.749",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1064,
+            "Price": "$0.71",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2128,
+            "Price": "$0.69",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5320,
+            "Price": "$0.633",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2506-6003-SH-06P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeNUo23P7hf4jQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1053",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "616 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 14 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2514-6003-SH 14P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2514-600314ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "616"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.999",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.849",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.747",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.711",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2464,
+            "Price": "$0.702",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5544,
+            "Price": "$0.639",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2514-6003-SH-14P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeMmTJW363Krdg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "616",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "477 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 20 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2520-6003-SH 20P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2520-600320ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "504"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.39",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 504,
+            "Price": "$0.893",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$0.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$0.835",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.759",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2520-6003-SH-20P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeMZdmPia%252BXJeA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "477",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "334 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 64 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2564-6003-SH 64P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2564-600364ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$2.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$2.14",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.95",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2564-6003-SH-64P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeNgcC7wrhOYNw%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "334",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "784 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 10 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2510-6002-SH 10P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2510-600210ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "784"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.99",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.839",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.714",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.636",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 784,
+            "Price": "$0.587",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2352,
+            "Price": "$0.578",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5488,
+            "Price": "$0.537",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2510-6002-SH-10P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYeN98z0g2a7zLQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "784",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "292 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 26 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2526-6002-SH 26P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2526-600226ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "392"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.61",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 392,
+            "Price": "$1.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1176,
+            "Price": "$0.977",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2744,
+            "Price": "$0.952",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5096,
+            "Price": "$0.881",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2526-6002-SH-26P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePrF%2F7imYS%2FVA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "292",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1120 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 36 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2536-6002-SH 36P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2536-600236ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1120"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.73",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2240,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5600,
+            "Price": "$1.11",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2536-6002-SH-36P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYeNt1%2F%252Bg2vhCmA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1120",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "326 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 30 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2530-6002-SH 30P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2530-600230ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.75",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$1.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.956",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2530-6002-SH-30P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYeNfENxIxEB7eg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "326",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "392 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 24 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2524-6002-SH 24P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2524-600224ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "392"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.53",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 392,
+            "Price": "$0.953",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1176,
+            "Price": "$0.926",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2744,
+            "Price": "$0.899",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5096,
+            "Price": "$0.835",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2524-6002-SH-24P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePYuY%2FBOosxnQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "392",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 60 Pin, Right Angle Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2560-5003-SH 60P RA HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2560-500360RA155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.97",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.78",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2560-5003-SH-60P-RA-HDR-0.155-GF?qs=jcD%2FCkGBYeOyyOn%252B4qf10w%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "280 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 36 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2536-5002-SH 36P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2536-500236RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.12",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2536-5002-SH-36P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeObXeRoO%2FkY1A%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "280",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 64 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2564-5002-SH 64P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2564-500264RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.59",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.50",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$2.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$2.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.96",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2564-5002-SH-64P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYePSG3NorRxFOA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "550 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 16 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "69 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2516-5002-SH 16P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2516-500216RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "560"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.27",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.911",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$0.806",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$0.768",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2800,
+            "Price": "$0.758",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.69",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2516-5002-SH-16P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeM%2Fac%2FHeN8i8Q%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "550",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "260 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 40 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2540-6002-SH 40P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2540-600240ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.86",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.19",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2540-6002-SH-40P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePPpoUgXV7EKA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "260",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "223 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 50 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2550-5002-SH 50P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2550-500250RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "224"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.93",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.50",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 224,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 448,
+            "Price": "$1.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5152,
+            "Price": "$1.60",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2550-5002-SH-50P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeORXUGpqPihqg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "223",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "495 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 16 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2516-6003-SH 16P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2516-600316ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "560"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.905",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$0.80",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$0.762",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2800,
+            "Price": "$0.752",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.685",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2516-6003-SH-16P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeMGkmr%252BQpYXKg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "495",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8536901100"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1120 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 36 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "69 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2536-6003-SH 36P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2536-600336ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1120"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.73",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.30",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2240,
+            "Price": "$1.11",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2536-6003-SH-36P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeMGoGE2Ztt0Og%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1120",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "184 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 50 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2550-6003-SH 50P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2550-600350ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "224"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.91",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.99",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 224,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 448,
+            "Price": "$1.83",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.77",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.73",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5152,
+            "Price": "$1.59",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2550-6003-SH-50P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeN3tszJKuXCHg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "184",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "249 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 34 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2534-6003-SH 34P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2534-600334ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "280"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.94",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.65",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 280,
+            "Price": "$1.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 560,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1120,
+            "Price": "$1.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$1.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.06",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2534-6003-SH-34P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeMqH3f%252BOf5Isg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "249",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "891 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 8 Pin Straight Header, 0.155 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2508-6003-SH 08P ST HDR 0.155 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2508-600308ST155",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "896"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.25",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.904",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.774",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 896,
+            "Price": "$0.737",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$0.731",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5376,
+            "Price": "$0.682",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2508-6003-SH-08P-ST-HDR-0.155-GF?qs=jcD%2FCkGBYeOoovIdyzIVmw%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "891",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "336 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 60 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2560-6002-SH 60P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2560-600260ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "336"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.76",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 336,
+            "Price": "$2.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2688,
+            "Price": "$1.94",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$1.77",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2560-6002-SH-60P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePQ9IIZ4dE%252Bww%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "336",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1226 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 14 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "83 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2514-6002-SH 14P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2514-600214ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1232"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.999",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.747",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.712",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2464,
+            "Price": "$0.695",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4928,
+            "Price": "$0.639",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2514-6002-SH-14P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYePVoBLM3uRdCg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1226",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "392 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 26 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "79 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2526-5002-SH 26P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2526-500226RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "392"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.62",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 392,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1176,
+            "Price": "$0.985",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2744,
+            "Price": "$0.97",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5096,
+            "Price": "$0.888",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2526-5002-SH-26P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeNSHbjutJdUqg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "392",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "499 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 20 Pin, Right Angle Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2508-5002-SH%208P-RA-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "78 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2520-5002-SH 20P RA HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2520-500220RA112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "504"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 504,
+            "Price": "$0.901",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$0.857",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$0.829",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.765",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2520-5002-SH-20P-RA-HDR-0.112-GF?qs=jcD%2FCkGBYeOjy7%252Bj%2Fckj8Q%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "499",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "500 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/167/1/ts0770.pdf",
+        "Description": "Headers & Wire Housings 3M Four-Wall Header 2500 Series, 20 Pin Straight Header, 0.112 Tail Length, Gold Flash",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/3m/images/Y2510-6002-SH-10P-ST-HDR-0.112-GF_SPL.jpg",
+        "Category": "Headers & Wire Housings",
+        "LeadTime": "107 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "3M",
+        "ManufacturerPartNumber": "Y2520-6002-SH 20P ST HDR 0.112 GF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "517-2520-600220ST112",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "504"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.39",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.18",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 504,
+            "Price": "$0.956",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1008,
+            "Price": "$0.85",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2520,
+            "Price": "$0.823",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5040,
+            "Price": "$0.759",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/3M/Y2520-6002-SH-20P-ST-HDR-0.112-GF?qs=jcD%2FCkGBYeMPDx8CCodTbQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "500",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8536694040"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8536690020"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853669000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8536691000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8536693000"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85366990"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/mouser/keyword_inductor_100uh.json
+++ b/tests/fixtures/mouser/keyword_inductor_100uh.json
@@ -1,0 +1,6278 @@
+{
+  "Errors": [],
+  "SearchResults": {
+    "NumberOfResult": 2358,
+    "Parts": [
+      {
+        "Availability": "2308 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD IND HPA 100uH 3.5A 2 PADS SMT",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/eatoncorporation/images/hcma0703_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "127 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "Eaton Electronics",
+        "ManufacturerPartNumber": "HPAL1V1260-101-R",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "504-HPAL1V1260-101-R",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.52",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.443",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.406",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.329",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.271",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.264",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Eaton-Electronics/HPAL1V1260-101-R?qs=3GbUB62Nf7dwlNZyo1xFDQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2308",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 44 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2459 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD IND HPA 100uH 4.0A 2 PADS SMT",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/eatoncorporation/images/hcma0703_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "Eaton Electronics",
+        "ManufacturerPartNumber": "HPAL1V1265-101-R",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "504-HPAL1V1265-101-R",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.52",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.443",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.406",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.329",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.271",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.264",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Eaton-Electronics/HPAL1V1265-101-R?qs=3GbUB62Nf7eeAxo8W0VDmA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2459",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 44 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3092 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/pcv.pdf",
+        "Description": "Power Inductors - Leaded 100uH UnShld 10% 10.1A 32mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/PCV_2_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "35 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "PCV-2-104-10L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-PCV-2-104-10L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "49"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$8.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$6.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 49,
+            "Price": "$5.93",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 98,
+            "Price": "$5.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 294,
+            "Price": "$5.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 539,
+            "Price": "$5.38",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/PCV-2-104-10L?qs=ZYnrCdKdyefP3nhtpjw9RA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0466
+        },
+        "AvailabilityInStock": "3092",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "33238 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/mss6132t.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 0.69A 660mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/MSS6132_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSS6132T-104MLC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSS6132T-104MLC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.73",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.59",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.981",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.947",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSS6132T-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSS6132T-104MLC?qs=qSfuJ%252Bfl%2Fd430mL0sMQ5xw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00038
+        },
+        "AvailabilityInStock": "33238",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3826 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/184/1/ACMS_Q3222F.pdf",
+        "Description": "Common Mode Chokes / Filters CMC 100uH 0.15A 2500mOhm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/abracon/images/ACMP-Q3226_SPL.jpg",
+        "Category": "Common Mode Chokes / Filters",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "ABRACON",
+        "ManufacturerPartNumber": "ACMS-Q3222F-101-T",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "815-ACMS-Q3222F-101T",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.891",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.733",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.731",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.704",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.627",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.575",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.529",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/ABRACON/ACMS-Q3222F-101-T?qs=Znm5pLBrcALqJsph8x9NiA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "3826",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "854800000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "941 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/mss1583.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 10% 4.8A 103mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/MSS1583_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "59 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSS1583-104KED",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSS1583-104KED",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "300"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$1.77",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 600,
+            "Price": "$1.66",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSS1583-104KEB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSS1583-104KED?qs=ZYnrCdKdyeeVa6Ur7wpePw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0044
+        },
+        "AvailabilityInStock": "941",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 1500,
+            "Date": "2026-04-10T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "50396 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH 760mA 10% 5.6x5mmSMDAECQ200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tdk/images/B82442T.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "42 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "EPCOS / TDK",
+        "ManufacturerPartNumber": "B82442T1104K050",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "871-B82442T1104K050",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.99",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.865",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.80",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.711",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.681",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.643",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.575",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1500,
+            "Price": "$0.549",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/EPCOS-TDK/B82442T1104K050?qs=x3Z3TaiycduVzHqGgYB07A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00048
+        },
+        "AvailabilityInStock": "50396",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2993 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/lps4018.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 370mA 1.4 Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/LPS4018_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "62 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "LPS4018-104MRC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-LPS4018-104MRC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.796",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.796",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.726",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "LPS4018-104MRB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/LPS4018-104MRC?qs=QQJxVsr8EGaQieW13bMEOg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0001
+        },
+        "AvailabilityInStock": "2993",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2191 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/do1608c.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 0.5A 1.27Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/DO1608_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "65 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "DO1608C-104MLC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-DO1608C-104MLC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "750"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.55",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.52",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 750,
+            "Price": "$1.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2250,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4500,
+            "Price": "$0.975",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "DO1608C-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/DO1608C-104MLC?qs=zCSbvcPd3paQXXto9lqb7A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00013
+        },
+        "AvailabilityInStock": "2191",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 1500,
+            "Date": "2026-04-17T00:00:00"
+          },
+          {
+            "Quantity": 5250,
+            "Date": "2026-05-04T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6103 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/184/1/ACMS-Q3225.pdf",
+        "Description": "Common Mode Chokes / Filters CMC 100uH 0.15A 1500mOhm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/abracon/images/ACMS-Q3225_SPL.jpg",
+        "Category": "Common Mode Chokes / Filters",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "ABRACON",
+        "ManufacturerPartNumber": "ACMS-Q3225-101-T",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "815-ACMS-Q3225-101-T",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.57",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.467",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.384",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.364",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.306",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.279",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.276",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/ABRACON/ACMS-Q3225-101-T?qs=Znm5pLBrcALMx6OfC27mmQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "6103",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "854800000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8687 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/do3316p.pdf",
+        "Description": "Power Inductors - SMD 100uH Unshld 20% 1.3A 280mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/DO3316_series_t.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "56 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "DO3316P-104MLD",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-DO3316P-104MLD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.83",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.46",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "DO3316P-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/DO3316P-104MLD?qs=zCSbvcPd3pbgNGEz7ZAmHQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.001
+        },
+        "AvailabilityInStock": "8687",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "50606 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD WE-PD 100uH 1.9A DCR=140mOhms AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/wurthelectronics/images/7447706015_WES_t.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "0 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Wurth Elektronik",
+        "ManufacturerPartNumber": "7447706101",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "710-7447706101",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.14",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$1.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.928",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Wurth-Elektronik/7447706101?qs=GBLSl2AkirvKlHtMoOoomg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.003009
+        },
+        "AvailabilityInStock": "50606",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "947 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH 15%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/IHSM_7832_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Dale",
+        "ManufacturerPartNumber": "IHSM7832ER101L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "70-IHSM7832ER101L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.55",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$2.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$2.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$2.01",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Dale/IHSM7832ER101L?qs=XQ00FSfuEDAWDXtSu3JRSg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.004549
+        },
+        "AvailabilityInStock": "947",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3406 In Stock",
+        "DataSheetUrl": "",
+        "Description": "RF Inductors - SMD 100uH 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/ISC_1210_SPL.jpg",
+        "Category": "RF Inductors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Dale",
+        "ManufacturerPartNumber": "ISC1210ER101K",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "70-ISC1210ER101K",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.65",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.625",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.622",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.621",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Dale/ISC1210ER101K?qs=z4MKnX0KyNznP2dSiXehrA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5e-05
+        },
+        "AvailabilityInStock": "3406",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "7695 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/76/2/JELF243A_9157.pdf",
+        "Description": "RF Inductors - SMD",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/murata/images/LQH2HNH-series_SPL.jpg",
+        "Category": "RF Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Murata Electronics",
+        "ManufacturerPartNumber": "LQH2HNH101J03L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "81-LQH2HNH101J03L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "3000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.272",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.271",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.202",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 6000,
+            "Price": "$0.186",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 9000,
+            "Price": "$0.183",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Murata-Electronics/LQH2HNH101J03L?qs=t7xnP681wgVMHYq5XfcGGA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "7695",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5037 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD WE-PD2 5848 100uH .57A .65Ohm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/wurthelectronics/images/WE_PD2_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "20 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Wurth Elektronik",
+        "ManufacturerPartNumber": "74477420",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "710-74477420",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.87",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.79",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$1.61",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.43",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1500,
+            "Price": "$1.19",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Wurth-Elektronik/74477420?qs=rS3zZhy2AQMRbX1Obdv9xw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.000491
+        },
+        "AvailabilityInStock": "5037",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1951 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/184/1/ACMS_Q4526C.pdf",
+        "Description": "Common Mode Chokes / Filters CMC 100uH 0.2A 2000mOhm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/abracon/images/ACMP-Q3226_SPL.jpg",
+        "Category": "Common Mode Chokes / Filters",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "ABRACON",
+        "ManufacturerPartNumber": "ACMS-Q4526C-101-T",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "815-ACMS-Q4526C-101T",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.672",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.553",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.546",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.516",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.455",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.415",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.404",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/ABRACON/ACMS-Q4526C-101-T?qs=Znm5pLBrcAKwmqQGtdwT9A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1951",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "854800000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3587 In Stock",
+        "DataSheetUrl": "",
+        "Description": "RF Inductors - SMD 100uH 2.2ohms 55mA +/-10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tdk/images/NLF32-EF_SPL.jpg",
+        "Category": "RF Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "TDK",
+        "ManufacturerPartNumber": "NLFV32T-101K-EFT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "810-NLFV32T-101K-EFT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.279",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.258",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.209",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.202",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.153",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.137",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.133",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.122",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/TDK/NLFV32T-101K-EFT?qs=U%2FZX79kHR%2FldD1gsbJC6WA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5e-05
+        },
+        "AvailabilityInStock": "3587",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 15 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "7 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/pcv.pdf",
+        "Description": "Power Inductors - Leaded 100uH UnShld 4.4A 80mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/PCV_2_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "35 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "PCV-2-104-03L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-PCV-2-104-03L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "49"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$6.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$5.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$4.51",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 49,
+            "Price": "$4.26",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 98,
+            "Price": "$3.95",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 294,
+            "Price": "$3.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 539,
+            "Price": "$3.64",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1029,
+            "Price": "$3.51",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/PCV-2-104-03L?qs=ZYnrCdKdyee98Uihcc87SA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0192
+        },
+        "AvailabilityInStock": "7",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "8504500001"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3091 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Coupled Inductors WE-DD SMD Size 7345 100uH 1.029Ohm Strt",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/wurthelectronics/images/744877001_SPL.JPG",
+        "Category": "Coupled Inductors",
+        "LeadTime": "36 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Wurth Elektronik",
+        "ManufacturerPartNumber": "744877101",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "710-744877101",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.53",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$2.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$1.45",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Wurth-Elektronik/744877101?qs=%252B97ACBfLqz9DcktmtuoDuQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.000805
+        },
+        "AvailabilityInStock": "3091",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509010"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "10419 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD WE-PD 100uH 620mA DCR=790mOhms AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/wurthelectronics/images/ITP_710-74477820_t.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "17 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Wurth Elektronik",
+        "ManufacturerPartNumber": "74477820",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "710-74477820",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.51",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$2.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.92",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.48",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Wurth-Elektronik/74477820?qs=u16ybLDytRbv8rOkX2Ni7Q%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.000618
+        },
+        "AvailabilityInStock": "10419",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "585 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/msd1514.pdf",
+        "Description": "Coupled Inductors 100uH Shld 10% 5.15A 126mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/MSD1514_SPL.jpg",
+        "Category": "Coupled Inductors",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSD1514-104KED",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSD1514-104KED",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "175"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.59",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 175,
+            "Price": "$2.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 350,
+            "Price": "$2.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 875,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2450,
+            "Price": "$1.93",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4900,
+            "Price": "$1.83",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSD1514-104KEB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSD1514-104KED?qs=0gpYmj5HUPLkayo5Wr2%2F1A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.18e-05
+        },
+        "AvailabilityInStock": "585",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2425 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/catalog/specsheets/Vishay_ihle-5050fh-5a.pdf",
+        "Description": "Power Inductors - SMD 100uH 20% w/E-Field Shield",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/IHLE5050FHR_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Dale",
+        "ManufacturerPartNumber": "IHLE5050FHER101M51",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "70-IHLE5050FHR101M51",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$4.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$3.12",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.45",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$2.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$2.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.97",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Dale/IHLE5050FHER101M51?qs=CT2LuZh%2F7ENxGbzP8rTeZw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "2425",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 41 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6658 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH 0.45A 20 % 7.3x7.3mm SMD",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tdk/images/b82462.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "EPCOS / TDK",
+        "ManufacturerPartNumber": "B82472G4104M",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "871-B82472G4104M",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.672",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.553",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.552",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.544",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.431",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.403",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.394",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/EPCOS-TDK/B82472G4104M?qs=Gus83tocK7s2lGjeaVCg4Q%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0015
+        },
+        "AvailabilityInStock": "6658",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "266 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/msd1048.pdf",
+        "Description": "Coupled Inductors 100uH Shld 20% 1.2A 387mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/MSD1048_SPL.jpg",
+        "Category": "Coupled Inductors",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSD1048-104MED",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSD1048-104MED",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "800"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.90",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 800,
+            "Price": "$1.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4800,
+            "Price": "$1.03",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSD1048-104MEB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSD1048-104MED?qs=W%252BCsJ1hlA%252BeYaxMSBYmJ8w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "266",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "575 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH 11MHz DCR=6.98Ohms +/-20% AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/XFL2010-series_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "XFL2010-104MEC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-XFL2010-104MEC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.72",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.14",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.994",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.975",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/XFL2010-104MEC?qs=T%252BzbugeAwjhC%2FmItjLxn%252BQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "575",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "467 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/rfc0807.pdf",
+        "Description": "Power Inductors - Leaded 100uH UnShld 10% 1.25A 355mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/RFC0807_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "58 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "RFC0807B-104KE",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-RFC0807B-104KE",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "150"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.861",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.783",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.612",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$0.564",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 600,
+            "Price": "$0.533",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1050,
+            "Price": "$0.486",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2550,
+            "Price": "$0.47",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5100,
+            "Price": "$0.454",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/RFC0807B-104KE?qs=ZYnrCdKdyecdMzG%2Fs7JD%252Bg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0023
+        },
+        "AvailabilityInStock": "467",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "8504500001"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "145 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/do3308p.pdf",
+        "Description": "Power Inductors - SMD 100uH Unshld 20% 0.87A 690mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/DO3308P_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "DO3308P-104MLD",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-DO3308P-104MLD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.71",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.66",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.44",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$1.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.36",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "DO3308P-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/DO3308P-104MLD?qs=ZYnrCdKdyee7Z7coM9Kijg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0006
+        },
+        "AvailabilityInStock": "145",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 500,
+            "Date": "2026-04-16T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6882 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/265/1/CDRH127LD__en_.pdf",
+        "Description": "Power Inductors - SMD 100uH 2.1A",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/sumida/images/CDRH127.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "164 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Sumida",
+        "ManufacturerPartNumber": "CDRH127/LDNP-101MC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "851-CDRH127LDNP101MC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.977",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.789",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.777",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.646",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.601",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.568",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.563",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Sumida/CDRH127-LDNP-101MC?qs=MBofh%252Bwah4wcOUegW5kDiA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "REACH-SVHC": [
+          "Dechlorane plus",
+          "Dechlorane+",
+          "1,6,7,8,9,14,15,16,17,17,18,18-dodecachloropentacyclo[12.2.1.16,9.02,13.05,10]octadeca-7,15-diene (13560-89-9)"
+        ],
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0036
+        },
+        "AvailabilityInStock": "6882",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "206 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - Leaded 100uH 20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/IHTH-1125KZ-5A%203P.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Dale",
+        "ManufacturerPartNumber": "IHTH1125KZEB101M5A",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "70-IHTH1125KZEB101M5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "50"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$9.05",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$7.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$6.92",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$6.70",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$6.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$6.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$6.16",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Dale/IHTH1125KZEB101M5A?qs=%252BW0qg7sgkX%252BOb2eQkaU4ug%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "206",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 41 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "479 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 270mA 2.4 Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/LPS4012_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "LPS4012-104MRC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-LPS4012-104MRC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.12",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.796",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.703",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.691",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.68",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "LPS4012-104MRB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/LPS4012-104MRC?qs=QQJxVsr8EGYzE3Q1Yk1Z0g%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6.4e-05
+        },
+        "AvailabilityInStock": "479",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "500 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/lps4414.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 285mA 1.9 Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/LPS4414_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "LPS4414-104MRC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-LPS4414-104MRC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.847",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.792",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.674",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.652",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.56",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "LPS4414-104MRB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/LPS4414-104MRC?qs=QQJxVsr8EGaKvtK0U7uwkg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 8.9e-05
+        },
+        "AvailabilityInStock": "500",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "8504500001"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "180 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 240mA 2.75 Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/LPS3314_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "42 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "LPS3314-104MRC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-LPS3314-104MRC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.52",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.915",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.892",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.758",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.733",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.707",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "LPS3314-104MRB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/LPS3314-104MRC?qs=QQJxVsr8EGb811e%2FtyWY1A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5.1e-05
+        },
+        "AvailabilityInStock": "180",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "8504500001"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "18494 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/265/1/CDR6D23MN.pdf",
+        "Description": "Power Inductors - SMD 100uH 0.55A 0.723ohm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/sumida/images/CDR6D23MN.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "138 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Sumida",
+        "ManufacturerPartNumber": "CDR6D23MNNP-101NC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "851-CDR6D23MNNP101NC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.97",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.864",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.812",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.699",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.668",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.647",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.613",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1500,
+            "Price": "$0.591",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 3000,
+            "Price": "$0.572",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Sumida/CDR6D23MNNP-101NC?qs=ttApTud31JZEGG5v%2Fc02Jw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0003
+        },
+        "AvailabilityInStock": "18494",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "476 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/dr0608.pdf",
+        "Description": "Power Inductors - Leaded 100uH Unshld 10% 1.3A 380mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/DR0608_series_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "DR0608-104L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-DR0608-104L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "300"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.878",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.806",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.652",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$0.616",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 600,
+            "Price": "$0.528",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1200,
+            "Price": "$0.469",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5100,
+            "Price": "$0.454",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/DR0608-104L?qs=ZYnrCdKdyefdNsWKKNSV6w%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0013
+        },
+        "AvailabilityInStock": "476",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "150 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/lps8045b.pdf",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 780mA 342mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/LPS8045B_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "48 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "LPS8045B-104MRC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-LPS8045B-104MRC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "250"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.92",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.44",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.70",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$1.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.37",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "LPS8045B-104MRB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/LPS8045B-104MRC?qs=W38ilblRkRn%2FNelYYtPZ9Q%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00084
+        },
+        "AvailabilityInStock": "150",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "406 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/pcv.pdf",
+        "Description": "Power Inductors - Leaded 100uH UnShld 10% 5.5A 55mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/PCV_0_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "35 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "PCV-0-104-05L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-PCV-0-104-05L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "98"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$4.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.63",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$3.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$3.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 98,
+            "Price": "$2.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 294,
+            "Price": "$2.53",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 588,
+            "Price": "$2.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1078,
+            "Price": "$2.29",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2548,
+            "Price": "$2.21",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/PCV-0-104-05L?qs=ZYnrCdKdyedkoapwnEL7mA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0213
+        },
+        "AvailabilityInStock": "406",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "60 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/rfb.pdf",
+        "Description": "Power Inductors - Leaded 100uH UnShld 10% 1.3A 400mOhms AECQ2",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/RFB0807_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "RFB0807-101L",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-RFB0807-101L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "150"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.985",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.769",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$0.709",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 600,
+            "Price": "$0.67",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1050,
+            "Price": "$0.611",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2550,
+            "Price": "$0.591",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5100,
+            "Price": "$0.572",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/RFB0807-101L?qs=ZYnrCdKdyedu6A5abBf11g%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00146
+        },
+        "AvailabilityInStock": "60",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "215 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/msd1583.pdf",
+        "Description": "Coupled Inductors 100uH Shld 10% 1.75A 260mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/msd1583.jpg",
+        "Category": "Coupled Inductors",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSD1583-104KED",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSD1583-104KED",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "300"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.57",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$1.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 600,
+            "Price": "$1.84",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 900,
+            "Price": "$1.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2400,
+            "Price": "$1.72",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4800,
+            "Price": "$1.58",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSD1583-104KEB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSD1583-104KED?qs=zCSbvcPd3pbv9OIfWwkrsw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "215",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "639 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 135mA 12.25Ohms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/XFL2006_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "XFL2006-104MEC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-XFL2006-104MEC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.33",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$1.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.98",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.856",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.841",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.827",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "XFL2006-104MEB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/XFL2006-104MEC?qs=zCSbvcPd3pb3RD7ERwzYpg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "639",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "355 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD 100uH Shld 20% 560mA 800mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/MOS6020_series_DSL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "42 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MOS6020-104MLC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MOS6020-104MLC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.72",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.58",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$0.981",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.87",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MOS6020-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MOS6020-104MLC?qs=zCSbvcPd3pbsZyXmUPFLiw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00021
+        },
+        "AvailabilityInStock": "355",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3460 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/pm5022_series.pdf",
+        "Description": "Power Inductors - SMD 100uH 20%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/PM5022_series_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "PM5022-101M-RC",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "542-PM5022-101M-RC",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "250"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.533",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.517",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.436",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.408",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.403",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.402",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/PM5022-101M-RC?qs=7QcrjDbQYDcI%252BDYrjk3%2Fbg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "652-CM322522-R39KL",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0044
+        },
+        "AvailabilityInStock": "3460",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 27 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2007 In Stock",
+        "DataSheetUrl": "",
+        "Description": "RF Inductors - SMD 100uH 5%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/IMC_1210_series_SPL.jpg",
+        "Category": "RF Inductors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Dale",
+        "ManufacturerPartNumber": "IMC1210ER101J",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "70-IMC1210ER101J",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.42",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.857",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.791",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.747",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.681",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.622",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Dale/IMC1210ER101J?qs=gUBhq%2ForQ06aaJB7LjXUSA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 5e-05
+        },
+        "AvailabilityInStock": "2007",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "24 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/msd1278.pdf",
+        "Description": "Coupled Inductors 100uH Shld 20% 1.59A 300mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/msd1278.jpg",
+        "Category": "Coupled Inductors",
+        "LeadTime": "71 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSD1278-104MLD",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSD1278-104MLD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$2.00",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$1.24",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.10",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSD1278-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSD1278-104MLD?qs=zCSbvcPd3paefSQC7WLuMQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0044
+        },
+        "AvailabilityInStock": "24",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 500,
+            "Date": "2026-04-24T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504509090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1963 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/184/1/ACMS_Q3225C.pdf",
+        "Description": "Common Mode Chokes / Filters CMC 100uH 0.15A 2200mOhm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/abracon/images/ACMS-Q3225_SPL.jpg",
+        "Category": "Common Mode Chokes / Filters",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "ABRACON",
+        "ManufacturerPartNumber": "ACMS-Q3225C-101-T",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "815-ACMS-Q3225C-101T",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "2000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.792",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.606",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.605",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.551",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.478",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.475",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/ABRACON/ACMS-Q3225C-101-T?qs=Znm5pLBrcALVQUNva6g6Uw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "1963",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8548000000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "854800000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "311 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Coupled Inductors 100uH Shld 20% 1.5A 322mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/msd1260.jpg",
+        "Category": "Coupled Inductors",
+        "LeadTime": "49 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "MSD1260-104MLD",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-MSD1260-104MLD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.45",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.93",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.31",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2500,
+            "Price": "$1.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.06",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MSD1260-104MLB"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/MSD1260-104MLD?qs=zCSbvcPd3pZE%252BQlO263eDg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0032
+        },
+        "AvailabilityInStock": "311",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "355 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/995/1/rfs1113.pdf",
+        "Description": "Power Inductors - Leaded 100uH Shld 20% 1.55A 200mOhms",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/coilcraft/images/RFS1113_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "59 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Coilcraft",
+        "ManufacturerPartNumber": "RFS1113-104ME",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "994-RFS1113-104ME",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "169"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.94",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.65",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.52",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.14",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 169,
+            "Price": "$1.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 507,
+            "Price": "$1.04",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1014,
+            "Price": "$0.97",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2535,
+            "Price": "$0.938",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5070,
+            "Price": "$0.905",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Coilcraft/RFS1113-104ME?qs=W38ilblRkRmIvTNPDCunCw%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0033
+        },
+        "AvailabilityInStock": "355",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 338,
+            "Date": "2026-04-17T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2926 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/76/1/kmp_2400.pdf",
+        "Description": "Power Inductors - SMD SMD Inductor 100uH 0.52A",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/murata/images/2400_SPL.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "88 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Murata Power Solutions",
+        "ManufacturerPartNumber": "24101C",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "580-24101C",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.58",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1500,
+            "Price": "$0.58",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Murata-Power-Solutions/24101C?qs=5CKLVr1iF0njZfJuE8uwNw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.00043
+        },
+        "AvailabilityInStock": "2926",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 36 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9029 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Power Inductors - SMD WE-PD 100uH 790mA DCR=290mOhms AEC-Q200",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/wurthelectronics/images/ITP_710-74477720_t.jpg",
+        "Category": "Power Inductors - SMD",
+        "LeadTime": "0 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Wurth Elektronik",
+        "ManufacturerPartNumber": "74477720",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "710-74477720",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.37",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$2.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$1.96",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.89",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$1.81",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.66",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Wurth-Elektronik/74477720?qs=u16ybLDytRb05rQCixKVTQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.000793
+        },
+        "AvailabilityInStock": "9029",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 40 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1114 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/184/1/ATCASeries.pdf",
+        "Description": "Power Inductors - Leaded IND 100.00 uH 2.000 A 81.00 mOhm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/abracon/images/atca_01_v_SPL.jpg",
+        "Category": "Power Inductors - Leaded",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "ABRACON",
+        "ManufacturerPartNumber": "ATCA-01-101M-V",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "815-ATCA-01-101M-V",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Tray"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "150"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2550,
+            "Price": "$2.15",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/ABRACON/ATCA-01-101M-V?qs=AvgxZrxb8y1jrboQ6dH3zQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 0.0006
+        },
+        "AvailabilityInStock": "1114",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8504508000"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8504500000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "850450000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8504502090"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8504500090"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8504509199"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85045000"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/mouser/keyword_resistor_10k_0603.json
+++ b/tests/fixtures/mouser/keyword_resistor_10k_0603.json
@@ -1,0 +1,6193 @@
+{
+  "Errors": [],
+  "SearchResults": {
+    "NumberOfResult": 1596,
+    "Parts": [
+      {
+        "Availability": "17964 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-50 1% P5 10K2",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "63 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030C1022FP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030C1022FP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.074",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.041",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.034",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.03",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.026",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.023",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.017",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030C1022FP500?qs=hjSuqQECij%252BwfccFNIpVsA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "17964",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5975 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-25 0.1% AT P5 10K5",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT_MCU_MCS_MCA_series_DSL.JPG",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603MD1052BP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603MD1052BP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.49",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.353",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.247",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.212",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.186",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.17",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.155",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.135",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603MD1052BP500?qs=17u8i%2FzlE883pCG3RQV5%2Fw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "5975",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "20000 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD CRG0603 1% 1M0 10K RL",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tycoelectronics/images/crg0.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "66 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "TE Connectivity / Holsworthy",
+        "ManufacturerPartNumber": "CRG0603F1M0/10",
+        "Min": "10000",
+        "Mult": "10000",
+        "MouserPartNumber": "279-CRG0603F1M0/10",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 10000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.004",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/TE-Connectivity-Holsworthy/CRG0603F1M0-10?qs=s1WWODT2SXVmMRw54xD%2FMg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "20000",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "722 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-50 1% VG01 P1 10K",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/mcs.JPG",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603HC1002FP100",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603HC1002FP1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.81",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.572",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.387",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.369",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.353",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.335",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.333",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.307",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603HC1002FP100?qs=qwSSGa6Vz%252B7PwDjErIH6Jg%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "722",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9228 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-25 0.1% PW 10K",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCS04020D4021BE000_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "77 Days",
+        "LifecycleStatus": "New at Mouser",
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030D1002BPW00",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030D1002BPW",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "20000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.39",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.20",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.118",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.087",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.077",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.064",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.053",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030D1002BPW00?qs=17u8i%2FzlE8%252Ba%2FPOkVIgBOQ%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "9228",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "889 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD PTN0603 25PPM 10K 0.1% S T0 e1",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/PTN_series_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PTN0603E1002BST0",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PTN0603E1002BST0",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "100"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.79",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.378",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 300,
+            "Price": "$0.35",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.326",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.303",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.28",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PTN0603E1002BST0?qs=Mv7BduZupUizTfGgcLJ4nA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "889",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "400 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD 12.5mWatts 10Kohms1% 1% 230 C Op Temp",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/CHPHT_series.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Sfernice",
+        "ManufacturerPartNumber": "CHPHT0603K1002FGT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-CHPHT0603K1002FGT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$12.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$8.19",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$7.91",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$7.53",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$6.62",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$6.11",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Sfernice/CHPHT0603K1002FGT?qs=hcpCFr%252B3G5Pwu6l3MBe29g%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "400",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "19058 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/chp_a.pdf",
+        "Description": "Thick Film Resistors - SMD ResHighPowerA 0603 100k 1% 1/3W TC100",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CHP_series_DSL_t.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CHP0603AFX-1003ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CHP0603AFX1003EL",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.125",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.109",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.099",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.093",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.086",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.073",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.063",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CHP0603AFX-1003ELF?qs=BJlw7L4Cy79KOrxkyd9dmw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "19058",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8388 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD 150mW 10kohm 0.1% 25PPM 0603",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/PAT_Series_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PAT0603E1002BST1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PAT0603E1002BST1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.65",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.475",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.449",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.419",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.399",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.361",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.349",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.34",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PAT0603E1002BST1?qs=Bakm8ERcljqvBn%2FqxsRhBQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "8388",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "897 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-50 1% VG01 P5 10K",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603HC1002FP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603HC1002FP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.331",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.231",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.199",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.175",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.159",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.125",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.124",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603HC1002FP500?qs=17u8i%2FzlE8%2Fy4riIF6%2FJNA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "897",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 5000,
+            "Date": "2026-03-10T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1312 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .1watt 10.7Kohms .1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "63 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030D1072BP100",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030D1072BP1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.61",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.432",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.299",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.267",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.241",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.233",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.22",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030D1072BP100?qs=hjSuqQECij9XfVHOmNFy6w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "1312",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "997 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD 150mW 10Kohms .1% 25ppm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/p-ns.JPG",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PNM0603E1002BST1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PNM0603E1002BST1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$2.40",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.74",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.46",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$1.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$1.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$1.02",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PNM0603E1002BST1?qs=GmxlWZd7RPKLOZBCHoq5GA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "997",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "28 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD P 0603 E 1002 B N TR e2",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/P-series_SPL.JPG",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Sfernice",
+        "ManufacturerPartNumber": "P0603E1002BNT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "72-P0603E1002BNT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Waffle"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$7.94",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$6.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$5.97",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$5.54",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$4.78",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$4.65",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Sfernice/P0603E1002BNT?qs=uSBwRNbpOOKLTkjZiY1mRA%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "28",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 100,
+            "Date": "2026-06-26T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "4283 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD 25ppm 10Kohms .1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/PTN_series_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PTN0603E1002BBTF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PTN0603E1002BBTF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.56",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.411",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.389",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.36",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.341",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.328",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.305",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.286",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.284",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PTN0603E1002BBTF?qs=q3SJ8jb5d6YkLl%252BVOSlXIg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "REACH-SVHC": [
+          "Lead (7439-92-1)"
+        ],
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "4283",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "20000 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD RMC 0603 1/10W 0.5% T/R-5000",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/royalohm/images/Gen_Purpose_Thick_film_DSL.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Royalohm",
+        "ManufacturerPartNumber": "0603WAD1002T5E",
+        "Min": "5000",
+        "Mult": "5000",
+        "MouserPartNumber": "303-0603WAD1002T5E",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 5000,
+            "Price": "$0.004",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.003",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Royalohm/0603WAD1002T5E?qs=e8oIoAS2J1SIj9xt36q40A%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "20000",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "27500 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD RMC 0603 1/10W 5% T/R-10000",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "Royalohm",
+        "ManufacturerPartNumber": "0603WAJ0103TCE",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "303-0603WAJ0103TCE",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.007",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.004",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.003",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.002",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.001",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Royalohm/0603WAJ0103TCE?qs=jcD%2FCkGBYeOF%252BjMul0vyoA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "27500",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 100000,
+            "Date": "2026-03-06T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6898 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/5925/1/1.pdf",
+        "Description": "Thick Film Resistors - SMD RMC 0603 1/10W-S 1% S/B-5000",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "Royalohm",
+        "ManufacturerPartNumber": "0603SAF1002P5E",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "303-0603SAF1002P5E",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.22",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.041",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.021",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.014",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.012",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.008",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.007",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.006",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Royalohm/0603SAF1002P5E?qs=jcD%2FCkGBYeNKcbtPL7aaQw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "6898",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "20000 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD RMC 0603 1/16W 1% T/R-5000",
+        "FactoryStock": "0",
+        "ImagePath": null,
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Royalohm",
+        "ManufacturerPartNumber": "0603WGF1002T5E",
+        "Min": "5000",
+        "Mult": "5000",
+        "MouserPartNumber": "303-0603WGF1002T5E",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 5000,
+            "Price": "$0.001",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Royalohm/0603WGF1002T5E?qs=By6Nw2ByBD2xMz1psGTSig%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "20000",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 100000,
+            "Date": "2026-04-10T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 16 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3933 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-05 0.1% AT P5 10K",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCx_series_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603MG1002BP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603MG1002BP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.48",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.23",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$1.08",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$1.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.956",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.912",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.886",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.852",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603MG1002BP500?qs=Y0Uzf4wQF3kTztUxcSxY1w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "3933",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "4211 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-10 0.1% P5 10K",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030F1002BP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030F1002BP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.687",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.535",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.451",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.425",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.373",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.37",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030F1002BP500?qs=ipmmcVavBGcvVRYYh5jc9g%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "4211",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "21059 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/catalog/specsheets/Bourns_08052024_CRT-A_Datasheet.pdf",
+        "Description": "Thin Film Resistors - SMD ResThinFilm 0603 10kR 0.5% 100mW TC25",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT-ST_DSL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": "New Product",
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603ADY-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603ADY-1002E",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.035",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.034",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.028",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.027",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.023",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603ADY-1002ELF?qs=IKkN%2F947nfCsFm5FPHOU%252Bw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "AvailabilityInStock": "21059",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "61689 In Stock",
+        "DataSheetUrl": "",
+        "Description": "NTC Thermistors 10Kohms 1% SMD",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/NTCSxxxxE3.JPG",
+        "Category": "NTC Thermistors",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / BC Components",
+        "ManufacturerPartNumber": "NTCS0603E3103FLT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-NTCS0603E3103FLT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.61",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.575",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.531",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$0.512",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.454",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.445",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.407",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.338",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-BC-Components/NTCS0603E3103FLT?qs=%2FWiulJ9oly66lfIcr%252B1Bpw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.2e-06
+        },
+        "AvailabilityInStock": "61689",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533408070"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853340000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533409000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533401000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533409102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85334011"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "28505 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-50 1% PW 10K",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "77 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030C1002FPW00",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030C1002FPW",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "20000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.024",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.023",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.021",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.017",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.016",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 20000,
+            "Price": "$0.015",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030C1002FPW00?qs=hjSuqQECij96RPJROgBN0Q%3D%3D",
+        "Reeling": false,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "28505",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "29024 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/cr_a_as.pdf",
+        "Description": "Thick Film Resistors - SMD ResA-AS 0603 10k 1% 100mW TC100",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRxxxxA-AS_series_t.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CR0603AFX-1002EAS",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CR0603AFX1002EAS",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.016",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.013",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.011",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.009",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.004",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CR0603AFX-1002EAS?qs=PzGy0jfpSMvnIWl2FjD7DQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "29024",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "113382 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .1W 10Kohms 1% 0603 50ppm Auto",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "77 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030C1002FP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030C1002FP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.024",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.023",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.021",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.016",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.015",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.014",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030C1002FP500?qs=Wvg1umJc15zoHgIjwqoGHw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "113382",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "37377 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/80/9/ENG_CD_1622886_BA.pdf",
+        "Description": "Thick Film Resistors - SMD CRG0603 1% 22K 10K RL",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tycoelectronics/images/crg0.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "66 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "TE Connectivity / Holsworthy",
+        "ManufacturerPartNumber": "CRG0603F22K/10",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "279-CRG0603F22K/10",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "10000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.016",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.013",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.011",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.01",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.007",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.003",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/TE-Connectivity-Holsworthy/CRG0603F22K-10?qs=9ylKvqdyudmQ1ZF2LQQoZA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "37377",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "6202 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .1W 10Kohms .1% 0603 15ppm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030E1002BP100",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030E1002BP1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.60",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.427",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.384",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.366",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.341",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.327",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.316",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.275",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MCT06030E1002BP500"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030E1002BP100?qs=hjSuqQECij8a4wyJBhoGbA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "6202",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "28506 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/CRT.pdf",
+        "Description": "Thin Film Resistors - SMD CHIP RESISTOR Precision",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603-FY-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603FY1002ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.056",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.039",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.032",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.028",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.024",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.021",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.02",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603-FY-1002ELF?qs=oyIm%2F3giSj4uSkUsV8azlw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "28506",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "723 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD 150mW 10kOHM 0.05% 0603 5PPM",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/plt.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "112 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PLT0603Z1002AST5",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PLT0603Z1002AST5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "500"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$3.79",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$3.28",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$3.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$2.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$2.72",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$2.44",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PLT0603Z1002AST5?qs=oBjDkOCjPF3IytMPQai%2F5g%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "723",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 500,
+            "Date": "2026-03-16T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "64649 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/CRT.pdf",
+        "Description": "Thin Film Resistors - SMD CHIP RESISTOR Precision",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603-FZ-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603FZ1002ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.038",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.024",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.02",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.018",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.015",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.013",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603-FZ-1002ELF?qs=oyIm%2F3giSj6U5mW%252Br09LDQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "64649",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "19580 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/CRT.pdf",
+        "Description": "Thin Film Resistors - SMD 1/10watts 10K .1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603-BY-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603BY1002ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.066",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.059",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.049",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.045",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.043",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603-BY-1002ELF?qs=LKPZbmhlTxgzUffbGyQsfg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "19580",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 25000,
+            "Date": "2026-05-08T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "769858 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/cr.pdf",
+        "Description": "Thick Film Resistors - SMD 10K 1% 1/10W",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/chpreztr.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CR0603-FX-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CR0603FX-1002ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.011",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.009",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.007",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.006",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.002",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CR0603-FX-1002ELF?qs=K5ddiUFZPT6XHG0dQH96QA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "769858",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 800000,
+            "Date": "2026-05-20T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8574 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/CRT.pdf",
+        "Description": "Thin Film Resistors - SMD CHIP RESISTOR Precision",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603-FX-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603FX1002ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.15",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.113",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.111",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.103",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.09",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.087",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.071",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.06",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603-FX-1002ELF?qs=9fn1gpisni7scx1VGwVssQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "8574",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "35964 In Stock",
+        "DataSheetUrl": "",
+        "Description": "NTC Thermistors 10Kohms 1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/NTCSxxxxE3.JPG",
+        "Category": "NTC Thermistors",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / BC Components",
+        "ManufacturerPartNumber": "NTCS0603E3103FMT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-NTCS0603E3103FMT",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.61",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.575",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.538",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 50,
+            "Price": "$0.512",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.474",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.414",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.382",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.333",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-BC-Components/NTCS0603E3103FMT?qs=%2FWiulJ9oly7Ouwyz2sB2aA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.2e-06
+        },
+        "AvailabilityInStock": "35964",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533408070"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533401000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853340000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533409000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533409102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85334011"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "5066 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/crt_as.pdf",
+        "Description": "Thin Film Resistors - SMD 10K OHMS 0.1% 0603 Anti-Sulfur",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CRT_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CRT0603-BY-1002EAS",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CRT0603BY1002EAS",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.108",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.101",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.089",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.081",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.072",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.07",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.053",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CRT0603-BY-1002EAS?qs=EvbCu83THBCh1lt9vIhMzA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.83e-06
+        },
+        "AvailabilityInStock": "5066",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3084 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .375watt 10Kohm .1% 25PPM",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/PHP_series.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PHP00603E1002BST1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PHP00603E1002BST1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$1.41",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$1.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.977",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.842",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.829",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.818",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.781",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 2000,
+            "Price": "$0.737",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.733",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PHP00603E1002BST1?qs=gtRTXsew4b93R3AaiVx9Kw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "3084",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "10765 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/chp_a.pdf",
+        "Description": "Thick Film Resistors - SMD 10K   OHM   1% 1/3W",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CHP_series_DSL_t.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CHP0603AFX-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CHP0603AFX1002EL",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.34",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.133",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.101",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.093",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.086",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.073",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.063",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CHP0603AFX-1002ELF?qs=BJlw7L4Cy7%252Bn%2FM7sjC7LSA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "10765",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9814 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/catalog/specsheets/Bourns_CMP_Datasheet_05.28.20.pdf",
+        "Description": "Thick Film Resistors - SMD 10K   OHM   1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CMP_CMP-A_series_t.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CMP0603-FX-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CMP0603-FX-1002L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.053",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.041",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.036",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.033",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.022",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.021",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.019",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CMP0603-FX-1002ELF?qs=TiOZkKH1s2RjiDXhjsUTgw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "9814",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 5000,
+            "Date": "2026-05-27T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "8383 In Stock",
+        "DataSheetUrl": "",
+        "Description": "NTC Thermistors 10K OHM 10%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/NTCSxxxxE3.JPG",
+        "Category": "NTC Thermistors",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / BC Components",
+        "ManufacturerPartNumber": "NTCS0603E3103HMT",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-2381-615-36103",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.38",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.362",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.316",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.299",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.274",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.262",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.253",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.237",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.206",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-BC-Components/NTCS0603E3103HMT?qs=T%2FnZg7%2FCwxOGMrQuHMfIyA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.2e-06
+        },
+        "AvailabilityInStock": "8383",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533408070"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853340000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533409000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533401000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533409102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85334011"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "2535 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .15watt 10Kohm .1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/patt.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "91 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Thin Film",
+        "ManufacturerPartNumber": "PATT0603E1002BGT1",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-PATT0603E1002BGT1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.82",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.682",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.599",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.567",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.555",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.55",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.467",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Thin-Film/PATT0603E1002BGT1?qs=zxTme0yW%2FbZOYzveCP7Tjg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "2535",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "7869 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD MCT 0603-25 0.1% P5 10K2",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030D1022BP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030D1022BP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.11",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.079",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.074",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.069",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.065",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.062",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.061",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.051",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030D1022BP500?qs=wTZ%2FFzl837a7xmYDePLgqQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "7869",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "1728 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .032W 10Kohm 0.1% 0603 25ppm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "77 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT06030D1002BP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT06030D1002BP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.13",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.099",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.094",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.087",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.082",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.075",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.059",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.057",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.053",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MCT06030D1002BP100"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT06030D1002BP500?qs=ncxkyCpAYDAJSzgYSRSsnA%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "1728",
+        "AvailabilityOnOrder": [
+          {
+            "Quantity": 25000,
+            "Date": "2026-12-14T00:00:00"
+          }
+        ],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "258403 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/cr.pdf",
+        "Description": "Thick Film Resistors - SMD 10.7K 1% 1/10W",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/chpreztr.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CR0603-FX-1072ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CR0603FX-1072ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.009",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.006",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CR0603-FX-1072ELF?qs=e7cxVwPieurQbFfS6uM%252BCQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "258403",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "345487 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/cr.pdf",
+        "Description": "Thick Film Resistors - SMD 10.5K 1% 1/10W",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/chpreztr.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CR0603-FX-1052ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CR0603FX-1052ELF",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.019",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.009",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.006",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.005",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CR0603-FX-1052ELF?qs=e7cxVwPieuqJRhSHkc5uMQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "345487",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "3662 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .125W 10Kohms 0.1% 0603 SMD 25ppm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603MD1002BP100",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603MD1002BP1",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "1000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.47",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.343",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.324",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.302",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.287",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.268",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.259",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.244",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": [
+          {
+            "APMfrPN": "MCT0603MD1002BP500"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603MD1002BP100?qs=oBjDkOCjPF3pqK8R7NBaMQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "3662",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "31710 In Stock",
+        "DataSheetUrl": "",
+        "Description": "NTC Thermistors 0603 10K 3% B 4000 55/125/56",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/tdk/images/B57371V_DSL.jpg",
+        "Category": "NTC Thermistors",
+        "LeadTime": "84 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "EPCOS / TDK",
+        "ManufacturerPartNumber": "B57321V2103H60",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "871-B57321V2103H60",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "4000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.32",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.276",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25,
+            "Price": "$0.244",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.195",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.146",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.136",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 4000,
+            "Price": "$0.115",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 8000,
+            "Price": "$0.104",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 24000,
+            "Price": "$0.098",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/EPCOS-TDK/B57321V2103H60?qs=jkF2ZuEVxWCYB2UAz9%252B1hQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 6e-06
+        },
+        "AvailabilityInStock": "31710",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533408070"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533400000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853340000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533409000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533401000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533409102"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85334011"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "9073 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .250W 10Kohms .5% 0603 25ppm Hi Power",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603PD1002DP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603PD1002DP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.16",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.118",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.111",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.103",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.098",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.093",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.088",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.083",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.081",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603PD1002DP500?qs=5aG0NVq1C4wm%252BTUxfCiPtw%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 1.9e-06
+        },
+        "AvailabilityInStock": "9073",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "26886 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thick Film Resistors - SMD .1watt 4.99kohms 1% 0603 100ppm",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/20047-pt-medium.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Draloric",
+        "ManufacturerPartNumber": "RCG06034K99FKEA",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "71-RCG06034K99FKEA",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.14",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.043",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.036",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.029",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.026",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.023",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.016",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.014",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 25000,
+            "Price": "$0.013",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Draloric/RCG06034K99FKEA?qs=vOeJqewp7jAUzEhm8V8GiQ%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "26886",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 10 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "25169 In Stock",
+        "DataSheetUrl": "https://www.mouser.com/datasheet/3/40/1/cmp_a.pdf",
+        "Description": "Thick Film Resistors - SMD 10K   OHM   1%",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/bourns/images/CMP_CMP-A_series_t.jpg",
+        "Category": "Thick Film Resistors - SMD",
+        "LeadTime": "98 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Bourns",
+        "ManufacturerPartNumber": "CMP0603AFX-1002ELF",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "652-CMP0603AFX-1002L",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.21",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.072",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.06",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 250,
+            "Price": "$0.052",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 500,
+            "Price": "$0.047",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 1000,
+            "Price": "$0.043",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.031",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10000,
+            "Price": "$0.029",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Bourns/CMP0603AFX-1002ELF?qs=TiOZkKH1s2Q14lKL9rbzLg%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "25169",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": null,
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      },
+      {
+        "Availability": "13237 In Stock",
+        "DataSheetUrl": "",
+        "Description": "Thin Film Resistors - SMD .15W 10Kohms 1% 0603 50ppm Auto",
+        "FactoryStock": "0",
+        "ImagePath": "https://www.mouser.com/images/vishay/images/MCT0603_series_SPL.jpg",
+        "Category": "Thin Film Resistors - SMD",
+        "LeadTime": "70 Days",
+        "LifecycleStatus": null,
+        "Manufacturer": "Vishay / Beyschlag",
+        "ManufacturerPartNumber": "MCT0603MC1002FP500",
+        "Min": "1",
+        "Mult": "1",
+        "MouserPartNumber": "594-MCT0603MC1002FP5",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Reel"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "Cut Tape"
+          },
+          {
+            "AttributeName": "Packaging",
+            "AttributeValue": "MouseReel",
+            "AttributeCost": "$7.00 MouseReel\u2122 fee will be added and calculated in your shopping cart. All MouseReel\u2122 orders are non-cancellable and non-returnable."
+          },
+          {
+            "AttributeName": "Standard Pack Qty",
+            "AttributeValue": "5000"
+          }
+        ],
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.10",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 10,
+            "Price": "$0.037",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 100,
+            "Price": "$0.036",
+            "Currency": "USD"
+          },
+          {
+            "Quantity": 5000,
+            "Price": "$0.036",
+            "Currency": "USD"
+          }
+        ],
+        "AlternatePackagings": null,
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Vishay-Beyschlag/MCT0603MC1002FP500?qs=OMDV80DKjRoKmiwn8yr64w%3D%3D",
+        "Reeling": true,
+        "ROHSStatus": "RoHS Compliant By Exemption",
+        "SuggestedReplacement": "",
+        "MultiSimBlue": 0,
+        "UnitWeightKg": {
+          "UnitWeight": 2e-06
+        },
+        "AvailabilityInStock": "13237",
+        "AvailabilityOnOrder": [],
+        "InfoMessages": [],
+        "SurchargeMessages": [
+          {
+            "code": "TARIFF_US",
+            "message": "A tariff of 14 % may be applied."
+          }
+        ],
+        "ProductCompliance": [
+          {
+            "ComplianceName": "USHTS",
+            "ComplianceValue": "8533210030"
+          },
+          {
+            "ComplianceName": "CNHTS",
+            "ComplianceValue": "8533211000"
+          },
+          {
+            "ComplianceName": "CAHTS",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "JPHTS",
+            "ComplianceValue": "853321000"
+          },
+          {
+            "ComplianceName": "KRHTS",
+            "ComplianceValue": "8533219000"
+          },
+          {
+            "ComplianceName": "TARIC",
+            "ComplianceValue": "8533210000"
+          },
+          {
+            "ComplianceName": "MXHTS",
+            "ComplianceValue": "8533210100"
+          },
+          {
+            "ComplianceName": "BRHTS",
+            "ComplianceValue": "85332120"
+          },
+          {
+            "ComplianceName": "ECCN",
+            "ComplianceValue": "EAR99"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/services/search/test_mouser_contract.py
+++ b/tests/services/search/test_mouser_contract.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from conftest import load_mouser_fixture
+from jbom.services.search.mouser_provider import MouserProvider
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "keyword_resistor_10k_0603",
+        "keyword_capacitor_1uf_0805",
+        "keyword_inductor_100uh",
+        "keyword_connector_header",
+        "empty_results",
+        "error_response",
+    ],
+)
+def test_mouser_contract_fixtures_parse_to_search_results(fixture_name: str) -> None:
+    data = load_mouser_fixture(fixture_name)
+    provider = MouserProvider(api_key="dummy")
+
+    results = provider._parse_results(data)
+
+    assert isinstance(results, list)
+
+    for result in results:
+        assert result.manufacturer
+        assert result.mpn
+        assert result.distributor_part_number
+
+        assert isinstance(result.stock_quantity, int)
+        assert result.stock_quantity >= 0
+
+        assert isinstance(result.attributes, dict)
+
+
+@pytest.mark.parametrize("fixture_name", ["empty_results", "error_response"])
+def test_mouser_contract_empty_and_error_fixtures_return_empty_list(
+    fixture_name: str,
+) -> None:
+    data = load_mouser_fixture(fixture_name)
+    provider = MouserProvider(api_key="dummy")
+
+    assert provider._parse_results(data) == []

--- a/tests/services/search/test_mouser_integration.py
+++ b/tests/services/search/test_mouser_integration.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import functools
+import os
+
+import pytest
+
+from jbom.services.search.mouser_provider import MouserProvider
+from jbom.services.search.models import SearchResult
+
+
+MOUSER_API_KEY = os.environ.get("MOUSER_API_KEY")
+
+
+@functools.lru_cache(maxsize=1)
+def _live_keyword_search_results() -> list[SearchResult]:
+    provider = MouserProvider()
+    return provider.search("10K resistor 0603", limit=3)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not MOUSER_API_KEY, reason="MOUSER_API_KEY not set")
+class TestMouserIntegration:
+    def test_live_keyword_search_returns_results(self) -> None:
+        results = _live_keyword_search_results()
+        assert results
+
+    def test_live_search_result_has_required_fields(self) -> None:
+        results = _live_keyword_search_results()
+        first = results[0]
+
+        assert first.manufacturer
+        assert first.mpn
+        assert first.distributor_part_number
+
+        assert isinstance(first.stock_quantity, int)
+        assert first.stock_quantity >= 0
+
+        assert isinstance(first.attributes, dict)


### PR DESCRIPTION
Closes #79

Summary
- Added fixture directory `tests/fixtures/mouser/` with recorded Mouser keyword-search responses (plus empty/error fixtures).
- Added `scripts/record_mouser_fixture.py` to record raw Mouser JSON responses using `MOUSER_API_KEY`.
- Added `load_mouser_fixture()` helper in `tests/conftest.py`.
- Added offline contract tests for `MouserProvider._parse_results()` against the committed fixtures.
- Added live integration test skeleton (marked `integration`) that is skipped unless `MOUSER_API_KEY` is set.
- Updated `docs/CHANGELOG.md` with an Unreleased entry.

How to (re)record fixtures
- `python scripts/record_mouser_fixture.py --query '10K resistor 0603' --output tests/fixtures/mouser/keyword_resistor_10k_0603.json`

Verification
- `python -m pytest tests/`
- `env -u MOUSER_API_KEY python -m pytest tests/services/search/test_mouser_integration.py` (confirms integration tests auto-skip without a key)
- `python -m behave --format progress`

Notes
- No domain logic / CLI behavior changes; this is test/fixture infrastructure only.