### PR TITLE
Search [5/6] (#83): externalize type_query_keywords + improve search result table

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.
 - `inventory-search` now deduplicates identical queries within a run to reduce provider API calls.
 - Search parametric filtering now supports category-aware value normalization for RES/CAP/IND/REG and uses canonical values as a tertiary sort key.
+- `inventory-search` query construction now supports per-supplier `search.type_query_keywords` with a safe hardcoded fallback.
+- `jbom search` console output now includes Description plus up to 2 heuristic parametric columns.
 
 ## [7.0.0] - 2026-02-27
 

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -16,6 +16,15 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.common.value_parsing import (
+    farad_to_eia,
+    henry_to_eia,
+    ohms_to_eia,
+    parse_cap_to_farad,
+    parse_ind_to_henry,
+    parse_res_to_ohms,
+    parse_voltage_to_volts,
+)
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.filtering import (
     SearchFilter,
@@ -191,32 +200,56 @@ def _print_console(results: list[SearchResult]) -> None:
         print("No results found.")
         return
 
-    rows = [_row_for_result(r) for r in results]
+    # Heuristic (intentionally simple for Issue #83): inspect the top 10 results and
+    # choose up to 2 parametric attribute columns from a curated allowlist, ranked by
+    # how often they appear.
+    parametric_keys = _select_parametric_keys(results, limit=2)
+
+    rows = [_row_for_result(r, parametric_keys=parametric_keys) for r in results]
+
     cols = [
         Column(
             header="Manufacturer", key="manufacturer", preferred_width=18, wrap=True
         ),
         Column(header="MPN", key="mpn", preferred_width=28, wrap=True),
+        Column(header="Description", key="description", preferred_width=34, wrap=True),
         Column(
             header="Distributor PN",
             key="distributor_part_number",
             preferred_width=22,
             wrap=True,
         ),
-        Column(
-            header="Price", key="price", preferred_width=10, fixed=True, align="right"
-        ),
-        Column(
-            header="Stock",
-            key="stock_quantity",
-            preferred_width=8,
-            fixed=True,
-            align="right",
-        ),
-        Column(
-            header="Lifecycle", key="lifecycle_status", preferred_width=10, wrap=True
-        ),
     ]
+
+    for key in parametric_keys:
+        cols.append(
+            Column(header=key, key=f"attr:{key}", preferred_width=14, wrap=True)
+        )
+
+    cols.extend(
+        [
+            Column(
+                header="Price",
+                key="price",
+                preferred_width=10,
+                fixed=True,
+                align="right",
+            ),
+            Column(
+                header="Stock",
+                key="stock_quantity",
+                preferred_width=8,
+                fixed=True,
+                align="right",
+            ),
+            Column(
+                header="Lifecycle",
+                key="lifecycle_status",
+                preferred_width=10,
+                wrap=True,
+            ),
+        ]
+    )
 
     print("")
     print_table(rows, cols, terminal_width=120)
@@ -229,6 +262,62 @@ def _print_csv(results: list[SearchResult], *, out: TextIO) -> None:
     writer.writeheader()
     for r in results:
         writer.writerow(_csv_row_for_result(r))
+
+
+def _select_parametric_keys(results: list[SearchResult], *, limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+
+    allowlist = [
+        "Resistance",
+        "Capacitance",
+        "Inductance",
+        "Tolerance",
+        "Voltage Rating",
+        "Output Voltage",
+        "Current Rating",
+        "Power",
+        "Package",
+    ]
+
+    # Consider the first N results only (table is for interactive use, so prioritize
+    # what the user sees at the top).
+    sample = results[: min(10, len(results))]
+
+    freq: dict[str, int] = {k: 0 for k in allowlist}
+    for r in sample:
+        keys = set((r.attributes or {}).keys())
+        for k in allowlist:
+            if k in keys:
+                freq[k] += 1
+
+    ranked = [k for k in allowlist if freq[k] > 0]
+    ranked.sort(key=lambda k: (-freq[k], allowlist.index(k)))
+    return ranked[:limit]
+
+
+def _format_parametric_value(attr_name: str, raw: str) -> str:
+    t = (raw or "").strip()
+    if not t:
+        return ""
+
+    if attr_name == "Resistance":
+        v = parse_res_to_ohms(t)
+        return ohms_to_eia(v) if v is not None else t
+
+    if attr_name == "Capacitance":
+        v = parse_cap_to_farad(t)
+        return farad_to_eia(v) if v is not None else t
+
+    if attr_name == "Inductance":
+        v = parse_ind_to_henry(t)
+        return henry_to_eia(v) if v is not None else t
+
+    if attr_name in {"Voltage Rating", "Output Voltage"}:
+        v = parse_voltage_to_volts(t)
+        return f"{v:g}V" if v is not None else t
+
+    return t
 
 
 def _csv_headers() -> list[str]:
@@ -261,11 +350,12 @@ def _csv_row_for_result(r: SearchResult) -> dict[str, str]:
     }
 
 
-def _row_for_result(r: SearchResult) -> dict[str, str]:
+def _row_for_result(r: SearchResult, *, parametric_keys: list[str]) -> dict[str, str]:
     # Internal row mapping used by console output.
-    return {
+    out: dict[str, str] = {
         "manufacturer": r.manufacturer,
         "mpn": r.mpn,
+        "description": r.description,
         "distributor": r.distributor,
         "distributor_part_number": r.distributor_part_number,
         "availability": r.availability,
@@ -274,3 +364,9 @@ def _row_for_result(r: SearchResult) -> dict[str, str]:
         "lifecycle_status": r.lifecycle_status,
         "details_url": r.details_url,
     }
+
+    for k in parametric_keys:
+        raw = (r.attributes or {}).get(k, "")
+        out[f"attr:{k}"] = _format_parametric_value(k, raw)
+
+    return out

--- a/src/jbom/config/suppliers.py
+++ b/src/jbom/config/suppliers.py
@@ -11,7 +11,7 @@ Future scope: support hierarchical override/extension locations.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 
@@ -40,6 +40,10 @@ class SupplierConfig:
     search_timeout_seconds: Optional[float] = None
     search_max_retries: Optional[int] = None
     search_retry_delay_seconds: Optional[float] = None
+
+    # Optional category -> keyword mapping used by inventory-search query construction.
+    # Keys should be normalized component category tokens (e.g. RES, CAP, IND).
+    search_type_query_keywords: dict[str, str] = field(default_factory=dict)
 
     @staticmethod
     def from_yaml_dict(data: Dict[str, Any], *, default_id: str) -> "SupplierConfig":
@@ -114,6 +118,24 @@ class SupplierConfig:
         if not isinstance(api_cfg, dict):
             raise ValueError(f"Supplier '{sid}' search.api must be a mapping")
 
+        type_query_keywords_cfg = search_cfg.get("type_query_keywords") or {}
+        if not isinstance(type_query_keywords_cfg, dict):
+            raise ValueError(
+                f"Supplier '{sid}' search.type_query_keywords must be a mapping"
+            )
+
+        type_query_keywords: dict[str, str] = {}
+        for k, v in type_query_keywords_cfg.items():
+            if not isinstance(k, str) or not k.strip():
+                raise ValueError(
+                    f"Supplier '{sid}' search.type_query_keywords keys must be non-empty strings"
+                )
+            if not isinstance(v, str) or not v.strip():
+                raise ValueError(
+                    f"Supplier '{sid}' search.type_query_keywords[{k!r}] must be a non-empty string"
+                )
+            type_query_keywords[k.strip().upper()] = v.strip()
+
         timeout_seconds = api_cfg.get("timeout_seconds")
         if timeout_seconds is not None and not isinstance(
             timeout_seconds, (int, float)
@@ -179,6 +201,7 @@ class SupplierConfig:
             search_retry_delay_seconds=(
                 float(retry_delay_seconds) if retry_delay_seconds is not None else None
             ),
+            search_type_query_keywords=type_query_keywords,
         )
 
 

--- a/src/jbom/config/suppliers/mouser.supplier.yaml
+++ b/src/jbom/config/suppliers/mouser.supplier.yaml
@@ -16,3 +16,23 @@ search:
     timeout_seconds: 10.0
     max_retries: 3
     retry_delay_seconds: 1.0
+
+  # Keyword appended to query per normalized component category.
+  type_query_keywords:
+    RES: "resistor"
+    CAP: "capacitor"
+    IND: "inductor"
+    LED: "LED"
+    DIO: "diode"
+    Z: "zener diode"
+    Q: "transistor"
+    IC: "IC"
+    OSC: "oscillator"
+    REG: "regulator"
+    CON: "connector"
+    CONN: "connector"
+    XFMR: "transformer"
+    XTL: "crystal"
+    SW: "switch"
+    FUSE: "fuse"
+    RLY: "relay"

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.types import Component, InventoryItem
+from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import normalize_query
 from jbom.services.search.filtering import SearchSorter, apply_default_filters
 from jbom.services.search.models import SearchResult
@@ -145,7 +146,7 @@ class InventorySearchService:
         return out
 
     def build_query(self, item: InventoryItem) -> str:
-        """Build a Mouser-friendly keyword query string."""
+        """Build a provider-friendly keyword query string."""
 
         parts: list[str] = []
 
@@ -153,7 +154,8 @@ class InventorySearchService:
             parts.append(_normalize_ascii_value(item.value))
 
         cat = _category_token(item.category)
-        type_keywords = {
+
+        default_type_keywords = {
             "RES": "resistor",
             "CAP": "capacitor",
             "IND": "inductor",
@@ -165,6 +167,13 @@ class InventorySearchService:
             "CON": "connector",
             "CONN": "connector",
         }
+
+        supplier = resolve_supplier_by_id(self._provider.provider_id)
+        type_keywords = dict(default_type_keywords)
+        if supplier is not None and supplier.search_type_query_keywords:
+            # Supplier config overrides/adds to the built-in defaults.
+            type_keywords.update(supplier.search_type_query_keywords)
+
         if cat in type_keywords:
             parts.append(type_keywords[cat])
 

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from jbom.common.types import InventoryItem
+from jbom.config.suppliers import SupplierConfig
 from jbom.services.search.inventory_search_service import InventorySearchService
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
@@ -136,6 +137,37 @@ def test_filter_searchable_items_allows_led_single_character_value() -> None:
 
     filtered = InventorySearchService.filter_searchable_items(items, categories=None)
     assert [i.ipn for i in filtered] == ["LED-R-1"]
+
+
+def test_build_query_uses_supplier_config_keywords(monkeypatch) -> None:
+    supplier = SupplierConfig(
+        id="mouser",
+        name="Mouser",
+        inventory_column="Mouser",
+        search_type_query_keywords={"RES": "thick film resistor"},
+    )
+
+    import jbom.services.search.inventory_search_service as iss
+
+    monkeypatch.setattr(iss, "resolve_supplier_by_id", lambda _sid: supplier)
+
+    class _Provider:
+        provider_id = "mouser"
+
+        def search(self, query: str, *, limit: int = 10) -> list[SearchResult]:
+            return []
+
+    svc = InventorySearchService(_Provider())
+    item = _inv_item(
+        ipn="R-TEST",
+        category="RES",
+        value="10K",
+        package="0603",
+        tolerance="1%",
+    )
+
+    query = svc.build_query(item)
+    assert "thick film resistor" in query
 
 
 def test_inventory_search_service_fans_out_provider_errors_to_all_items() -> None:

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -76,7 +76,8 @@ def test_search_console_output(monkeypatch, capsys):
     assert rc == 0
 
     out = capsys.readouterr().out
-    assert "Manufacturer" in out
+    assert "MPN" in out
+    assert "Description" in out
     assert "Yageo" in out
 
 

--- a/tests/unit/test_supplier_config_schema.py
+++ b/tests/unit/test_supplier_config_schema.py
@@ -38,6 +38,19 @@ def test_load_supplier_lcsc() -> None:
 
     assert lcsc.search_cache_ttl_hours == 24
 
+    assert isinstance(lcsc.search_type_query_keywords, dict)
+    assert lcsc.search_type_query_keywords == {}
+
+
+def test_load_supplier_mouser_has_type_query_keywords() -> None:
+    mouser = load_supplier("mouser")
+    assert isinstance(mouser.search_type_query_keywords, dict)
+
+    # Contract: the keys are normalized category tokens.
+    assert mouser.search_type_query_keywords.get("RES") == "resistor"
+    assert mouser.search_type_query_keywords.get("CAP") == "capacitor"
+    assert mouser.search_type_query_keywords.get("IND") == "inductor"
+
 
 def test_load_unknown_supplier_raises() -> None:
     with pytest.raises(ValueError, match=r"Unknown supplier"):


### PR DESCRIPTION
Closes #83

Summary
- Add `search.type_query_keywords` to `mouser.supplier.yaml` and load it via `SupplierConfig.search_type_query_keywords` (defaults to empty dict).
- `InventorySearchService.build_query()` now uses supplier-configured keywords when available, with a safe hardcoded fallback.
- Improve `jbom search` console table: add Description column and up to 2 heuristic parametric columns (from a curated allowlist, based on top-10 frequency).

Notes
- The parametric-column selection heuristic is intentionally simplistic for correctness-first; follow-up tracked in #91.

Testing
- `python -m pytest -q`

Co-Authored-By: Oz <oz-agent@warp.dev>
