### PR TITLE
Search: disk cache w/ TTL + Mouser retry/backoff + cache flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - Mouser search fixtures and offline contract/integration test scaffolding.
+- Persistent disk-backed search cache (default, 24h TTL) with `--no-cache` and `--clear-cache` flags.
+
+### Changed
+- Mouser provider now supports configurable timeout + retry/backoff for transient failures.
 
 ## [7.0.0] - 2026-02-27
 

--- a/src/jbom/cli/inventory_search.py
+++ b/src/jbom/cli/inventory_search.py
@@ -183,7 +183,7 @@ def handle_inventory_search(
 
 def _build_cache(args: argparse.Namespace) -> SearchCache:
     if getattr(args, "clear_cache", False):
-        DiskSearchCache(args.provider).clear()
+        DiskSearchCache.clear_provider(args.provider)
 
     if getattr(args, "no_cache", False):
         return InMemorySearchCache()

--- a/src/jbom/cli/inventory_search.py
+++ b/src/jbom/cli/inventory_search.py
@@ -17,7 +17,7 @@ from jbom.cli.output import (
     resolve_output_destination,
 )
 from jbom.services.inventory_reader import InventoryReader
-from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.inventory_search_service import InventorySearchService
 from jbom.services.search.mouser_provider import MouserProvider
 
@@ -68,6 +68,18 @@ def register_command(subparsers) -> None:
     )
 
     parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable persistent disk cache for this run",
+    )
+
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear persistent cache entries for this provider before running",
+    )
+
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Validate input and compute searchable items without performing API calls",
@@ -81,7 +93,9 @@ def register_command(subparsers) -> None:
     parser.set_defaults(handler=handle_inventory_search)
 
 
-def handle_inventory_search(args: argparse.Namespace) -> int:
+def handle_inventory_search(
+    args: argparse.Namespace, *, _cache: SearchCache | None = None
+) -> int:
     try:
         inventory_path = Path(args.inventory_file)
         if not inventory_path.exists():
@@ -103,7 +117,7 @@ def handle_inventory_search(args: argparse.Namespace) -> int:
             _print_dry_run_summary(searchable)
             return 0
 
-        cache = InMemorySearchCache()
+        cache = _cache if _cache is not None else _build_cache(args)
         provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
         service = InventorySearchService(
             provider,
@@ -167,7 +181,19 @@ def handle_inventory_search(args: argparse.Namespace) -> int:
         return 1
 
 
-def _create_provider(provider_id: str, *, api_key: str | None, cache) -> MouserProvider:
+def _build_cache(args: argparse.Namespace) -> SearchCache:
+    if getattr(args, "clear_cache", False):
+        DiskSearchCache(args.provider).clear()
+
+    if getattr(args, "no_cache", False):
+        return InMemorySearchCache()
+
+    return DiskSearchCache(args.provider)
+
+
+def _create_provider(
+    provider_id: str, *, api_key: str | None, cache: SearchCache
+) -> MouserProvider:
     pid = (provider_id or "").strip().lower()
     if pid == "mouser":
         return MouserProvider(api_key=api_key, cache=cache)

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -16,7 +16,7 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
-from jbom.services.search.cache import InMemorySearchCache, SearchCache
+from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.filtering import (
     SearchFilter,
     SearchSorter,
@@ -57,6 +57,18 @@ def register_command(subparsers) -> None:
     parser.add_argument("--api-key", help="API key (overrides env vars)")
 
     parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable persistent disk cache for this run",
+    )
+
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear persistent cache entries for this provider before running",
+    )
+
+    parser.add_argument(
         "--all",
         action="store_true",
         help="Disable default filters (show out-of-stock/obsolete results)",
@@ -78,10 +90,12 @@ def register_command(subparsers) -> None:
     parser.set_defaults(handler=handle_search)
 
 
-def handle_search(args: argparse.Namespace) -> int:
+def handle_search(
+    args: argparse.Namespace, *, _cache: SearchCache | None = None
+) -> int:
     """Handle `jbom search` command."""
 
-    cache = InMemorySearchCache()
+    cache = _cache if _cache is not None else _build_cache(args)
 
     try:
         provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
@@ -111,6 +125,16 @@ def handle_search(args: argparse.Namespace) -> int:
 
     force = bool(getattr(args, "force", False))
     return _output_results(results, output=args.output, force=force)
+
+
+def _build_cache(args: argparse.Namespace) -> SearchCache:
+    if getattr(args, "clear_cache", False):
+        DiskSearchCache(args.provider).clear()
+
+    if getattr(args, "no_cache", False):
+        return InMemorySearchCache()
+
+    return DiskSearchCache(args.provider)
 
 
 def _create_provider(

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -129,7 +129,7 @@ def handle_search(
 
 def _build_cache(args: argparse.Namespace) -> SearchCache:
     if getattr(args, "clear_cache", False):
-        DiskSearchCache(args.provider).clear()
+        DiskSearchCache.clear_provider(args.provider)
 
     if getattr(args, "no_cache", False):
         return InMemorySearchCache()

--- a/src/jbom/config/suppliers.py
+++ b/src/jbom/config/suppliers.py
@@ -36,6 +36,8 @@ class SupplierConfig:
     part_number_example: Optional[str] = None
 
     # Search behavior tuning (optional).
+    # TTL can be expressed in either seconds or hours.
+    search_cache_ttl_seconds: Optional[float] = None
     search_cache_ttl_hours: Optional[float] = None
     search_timeout_seconds: Optional[float] = None
     search_max_retries: Optional[int] = None
@@ -101,6 +103,14 @@ class SupplierConfig:
         cache_cfg = search_cfg.get("cache") or {}
         if not isinstance(cache_cfg, dict):
             raise ValueError(f"Supplier '{sid}' search.cache must be a mapping")
+
+        cache_ttl_seconds = cache_cfg.get("ttl_seconds")
+        if cache_ttl_seconds is not None and not isinstance(
+            cache_ttl_seconds, (int, float)
+        ):
+            raise ValueError(
+                f"Supplier '{sid}' search.cache.ttl_seconds must be a number or null"
+            )
 
         cache_ttl_hours = cache_cfg.get("ttl_hours")
         if cache_ttl_hours is not None and not isinstance(
@@ -169,6 +179,9 @@ class SupplierConfig:
             search_url_template=search_url_template,
             part_number_pattern=pattern,
             part_number_example=example,
+            search_cache_ttl_seconds=(
+                float(cache_ttl_seconds) if cache_ttl_seconds is not None else None
+            ),
             search_cache_ttl_hours=(
                 float(cache_ttl_hours) if cache_ttl_hours is not None else None
             ),

--- a/src/jbom/config/suppliers.py
+++ b/src/jbom/config/suppliers.py
@@ -35,6 +35,12 @@ class SupplierConfig:
     part_number_pattern: Optional[str] = None
     part_number_example: Optional[str] = None
 
+    # Search behavior tuning (optional).
+    search_cache_ttl_hours: Optional[float] = None
+    search_timeout_seconds: Optional[float] = None
+    search_max_retries: Optional[int] = None
+    search_retry_delay_seconds: Optional[float] = None
+
     @staticmethod
     def from_yaml_dict(data: Dict[str, Any], *, default_id: str) -> "SupplierConfig":
         """Parse a SupplierConfig from a YAML dict.
@@ -87,6 +93,49 @@ class SupplierConfig:
         if url_template is not None and not isinstance(url_template, str):
             raise ValueError(f"Supplier '{sid}' url_template must be a string or null")
 
+        # Optional search behavior tuning.
+        search_cfg = data.get("search") or {}
+        if not isinstance(search_cfg, dict):
+            raise ValueError(f"Supplier '{sid}' search must be a mapping")
+
+        cache_cfg = search_cfg.get("cache") or {}
+        if not isinstance(cache_cfg, dict):
+            raise ValueError(f"Supplier '{sid}' search.cache must be a mapping")
+
+        cache_ttl_hours = cache_cfg.get("ttl_hours")
+        if cache_ttl_hours is not None and not isinstance(
+            cache_ttl_hours, (int, float)
+        ):
+            raise ValueError(
+                f"Supplier '{sid}' search.cache.ttl_hours must be a number or null"
+            )
+
+        api_cfg = search_cfg.get("api") or {}
+        if not isinstance(api_cfg, dict):
+            raise ValueError(f"Supplier '{sid}' search.api must be a mapping")
+
+        timeout_seconds = api_cfg.get("timeout_seconds")
+        if timeout_seconds is not None and not isinstance(
+            timeout_seconds, (int, float)
+        ):
+            raise ValueError(
+                f"Supplier '{sid}' search.api.timeout_seconds must be a number or null"
+            )
+
+        max_retries = api_cfg.get("max_retries")
+        if max_retries is not None and not isinstance(max_retries, int):
+            raise ValueError(
+                f"Supplier '{sid}' search.api.max_retries must be an int or null"
+            )
+
+        retry_delay_seconds = api_cfg.get("retry_delay_seconds")
+        if retry_delay_seconds is not None and not isinstance(
+            retry_delay_seconds, (int, float)
+        ):
+            raise ValueError(
+                f"Supplier '{sid}' search.api.retry_delay_seconds must be a number or null"
+            )
+
         search_url_template = data.get("search_url_template")
         if search_url_template is not None and not isinstance(search_url_template, str):
             raise ValueError(
@@ -120,6 +169,16 @@ class SupplierConfig:
             search_url_template=search_url_template,
             part_number_pattern=pattern,
             part_number_example=example,
+            search_cache_ttl_hours=(
+                float(cache_ttl_hours) if cache_ttl_hours is not None else None
+            ),
+            search_timeout_seconds=(
+                float(timeout_seconds) if timeout_seconds is not None else None
+            ),
+            search_max_retries=(int(max_retries) if max_retries is not None else None),
+            search_retry_delay_seconds=(
+                float(retry_delay_seconds) if retry_delay_seconds is not None else None
+            ),
         )
 
 

--- a/src/jbom/config/suppliers.py
+++ b/src/jbom/config/suppliers.py
@@ -36,8 +36,6 @@ class SupplierConfig:
     part_number_example: Optional[str] = None
 
     # Search behavior tuning (optional).
-    # TTL can be expressed in either seconds or hours.
-    search_cache_ttl_seconds: Optional[float] = None
     search_cache_ttl_hours: Optional[float] = None
     search_timeout_seconds: Optional[float] = None
     search_max_retries: Optional[int] = None
@@ -103,14 +101,6 @@ class SupplierConfig:
         cache_cfg = search_cfg.get("cache") or {}
         if not isinstance(cache_cfg, dict):
             raise ValueError(f"Supplier '{sid}' search.cache must be a mapping")
-
-        cache_ttl_seconds = cache_cfg.get("ttl_seconds")
-        if cache_ttl_seconds is not None and not isinstance(
-            cache_ttl_seconds, (int, float)
-        ):
-            raise ValueError(
-                f"Supplier '{sid}' search.cache.ttl_seconds must be a number or null"
-            )
 
         cache_ttl_hours = cache_cfg.get("ttl_hours")
         if cache_ttl_hours is not None and not isinstance(
@@ -179,9 +169,6 @@ class SupplierConfig:
             search_url_template=search_url_template,
             part_number_pattern=pattern,
             part_number_example=example,
-            search_cache_ttl_seconds=(
-                float(cache_ttl_seconds) if cache_ttl_seconds is not None else None
-            ),
             search_cache_ttl_hours=(
                 float(cache_ttl_hours) if cache_ttl_hours is not None else None
             ),

--- a/src/jbom/config/suppliers/digikey.supplier.yaml
+++ b/src/jbom/config/suppliers/digikey.supplier.yaml
@@ -8,3 +8,7 @@ inventory_column: "DigiKey"
 url_template: null
 search_url_template: "https://www.digikey.com/en/products?keywords={query}"
 part_number: {}
+
+search:
+  cache:
+    ttl_seconds: 10

--- a/src/jbom/config/suppliers/digikey.supplier.yaml
+++ b/src/jbom/config/suppliers/digikey.supplier.yaml
@@ -11,4 +11,4 @@ part_number: {}
 
 search:
   cache:
-    ttl_seconds: 10
+    ttl_hours: 24

--- a/src/jbom/config/suppliers/generic.supplier.yaml
+++ b/src/jbom/config/suppliers/generic.supplier.yaml
@@ -6,3 +6,7 @@ inventory_column: "Supplier"
 url_template: null
 search_url_template: null
 part_number: {}
+
+search:
+  cache:
+    ttl_seconds: 10

--- a/src/jbom/config/suppliers/generic.supplier.yaml
+++ b/src/jbom/config/suppliers/generic.supplier.yaml
@@ -9,4 +9,4 @@ part_number: {}
 
 search:
   cache:
-    ttl_seconds: 10
+    ttl_hours: 24

--- a/src/jbom/config/suppliers/lcsc.supplier.yaml
+++ b/src/jbom/config/suppliers/lcsc.supplier.yaml
@@ -11,4 +11,4 @@ search_url_template: "https://www.lcsc.com/search?q={query}"
 
 search:
   cache:
-    ttl_seconds: 10
+    ttl_hours: 24

--- a/src/jbom/config/suppliers/lcsc.supplier.yaml
+++ b/src/jbom/config/suppliers/lcsc.supplier.yaml
@@ -8,3 +8,7 @@ part_number:
   example: "C25231"
 url_template: "https://www.lcsc.com/product-detail/{pn}.html"
 search_url_template: "https://www.lcsc.com/search?q={query}"
+
+search:
+  cache:
+    ttl_seconds: 10

--- a/src/jbom/config/suppliers/mouser.supplier.yaml
+++ b/src/jbom/config/suppliers/mouser.supplier.yaml
@@ -8,3 +8,11 @@ part_number:
   example: "595-TPS62133DQCR"
 url_template: "https://www.mouser.com/ProductDetail/{pn}"
 search_url_template: "https://www.mouser.com/c/?q={query}"
+
+search:
+  cache:
+    ttl_hours: 24
+  api:
+    timeout_seconds: 10.0
+    max_retries: 3
+    retry_delay_seconds: 1.0

--- a/src/jbom/services/search/cache.py
+++ b/src/jbom/services/search/cache.py
@@ -1,14 +1,19 @@
 """Search caching helpers.
 
 Phase 6 constraint: keep web API usage low (rate limits / bandwidth). For now we
-use in-memory caching, but the interface is designed so we can later add a
-persistent user-level cache.
+use in-memory caching, but we also support an optional persistent disk cache.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import shutil
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional, Protocol
 
 from jbom.services.search.models import SearchResult
 
@@ -59,7 +64,158 @@ class InMemorySearchCache:
         self._data[key] = list(value)
 
 
+def _serialize_search_result(result: SearchResult) -> dict[str, Any]:
+    return {
+        "manufacturer": result.manufacturer,
+        "mpn": result.mpn,
+        "description": result.description,
+        "datasheet": result.datasheet,
+        "distributor": result.distributor,
+        "distributor_part_number": result.distributor_part_number,
+        "availability": result.availability,
+        "price": result.price,
+        "details_url": result.details_url,
+        "raw_data": result.raw_data,
+        "lifecycle_status": result.lifecycle_status,
+        "min_order_qty": result.min_order_qty,
+        "category": result.category,
+        "attributes": dict(result.attributes or {}),
+        "stock_quantity": result.stock_quantity,
+    }
+
+
+def _deserialize_search_result(data: dict[str, Any]) -> SearchResult:
+    return SearchResult(
+        manufacturer=str(data.get("manufacturer", "")),
+        mpn=str(data.get("mpn", "")),
+        description=str(data.get("description", "")),
+        datasheet=str(data.get("datasheet", "")),
+        distributor=str(data.get("distributor", "")),
+        distributor_part_number=str(data.get("distributor_part_number", "")),
+        availability=str(data.get("availability", "")),
+        price=str(data.get("price", "")),
+        details_url=str(data.get("details_url", "")),
+        raw_data=dict(data.get("raw_data", {}) or {}),
+        lifecycle_status=str(data.get("lifecycle_status", "Unknown")),
+        min_order_qty=int(data.get("min_order_qty", 1) or 1),
+        category=str(data.get("category", "")),
+        attributes=dict(data.get("attributes", {}) or {}),
+        stock_quantity=int(data.get("stock_quantity", 0) or 0),
+    )
+
+
+def _parse_iso8601_timestamp(text: str) -> datetime:
+    """Parse an ISO8601 timestamp.
+
+    Supports the common trailing 'Z' suffix.
+    """
+
+    t = (text or "").strip()
+    if t.endswith("Z"):
+        t = t[:-1] + "+00:00"
+
+    dt = datetime.fromisoformat(t)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+class DiskSearchCache:
+    """Persistent per-provider search cache.
+
+    Stores one JSON file per cache key at `~/.cache/jbom/search/{provider_id}/`.
+    """
+
+    def __init__(
+        self,
+        provider_id: str,
+        *,
+        ttl: timedelta | None = None,
+        cache_root: Path | None = None,
+    ) -> None:
+        self._provider_id = (provider_id or "").strip().lower()
+        self._ttl = ttl if ttl is not None else timedelta(hours=24)
+
+        root = cache_root if cache_root is not None else Path("~/.cache/jbom/search")
+        self._root = Path(root).expanduser()
+        self._provider_dir = self._root / self._provider_id
+
+    @property
+    def provider_id(self) -> str:
+        return self._provider_id
+
+    def clear(self) -> None:
+        """Delete all cached entries for this provider."""
+
+        if self._provider_dir.exists():
+            shutil.rmtree(self._provider_dir)
+
+    def _key_filename(self, key: SearchCacheKey) -> str:
+        token = f"{key.provider_id}{key.query}{key.limit}"
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        return f"{digest}.json"
+
+    def _path_for_key(self, key: SearchCacheKey) -> Path:
+        return self._provider_dir / self._key_filename(key)
+
+    def get(self, key: SearchCacheKey) -> Optional[list[SearchResult]]:
+        path = self._path_for_key(key)
+        if not path.exists():
+            return None
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            expires_at = _parse_iso8601_timestamp(str(payload.get("expires_at", "")))
+        except Exception:
+            # Corrupt cache entry — delete and treat as miss.
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            return None
+
+        now = datetime.now(timezone.utc)
+        if expires_at <= now:
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            return None
+
+        results = payload.get("results", [])
+        if not isinstance(results, list):
+            return None
+
+        out: list[SearchResult] = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            out.append(_deserialize_search_result(r))
+
+        return out
+
+    def set(self, key: SearchCacheKey, value: list[SearchResult]) -> None:
+        self._provider_dir.mkdir(parents=True, exist_ok=True)
+
+        expires_at = datetime.now(timezone.utc) + self._ttl
+        payload = {
+            "key": {
+                "provider_id": key.provider_id,
+                "query": key.query,
+                "limit": key.limit,
+            },
+            "results": [_serialize_search_result(r) for r in value],
+            "expires_at": expires_at.isoformat(),
+        }
+
+        path = self._path_for_key(key)
+        tmp_path = Path(str(path) + ".tmp")
+        tmp_path.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp_path, path)
+
+
 __all__ = [
+    "DiskSearchCache",
     "InMemorySearchCache",
     "SearchCache",
     "SearchCacheKey",

--- a/src/jbom/services/search/cache.py
+++ b/src/jbom/services/search/cache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import shutil
 from dataclasses import dataclass
@@ -17,6 +18,8 @@ from typing import Any, Optional, Protocol
 
 from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.models import SearchResult
+
+logger = logging.getLogger(__name__)
 
 
 def normalize_query(query: str) -> str:
@@ -141,11 +144,28 @@ class DiskSearchCache:
             ttl_hours = (
                 supplier.search_cache_ttl_hours if supplier is not None else None
             )
+
             if ttl_hours is None:
-                raise ValueError(
-                    "DiskSearchCache requires a ttl, or supplier profile must define search.cache.ttl_hours"
+                logger.warning(
+                    "Supplier profile '%s' missing search.cache.ttl_hours; defaulting DiskSearchCache TTL to 10s",
+                    self._provider_id,
                 )
-            ttl = timedelta(hours=float(ttl_hours))
+                ttl = timedelta(seconds=10)
+            else:
+                try:
+                    ttl_hours_f = float(ttl_hours)
+                except (TypeError, ValueError):
+                    ttl_hours_f = 0.0
+
+                if ttl_hours_f <= 0:
+                    logger.warning(
+                        "Supplier profile '%s' has invalid search.cache.ttl_hours=%r; defaulting DiskSearchCache TTL to 10s",
+                        self._provider_id,
+                        ttl_hours,
+                    )
+                    ttl = timedelta(seconds=10)
+                else:
+                    ttl = timedelta(hours=ttl_hours_f)
 
         self._ttl = ttl
 

--- a/src/jbom/services/search/cache.py
+++ b/src/jbom/services/search/cache.py
@@ -141,34 +141,16 @@ class DiskSearchCache:
 
         if ttl is None:
             supplier = resolve_supplier_by_id(self._provider_id)
-            ttl_seconds = (
-                supplier.search_cache_ttl_seconds if supplier is not None else None
-            )
             ttl_hours = (
                 supplier.search_cache_ttl_hours if supplier is not None else None
             )
 
-            if ttl_seconds is None and ttl_hours is None:
+            if ttl_hours is None:
                 logger.warning(
-                    "Supplier profile '%s' missing search.cache.ttl_seconds/ttl_hours; defaulting DiskSearchCache TTL to 10s",
+                    "Supplier profile '%s' missing search.cache.ttl_hours; defaulting DiskSearchCache TTL to 24h",
                     self._provider_id,
                 )
-                ttl = timedelta(seconds=10)
-            elif ttl_seconds is not None:
-                try:
-                    ttl_seconds_f = float(ttl_seconds)
-                except (TypeError, ValueError):
-                    ttl_seconds_f = 0.0
-
-                if ttl_seconds_f <= 0:
-                    logger.warning(
-                        "Supplier profile '%s' has invalid search.cache.ttl_seconds=%r; defaulting DiskSearchCache TTL to 10s",
-                        self._provider_id,
-                        ttl_seconds,
-                    )
-                    ttl = timedelta(seconds=10)
-                else:
-                    ttl = timedelta(seconds=ttl_seconds_f)
+                ttl = timedelta(hours=24)
             else:
                 try:
                     ttl_hours_f = float(ttl_hours)
@@ -177,11 +159,11 @@ class DiskSearchCache:
 
                 if ttl_hours_f <= 0:
                     logger.warning(
-                        "Supplier profile '%s' has invalid search.cache.ttl_hours=%r; defaulting DiskSearchCache TTL to 10s",
+                        "Supplier profile '%s' has invalid search.cache.ttl_hours=%r; defaulting DiskSearchCache TTL to 24h",
                         self._provider_id,
                         ttl_hours,
                     )
-                    ttl = timedelta(seconds=10)
+                    ttl = timedelta(hours=24)
                 else:
                     ttl = timedelta(hours=ttl_hours_f)
 

--- a/src/jbom/services/search/cache.py
+++ b/src/jbom/services/search/cache.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional, Protocol
 
+from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.models import SearchResult
 
 
@@ -134,7 +135,19 @@ class DiskSearchCache:
         cache_root: Path | None = None,
     ) -> None:
         self._provider_id = (provider_id or "").strip().lower()
-        self._ttl = ttl if ttl is not None else timedelta(hours=24)
+
+        if ttl is None:
+            supplier = resolve_supplier_by_id(self._provider_id)
+            ttl_hours = (
+                supplier.search_cache_ttl_hours if supplier is not None else None
+            )
+            if ttl_hours is None:
+                raise ValueError(
+                    "DiskSearchCache requires a ttl, or supplier profile must define search.cache.ttl_hours"
+                )
+            ttl = timedelta(hours=float(ttl_hours))
+
+        self._ttl = ttl
 
         root = cache_root if cache_root is not None else Path("~/.cache/jbom/search")
         self._root = Path(root).expanduser()
@@ -144,11 +157,21 @@ class DiskSearchCache:
     def provider_id(self) -> str:
         return self._provider_id
 
+    @staticmethod
+    def clear_provider(provider_id: str, *, cache_root: Path | None = None) -> None:
+        """Delete all cached entries for provider_id."""
+
+        pid = (provider_id or "").strip().lower()
+        root = cache_root if cache_root is not None else Path("~/.cache/jbom/search")
+        provider_dir = Path(root).expanduser() / pid
+
+        if provider_dir.exists():
+            shutil.rmtree(provider_dir)
+
     def clear(self) -> None:
         """Delete all cached entries for this provider."""
 
-        if self._provider_dir.exists():
-            shutil.rmtree(self._provider_dir)
+        DiskSearchCache.clear_provider(self._provider_id, cache_root=self._root)
 
     def _key_filename(self, key: SearchCacheKey) -> str:
         token = f"{key.provider_id}{key.query}{key.limit}"

--- a/src/jbom/services/search/cache.py
+++ b/src/jbom/services/search/cache.py
@@ -141,16 +141,34 @@ class DiskSearchCache:
 
         if ttl is None:
             supplier = resolve_supplier_by_id(self._provider_id)
+            ttl_seconds = (
+                supplier.search_cache_ttl_seconds if supplier is not None else None
+            )
             ttl_hours = (
                 supplier.search_cache_ttl_hours if supplier is not None else None
             )
 
-            if ttl_hours is None:
+            if ttl_seconds is None and ttl_hours is None:
                 logger.warning(
-                    "Supplier profile '%s' missing search.cache.ttl_hours; defaulting DiskSearchCache TTL to 10s",
+                    "Supplier profile '%s' missing search.cache.ttl_seconds/ttl_hours; defaulting DiskSearchCache TTL to 10s",
                     self._provider_id,
                 )
                 ttl = timedelta(seconds=10)
+            elif ttl_seconds is not None:
+                try:
+                    ttl_seconds_f = float(ttl_seconds)
+                except (TypeError, ValueError):
+                    ttl_seconds_f = 0.0
+
+                if ttl_seconds_f <= 0:
+                    logger.warning(
+                        "Supplier profile '%s' has invalid search.cache.ttl_seconds=%r; defaulting DiskSearchCache TTL to 10s",
+                        self._provider_id,
+                        ttl_seconds,
+                    )
+                    ttl = timedelta(seconds=10)
+                else:
+                    ttl = timedelta(seconds=ttl_seconds_f)
             else:
                 try:
                     ttl_hours_f = float(ttl_hours)

--- a/src/jbom/services/search/mouser_provider.py
+++ b/src/jbom/services/search/mouser_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Any, Optional
 
 from jbom.services.search.cache import SearchCache, SearchCacheKey
@@ -24,13 +25,22 @@ class MouserProvider(SearchProvider):
     BASE_URL = "https://api.mouser.com/api/v1/search"
 
     def __init__(
-        self, *, api_key: Optional[str] = None, cache: Optional[SearchCache] = None
-    ):
+        self,
+        *,
+        api_key: Optional[str] = None,
+        cache: Optional[SearchCache] = None,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> None:
         """Create a provider.
 
         Args:
             api_key: Mouser API key. Defaults to MOUSER_API_KEY environment variable.
             cache: Optional cache used to reduce repeated API calls.
+            timeout: Request timeout in seconds.
+            max_retries: Max retry attempts for transient failures (connection/5xx).
+            retry_delay: Initial delay (seconds) before retry; uses exponential backoff.
 
         Raises:
             ValueError: When api_key is not provided and MOUSER_API_KEY is not set.
@@ -43,6 +53,9 @@ class MouserProvider(SearchProvider):
             )
 
         self._cache = cache
+        self._timeout = max(0.0, float(timeout))
+        self._max_retries = max(0, int(max_retries))
+        self._retry_delay = max(0.0, float(retry_delay))
 
     @property
     def provider_id(self) -> str:
@@ -81,21 +94,92 @@ class MouserProvider(SearchProvider):
             }
         }
 
-        try:
-            response = requests.post(
-                url,
-                params={"apiKey": self._api_key},
-                json=payload,
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
-                timeout=10,
-            )
-            response.raise_for_status()
-            data = response.json()
-        except Exception as exc:
-            logger.error("Mouser API request failed: %s", exc)
+        req_excs = getattr(requests, "exceptions", None)
+        request_exc_type: type[BaseException] | tuple[
+            type[BaseException], ...
+        ] = Exception
+        if req_excs is not None:
+            candidate = getattr(req_excs, "RequestException", None)
+            if isinstance(candidate, type):
+                request_exc_type = candidate
+            elif isinstance(candidate, tuple) and all(
+                isinstance(t, type) for t in candidate
+            ):
+                request_exc_type = candidate
+
+        data: dict[str, Any] | None = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = requests.post(
+                    url,
+                    params={"apiKey": self._api_key},
+                    json=payload,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                    },
+                    timeout=self._timeout,
+                )
+
+                status_raw = getattr(response, "status_code", 200)
+                try:
+                    status = int(status_raw)  # type: ignore[arg-type]
+                except Exception:
+                    status = 200
+                if 400 <= status < 500:
+                    logger.error(
+                        "Mouser API request failed (client error %s): %s",
+                        status,
+                        response.text,
+                    )
+                    return []
+
+                if status >= 500:
+                    raise RuntimeError(f"Mouser API server error {status}")
+
+                response.raise_for_status()
+                data = response.json()
+                break
+
+            except Exception as exc:
+                status = 0
+                exc_resp = getattr(exc, "response", None)
+                if exc_resp is not None:
+                    status_raw = getattr(exc_resp, "status_code", 0)
+                    try:
+                        status = int(status_raw)  # type: ignore[arg-type]
+                    except Exception:
+                        status = 0
+
+                if 400 <= status < 500:
+                    logger.error(
+                        "Mouser API request failed (client error %s): %s", status, exc
+                    )
+                    return []
+
+                retryable = False
+                if status >= 500:
+                    retryable = True
+                elif isinstance(exc, request_exc_type):
+                    # Connection/timeout/etc.
+                    retryable = True
+
+                if not retryable or attempt >= self._max_retries:
+                    logger.error("Mouser API request failed: %s", exc)
+                    return []
+
+                delay = self._retry_delay * (2**attempt)
+                logger.debug(
+                    "Mouser API request failed; retrying %s/%s in %.2fs: %s",
+                    attempt + 1,
+                    self._max_retries,
+                    delay,
+                    exc,
+                )
+                time.sleep(delay)
+
+        if data is None:
             return []
 
         # Mouser embeds error strings inside the JSON body.

--- a/src/jbom/services/search/mouser_provider.py
+++ b/src/jbom/services/search/mouser_provider.py
@@ -127,19 +127,6 @@ class MouserProvider(SearchProvider):
             }
         }
 
-        req_excs = getattr(requests, "exceptions", None)
-        request_exc_type: type[BaseException] | tuple[
-            type[BaseException], ...
-        ] = Exception
-        if req_excs is not None:
-            candidate = getattr(req_excs, "RequestException", None)
-            if isinstance(candidate, type):
-                request_exc_type = candidate
-            elif isinstance(candidate, tuple) and all(
-                isinstance(t, type) for t in candidate
-            ):
-                request_exc_type = candidate
-
         data: dict[str, Any] | None = None
 
         for attempt in range(self._max_retries + 1):
@@ -154,51 +141,8 @@ class MouserProvider(SearchProvider):
                     },
                     timeout=self._timeout,
                 )
-
-                status_raw = getattr(response, "status_code", 200)
-                try:
-                    status = int(status_raw)  # type: ignore[arg-type]
-                except Exception:
-                    status = 200
-                if 400 <= status < 500:
-                    logger.error(
-                        "Mouser API request failed (client error %s): %s",
-                        status,
-                        response.text,
-                    )
-                    return []
-
-                if status >= 500:
-                    raise RuntimeError(f"Mouser API server error {status}")
-
-                response.raise_for_status()
-                data = response.json()
-                break
-
             except Exception as exc:
-                status = 0
-                exc_resp = getattr(exc, "response", None)
-                if exc_resp is not None:
-                    status_raw = getattr(exc_resp, "status_code", 0)
-                    try:
-                        status = int(status_raw)  # type: ignore[arg-type]
-                    except Exception:
-                        status = 0
-
-                if 400 <= status < 500:
-                    logger.error(
-                        "Mouser API request failed (client error %s): %s", status, exc
-                    )
-                    return []
-
-                retryable = False
-                if status >= 500:
-                    retryable = True
-                elif isinstance(exc, request_exc_type):
-                    # Connection/timeout/etc.
-                    retryable = True
-
-                if not retryable or attempt >= self._max_retries:
+                if attempt >= self._max_retries:
                     logger.error("Mouser API request failed: %s", exc)
                     return []
 
@@ -211,6 +155,50 @@ class MouserProvider(SearchProvider):
                     exc,
                 )
                 time.sleep(delay)
+                continue
+
+            status_raw = getattr(response, "status_code", 200)
+            try:
+                status = int(status_raw)  # type: ignore[arg-type]
+            except Exception:
+                status = 200
+
+            if 400 <= status < 500:
+                logger.error(
+                    "Mouser API request failed (client error %s): %s",
+                    status,
+                    response.text,
+                )
+                return []
+
+            if status >= 500:
+                if attempt >= self._max_retries:
+                    logger.error(
+                        "Mouser API request failed (server error %s): %s",
+                        status,
+                        response.text,
+                    )
+                    return []
+
+                delay = self._retry_delay * (2**attempt)
+                logger.debug(
+                    "Mouser API request failed (server error %s); retrying %s/%s in %.2fs",
+                    status,
+                    attempt + 1,
+                    self._max_retries,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+
+            try:
+                response.raise_for_status()
+                data = response.json()
+                break
+            except Exception as exc:
+                # Non-retryable at this point.
+                logger.error("Mouser API request failed: %s", exc)
+                return []
 
         if data is None:
             return []

--- a/src/jbom/services/search/mouser_provider.py
+++ b/src/jbom/services/search/mouser_provider.py
@@ -66,10 +66,25 @@ class MouserProvider(SearchProvider):
                 supplier.search_retry_delay_seconds if supplier is not None else None
             )
 
-        if timeout is None or max_retries is None or retry_delay is None:
-            raise ValueError(
-                "Mouser search settings must be configured via supplier profile 'mouser.supplier.yaml' (search.api.*)"
+        # Keep behavior robust if the supplier profile is incomplete.
+        if timeout is None:
+            logger.warning(
+                "Supplier profile '%s' missing search.api.timeout_seconds; defaulting to 10s",
+                self.provider_id,
             )
+            timeout = 10.0
+        if max_retries is None:
+            logger.warning(
+                "Supplier profile '%s' missing search.api.max_retries; defaulting to 3",
+                self.provider_id,
+            )
+            max_retries = 3
+        if retry_delay is None:
+            logger.warning(
+                "Supplier profile '%s' missing search.api.retry_delay_seconds; defaulting to 1s",
+                self.provider_id,
+            )
+            retry_delay = 1.0
 
         self._timeout = max(0.0, float(timeout))
         self._max_retries = max(0, int(max_retries))

--- a/src/jbom/services/search/mouser_provider.py
+++ b/src/jbom/services/search/mouser_provider.py
@@ -7,6 +7,7 @@ import os
 import time
 from typing import Any, Optional
 
+from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import SearchCache, SearchCacheKey
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
@@ -29,18 +30,18 @@ class MouserProvider(SearchProvider):
         *,
         api_key: Optional[str] = None,
         cache: Optional[SearchCache] = None,
-        timeout: float = 10.0,
-        max_retries: int = 3,
-        retry_delay: float = 1.0,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        retry_delay: float | None = None,
     ) -> None:
         """Create a provider.
 
         Args:
             api_key: Mouser API key. Defaults to MOUSER_API_KEY environment variable.
             cache: Optional cache used to reduce repeated API calls.
-            timeout: Request timeout in seconds.
-            max_retries: Max retry attempts for transient failures (connection/5xx).
-            retry_delay: Initial delay (seconds) before retry; uses exponential backoff.
+            timeout: Request timeout in seconds (defaults to supplier profile).
+            max_retries: Max retry attempts for transient failures (defaults to supplier profile).
+            retry_delay: Initial delay (seconds) before retry; uses exponential backoff (defaults to supplier profile).
 
         Raises:
             ValueError: When api_key is not provided and MOUSER_API_KEY is not set.
@@ -53,6 +54,23 @@ class MouserProvider(SearchProvider):
             )
 
         self._cache = cache
+
+        supplier = resolve_supplier_by_id(self.provider_id)
+
+        if timeout is None:
+            timeout = supplier.search_timeout_seconds if supplier is not None else None
+        if max_retries is None:
+            max_retries = supplier.search_max_retries if supplier is not None else None
+        if retry_delay is None:
+            retry_delay = (
+                supplier.search_retry_delay_seconds if supplier is not None else None
+            )
+
+        if timeout is None or max_retries is None or retry_delay is None:
+            raise ValueError(
+                "Mouser search settings must be configured via supplier profile 'mouser.supplier.yaml' (search.api.*)"
+            )
+
         self._timeout = max(0.0, float(timeout))
         self._max_retries = max(0, int(max_retries))
         self._retry_delay = max(0.0, float(retry_delay))

--- a/tests/services/search/test_disk_cache.py
+++ b/tests/services/search/test_disk_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from jbom.config.suppliers import SupplierConfig
 from jbom.services.search.cache import DiskSearchCache, SearchCacheKey
 from jbom.services.search.models import SearchResult
 from jbom.services.search.mouser_provider import MouserProvider
@@ -69,6 +70,30 @@ def test_disk_cache_clear_removes_provider_dir(tmp_path) -> None:
 
     cache.clear()
     assert not provider_dir.exists()
+
+
+def test_disk_cache_missing_profile_ttl_falls_back_to_10s(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    from jbom.services.search import cache as cache_mod
+
+    supplier = SupplierConfig(
+        id="mouser",
+        name="Mouser",
+        inventory_column="Mouser",
+        # Missing TTL entries on purpose.
+        search_cache_ttl_seconds=None,
+        search_cache_ttl_hours=None,
+    )
+
+    monkeypatch.setattr(cache_mod, "resolve_supplier_by_id", lambda _sid: supplier)
+
+    cache = DiskSearchCache("mouser", cache_root=tmp_path)
+    assert cache._ttl == timedelta(seconds=10)
+
+    assert any(
+        "defaulting DiskSearchCache TTL to 10s" in rec.message for rec in caplog.records
+    )
 
 
 class _FakeResponse:

--- a/tests/services/search/test_disk_cache.py
+++ b/tests/services/search/test_disk_cache.py
@@ -72,7 +72,7 @@ def test_disk_cache_clear_removes_provider_dir(tmp_path) -> None:
     assert not provider_dir.exists()
 
 
-def test_disk_cache_missing_profile_ttl_falls_back_to_10s(
+def test_disk_cache_missing_profile_ttl_falls_back_to_24h(
     tmp_path, monkeypatch, caplog
 ) -> None:
     from jbom.services.search import cache as cache_mod
@@ -82,17 +82,16 @@ def test_disk_cache_missing_profile_ttl_falls_back_to_10s(
         name="Mouser",
         inventory_column="Mouser",
         # Missing TTL entries on purpose.
-        search_cache_ttl_seconds=None,
         search_cache_ttl_hours=None,
     )
 
     monkeypatch.setattr(cache_mod, "resolve_supplier_by_id", lambda _sid: supplier)
 
     cache = DiskSearchCache("mouser", cache_root=tmp_path)
-    assert cache._ttl == timedelta(seconds=10)
+    assert cache._ttl == timedelta(hours=24)
 
     assert any(
-        "defaulting DiskSearchCache TTL to 10s" in rec.message for rec in caplog.records
+        "defaulting DiskSearchCache TTL to 24h" in rec.message for rec in caplog.records
     )
 
 

--- a/tests/services/search/test_disk_cache.py
+++ b/tests/services/search/test_disk_cache.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from jbom.services.search.cache import DiskSearchCache, SearchCacheKey
+from jbom.services.search.models import SearchResult
+from jbom.services.search.mouser_provider import MouserProvider
+
+
+def _sr(**kw) -> SearchResult:
+    base = dict(
+        manufacturer="Yageo",
+        mpn="RC0603FR-0710KL",
+        description="RES 10K",
+        datasheet="http://example",
+        distributor="mouser",
+        distributor_part_number="123-ABC",
+        availability="6,609 In Stock",
+        price="$0.10",
+        details_url="http://detail",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        category="Resistors",
+        attributes={"Resistance": "10 kOhms"},
+        stock_quantity=6609,
+    )
+    base.update(kw)
+    return SearchResult(**base)
+
+
+def test_disk_cache_round_trip(tmp_path) -> None:
+    cache = DiskSearchCache("mouser", cache_root=tmp_path, ttl=timedelta(hours=1))
+    key = SearchCacheKey.create(provider_id="mouser", query="10k 0603", limit=3)
+
+    value = [_sr()]
+    cache.set(key, value)
+
+    # No temp file should remain after atomic replace.
+    provider_dir = tmp_path / "mouser"
+    assert provider_dir.exists()
+    assert not any(p.name.endswith(".tmp") for p in provider_dir.iterdir())
+
+    got = cache.get(key)
+    assert got == value
+
+
+def test_disk_cache_expiry_deletes_entry(tmp_path) -> None:
+    cache = DiskSearchCache("mouser", cache_root=tmp_path, ttl=timedelta(seconds=-1))
+    key = SearchCacheKey.create(provider_id="mouser", query="10k 0603", limit=3)
+
+    cache.set(key, [_sr()])
+
+    # Immediately expired.
+    assert cache.get(key) is None
+
+    provider_dir = tmp_path / "mouser"
+    assert provider_dir.exists()
+    assert list(provider_dir.iterdir()) == []
+
+
+def test_disk_cache_clear_removes_provider_dir(tmp_path) -> None:
+    cache = DiskSearchCache("mouser", cache_root=tmp_path, ttl=timedelta(hours=1))
+    key = SearchCacheKey.create(provider_id="mouser", query="10k 0603", limit=3)
+
+    cache.set(key, [_sr()])
+    provider_dir = tmp_path / "mouser"
+    assert provider_dir.exists()
+
+    cache.clear()
+    assert not provider_dir.exists()
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.text = "OK"
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {"SearchResults": {"Parts": []}}
+
+
+def test_mouser_provider_uses_disk_cache_across_instances(
+    tmp_path, monkeypatch
+) -> None:
+    from jbom.services.search import mouser_provider
+
+    calls = {"count": 0}
+
+    def _fake_post(*_args, **_kwargs):
+        calls["count"] += 1
+        return _FakeResponse()
+
+    monkeypatch.setattr(mouser_provider.requests, "post", _fake_post)
+    monkeypatch.setattr(
+        MouserProvider,
+        "_parse_results",
+        lambda _self, _data: [_sr()],
+    )
+
+    cache1 = DiskSearchCache("mouser", cache_root=tmp_path, ttl=timedelta(hours=1))
+    provider1 = MouserProvider(api_key="dummy", cache=cache1, max_retries=0)
+    got1 = provider1.search("10k 0603", limit=1)
+    assert calls["count"] == 1
+    assert got1
+
+    # New provider instance, same disk cache root -> should be a cache hit.
+    cache2 = DiskSearchCache("mouser", cache_root=tmp_path, ttl=timedelta(hours=1))
+    provider2 = MouserProvider(api_key="dummy", cache=cache2, max_retries=0)
+    got2 = provider2.search("10k 0603", limit=1)
+
+    assert got2 == got1
+    assert calls["count"] == 1

--- a/tests/services/search/test_inventory_search_cli_cache_flags.py
+++ b/tests/services/search/test_inventory_search_cli_cache_flags.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+
+from jbom.cli.inventory_search import _build_cache as _build_inventory_cache
+from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache
+
+
+def test_inventory_build_cache_no_cache_flag_returns_inmemory() -> None:
+    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=False)
+    cache = _build_inventory_cache(args)
+    assert isinstance(cache, InMemorySearchCache)
+
+
+def test_inventory_build_cache_clear_cache_flag_calls_clear_provider(
+    monkeypatch,
+) -> None:
+    calls: dict[str, str] = {}
+
+    def _clear_provider(provider_id: str, *, cache_root=None) -> None:
+        calls["provider_id"] = provider_id
+
+    monkeypatch.setattr(
+        DiskSearchCache, "clear_provider", staticmethod(_clear_provider)
+    )
+
+    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=True)
+    cache = _build_inventory_cache(args)
+    assert isinstance(cache, InMemorySearchCache)
+    assert calls["provider_id"] == "mouser"

--- a/tests/services/search/test_mouser_provider.py
+++ b/tests/services/search/test_mouser_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from jbom.config.suppliers import SupplierConfig
 from jbom.services.search.cache import InMemorySearchCache
 from jbom.services.search.mouser_provider import MouserProvider
 
@@ -87,3 +88,35 @@ def test_mouser_provider_uses_cache(monkeypatch):
     provider.search("abc", limit=10)
 
     assert post.call_count == 1
+
+
+def test_mouser_provider_defaults_retry_settings_when_profile_missing(
+    monkeypatch, caplog
+):
+    cache = InMemorySearchCache()
+    monkeypatch.setenv("MOUSER_API_KEY", "dummy")
+
+    import jbom.services.search.mouser_provider as mp
+
+    # Simulate a supplier profile that exists but doesn't specify search.api.*.
+    supplier = SupplierConfig(
+        id="mouser",
+        name="Mouser",
+        inventory_column="Mouser",
+        search_cache_ttl_hours=24,
+    )
+    monkeypatch.setattr(mp, "resolve_supplier_by_id", lambda _sid: supplier)
+
+    provider = MouserProvider(cache=cache)
+
+    assert provider._timeout == 10.0
+    assert provider._max_retries == 3
+    assert provider._retry_delay == 1.0
+
+    assert any(
+        "missing search.api.timeout_seconds" in r.message for r in caplog.records
+    )
+    assert any("missing search.api.max_retries" in r.message for r in caplog.records)
+    assert any(
+        "missing search.api.retry_delay_seconds" in r.message for r in caplog.records
+    )

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 
+from jbom.cli.search import _build_cache as _build_search_cache
 from jbom.cli.search import handle_search
-from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache
 from jbom.services.search.models import SearchResult
 
 
@@ -27,6 +28,28 @@ def _sr(**kw) -> SearchResult:
     )
     base.update(kw)
     return SearchResult(**base)
+
+
+def test_build_cache_no_cache_flag_returns_inmemory(monkeypatch) -> None:
+    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=False)
+    cache = _build_search_cache(args)
+    assert isinstance(cache, InMemorySearchCache)
+
+
+def test_build_cache_clear_cache_flag_calls_clear_provider(monkeypatch) -> None:
+    calls: dict[str, str] = {}
+
+    def _clear_provider(provider_id: str, *, cache_root=None) -> None:
+        calls["provider_id"] = provider_id
+
+    monkeypatch.setattr(
+        DiskSearchCache, "clear_provider", staticmethod(_clear_provider)
+    )
+
+    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=True)
+    cache = _build_search_cache(args)
+    assert isinstance(cache, InMemorySearchCache)
+    assert calls["provider_id"] == "mouser"
 
 
 def test_search_console_output(monkeypatch, capsys):

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 from jbom.cli.search import handle_search
+from jbom.services.search.cache import InMemorySearchCache
 from jbom.services.search.models import SearchResult
 
 
@@ -48,7 +49,7 @@ def test_search_console_output(monkeypatch, capsys):
         output="console",
     )
 
-    rc = handle_search(args)
+    rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     out = capsys.readouterr().out
@@ -75,7 +76,7 @@ def test_search_csv_stdout(monkeypatch, capsys):
         output="-",
     )
 
-    rc = handle_search(args)
+    rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     out = capsys.readouterr().out.splitlines()
@@ -104,7 +105,7 @@ def test_search_csv_file(monkeypatch, tmp_path):
         output=str(outpath),
     )
 
-    rc = handle_search(args)
+    rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     text = outpath.read_text(encoding="utf-8")

--- a/tests/unit/test_supplier_config_schema.py
+++ b/tests/unit/test_supplier_config_schema.py
@@ -36,8 +36,7 @@ def test_load_supplier_lcsc() -> None:
     assert lcsc.search_url_template
     assert lcsc.part_number_pattern
 
-    # Search cache TTL defaults are expressed in seconds for readability.
-    assert lcsc.search_cache_ttl_seconds == 10
+    assert lcsc.search_cache_ttl_hours == 24
 
 
 def test_load_unknown_supplier_raises() -> None:

--- a/tests/unit/test_supplier_config_schema.py
+++ b/tests/unit/test_supplier_config_schema.py
@@ -36,6 +36,9 @@ def test_load_supplier_lcsc() -> None:
     assert lcsc.search_url_template
     assert lcsc.part_number_pattern
 
+    # Search cache TTL defaults are expressed in seconds for readability.
+    assert lcsc.search_cache_ttl_seconds == 10
+
 
 def test_load_unknown_supplier_raises() -> None:
     with pytest.raises(ValueError, match=r"Unknown supplier"):


### PR DESCRIPTION
Closes #80

## Summary
- Added `DiskSearchCache` (default) storing per-provider search results under `~/.cache/jbom/search/{provider_id}/` with 24h TTL, one JSON file per cache key, and atomic writes.
- Added Mouser provider resiliency: configurable `timeout`, `max_retries`, `retry_delay`, and exponential backoff retries on connection errors and 5xx responses (no retry on 4xx).
- Added CLI flags to both `search` and `inventory-search`:
  - `--no-cache` (use in-memory cache for this run)
  - `--clear-cache` (delete provider cache dir before running; can be combined with `--no-cache`)
- Updated CLI handlers to accept `_cache` injectable override for test isolation and added/updated tests accordingly.

## Testing
- `pytest tests/`

Co-Authored-By: Oz <oz-agent@warp.dev>