### PR TITLE
Search: deduplicate inventory-search requests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.
+- `inventory-search` now deduplicates identical queries within a run to reduce provider API calls.
 
 ## [7.0.0] - 2026-02-27
 

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import re
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.types import Component, InventoryItem
+from jbom.services.search.cache import normalize_query
 from jbom.services.search.filtering import SearchSorter, apply_default_filters
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
@@ -178,12 +180,50 @@ class InventorySearchService:
         return " ".join(p for p in parts if p).strip()
 
     def search(self, items: list[InventoryItem]) -> list[InventorySearchRecord]:
-        """Search for candidates for each inventory item."""
+        """Search for candidates for each inventory item.
 
-        records: list[InventorySearchRecord] = []
+        This implementation deduplicates provider calls by normalized query so that
+        repeated inventory rows do not burn additional API quota.
+        """
+
+        # Phase 6.3 behavior: limit is purely service configuration.
+        provider_limit = max(10, self._candidate_limit * 3)
+
+        query_groups: dict[str, list[tuple[InventoryItem, str]]] = defaultdict(list)
+        per_item_query: list[tuple[InventoryItem, str, str]] = []
 
         for item in items:
             query = self.build_query(item)
+            key = normalize_query(query)
+            per_item_query.append((item, query, key))
+
+            if query:
+                query_groups[key].append((item, query))
+
+        # Dispatch unique queries.
+        ranked_by_query: dict[str, list[SearchResult]] = {}
+        error_by_query: dict[str, str] = {}
+
+        for key, group in query_groups.items():
+            # Keep the original (non-normalized) query string for the provider call.
+            provider_query = group[0][1]
+
+            try:
+                raw_results = self._provider.search(
+                    provider_query, limit=provider_limit
+                )
+                filtered = apply_default_filters(raw_results)
+                ranked_by_query[key] = SearchSorter.rank(filtered)
+            except Exception as exc:
+                error_by_query[key] = str(exc)
+
+            # Be conservative with public APIs (configurable for tests).
+            if self._request_delay_seconds > 0:
+                time.sleep(self._request_delay_seconds)
+
+        # Fan-out per-item scoring.
+        records: list[InventorySearchRecord] = []
+        for item, query, key in per_item_query:
             if not query:
                 records.append(
                     InventorySearchRecord(
@@ -195,25 +235,18 @@ class InventorySearchService:
                 )
                 continue
 
-            try:
-                raw_results = self._provider.search(
-                    query,
-                    limit=max(10, self._candidate_limit * 3),
-                )
-            except Exception as exc:
+            if key in error_by_query:
                 records.append(
                     InventorySearchRecord(
                         inventory_item=item,
                         query=query,
                         candidates=[],
-                        error=str(exc),
+                        error=error_by_query[key],
                     )
                 )
                 continue
 
-            filtered = apply_default_filters(raw_results)
-            ranked = SearchSorter.rank(filtered)
-
+            ranked = ranked_by_query.get(key, [])
             candidates = self._score_candidates(item, ranked)
             records.append(
                 InventorySearchRecord(
@@ -222,10 +255,6 @@ class InventorySearchService:
                     candidates=candidates[: self._candidate_limit],
                 )
             )
-
-            # Be conservative with public APIs (configurable for tests).
-            if self._request_delay_seconds > 0:
-                time.sleep(self._request_delay_seconds)
 
         return records
 
@@ -320,6 +349,10 @@ class InventorySearchService:
         successes = sum(1 for r in records if r.candidates)
         failures = total - successes
 
+        unique_queries = {
+            normalize_query(r.query) for r in records if (r.query or "").strip()
+        }
+
         by_cat: dict[str, dict[str, int]] = {}
         for r in records:
             cat = (r.inventory_item.category or "").strip().upper() or "(missing)"
@@ -333,6 +366,9 @@ class InventorySearchService:
         lines.append(f"Generated: {time.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
         lines.append(f"Total searchable items: {total}")
+        lines.append(
+            f"Unique queries dispatched: {len(unique_queries)} (of {total} items)"
+        )
         if total:
             lines.append(
                 f"Successful searches: {successes} ({successes/total*100:.1f}%)"

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -114,3 +114,57 @@ def test_inventory_search_service_deduplicates_provider_calls_and_fans_out() -> 
 
     report = svc.generate_report(records)
     assert "Unique queries dispatched: 3 (of 10 items)" in report
+
+
+def test_inventory_search_service_fans_out_provider_errors_to_all_items() -> None:
+    err_msg = "provider unavailable"
+
+    def _fake_search(query: str, *, limit: int = 10) -> list[SearchResult]:
+        if "10k" in query.lower():
+            raise RuntimeError(err_msg)
+        return [_sr()]
+
+    provider = Mock(spec=SearchProvider)
+    provider.search = Mock(side_effect=_fake_search)
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+
+    items = [
+        _inv_item(
+            ipn="R10K-1",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+        ),
+        _inv_item(
+            ipn="R10K-2",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+        ),
+        _inv_item(
+            ipn="R1K-1",
+            category="RES",
+            value="1K",
+            package="0603",
+            tolerance="1%",
+        ),
+    ]
+
+    records = svc.search(items)
+
+    # 2 unique queries: one fails, one succeeds.
+    assert provider.search.call_count == 2
+
+    by_ipn = {r.inventory_item.ipn: r for r in records}
+
+    assert by_ipn["R10K-1"].candidates == []
+    assert by_ipn["R10K-1"].error == err_msg
+
+    assert by_ipn["R10K-2"].candidates == []
+    assert by_ipn["R10K-2"].error == err_msg
+
+    assert by_ipn["R1K-1"].candidates
+    assert by_ipn["R1K-1"].error is None

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from jbom.common.types import InventoryItem
+from jbom.services.search.inventory_search_service import InventorySearchService
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+
+
+def _inv_item(
+    *,
+    ipn: str,
+    category: str,
+    value: str,
+    package: str,
+    tolerance: str,
+) -> InventoryItem:
+    return InventoryItem(
+        ipn=ipn,
+        keywords="",
+        category=category,
+        description="",
+        smd="",
+        value=value,
+        type="",
+        tolerance=tolerance,
+        voltage="",
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer="",
+        mfgpn="",
+        datasheet="",
+        package=package,
+    )
+
+
+def _sr(**kw) -> SearchResult:
+    base = dict(
+        manufacturer="Mfg",
+        mpn="MPN",
+        description="desc",
+        datasheet="",
+        distributor="mouser",
+        distributor_part_number="123",
+        availability="100 In Stock",
+        price="$0.10",
+        details_url="",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        category="",
+        attributes={},
+        stock_quantity=100,
+    )
+    base.update(kw)
+    return SearchResult(**base)
+
+
+def test_inventory_search_service_deduplicates_provider_calls_and_fans_out() -> None:
+    provider = Mock(spec=SearchProvider)
+    provider.search = Mock(return_value=[_sr()])
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+
+    items: list[InventoryItem] = []
+
+    # 10 items, 3 unique queries.
+    items.extend(
+        [
+            _inv_item(
+                ipn=f"R10K-{i}",
+                category="RES",
+                value="10K",
+                package="0603",
+                tolerance="1%",
+            )
+            for i in range(1, 6)
+        ]
+    )
+    items.extend(
+        [
+            _inv_item(
+                ipn=f"R1K-{i}",
+                category="RES",
+                value="1K",
+                package="0603",
+                tolerance="1%",
+            )
+            for i in range(1, 4)
+        ]
+    )
+    items.extend(
+        [
+            _inv_item(
+                ipn=f"C100N-{i}",
+                category="CAP",
+                value="100nF",
+                package="0603",
+                tolerance="10%",
+            )
+            for i in range(1, 3)
+        ]
+    )
+
+    records = svc.search(items)
+
+    assert provider.search.call_count == 3
+
+    # Preserve fan-out: one record per input item, maintaining associations.
+    assert [r.inventory_item.ipn for r in records] == [i.ipn for i in items]
+    assert {r.inventory_item.ipn for r in records}.issuperset({"R10K-1", "R10K-2"})
+
+    report = svc.generate_report(records)
+    assert "Unique queries dispatched: 3 (of 10 items)" in report


### PR DESCRIPTION
Closes #81

## Summary
- Deduplicate exact (normalized) queries in `InventorySearchService.search()` so identical inventory rows trigger only one provider call per unique query.
- Fan out the shared raw results back to each item and score candidates per item (unchanged scoring/filtering behavior).
- Enhance `generate_report()` with: `Unique queries dispatched: N (of M items)`

## Testing
- `python -m pytest`
- `python -m behave --format progress`
- `pre-commit` hooks (via commit + manual run on changed files)
