### PR TITLE
Search: config-driven fields + --fields/--list-fields

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -237,6 +237,12 @@ Searches distributor catalogs for parts matching a keyword or part number.
 **--no-parametric**
 : Disable smart parametric filtering derived from the query text.
 
+**--fields LIST**
+: Comma-separated list of output field *registry keys* (applies to console + CSV output). Use `--list-fields` to discover valid keys.
+
+**--list-fields**
+: Print available field keys alongside their display names, then exit. Does not require an API key.
+
 **-o, --output OUTPUT**
 : Output destination. Default: `console` (formatted table).
   - Use `-o console` (or omit `-o`) for a formatted table.

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -1,4 +1,4 @@
-"""Search command - catalog lookup via external distributors (Phase 6)."""
+"""Search command - catalog lookup via external suppliers (Phase 6)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,8 @@ import argparse
 import csv
 import shutil
 import sys
-from typing import Optional, TextIO
+from dataclasses import dataclass
+from typing import Callable, Optional, TextIO
 
 from jbom.cli.formatting import Column, print_table
 from jbom.cli.output import (
@@ -17,6 +18,7 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.filtering import (
     SearchFilter,
@@ -28,19 +30,115 @@ from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
 
 
+@dataclass(frozen=True)
+class _FieldDef:
+    """Registry entry describing a selectable search output field."""
+
+    key: str
+    column: Column
+    extractor: Callable[[SearchResult], str]
+
+
+def _s(r: SearchResult, value: object) -> str:
+    # Ensure everything is a safe string for console/CSV output.
+    return str(value if value is not None else "")
+
+
+_FIELD_REGISTRY: dict[str, _FieldDef] = {
+    # NOTE: SearchResult currently exposes distributor_part_number (normalized provider field).
+    # We use supplier_part_number as the public registry key to keep the CLI supplier-agnostic.
+    "supplier_part_number": _FieldDef(
+        key="supplier_part_number",
+        column=Column(
+            header="Supplier PN",
+            key="supplier_part_number",
+            preferred_width=28,
+            wrap=True,
+        ),
+        extractor=lambda r: _s(r, r.distributor_part_number),
+    ),
+    "mpn": _FieldDef(
+        key="mpn",
+        column=Column(header="MPN", key="mpn", preferred_width=18, wrap=True),
+        extractor=lambda r: _s(r, r.mpn),
+    ),
+    "manufacturer": _FieldDef(
+        key="manufacturer",
+        column=Column(
+            header="Manufacturer", key="manufacturer", preferred_width=16, wrap=True
+        ),
+        extractor=lambda r: _s(r, r.manufacturer),
+    ),
+    "price": _FieldDef(
+        key="price",
+        column=Column(
+            header="Price",
+            key="price",
+            preferred_width=10,
+            fixed=True,
+            align="right",
+        ),
+        extractor=lambda r: _s(r, r.price),
+    ),
+    "stock_quantity": _FieldDef(
+        key="stock_quantity",
+        column=Column(
+            header="Stock",
+            key="stock_quantity",
+            preferred_width=8,
+            fixed=True,
+            align="right",
+        ),
+        extractor=lambda r: _s(r, r.stock_quantity),
+    ),
+    "lifecycle_status": _FieldDef(
+        key="lifecycle_status",
+        column=Column(
+            header="Lifecycle",
+            key="lifecycle_status",
+            preferred_width=10,
+            wrap=True,
+        ),
+        extractor=lambda r: _s(r, r.lifecycle_status),
+    ),
+    "description": _FieldDef(
+        key="description",
+        column=Column(
+            header="Description", key="description", preferred_width=60, wrap=True
+        ),
+        extractor=lambda r: _s(r, r.description),
+    ),
+    "availability": _FieldDef(
+        key="availability",
+        column=Column(
+            header="Availability", key="availability", preferred_width=18, wrap=True
+        ),
+        extractor=lambda r: _s(r, r.availability),
+    ),
+    "details_url": _FieldDef(
+        key="details_url",
+        column=Column(
+            header="Details URL", key="details_url", preferred_width=40, wrap=True
+        ),
+        extractor=lambda r: _s(r, r.details_url),
+    ),
+}
+
+
 def register_command(subparsers) -> None:
     """Register search command with argument parser."""
 
     parser = subparsers.add_parser(
         "search",
-        help="Search distributor catalogs (e.g. Mouser)",
-        description="Search distributor catalogs and print results.",
+        help="Search supplier catalogs (e.g. Mouser)",
+        description="Search supplier catalogs and print results.",
     )
 
     parser.add_argument(
         "query", help="Search query (keyword, part number, description)"
     )
 
+    # Provider controls the API backend.
     parser.add_argument(
         "--provider",
         choices=["mouser"],
@@ -82,6 +180,17 @@ def register_command(subparsers) -> None:
     )
 
     parser.add_argument(
+        "--fields",
+        help="Comma-separated list of output field registry keys (use --list-fields to discover)",
+    )
+
+    parser.add_argument(
+        "--list-fields",
+        action="store_true",
+        help="List available field keys and exit",
+    )
+
+    parser.add_argument(
         "-o",
         "--output",
         help="Output destination: omit for console, use 'console' for table, '-' for CSV to stdout, or a file path",
@@ -95,6 +204,14 @@ def handle_search(
     args: argparse.Namespace, *, _cache: SearchCache | None = None
 ) -> int:
     """Handle `jbom search` command."""
+
+    if bool(getattr(args, "list_fields", False)):
+        _print_list_fields()
+        return 0
+
+    resolved_fields = _resolve_fields_from_args(args)
+    if resolved_fields is None:
+        return 1
 
     cache = _cache if _cache is not None else _build_cache(args)
 
@@ -125,7 +242,88 @@ def handle_search(
     results = results[:display_limit]
 
     force = bool(getattr(args, "force", False))
-    return _output_results(results, output=args.output, force=force)
+    return _output_results(
+        results,
+        output=args.output,
+        force=force,
+        fields=resolved_fields,
+    )
+
+
+def _print_list_fields() -> None:
+    width = max((len(k) for k in _FIELD_REGISTRY.keys()), default=1) + 2
+    print("\nAvailable fields:")
+    for key in sorted(_FIELD_REGISTRY.keys()):
+        label = _FIELD_REGISTRY[key].column.header
+        print(f"  {key:<{width}}{label}")
+    print("")
+
+
+def _parse_fields_argument(fields: str) -> list[str] | None:
+    raw = [t.strip() for t in (fields or "").split(",")]
+    tokens: list[str] = []
+    for tok in raw:
+        if not tok:
+            continue
+        tokens.append(tok)
+
+    if not tokens:
+        print("Error: --fields parameter cannot be empty", file=sys.stderr)
+        return None
+
+    # Registry keys only.
+    normalized = [t.strip().lower() for t in tokens]
+
+    unknown = [f for f in normalized if f not in _FIELD_REGISTRY]
+    if unknown:
+        print(f"Error: Unknown field(s): {', '.join(unknown)}", file=sys.stderr)
+        print("\nUse --list-fields to see valid field keys.", file=sys.stderr)
+        return None
+
+    # Deduplicate, preserve order.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for f in normalized:
+        if f not in seen:
+            seen.add(f)
+            deduped.append(f)
+
+    return deduped
+
+
+def _resolve_fields_from_args(args: argparse.Namespace) -> list[str] | None:
+    # 1) CLI override
+    if getattr(args, "fields", None) is not None:
+        return _parse_fields_argument(args.fields)
+
+    # 2) Supplier profile fields (provider id is the closest proxy for supplier id)
+    supplier_id = (getattr(args, "provider", "") or "").strip().lower()
+    supplier = resolve_supplier_by_id(supplier_id)
+    if supplier is not None and supplier.search_fields:
+        return list(supplier.search_fields)
+
+    # 3) Generic profile fields
+    try:
+        generic = load_supplier("generic")
+        if generic.search_fields:
+            return list(generic.search_fields)
+    except ValueError:
+        pass
+
+    # 4) Emergency fallback (keep it simple and always include description)
+    return [
+        "supplier_part_number",
+        "price",
+        "stock_quantity",
+        "lifecycle_status",
+        "description",
+    ]
+
+
+def _row_for_result(r: SearchResult) -> dict[str, str]:
+    """Build a row mapping containing every known registry key."""
+
+    return {k: _FIELD_REGISTRY[k].extractor(r) for k in _FIELD_REGISTRY.keys()}
 
 
 def _build_cache(args: argparse.Namespace) -> SearchCache:
@@ -149,7 +347,11 @@ def _create_provider(
 
 
 def _output_results(
-    results: list[SearchResult], *, output: Optional[str], force: bool
+    results: list[SearchResult],
+    *,
+    output: Optional[str],
+    force: bool,
+    fields: list[str],
 ) -> int:
     dest = resolve_output_destination(
         output,
@@ -157,11 +359,11 @@ def _output_results(
     )
 
     if dest.kind == OutputKind.CONSOLE:
-        _print_console(results)
+        _print_console(results, fields=fields)
         return 0
 
     if dest.kind == OutputKind.STDOUT:
-        _print_csv(results, out=sys.stdout)
+        _print_csv(results, fields=fields, out=sys.stdout)
         return 0
 
     if not dest.path:
@@ -178,7 +380,7 @@ def _output_results(
             force=force,
             refused_message=refused,
         ) as f:
-            _print_csv(results, out=f)
+            _print_csv(results, fields=fields, out=f)
     except OutputRefusedError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -187,45 +389,19 @@ def _output_results(
     return 0
 
 
-def _print_console(results: list[SearchResult]) -> None:
+def _print_console(results: list[SearchResult], *, fields: list[str]) -> None:
     if not results:
         print("No results found.")
         return
 
     rows = [_row_for_result(r) for r in results]
 
-    # Fixed, predictable columns: the supplier Description already carries the
-    # parametric summary in human-readable form (e.g. "CAP CER 0.1UF 50V X7R 0603").
-    # Description gets the remaining terminal width after the narrower fixed columns.
-    cols = [
-        Column(
-            header="Distributor PN",
-            key="distributor_part_number",
-            preferred_width=28,
-            wrap=True,
-        ),
-        Column(
-            header="Price",
-            key="price",
-            preferred_width=10,
-            fixed=True,
-            align="right",
-        ),
-        Column(
-            header="Stock",
-            key="stock_quantity",
-            preferred_width=8,
-            fixed=True,
-            align="right",
-        ),
-        Column(
-            header="Lifecycle",
-            key="lifecycle_status",
-            preferred_width=10,
-            wrap=True,
-        ),
-        Column(header="Description", key="description", preferred_width=60, wrap=True),
-    ]
+    cols: list[Column] = []
+    for f in fields:
+        if f not in _FIELD_REGISTRY:
+            # Defensive: should never happen after validation.
+            continue
+        cols.append(_FIELD_REGISTRY[f].column)
 
     terminal_width = shutil.get_terminal_size(fallback=(120, 24)).columns
     print("")
@@ -234,49 +410,19 @@ def _print_console(results: list[SearchResult]) -> None:
     print(f"Found {len(results)} results.")
 
 
-def _print_csv(results: list[SearchResult], *, out: TextIO) -> None:
-    writer = csv.DictWriter(out, fieldnames=_csv_headers())
-    writer.writeheader()
+def _print_csv(results: list[SearchResult], *, fields: list[str], out: TextIO) -> None:
+    writer = csv.writer(out)
+    writer.writerow(_csv_headers(fields))
+
     for r in results:
-        writer.writerow(_csv_row_for_result(r))
+        row = _csv_row_for_result(r, fields)
+        writer.writerow(row)
 
 
-def _csv_headers() -> list[str]:
-    # House style: human-readable headers (Title Case / abbreviations) similar to
-    # other jbom-new CSV outputs.
-    return [
-        "Manufacturer",
-        "MPN",
-        "Distributor",
-        "Distributor PN",
-        "Availability",
-        "Stock",
-        "Price",
-        "Lifecycle",
-        "Details URL",
-    ]
+def _csv_headers(fields: list[str]) -> list[str]:
+    return [_FIELD_REGISTRY[f].column.header for f in fields]
 
 
-def _csv_row_for_result(r: SearchResult) -> dict[str, str]:
-    return {
-        "Manufacturer": r.manufacturer,
-        "MPN": r.mpn,
-        "Distributor": r.distributor,
-        "Distributor PN": r.distributor_part_number,
-        "Availability": r.availability,
-        "Stock": str(r.stock_quantity),
-        "Price": r.price,
-        "Lifecycle": r.lifecycle_status,
-        "Details URL": r.details_url,
-    }
-
-
-def _row_for_result(r: SearchResult) -> dict[str, str]:
-    """Build the console row mapping for a single search result."""
-    return {
-        "distributor_part_number": r.distributor_part_number,
-        "price": r.price,
-        "stock_quantity": str(r.stock_quantity),
-        "lifecycle_status": r.lifecycle_status,
-        "description": r.description,
-    }
+def _csv_row_for_result(r: SearchResult, fields: list[str]) -> list[str]:
+    full = _row_for_result(r)
+    return [str(full.get(f, "")) for f in fields]

--- a/src/jbom/config/suppliers.py
+++ b/src/jbom/config/suppliers.py
@@ -35,6 +35,9 @@ class SupplierConfig:
     part_number_pattern: Optional[str] = None
     part_number_example: Optional[str] = None
 
+    # Search output field selection (applies to console + CSV output).
+    search_fields: list[str] = field(default_factory=list)
+
     # Search behavior tuning (optional).
     search_cache_ttl_hours: Optional[float] = None
     search_timeout_seconds: Optional[float] = None
@@ -101,6 +104,18 @@ class SupplierConfig:
         search_cfg = data.get("search") or {}
         if not isinstance(search_cfg, dict):
             raise ValueError(f"Supplier '{sid}' search must be a mapping")
+
+        fields_cfg = search_cfg.get("fields") or []
+        if not isinstance(fields_cfg, list):
+            raise ValueError(f"Supplier '{sid}' search.fields must be a list")
+
+        search_fields: list[str] = []
+        for f in fields_cfg:
+            if not isinstance(f, str) or not f.strip():
+                raise ValueError(
+                    f"Supplier '{sid}' search.fields entries must be non-empty strings"
+                )
+            search_fields.append(f.strip().lower())
 
         cache_cfg = search_cfg.get("cache") or {}
         if not isinstance(cache_cfg, dict):
@@ -191,6 +206,7 @@ class SupplierConfig:
             search_url_template=search_url_template,
             part_number_pattern=pattern,
             part_number_example=example,
+            search_fields=search_fields,
             search_cache_ttl_hours=(
                 float(cache_ttl_hours) if cache_ttl_hours is not None else None
             ),

--- a/src/jbom/config/suppliers/generic.supplier.yaml
+++ b/src/jbom/config/suppliers/generic.supplier.yaml
@@ -8,5 +8,12 @@ search_url_template: null
 part_number: {}
 
 search:
+  fields:
+    - supplier_part_number
+    - price
+    - stock_quantity
+    - lifecycle_status
+    - description
+
   cache:
     ttl_hours: 24

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -70,15 +70,17 @@ def test_search_console_output(monkeypatch, capsys):
         all=True,
         no_parametric=True,
         output="console",
+        fields=None,
+        list_fields=False,
     )
 
     rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     out = capsys.readouterr().out
-    assert "Distributor PN" in out
+    assert "Supplier PN" in out
     assert "Description" in out
-    assert "123-ABC" in out  # distributor part number
+    assert "123-ABC" in out  # supplier_part_number
 
 
 def test_search_csv_stdout(monkeypatch, capsys):
@@ -98,14 +100,16 @@ def test_search_csv_stdout(monkeypatch, capsys):
         all=True,
         no_parametric=True,
         output="-",
+        fields=None,
+        list_fields=False,
     )
 
     rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     out = capsys.readouterr().out.splitlines()
-    assert out[0].startswith("Manufacturer,MPN,Distributor")
-    assert any("Yageo" in line for line in out[1:])
+    assert out[0].startswith("Supplier PN,Price,Stock")
+    assert any("123-ABC" in line for line in out[1:])
 
 
 def test_search_csv_file(monkeypatch, tmp_path):
@@ -127,11 +131,100 @@ def test_search_csv_file(monkeypatch, tmp_path):
         all=True,
         no_parametric=True,
         output=str(outpath),
+        fields=None,
+        list_fields=False,
     )
 
     rc = handle_search(args, _cache=InMemorySearchCache())
     assert rc == 0
 
     text = outpath.read_text(encoding="utf-8")
-    assert text.splitlines()[0].startswith("Manufacturer,MPN,Distributor")
-    assert "Yageo" in text
+    assert text.splitlines()[0].startswith("Supplier PN,Price,Stock")
+    assert "123-ABC" in text
+
+
+def test_search_list_fields_exits_without_api_key(monkeypatch, capsys):
+    # This should not require an API key and should not call providers.
+    from jbom.services.search import mouser_provider
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("Provider.search should not be called for --list-fields")
+
+    monkeypatch.setattr(mouser_provider.MouserProvider, "search", _boom)
+
+    args = argparse.Namespace(
+        query="ignored",
+        provider="mouser",
+        limit=1,
+        api_key=None,
+        all=True,
+        no_parametric=True,
+        output="console",
+        fields=None,
+        list_fields=True,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "supplier_part_number" in out
+    assert "Supplier PN" in out
+
+
+def test_search_fields_override_affects_csv_schema(monkeypatch, capsys):
+    from jbom.services.search import mouser_provider
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [_sr()],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        provider="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+        fields="mpn,manufacturer",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+
+    out = capsys.readouterr().out.splitlines()
+    assert out[0] == "MPN,Manufacturer"
+    assert any("RC0603FR-0710KL" in line for line in out[1:])
+    assert any("Yageo" in line for line in out[1:])
+
+
+def test_search_unknown_field_rejected(monkeypatch, capsys):
+    from jbom.services.search import mouser_provider
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("Provider.search should not be called on invalid --fields")
+
+    monkeypatch.setattr(mouser_provider.MouserProvider, "search", _boom)
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        provider="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="console",
+        fields="does_not_exist",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 1
+
+    captured = capsys.readouterr()
+    assert "Unknown field" in captured.err
+    assert "does_not_exist" in captured.err

--- a/tests/unit/test_supplier_config_schema.py
+++ b/tests/unit/test_supplier_config_schema.py
@@ -38,6 +38,9 @@ def test_load_supplier_lcsc() -> None:
 
     assert lcsc.search_cache_ttl_hours == 24
 
+    # LCSC does not currently override search.fields; it should fall back to generic.
+    assert lcsc.search_fields == []
+
     assert isinstance(lcsc.search_type_query_keywords, dict)
     assert lcsc.search_type_query_keywords == {}
 
@@ -70,3 +73,15 @@ def test_validate_part_number_without_pattern_is_advisory() -> None:
 
     assert validate_part_number(generic, "ANYTHING") is True
     assert validate_part_number(generic, "") is False
+
+
+def test_load_supplier_generic_has_search_fields() -> None:
+    generic = load_supplier("generic")
+
+    assert generic.search_fields == [
+        "supplier_part_number",
+        "price",
+        "stock_quantity",
+        "lifecycle_status",
+        "description",
+    ]


### PR DESCRIPTION
Closes #97.

Summary
- Adds config-driven search output field selection via `search.fields` in supplier profiles.
- Introduces `jbom search --fields` (registry keys only) and `jbom search --list-fields`.
- Implements a field registry in `src/jbom/cli/search.py` with supplier-agnostic key `supplier_part_number` (displayed as "Supplier PN").
- Applies field selection consistently across console table and CSV outputs.

Config
- `src/jbom/config/suppliers/generic.supplier.yaml` now defines the baseline `search.fields`.
- `SupplierConfig` parses `search.fields` as `search_fields`.

Testing
- `python -m pytest`
- `python -m behave --format progress`

Notes
- `--list-fields` exits without requiring an API key and does not invoke provider network calls.

Co-Authored-By: Oz <oz-agent@warp.dev>