### PR TITLE
Search: parse_value_to_normal dispatch + category-aware parametric filtering (Issue #82)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.
 - `inventory-search` now deduplicates identical queries within a run to reduce provider API calls.
+- Search parametric filtering now supports category-aware value normalization for RES/CAP/IND/REG and uses canonical values as a tertiary sort key.
 
 ## [7.0.0] - 2026-02-27
 

--- a/src/jbom/common/value_parsing.py
+++ b/src/jbom/common/value_parsing.py
@@ -18,6 +18,7 @@ from jbom.common.component_classification import normalize_component_type
 
 __all__ = [
     "parse_res_to_ohms",
+    "parse_voltage_to_volts",
     "parse_value_to_normal",
     "ohms_to_eia",
     "cap_unit_multiplier",
@@ -31,7 +32,7 @@ __all__ = [
 _OHM_RE = re.compile(r"^\s*([0-9]*\.?[0-9]+)\s*([kKmMrR]?)\s*\+?\s*$")
 
 
-def _parse_voltage_to_volts(value: str) -> Optional[float]:
+def parse_voltage_to_volts(value: str) -> Optional[float]:
     """Parse a voltage string into volts.
 
     Examples:
@@ -89,7 +90,7 @@ def parse_value_to_normal(category: str, text: str) -> Optional[float]:
     if cat == "IND":
         return parse_ind_to_henry(text)
     if cat == "REG":
-        return _parse_voltage_to_volts(text)
+        return parse_voltage_to_volts(text)
 
     return None
 

--- a/src/jbom/common/value_parsing.py
+++ b/src/jbom/common/value_parsing.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 import re
 from typing import Optional
 
+from jbom.common.component_classification import normalize_component_type
+
 __all__ = [
     "parse_res_to_ohms",
+    "parse_value_to_normal",
     "ohms_to_eia",
     "cap_unit_multiplier",
     "parse_cap_to_farad",
@@ -26,6 +29,69 @@ __all__ = [
 ]
 
 _OHM_RE = re.compile(r"^\s*([0-9]*\.?[0-9]+)\s*([kKmMrR]?)\s*\+?\s*$")
+
+
+def _parse_voltage_to_volts(value: str) -> Optional[float]:
+    """Parse a voltage string into volts.
+
+    Examples:
+        - "3.3V" -> 3.3
+        - "600mV" -> 0.6
+
+    Returns:
+        Parsed voltage in volts, or None if parsing fails.
+    """
+
+    if not value:
+        return None
+
+    t = str(value).strip().lower().replace(" ", "")
+    t = t.replace("μ", "u").replace("µ", "u")
+
+    # Common forms: 3.3v, 600mv
+    m = re.match(r"^([0-9]*\.?[0-9]+)(mv|v)$", t)
+    if not m:
+        return None
+
+    num = float(m.group(1))
+    unit = m.group(2)
+    if unit == "mv":
+        return num * 1e-3
+    return num
+
+
+def parse_value_to_normal(category: str, text: str) -> Optional[float]:
+    """Parse a value string to SI base units for the given component category.
+
+    Args:
+        category: Normalized component type string as returned by
+            normalize_component_type() — e.g. "RES", "CAP", "IND", "REG".
+        text: Raw value string from inventory or supplier attribute.
+
+    Returns:
+        float in SI base units (ohms, farads, henries, volts), or None if the value
+        is unparseable or the category is unsupported.
+
+    Notes:
+        This API intentionally returns numeric canonical values only. For component
+        categories whose "Value" field is not meaningfully numeric (e.g. LEDs as
+        color, diodes as part numbers), this returns None.
+    """
+
+    cat = normalize_component_type(category or "")
+    if not cat:
+        return None
+
+    if cat == "RES":
+        return parse_res_to_ohms(text)
+    if cat == "CAP":
+        return parse_cap_to_farad(text)
+    if cat == "IND":
+        return parse_ind_to_henry(text)
+    if cat == "REG":
+        return _parse_voltage_to_volts(text)
+
+    return None
 
 
 def parse_res_to_ohms(value: str) -> Optional[float]:
@@ -186,7 +252,7 @@ def parse_cap_to_farad(value: str) -> Optional[float]:
     if not value:
         return None
 
-    t = value.strip().lower().replace("μ", "u")
+    t = value.strip().lower().replace("μ", "u").replace("µ", "u")
     t = t.replace(" ", "")
 
     m = re.match(r"^([0-9]*\.?[0-9]+)\s*([fpnum]?)(f)?$", t)
@@ -282,7 +348,7 @@ def parse_ind_to_henry(value: str) -> Optional[float]:
     if not value:
         return None
 
-    t = value.strip().lower().replace("μ", "u")
+    t = value.strip().lower().replace("μ", "u").replace("µ", "u")
     t = t.replace(" ", "")
     t = t.replace("h", "")
 

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -13,15 +13,48 @@ from __future__ import annotations
 import re
 from typing import Iterable
 
-from jbom.common.value_parsing import parse_res_to_ohms
+from jbom.common.component_classification import normalize_component_type
+from jbom.common.value_parsing import parse_res_to_ohms, parse_value_to_normal
 from jbom.services.search.models import SearchResult
+
+
+def _parse_voltage_to_volts(value: str) -> float | None:
+    if not value:
+        return None
+
+    t = str(value).strip().lower().replace(" ", "")
+    t = t.replace("μ", "u").replace("µ", "u")
+
+    m = re.match(r"^([0-9]*\.?[0-9]+)(mv|v)$", t)
+    if not m:
+        return None
+
+    try:
+        num = float(m.group(1))
+    except ValueError:
+        return None
+
+    unit = m.group(2)
+    if unit == "mv":
+        return num * 1e-3
+    return num
+
+
+def _close_enough(a: float, b: float, *, rel_tol: float = 0.001) -> bool:
+    if a == b:
+        return True
+    if b == 0:
+        return abs(a) < rel_tol
+    return abs(a - b) <= abs(b) * rel_tol
 
 
 class SearchFilter:
     """Client-side filtering helpers."""
 
     @staticmethod
-    def filter_by_query(results: list[SearchResult], query: str) -> list[SearchResult]:
+    def filter_by_query(
+        results: list[SearchResult], query: str, *, category: str = ""
+    ) -> list[SearchResult]:
         """Filter results based on query terms matching parametric attributes.
 
         Current behavior mirrors legacy jBOM's implementation for resistors:
@@ -35,16 +68,36 @@ class SearchFilter:
 
         filtered: list[SearchResult] = []
 
-        # Resistance target.
-        # Queries are usually multi-token (e.g. "10K resistor 0603"), while the
-        # value parser expects a single value token.
-        target_ohms = None
-        for token in re.split(r"[\s,]+", query or ""):
-            if not token:
-                continue
-            target_ohms = parse_res_to_ohms(token)
-            if target_ohms is not None:
-                break
+        cat = normalize_component_type(category or "")
+
+        # Primary numeric target (category-specific). If category is not provided,
+        # preserve legacy behavior: resistance matching only.
+        target_value: float | None = None
+        if cat:
+            for token in re.split(r"[\s,]+", query or ""):
+                if not token:
+                    continue
+                target_value = parse_value_to_normal(cat, token)
+                if target_value is not None:
+                    break
+        else:
+            for token in re.split(r"[\s,]+", query or ""):
+                if not token:
+                    continue
+                target_value = parse_res_to_ohms(token)
+                if target_value is not None:
+                    cat = "RES"
+                    break
+
+        # Optional capacitor voltage rating target.
+        target_volts: float | None = None
+        if cat == "CAP":
+            for token in re.split(r"[\s,]+", query or ""):
+                if not token:
+                    continue
+                target_volts = _parse_voltage_to_volts(token)
+                if target_volts is not None:
+                    break
 
         # Tolerance target (e.g. "1%", "5%")
         target_tol: float | None = None
@@ -62,13 +115,29 @@ class SearchFilter:
 
             keep = True
 
-            if target_ohms is not None:
-                res_attr = r.attributes.get("Resistance", "")
-                if res_attr:
-                    attr_ohms = parse_res_to_ohms(res_attr)
-                    if attr_ohms is None or abs(attr_ohms - target_ohms) > (
-                        target_ohms * 0.001
-                    ):
+            if target_value is not None:
+                attr_name_by_cat = {
+                    "RES": "Resistance",
+                    "CAP": "Capacitance",
+                    "IND": "Inductance",
+                    "REG": "Output Voltage",
+                }
+                attr_name = attr_name_by_cat.get(cat, "")
+                if attr_name:
+                    raw_attr = r.attributes.get(attr_name, "")
+                    if raw_attr:
+                        attr_value = parse_value_to_normal(cat, raw_attr)
+                        if attr_value is None or not _close_enough(
+                            attr_value, target_value
+                        ):
+                            keep = False
+
+            if keep and cat == "CAP" and target_volts is not None:
+                vr_attr = r.attributes.get("Voltage Rating", "")
+                if vr_attr:
+                    attr_volts = _parse_voltage_to_volts(vr_attr)
+                    # Interpret voltage rating as a minimum requirement.
+                    if attr_volts is None or attr_volts + 1e-12 < target_volts:
                         keep = False
 
             if keep and target_tol is not None:
@@ -119,10 +188,19 @@ class SearchSorter:
     """Sorting utilities."""
 
     @staticmethod
-    def rank(results: list[SearchResult]) -> list[SearchResult]:
-        """Rank by stock (desc) then price (asc)."""
+    def rank(results: list[SearchResult], *, category: str = "") -> list[SearchResult]:
+        """Rank by stock (desc), price (asc), then category value (asc)."""
 
-        def sort_key(r: SearchResult) -> tuple[int, float]:
+        cat = normalize_component_type(category or "")
+        attr_name_by_cat = {
+            "RES": "Resistance",
+            "CAP": "Capacitance",
+            "IND": "Inductance",
+            "REG": "Output Voltage",
+        }
+        attr_name = attr_name_by_cat.get(cat, "")
+
+        def sort_key(r: SearchResult) -> tuple[int, float, float]:
             stock = r.stock_quantity
             try:
                 price_clean = (
@@ -135,7 +213,16 @@ class SearchSorter:
                 price_value = float(price_clean)
             except ValueError:
                 price_value = float("inf")
-            return (-stock, price_value)
+
+            canonical = float("inf")
+            if attr_name and r.attributes:
+                raw = r.attributes.get(attr_name, "")
+                if raw:
+                    v = parse_value_to_normal(cat, raw)
+                    if v is not None:
+                        canonical = v
+
+            return (-stock, price_value, canonical)
 
         return sorted(results, key=sort_key)
 

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -14,30 +14,20 @@ import re
 from typing import Iterable
 
 from jbom.common.component_classification import normalize_component_type
-from jbom.common.value_parsing import parse_res_to_ohms, parse_value_to_normal
+from jbom.common.value_parsing import (
+    parse_res_to_ohms,
+    parse_value_to_normal,
+    parse_voltage_to_volts,
+)
 from jbom.services.search.models import SearchResult
 
 
-def _parse_voltage_to_volts(value: str) -> float | None:
-    if not value:
-        return None
-
-    t = str(value).strip().lower().replace(" ", "")
-    t = t.replace("μ", "u").replace("µ", "u")
-
-    m = re.match(r"^([0-9]*\.?[0-9]+)(mv|v)$", t)
-    if not m:
-        return None
-
-    try:
-        num = float(m.group(1))
-    except ValueError:
-        return None
-
-    unit = m.group(2)
-    if unit == "mv":
-        return num * 1e-3
-    return num
+_CATEGORY_ATTR_NAME: dict[str, str] = {
+    "RES": "Resistance",
+    "CAP": "Capacitance",
+    "IND": "Inductance",
+    "REG": "Output Voltage",
+}
 
 
 def _close_enough(a: float, b: float, *, rel_tol: float = 0.001) -> bool:
@@ -95,7 +85,7 @@ class SearchFilter:
             for token in re.split(r"[\s,]+", query or ""):
                 if not token:
                     continue
-                target_volts = _parse_voltage_to_volts(token)
+                target_volts = parse_voltage_to_volts(token)
                 if target_volts is not None:
                     break
 
@@ -116,13 +106,7 @@ class SearchFilter:
             keep = True
 
             if target_value is not None:
-                attr_name_by_cat = {
-                    "RES": "Resistance",
-                    "CAP": "Capacitance",
-                    "IND": "Inductance",
-                    "REG": "Output Voltage",
-                }
-                attr_name = attr_name_by_cat.get(cat, "")
+                attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
                 if attr_name:
                     raw_attr = r.attributes.get(attr_name, "")
                     if raw_attr:
@@ -135,7 +119,7 @@ class SearchFilter:
             if keep and cat == "CAP" and target_volts is not None:
                 vr_attr = r.attributes.get("Voltage Rating", "")
                 if vr_attr:
-                    attr_volts = _parse_voltage_to_volts(vr_attr)
+                    attr_volts = parse_voltage_to_volts(vr_attr)
                     # Interpret voltage rating as a minimum requirement.
                     if attr_volts is None or attr_volts + 1e-12 < target_volts:
                         keep = False
@@ -192,13 +176,7 @@ class SearchSorter:
         """Rank by stock (desc), price (asc), then category value (asc)."""
 
         cat = normalize_component_type(category or "")
-        attr_name_by_cat = {
-            "RES": "Resistance",
-            "CAP": "Capacitance",
-            "IND": "Inductance",
-            "REG": "Output Voltage",
-        }
-        attr_name = attr_name_by_cat.get(cat, "")
+        attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
 
         def sort_key(r: SearchResult) -> tuple[int, float, float]:
             stock = r.stock_quantity

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -135,7 +135,8 @@ class InventorySearchService:
             if cat_norm in excluded:
                 continue
 
-            if not item.value or len(str(item.value).strip()) < 2:
+            min_value_len = 1 if cat_norm == "LED" else 2
+            if not item.value or len(str(item.value).strip()) < min_value_len:
                 continue
 
             if any(_category_matches(cat_raw, s) for s in selectors):

--- a/tests/services/search/test_filtering.py
+++ b/tests/services/search/test_filtering.py
@@ -54,6 +54,34 @@ def test_filter_by_query_resistance_strict_matches_when_attribute_present():
     assert "C" in mpns
 
 
+def test_filter_by_query_capacitance_when_category_provided():
+    results = [
+        _sr(attributes={"Capacitance": "100nF"}, mpn="A"),
+        _sr(attributes={"Capacitance": "1uF"}, mpn="B"),
+        _sr(attributes={}, mpn="C"),  # fail-open
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "100nF 0805", category="CAP")
+    mpns = {r.mpn for r in filtered}
+    assert "A" in mpns
+    assert "B" not in mpns
+    assert "C" in mpns
+
+
+def test_filter_by_query_capacitor_voltage_rating_when_present_in_query():
+    results = [
+        _sr(attributes={"Capacitance": "100nF", "Voltage Rating": "16V"}, mpn="A"),
+        _sr(attributes={"Capacitance": "100nF", "Voltage Rating": "10V"}, mpn="B"),
+        _sr(attributes={"Capacitance": "100nF"}, mpn="C"),  # fail-open for voltage
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "100nF 16V 0805", category="CAP")
+    mpns = {r.mpn for r in filtered}
+    assert "A" in mpns
+    assert "B" not in mpns
+    assert "C" in mpns
+
+
 def test_sorter_prefers_higher_stock_then_lower_price():
     results = [
         _sr(stock_quantity=10, price="$0.20", mpn="A"),
@@ -63,3 +91,29 @@ def test_sorter_prefers_higher_stock_then_lower_price():
 
     ranked = SearchSorter.rank(results)
     assert [r.mpn for r in ranked] == ["C", "B", "A"]
+
+
+def test_sorter_uses_numeric_value_as_tertiary_key_when_category_provided():
+    results = [
+        _sr(
+            stock_quantity=10,
+            price="$0.10",
+            mpn="A",
+            attributes={"Capacitance": "1uF"},
+        ),
+        _sr(
+            stock_quantity=10,
+            price="$0.10",
+            mpn="B",
+            attributes={"Capacitance": "100nF"},
+        ),
+        _sr(
+            stock_quantity=10,
+            price="$0.10",
+            mpn="C",
+            attributes={"Capacitance": "garbage"},
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, category="CAP")
+    assert [r.mpn for r in ranked] == ["B", "A", "C"]

--- a/tests/services/search/test_filtering.py
+++ b/tests/services/search/test_filtering.py
@@ -54,6 +54,20 @@ def test_filter_by_query_resistance_strict_matches_when_attribute_present():
     assert "C" in mpns
 
 
+def test_filter_by_query_backward_compat_empty_category_filters_resistance():
+    results = [
+        _sr(attributes={"Resistance": "10 kOhms"}, mpn="A"),
+        _sr(attributes={"Resistance": "22 kOhms"}, mpn="B"),
+        _sr(attributes={}, mpn="C"),  # fail-open
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10K 0603", category="")
+    mpns = {r.mpn for r in filtered}
+    assert "A" in mpns
+    assert "B" not in mpns
+    assert "C" in mpns
+
+
 def test_filter_by_query_capacitance_when_category_provided():
     results = [
         _sr(attributes={"Capacitance": "100nF"}, mpn="A"),
@@ -76,6 +90,20 @@ def test_filter_by_query_capacitor_voltage_rating_when_present_in_query():
     ]
 
     filtered = SearchFilter.filter_by_query(results, "100nF 16V 0805", category="CAP")
+    mpns = {r.mpn for r in filtered}
+    assert "A" in mpns
+    assert "B" not in mpns
+    assert "C" in mpns
+
+
+def test_filter_by_query_inductance_when_category_provided():
+    results = [
+        _sr(attributes={"Inductance": "100uH"}, mpn="A"),
+        _sr(attributes={"Inductance": "10uH"}, mpn="B"),
+        _sr(attributes={}, mpn="C"),  # fail-open
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "100uH 0603", category="IND")
     mpns = {r.mpn for r in filtered}
     assert "A" in mpns
     assert "B" not in mpns

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -116,6 +116,28 @@ def test_inventory_search_service_deduplicates_provider_calls_and_fans_out() -> 
     assert "Unique queries dispatched: 3 (of 10 items)" in report
 
 
+def test_filter_searchable_items_allows_led_single_character_value() -> None:
+    items = [
+        _inv_item(
+            ipn="LED-R-1",
+            category="LED",
+            value="R",
+            package="0603",
+            tolerance="",
+        ),
+        _inv_item(
+            ipn="LED-EMPTY",
+            category="LED",
+            value="",
+            package="0603",
+            tolerance="",
+        ),
+    ]
+
+    filtered = InventorySearchService.filter_searchable_items(items, categories=None)
+    assert [i.ipn for i in filtered] == ["LED-R-1"]
+
+
 def test_inventory_search_service_fans_out_provider_errors_to_all_items() -> None:
     err_msg = "provider unavailable"
 

--- a/tests/unit/test_value_parsing.py
+++ b/tests/unit/test_value_parsing.py
@@ -19,6 +19,7 @@ from jbom.common.value_parsing import (  # noqa: E402
     parse_cap_to_farad,
     parse_ind_to_henry,
     parse_res_to_ohms,
+    parse_value_to_normal,
 )
 
 
@@ -209,3 +210,31 @@ def test_resistor_round_trip_examples() -> None:
         parsed = parse_res_to_ohms(s)
         assert parsed is not None
         assert parse_res_to_ohms(ohms_to_eia(parsed)) == pytest.approx(parsed)
+
+
+def test_parse_value_to_normal_res() -> None:
+    assert parse_value_to_normal("RES", "10K") == pytest.approx(10000.0)
+
+
+def test_parse_value_to_normal_cap() -> None:
+    assert parse_value_to_normal("CAP", "100nF") == pytest.approx(1e-7)
+
+
+def test_parse_value_to_normal_ind() -> None:
+    assert parse_value_to_normal("IND", "100µH") == pytest.approx(1e-4)
+
+
+def test_parse_value_to_normal_regulator_output_voltage() -> None:
+    assert parse_value_to_normal("REG", "3.3V") == pytest.approx(3.3)
+
+
+def test_parse_value_to_normal_led_is_none() -> None:
+    assert parse_value_to_normal("LED", "R") is None
+
+
+def test_parse_value_to_normal_unknown_category_is_none() -> None:
+    assert parse_value_to_normal("UNKNOWN", "10K") is None
+
+
+def test_parse_value_to_normal_unparseable_is_none() -> None:
+    assert parse_value_to_normal("CAP", "garbage") is None


### PR DESCRIPTION
Closes #82

Summary
- Added `parse_value_to_normal(category, text) -> float | None` dispatch for numeric categories (RES/CAP/IND/REG).
- Extended `SearchFilter.filter_by_query()` with optional `category` parameter for category-aware parametric filtering.
- Extended `SearchSorter.rank()` with optional `category` parameter and uses canonical parsed values as a tertiary sort key.
- Adjusted `InventorySearchService.filter_searchable_items()` to allow 1-character LED values (e.g. `R`).
- Added/updated unit tests for the above and updated `docs/CHANGELOG.md`.

Notes
- For non-numeric categories (e.g. LED color, diode part numbers), `parse_value_to_normal()` returns None which naturally disables numeric parametric filtering/sorting for that dimension.
- Capacitor voltage tokens in the query (e.g. `16V`) are used to filter `Voltage Rating` as a minimum requirement when `category=CAP`.

Testing
- `python -m pytest -q`
- `python -m behave --format progress`
