### PR TITLE
feat: add typed parametric fields to InventoryItem (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # CHANGELOG
 
 
+## Unreleased
+
+### Features
+
+* feat: add typed parametric fields to InventoryItem (#90)
+
+  Add `resistance`, `capacitance`, `inductance` (SI-unit floats) and `name` fields
+  to `InventoryItem`. The inventory reader decodes these at intake from explicit
+  `Resistance`/`Capacitance`/`Inductance`/`Name` CSV columns, falling back to the
+  `Value` column for passives. A WARNING is logged when both sources disagree by
+  more than 0.1%. `build_query()` in `InventorySearchService` now uses the typed
+  fields to produce normalised EIA search strings for passives, and prefers the
+  `Name` field for non-passive components.
+
+  Co-Authored-By: Oz <oz-agent@warp.dev>
+
+
 ## v6.13.0 (2026-03-01)
 
 ### Features

--- a/src/jbom/common/types.py
+++ b/src/jbom/common/types.py
@@ -50,6 +50,11 @@ class InventoryItem:
     priority: int = (
         DEFAULT_PRIORITY  # Priority from CSV: 1=most desirable, higher=less desirable
     )
+    # Typed parametric fields (decoded at intake from explicit columns or Value fallback)
+    resistance: Optional[float] = None  # in ohms  (RES)
+    capacitance: Optional[float] = None  # in farads (CAP)
+    inductance: Optional[float] = None  # in henries (IND)
+    name: str = ""  # component name for non-passives (e.g. "LM358D", "AMS1117-3.3")
     # Source tracking for federated inventory
     source: str = "Unknown"  # e.g. "CSV", "JLC-Private", "Project"
     source_file: Optional[Path] = None  # Path to the file where this item was found

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -8,13 +8,78 @@ Handles loading inventory data from multiple file formats:
 """
 
 import csv
+import logging
 import warnings
 from pathlib import Path
 from typing import List, Dict, Optional, Union
 
-# warnings imported at line 11 already
+# warnings imported at line 12 already
+from jbom.common.component_classification import normalize_component_type
 from jbom.common.types import InventoryItem, DEFAULT_PRIORITY
+from jbom.common.value_parsing import parse_value_to_normal
 from jbom.services.jlc_loader import JLCPrivateInventoryLoader
+
+log = logging.getLogger(__name__)
+
+# Maps normalised category token → CSV column name for explicit typed values
+_TYPED_COLUMN: Dict[str, str] = {
+    "RES": "Resistance",
+    "CAP": "Capacitance",
+    "IND": "Inductance",
+}
+
+
+def _decode_typed_parametric(
+    category: str,
+    value: str,
+    row: Dict[str, str],
+) -> Optional[float]:
+    """Decode a typed parametric field from an inventory row.
+
+    Priority:
+    1. Explicit typed column (Resistance, Capacitance, or Inductance)
+    2. Value field as fallback
+
+    Logs a WARNING when both sources parse successfully but disagree by >0.1%.
+    Returns None when neither source is parseable or the category is unsupported.
+    """
+    cat = normalize_component_type(category)
+    if cat not in _TYPED_COLUMN:
+        return None
+
+    column = _TYPED_COLUMN[cat]
+    explicit_str = (row.get(column) or "").strip()
+    value_str = (value or "").strip()
+
+    explicit_val: Optional[float] = (
+        parse_value_to_normal(cat, explicit_str) if explicit_str else None
+    )
+    value_val: Optional[float] = (
+        parse_value_to_normal(cat, value_str) if value_str else None
+    )
+
+    # Sanity-check: warn when both are present but numerically disagree.
+    if explicit_val is not None and value_val is not None:
+        denominator = abs(explicit_val) if explicit_val != 0 else abs(value_val)
+        if denominator > 0:
+            rel_diff = abs(explicit_val - value_val) / denominator
+            if rel_diff > 0.001:  # >0.1 % tolerance
+                log.warning(
+                    "Inventory item has conflicting values: "
+                    "%s column='%s' (%g) disagrees with Value='%s' (%g). "
+                    "Using explicit column value.",
+                    column,
+                    explicit_str,
+                    explicit_val,
+                    value_str,
+                    value_val,
+                )
+
+    # Explicit typed column takes priority; fall back to Value.
+    if explicit_val is not None:
+        return explicit_val
+    return value_val
+
 
 # Suppress specific Numbers version warning
 warnings.filterwarnings(
@@ -285,13 +350,15 @@ class InventoryReader:
                 continue
 
             # No need to parse stocking info - Priority column handles all ranking
+            category = row.get("Category", "")
+            value = row.get("Value", "")
             item = InventoryItem(
                 ipn=row.get("IPN", ""),
                 keywords=row.get("Keywords", ""),
-                category=row.get("Category", ""),
+                category=category,
                 description=row.get("Description", ""),
                 smd=row.get("SMD", ""),
-                value=row.get("Value", ""),
+                value=value,
                 type=row.get("Type", ""),
                 tolerance=row.get("Tolerance", ""),
                 voltage=row.get("V", ""),
@@ -319,6 +386,13 @@ class InventoryReader:
                 priority=self._parse_priority(
                     row.get("Priority", str(DEFAULT_PRIORITY))
                 ),
+                # Typed parametric fields decoded at intake (#90).
+                # Each call passes the TARGET field's category so the helper knows
+                # which column to look in and which parse function to apply.
+                resistance=_decode_typed_parametric("RES", value, row),
+                capacitance=_decode_typed_parametric("CAP", value, row),
+                inductance=_decode_typed_parametric("IND", value, row),
+                name=(row.get("Name") or "").strip(),
                 source=source,
                 source_file=source_file,
                 raw_data=row,

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.types import Component, InventoryItem
+from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import normalize_query
 from jbom.services.search.filtering import SearchSorter, apply_default_filters
@@ -146,14 +147,38 @@ class InventorySearchService:
         return out
 
     def build_query(self, item: InventoryItem) -> str:
-        """Build a provider-friendly keyword query string."""
+        """Build a provider-friendly keyword query string.
+
+        Primary value token selection:
+        - Passives (RES/CAP/IND): use the typed numeric field formatted back to an
+          EIA string for consistent, normalised search terms.  Falls back to the
+          raw Value string when the typed field is absent.
+        - Non-passives: prefer the Name field (e.g. 'LM358D', 'AMS1117-3.3');
+          fall back to Value when Name is empty.
+        """
 
         parts: list[str] = []
 
-        if item.value:
-            parts.append(_normalize_ascii_value(item.value))
-
         cat = _category_token(item.category)
+
+        # Determine the primary value token.
+        if cat == "RES" and item.resistance is not None:
+            value_token = ohms_to_eia(item.resistance)
+        elif cat == "CAP" and item.capacitance is not None:
+            value_token = farad_to_eia(item.capacitance)
+        elif cat == "IND" and item.inductance is not None:
+            value_token = henry_to_eia(item.inductance)
+        elif cat in ("RES", "CAP", "IND"):
+            # Typed field absent — fall back to raw value string.
+            value_token = _normalize_ascii_value(item.value)
+        elif item.name:
+            # Non-passive with an explicit component name.
+            value_token = item.name
+        else:
+            value_token = _normalize_ascii_value(item.value)
+
+        if value_token:
+            parts.append(value_token)
 
         default_type_keywords = {
             "RES": "resistor",

--- a/tests/unit/test_typed_parametric_fields.py
+++ b/tests/unit/test_typed_parametric_fields.py
@@ -1,0 +1,321 @@
+"""Unit tests for Issue #90: InventoryItem typed parametric fields.
+
+Tests cover:
+- InventoryItem has new typed fields with correct defaults
+- Inventory reader decodes Resistance/Capacitance/Inductance columns at intake
+- Value-column fallback when explicit typed column is absent
+- Warning logged when explicit column and Value disagree numerically
+- build_query() uses typed float fields for passives (formatted as EIA strings)
+- build_query() uses Name field for non-passive components
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = PROJECT_ROOT / "src"
+sys.path.insert(0, str(SRC_DIR))
+
+from jbom.common.types import InventoryItem  # noqa: E402
+from jbom.services.inventory_reader import InventoryReader  # noqa: E402
+from jbom.services.search.inventory_search_service import (
+    InventorySearchService,
+)  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_inventory_item(**kwargs) -> InventoryItem:
+    """Return a minimal InventoryItem with sane defaults."""
+    defaults = dict(
+        ipn="TEST_001",
+        keywords="",
+        category="RES",
+        description="",
+        smd="SMD",
+        value="10K",
+        type="",
+        tolerance="1%",
+        voltage="",
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer="",
+        mfgpn="",
+        datasheet="",
+    )
+    defaults.update(kwargs)
+    return InventoryItem(**defaults)
+
+
+def _make_search_service() -> InventorySearchService:
+    """Return a service with a no-op mock provider."""
+    provider = MagicMock()
+    provider.provider_id = "mouser"
+    provider.search.return_value = []
+    return InventorySearchService(provider)
+
+
+def _csv_reader(csv_text: str) -> list:
+    """Load inventory items from in-memory CSV text via a temp file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(textwrap.dedent(csv_text))
+        tmp_path = Path(f.name)
+    reader = InventoryReader(tmp_path)
+    items, _ = reader.load()
+    os.unlink(tmp_path)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# InventoryItem field defaults
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryItemTypedFieldDefaults:
+    def test_resistance_defaults_to_none(self):
+        item = _make_inventory_item()
+        assert item.resistance is None
+
+    def test_capacitance_defaults_to_none(self):
+        item = _make_inventory_item(category="CAP", value="100nF")
+        assert item.capacitance is None
+
+    def test_inductance_defaults_to_none(self):
+        item = _make_inventory_item(category="IND", value="10uH")
+        assert item.inductance is None
+
+    def test_name_defaults_to_empty_string(self):
+        item = _make_inventory_item()
+        assert item.name == ""
+
+    def test_explicit_typed_fields_accepted(self):
+        item = _make_inventory_item(resistance=10_000.0, name="MyPart")
+        assert item.resistance == pytest.approx(10_000.0)
+        assert item.name == "MyPart"
+
+
+# ---------------------------------------------------------------------------
+# Inventory reader: decode from explicit typed column
+# ---------------------------------------------------------------------------
+
+
+# Shared CSV header matching the current inventory column layout.
+_INV_HEADER = (
+    "IPN,ComponentName,Keywords,Category,SMD,Value,Type,Description,"
+    "Name,Resistance,Capacitance,Inductance,Package,Tolerance,V,A,W,"
+    "Priority,Manufacturer,MPN,Datasheet\n"
+)
+
+
+class TestInventoryReaderTypedColumnDecode:
+    """Typed columns (Resistance, Capacitance, Inductance) are decoded at intake."""
+
+    def test_resistance_explicit_column_decoded(self):
+        csv = _INV_HEADER + "R1,,10K RES,RES,SMD,10K,,,,10K,,,0603,1%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].resistance == pytest.approx(10_000.0)
+
+    def test_capacitance_explicit_column_decoded(self):
+        csv = _INV_HEADER + "C1,,CAP,CAP,SMD,100nF,,,,, 100nF,,0603,10%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].capacitance == pytest.approx(100e-9)
+
+    def test_inductance_explicit_column_decoded(self):
+        csv = _INV_HEADER + "L1,,IND,IND,SMD,10uH,,,,,, 10uH,0603,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].inductance == pytest.approx(10e-6)
+
+    def test_name_column_read_for_nonpassive(self):
+        csv = _INV_HEADER + "IC1,,IC,IC,SMD,LM358D,,,LM358D,,,,,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].name == "LM358D"
+
+    def test_name_column_empty_for_passive(self):
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,10K,,,, 10K,,,0603,1%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].name == ""
+
+
+# ---------------------------------------------------------------------------
+# Inventory reader: Value-column fallback
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryReaderValueFallback:
+    """When explicit typed column is absent, Value column is decoded as fallback."""
+
+    def test_resistance_decoded_from_value_when_column_empty(self):
+        # Resistance column is empty; Value="10K"
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,10K,,,,,,,0603,1%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].resistance == pytest.approx(10_000.0)
+
+    def test_capacitance_decoded_from_value_when_column_empty(self):
+        csv = _INV_HEADER + "C1,,CAP,CAP,SMD,100nF,,,,,,,0603,10%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].capacitance == pytest.approx(100e-9)
+
+    def test_inductance_decoded_from_value_when_column_empty(self):
+        csv = _INV_HEADER + "L1,,IND,IND,SMD,10uH,,,,,,,0603,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].inductance == pytest.approx(10e-6)
+
+    def test_nonpassive_leaves_typed_fields_none(self):
+        # IC has no parseable Resistance/Capacitance/Inductance
+        csv = _INV_HEADER + "IC1,,IC,IC,SMD,LM358D,,,LM358D,,,,,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].resistance is None
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+
+    def test_unparseable_value_leaves_typed_field_none(self):
+        # Value is not a parseable resistance (e.g. "N/A")
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,N/A,,,,,,,0603,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].resistance is None
+
+
+# ---------------------------------------------------------------------------
+# Inventory reader: disagreement warning
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryReaderDisagreementWarning:
+    """A WARNING is logged when explicit typed column and Value parse to different values."""
+
+    def test_warning_when_resistance_and_value_disagree(self, caplog):
+        # Resistance column says 10K but Value says 1K — clear disagreement
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,1K,,,, 10K,,,0603,1%,,,,1,,,,\n"
+        with caplog.at_level(logging.WARNING, logger="jbom.services.inventory_reader"):
+            items = _csv_reader(csv)
+        assert items[0].resistance == pytest.approx(10_000.0)  # explicit column wins
+        assert any(
+            "conflict" in r.message.lower() or "disagree" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_no_warning_when_both_agree(self, caplog):
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,10K,,,, 10K,,,0603,1%,,,,1,,,,\n"
+        with caplog.at_level(logging.WARNING, logger="jbom.services.inventory_reader"):
+            items = _csv_reader(csv)
+        assert items[0].resistance == pytest.approx(10_000.0)
+        assert not any(
+            "conflict" in r.message.lower() or "disagree" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_no_warning_when_only_value_present(self, caplog):
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,10K,,,,,,,0603,1%,,,,1,,,,\n"
+        with caplog.at_level(logging.WARNING, logger="jbom.services.inventory_reader"):
+            _csv_reader(csv)
+        assert not any(
+            "conflict" in r.message.lower() or "disagree" in r.message.lower()
+            for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_query: typed fields for passives
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQueryTypedFields:
+    """build_query() uses typed float fields for passives, formatted back to EIA."""
+
+    def _svc(self) -> InventorySearchService:
+        return _make_search_service()
+
+    def test_resistor_uses_resistance_field(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="RES", value="10K", resistance=10_000.0)
+        query = svc.build_query(item)
+        assert "10K" in query
+
+    def test_resistor_normalizes_value_via_typed_field(self):
+        # value="200" (no unit suffix), resistance=200.0 → should format as "200R"
+        svc = self._svc()
+        item = _make_inventory_item(category="RES", value="200", resistance=200.0)
+        query = svc.build_query(item)
+        assert "200R" in query
+
+    def test_capacitor_uses_capacitance_field(self):
+        svc = self._svc()
+        item = _make_inventory_item(
+            category="CAP", value="0.01uF", capacitance=10e-9, tolerance="10%"
+        )
+        query = svc.build_query(item)
+        # 10nF is the normalized form of 0.01uF
+        assert "10nF" in query
+
+    def test_inductor_uses_inductance_field(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="IND", value="10uH", inductance=10e-6)
+        query = svc.build_query(item)
+        assert "10uH" in query
+
+    def test_resistor_falls_back_to_value_when_resistance_none(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="RES", value="10K", resistance=None)
+        query = svc.build_query(item)
+        assert "10K" in query
+
+    def test_capacitor_falls_back_to_value_when_capacitance_none(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="CAP", value="100nF", capacitance=None)
+        query = svc.build_query(item)
+        assert "100nF" in query
+
+
+# ---------------------------------------------------------------------------
+# build_query: Name field for non-passives
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQueryNameField:
+    """build_query() prefers item.name over item.value for non-passive components."""
+
+    def _svc(self) -> InventorySearchService:
+        return _make_search_service()
+
+    def test_ic_uses_name_field_when_set(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="IC", value="LM358D", name="LM358D")
+        query = svc.build_query(item)
+        assert "LM358D" in query
+
+    def test_reg_prefers_name_over_value_when_name_set(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="REG", value="3.3V", name="AMS1117-3.3")
+        query = svc.build_query(item)
+        assert "AMS1117-3.3" in query
+
+    def test_nonpassive_falls_back_to_value_when_name_empty(self):
+        svc = self._svc()
+        item = _make_inventory_item(category="IC", value="NE555", name="")
+        query = svc.build_query(item)
+        assert "NE555" in query
+
+    def test_name_not_used_for_passives(self):
+        """Even if name is populated, passives use typed fields / value."""
+        svc = self._svc()
+        # Hypothetical: name accidentally set on a resistor — should be ignored
+        item = _make_inventory_item(
+            category="RES", value="10K", resistance=10_000.0, name="SomeResistor"
+        )
+        query = svc.build_query(item)
+        assert "SomeResistor" not in query
+        assert "10K" in query


### PR DESCRIPTION
## Summary

Implements Issue #90: Add typed parametric fields (`resistance`, `capacitance`, `inductance`, `name`) to `InventoryItem` with intake-time decoding from inventory CSV columns.

## Changes Made

### `src/jbom/common/types.py`
- Added four new optional fields to `InventoryItem`:
  - `resistance: Optional[float] = None` — in ohms
  - `capacitance: Optional[float] = None` — in farads
  - `inductance: Optional[float] = None` — in henries
  - `name: str = ""` — component name for non-passives (e.g. `"LM358D"`, `"AMS1117-3.3"`)

### `src/jbom/services/inventory_reader.py`
- Added `_TYPED_COLUMN` dict mapping normalized category → CSV column name
- Added `_decode_typed_parametric(category, value, row)` helper that:
  1. Reads the explicit typed column (`Resistance`, `Capacitance`, or `Inductance`)
  2. Falls back to parsing the `Value` column when the typed column is empty
  3. Logs a `WARNING` when both sources parse successfully but disagree by >0.1%
  4. Returns the explicit typed column value when both are present (explicit wins)
- Updated `_process_inventory_data()` to decode all four new fields at intake

### `src/jbom/services/search/inventory_search_service.py`
- Updated `build_query()` to use typed numeric fields for the primary search token:
  - RES: `ohms_to_eia(item.resistance)` → normalised EIA string (e.g. `"200R"` instead of `"200"`)
  - CAP: `farad_to_eia(item.capacitance)` → normalised string (e.g. `"10nF"` instead of `"0.01uF"`)
  - IND: `henry_to_eia(item.inductance)` → normalised string
  - Non-passives: `item.name` if non-empty, else `item.value` as before
  - Falls back to raw `value` string when the typed field is `None`

### `tests/unit/test_typed_parametric_fields.py` (new)
- 28 tests across 6 test classes covering all new behaviour

## Verification

- `pytest`: 312 passed, 3 skipped
- `behave --format progress`: 192 scenarios passed, 0 failed
- All pre-commit hooks pass (black, flake8, bandit)

## Architecture Impact

Pure additive change. All new fields have defaults so existing callers need no modification. The `build_query()` change is backward-compatible: passives with no typed field fall back to raw `value` exactly as before.

Closes #90

Co-Authored-By: Oz <oz-agent@warp.dev>