### PR TITLE
Fab profiles: ordered supplier list + fab-relative sparseness (Phase 1)

### DIFF
--- a/src/jbom/cli/inventory_search.py
+++ b/src/jbom/cli/inventory_search.py
@@ -16,10 +16,31 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.common.cli_fabricator import (
+    add_fabricator_arguments,
+    resolve_fabricator_selection_from_args,
+)
+from jbom.config.fabricators import load_fabricator
 from jbom.services.inventory_reader import InventoryReader
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.inventory_search_service import InventorySearchService
 from jbom.services.search.mouser_provider import MouserProvider
+
+
+_PROVIDER_FACTORIES = {
+    "mouser": MouserProvider,
+}
+
+
+def _default_provider_for_fabricator(fabricator_id: str) -> str:
+    """Pick the first working provider based on fab supplier priority."""
+
+    fab = load_fabricator(fabricator_id)
+    for supplier_id in fab.suppliers:
+        if supplier_id in _PROVIDER_FACTORIES:
+            return supplier_id
+    # Fallback: preserve historical default behavior.
+    return "mouser"
 
 
 def register_command(subparsers) -> None:
@@ -50,9 +71,9 @@ def register_command(subparsers) -> None:
 
     parser.add_argument(
         "--provider",
-        choices=["mouser"],
-        default="mouser",
-        help="Search provider to use (default: mouser)",
+        choices=sorted(_PROVIDER_FACTORIES.keys()),
+        default=None,
+        help="Search provider to use (default: derived from fabricator supplier priority)",
     )
 
     parser.add_argument(
@@ -90,6 +111,10 @@ def register_command(subparsers) -> None:
         help="Comma-separated list of categories to search (e.g. 'RES,CAP,IC')",
     )
 
+    # Fabricator selection (optional). When specified, inventory-search will scope
+    # to items that are sparse for that fabricator.
+    add_fabricator_arguments(parser)
+
     parser.set_defaults(handler=handle_inventory_search)
 
 
@@ -113,12 +138,33 @@ def handle_inventory_search(
             items, categories=args.categories
         )
 
+        # Fab-relative sparseness is opt-in: only apply when the user explicitly
+        # selects a fabricator.
+        fabricator_id, fabricator_explicit = resolve_fabricator_selection_from_args(
+            args
+        )
+        if fabricator_explicit:
+            fab = load_fabricator(fabricator_id)
+            searchable = InventorySearchService.filter_sparse_items_for_fabricator(
+                searchable,
+                fabricator=fab,
+            )
+
         if args.dry_run:
             _print_dry_run_summary(searchable)
             return 0
 
-        cache = _cache if _cache is not None else _build_cache(args)
-        provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
+        provider_id = (args.provider or "").strip().lower()
+        if not provider_id:
+            # Preserve historical default when no fabricator is explicitly selected.
+            provider_id = (
+                _default_provider_for_fabricator(fabricator_id)
+                if fabricator_explicit
+                else "mouser"
+            )
+
+        cache = _cache if _cache is not None else _build_cache(provider_id, args)
+        provider = _create_provider(provider_id, api_key=args.api_key, cache=cache)
         service = InventorySearchService(
             provider,
             candidate_limit=args.limit,
@@ -181,24 +227,29 @@ def handle_inventory_search(
         return 1
 
 
-def _build_cache(args: argparse.Namespace) -> SearchCache:
+def _build_cache(provider_id: str, args: argparse.Namespace) -> SearchCache:
     if getattr(args, "clear_cache", False):
-        DiskSearchCache.clear_provider(args.provider)
+        DiskSearchCache.clear_provider(provider_id)
 
     if getattr(args, "no_cache", False):
         return InMemorySearchCache()
 
-    return DiskSearchCache(args.provider)
+    return DiskSearchCache(provider_id)
 
 
 def _create_provider(
     provider_id: str, *, api_key: str | None, cache: SearchCache
 ) -> MouserProvider:
     pid = (provider_id or "").strip().lower()
+
+    if pid not in _PROVIDER_FACTORIES:
+        raise ValueError(f"Unknown provider: {provider_id}")
+
     if pid == "mouser":
         return MouserProvider(api_key=api_key, cache=cache)
 
-    raise ValueError(f"Unknown provider: {provider_id}")
+    # Defensive: keep mypy happy if additional factories are added without updating.
+    raise AssertionError(f"Unhandled provider_id: {pid}")
 
 
 def _print_dry_run_summary(items) -> None:

--- a/src/jbom/common/cli_fabricator.py
+++ b/src/jbom/common/cli_fabricator.py
@@ -7,114 +7,109 @@ from __future__ import annotations
 
 import argparse
 
-from jbom.config.fabricators import get_available_fabricators
+from jbom.config.fabricators import get_available_fabricators, load_fabricator
+
+
+def _flag_dest(fabricator_id: str) -> str:
+    """Return argparse dest name for a dynamic fabricator shorthand flag."""
+
+    token = (fabricator_id or "").strip().replace("-", "_")
+    return f"fabricator_flag_{token}"
 
 
 def add_fabricator_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add standard fabricator selection arguments to argument parser.
+    """Add standard fabricator selection arguments to an argument parser.
 
-    Adds both --fabricator parameter and individual preset flags (--jlc, --generic, etc.)
-    used by BOM and POS commands.
+    Adds both --fabricator and per-fabricator shorthand flags (e.g. --jlc).
+
+    Flags are generated dynamically from the discovered built-in fabricator
+    profiles so the CLI help output stays accurate as profiles are added.
 
     Args:
-        parser: Argument parser to add fabricator arguments to
+        parser: Argument parser to add fabricator arguments to.
     """
+
+    available = get_available_fabricators()
+
     # Fabricator selection (for field presets / predictable output)
     parser.add_argument(
         "--fabricator",
-        choices=get_available_fabricators(),
+        choices=available,
+        default=None,
         help="Specify PCB fabricator for field presets (default: generic)",
     )
 
-    # Individual fabricator preset flags
-    parser.add_argument("--jlc", action="store_true", help="Use JLC preset")
-    parser.add_argument("--pcbway", action="store_true", help="Use PCBWay preset")
-    parser.add_argument("--seeed", action="store_true", help="Use Seeed preset")
-    parser.add_argument("--generic", action="store_true", help="Use Generic preset")
+    # Individual fabricator shorthand flags (e.g. --jlc).
+    for fid in available:
+        try:
+            display_name = load_fabricator(fid).name
+        except Exception:
+            display_name = fid
+
+        parser.add_argument(
+            f"--{fid}",
+            action="store_true",
+            dest=_flag_dest(fid),
+            help=f"Use {display_name} preset",
+        )
+
+
+def resolve_fabricator_selection_from_args(
+    args: argparse.Namespace,
+) -> tuple[str, bool]:
+    """Resolve fabricator selection from CLI args.
+
+    Returns:
+        (fabricator_id, is_explicit)
+
+    is_explicit is True only when the user provided --fabricator or a shorthand
+    flag, rather than falling back to the default.
+
+    Raises:
+        ValueError: when conflicting fabricator arguments are provided.
+    """
+
+    available = get_available_fabricators()
+
+    shorthand_selected: list[str] = []
+    for fid in available:
+        if getattr(args, _flag_dest(fid), False):
+            shorthand_selected.append(fid)
+
+    if len(shorthand_selected) > 1:
+        raise ValueError(
+            f"Cannot specify multiple fabricator presets: {', '.join('--' + f for f in shorthand_selected)}"
+        )
+
+    fabricator_param = getattr(args, "fabricator", None)
+    if fabricator_param and shorthand_selected:
+        raise ValueError(
+            f"Cannot specify both --fabricator {fabricator_param} and "
+            f"individual preset flags: {', '.join('--' + f for f in shorthand_selected)}"
+        )
+
+    if fabricator_param:
+        return str(fabricator_param), True
+
+    if shorthand_selected:
+        return shorthand_selected[0], True
+
+    return "generic", False
 
 
 def resolve_fabricator_from_args(args: argparse.Namespace) -> str:
     """Resolve effective fabricator from command line arguments.
 
-    Handles both --fabricator parameter and individual preset flags,
+    Handles both --fabricator parameter and individual shorthand flags,
     with fallback to "generic" if nothing specified.
-
-    Args:
-        args: Parsed command line arguments
-
-    Returns:
-        Effective fabricator ID (e.g., "jlc", "generic", "pcbway")
-
-    Raises:
-        ValueError: If multiple fabricator presets are specified
     """
-    # Check for multiple fabricator preset conflicts
-    preset_flags = []
-    if getattr(args, "jlc", False):
-        preset_flags.append("--jlc")
-    if getattr(args, "pcbway", False):
-        preset_flags.append("--pcbway")
-    if getattr(args, "seeed", False):
-        preset_flags.append("--seeed")
-    if getattr(args, "generic", False):
-        preset_flags.append("--generic")
 
-    if len(preset_flags) > 1:
-        raise ValueError(
-            f"Cannot specify multiple fabricator presets: {', '.join(preset_flags)}"
-        )
-
-    # Resolve fabricator from arguments
-    fabricator = getattr(args, "fabricator", None)
-
-    if not fabricator:
-        if getattr(args, "jlc", False):
-            fabricator = "jlc"
-        elif getattr(args, "pcbway", False):
-            fabricator = "pcbway"
-        elif getattr(args, "seeed", False):
-            fabricator = "seeed"
-        elif getattr(args, "generic", False):
-            fabricator = "generic"
-
-    # Default to generic if nothing specified
-    if not fabricator:
-        fabricator = "generic"
-
-    return fabricator
+    fid, _explicit = resolve_fabricator_selection_from_args(args)
+    return fid
 
 
 def validate_fabricator_args(args: argparse.Namespace) -> None:
-    """Validate fabricator-related arguments for consistency.
+    """Validate fabricator-related arguments for consistency."""
 
-    Checks for conflicts between --fabricator parameter and individual preset flags.
-
-    Args:
-        args: Parsed command line arguments
-
-    Raises:
-        ValueError: If both --fabricator and individual preset flags are specified
-    """
-    fabricator_param = getattr(args, "fabricator", None)
-    individual_flags = [
-        getattr(args, "jlc", False),
-        getattr(args, "pcbway", False),
-        getattr(args, "seeed", False),
-        getattr(args, "generic", False),
-    ]
-
-    if fabricator_param and any(individual_flags):
-        active_flags = []
-        if getattr(args, "jlc", False):
-            active_flags.append("--jlc")
-        if getattr(args, "pcbway", False):
-            active_flags.append("--pcbway")
-        if getattr(args, "seeed", False):
-            active_flags.append("--seeed")
-        if getattr(args, "generic", False):
-            active_flags.append("--generic")
-
-        raise ValueError(
-            f"Cannot specify both --fabricator {fabricator_param} and "
-            f"individual preset flags: {', '.join(active_flags)}"
-        )
+    # This is implemented by resolve_fabricator_selection_from_args.
+    resolve_fabricator_selection_from_args(args)

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -4,11 +4,16 @@ Loads fabricator definitions from built-in config files.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 import yaml
+
+from jbom.config.suppliers import resolve_supplier_by_id
+
+log = logging.getLogger(__name__)
 
 
 _SUPPORTED_TIER_OPERATORS = {"exists", "truthy", "equals", "not_empty"}
@@ -95,6 +100,10 @@ class FabricatorConfig:
     name: str
     pos_columns: Dict[str, str]  # Header -> internal field mapping
 
+    # Phase 1 schema: ordered supplier profile IDs.
+    # Position encodes priority (first entry is most preferred).
+    suppliers: list[str] = field(default_factory=list)
+
     # Phase 2 schema: field synonyms + explicit tier rules.
     field_synonyms: Dict[str, FieldSynonym] = field(default_factory=dict)
     tier_rules: Dict[int, TierRule] = field(default_factory=dict)
@@ -136,6 +145,26 @@ class FabricatorConfig:
         pcb_assembly = data.get("pcb_assembly")
         website = data.get("website")
 
+        # Phase 1: ordered supplier profile IDs.
+        suppliers_cfg = data.get("suppliers") or []
+        if not isinstance(suppliers_cfg, list):
+            raise ValueError("suppliers must be a list")
+
+        suppliers: list[str] = []
+        for raw_sid in suppliers_cfg:
+            if not isinstance(raw_sid, str) or not raw_sid.strip():
+                raise ValueError("suppliers entries must be non-empty strings")
+            sid = raw_sid.strip().lower()
+            suppliers.append(sid)
+
+            # Advisory validation: warn on unknown supplier IDs but do not error.
+            if resolve_supplier_by_id(sid) is None:
+                log.warning(
+                    "Unknown supplier profile id %r referenced by fabricator %r",
+                    sid,
+                    pid,
+                )
+
         # Schema migration guardrail: priority_fields has been replaced by
         # field_synonyms + tier_rules (Issue #59).
         if isinstance(part_number, dict) and "priority_fields" in part_number:
@@ -151,6 +180,7 @@ class FabricatorConfig:
             id=pid,
             name=name,
             pos_columns=pos_columns,
+            suppliers=suppliers,
             field_synonyms=field_synonyms,
             tier_rules=tier_rules,
             description=description,

--- a/src/jbom/config/fabricators/generic.fab.yaml
+++ b/src/jbom/config/fabricators/generic.fab.yaml
@@ -4,6 +4,16 @@ description: "Generic fabricator template"
 dynamic_name: true
 name_source: "manufacturer"
 
+# Ordered supplier profile IDs (position encodes priority).
+# Generic uses a broad, permissive scope.
+suppliers:
+  - generic
+  - lcsc
+  - mouser
+  - digikey
+  - farnell
+  - newark
+
 part_number:
   header: "Part Number"
 

--- a/src/jbom/config/fabricators/jlc.fab.yaml
+++ b/src/jbom/config/fabricators/jlc.fab.yaml
@@ -8,6 +8,15 @@ pcb_manufacturing:
 pcb_assembly:
   website: "https://jlcpcb.com/help/article/bill-of-materials-for-pcb-assembly"
 
+# Ordered supplier profile IDs (position encodes priority).
+# First entry is the fabricator's own catalog.
+suppliers:
+  - lcsc
+  - mouser
+  - digikey
+  - farnell
+  - newark
+
 part_number:
   header: "fabricator_part_number"
 

--- a/src/jbom/config/fabricators/pcbway.fab.yaml
+++ b/src/jbom/config/fabricators/pcbway.fab.yaml
@@ -3,6 +3,13 @@ id: "pcbway"
 description: "PCBWay Bill of Materials"
 website: "https://www.pcbway.com/helpcenter/assembly_help/How_to_place_an_assembly_order.html"
 
+# Ordered supplier profile IDs (position encodes priority).
+suppliers:
+  - mouser
+  - digikey
+  - farnell
+  - newark
+
 part_number:
   header: "Manufacturer Part Number"
 

--- a/src/jbom/config/fabricators/seeed.fab.yaml
+++ b/src/jbom/config/fabricators/seeed.fab.yaml
@@ -3,6 +3,13 @@ id: "seeed"
 description: "Seeed Studio Fusion PCBA"
 website: "https://www.seeedstudio.com/fusion_pcb.html"
 
+# Ordered supplier profile IDs (position encodes priority).
+suppliers:
+  - mouser
+  - digikey
+  - farnell
+  - newark
+
 part_number:
   header: "Seeed Part Number"
 

--- a/src/jbom/config/suppliers/farnell.supplier.yaml
+++ b/src/jbom/config/suppliers/farnell.supplier.yaml
@@ -1,0 +1,3 @@
+id: farnell
+name: "Farnell"
+inventory_column: "Farnell"

--- a/src/jbom/config/suppliers/newark.supplier.yaml
+++ b/src/jbom/config/suppliers/newark.supplier.yaml
@@ -1,0 +1,3 @@
+id: newark
+name: "Newark"
+inventory_column: "Newark"

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.types import Component, InventoryItem
 from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
+from jbom.config.fabricators import FabricatorConfig
 from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import normalize_query
 from jbom.services.search.filtering import SearchSorter, apply_default_filters
@@ -81,6 +82,52 @@ def _category_matches(item_category: str, selector: str) -> bool:
 
 class InventorySearchService:
     """Service that searches external catalogs for inventory backfill candidates."""
+
+    @staticmethod
+    def is_sparse_for_fabricator(
+        item: InventoryItem, fabricator: FabricatorConfig
+    ) -> bool:
+        """Return True if item has no PN for any supplier in fabricator.suppliers.
+
+        This is Phase 1 "fab-relative sparseness": sparseness is defined relative to
+        the fabricator's ordered supplier list.
+        """
+
+        # If a fabricator has no suppliers list, treat sparseness as "not applicable".
+        if not fabricator.suppliers:
+            return False
+
+        for supplier_id in fabricator.suppliers:
+            supplier = resolve_supplier_by_id(supplier_id)
+            if supplier is None:
+                # Unknown supplier IDs are warned at config load time.
+                continue
+
+            pn = ""
+            if supplier.id == "lcsc":
+                # InventoryReader populates InventoryItem.lcsc from several header variants.
+                pn = (item.lcsc or "").strip()
+            else:
+                pn = str(
+                    (item.raw_data or {}).get(supplier.inventory_column, "")
+                ).strip()
+
+            if pn:
+                return False
+
+        return True
+
+    @staticmethod
+    def filter_sparse_items_for_fabricator(
+        items: list[InventoryItem], *, fabricator: FabricatorConfig
+    ) -> list[InventoryItem]:
+        """Filter to items that are sparse for this fabricator."""
+
+        return [
+            i
+            for i in items
+            if InventorySearchService.is_sparse_for_fabricator(i, fabricator)
+        ]
 
     def __init__(
         self,

--- a/tests/services/search/test_inventory_search_cli_cache_flags.py
+++ b/tests/services/search/test_inventory_search_cli_cache_flags.py
@@ -7,8 +7,8 @@ from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache
 
 
 def test_inventory_build_cache_no_cache_flag_returns_inmemory() -> None:
-    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=False)
-    cache = _build_inventory_cache(args)
+    args = argparse.Namespace(no_cache=True, clear_cache=False)
+    cache = _build_inventory_cache("mouser", args)
     assert isinstance(cache, InMemorySearchCache)
 
 
@@ -24,7 +24,7 @@ def test_inventory_build_cache_clear_cache_flag_calls_clear_provider(
         DiskSearchCache, "clear_provider", staticmethod(_clear_provider)
     )
 
-    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=True)
-    cache = _build_inventory_cache(args)
+    args = argparse.Namespace(no_cache=True, clear_cache=True)
+    cache = _build_inventory_cache("mouser", args)
     assert isinstance(cache, InMemorySearchCache)
     assert calls["provider_id"] == "mouser"

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from jbom.common.types import InventoryItem
+from jbom.config.fabricators import load_fabricator
 from jbom.config.suppliers import SupplierConfig
 from jbom.services.search.inventory_search_service import InventorySearchService
 from jbom.services.search.models import SearchResult
@@ -16,6 +17,8 @@ def _inv_item(
     value: str,
     package: str,
     tolerance: str,
+    lcsc: str = "",
+    raw_data: dict[str, str] | None = None,
 ) -> InventoryItem:
     return InventoryItem(
         ipn=ipn,
@@ -29,11 +32,12 @@ def _inv_item(
         voltage="",
         amperage="",
         wattage="",
-        lcsc="",
+        lcsc=lcsc,
         manufacturer="",
         mfgpn="",
         datasheet="",
         package=package,
+        raw_data=raw_data or {},
     )
 
 
@@ -168,6 +172,49 @@ def test_build_query_uses_supplier_config_keywords(monkeypatch) -> None:
 
     query = svc.build_query(item)
     assert "thick film resistor" in query
+
+
+def test_filter_sparse_items_for_fabricator_scopes_by_supplier_columns() -> None:
+    fab = load_fabricator("jlc")
+
+    items = [
+        _inv_item(
+            ipn="HAS-LCSC",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+            lcsc="C123",
+        ),
+        _inv_item(
+            ipn="HAS-MOUSER",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+            raw_data={"Mouser": "123"},
+        ),
+        _inv_item(
+            ipn="HAS-FARNELL",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+            raw_data={"Farnell": "F-123"},
+        ),
+        _inv_item(
+            ipn="SPARSE",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+        ),
+    ]
+
+    sparse = InventorySearchService.filter_sparse_items_for_fabricator(
+        items, fabricator=fab
+    )
+    assert [i.ipn for i in sparse] == ["SPARSE"]
 
 
 def test_inventory_search_service_fans_out_provider_errors_to_all_items() -> None:

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -71,3 +71,19 @@ def test_root_help_includes_search_command():
 def test_root_help_includes_inventory_search_command():
     out = run_help([]).lower()
     assert "inventory-search" in out
+
+
+def test_inventory_search_help_includes_fabricator_choices():
+    out = run_help(["inventory-search"]).lower()
+    assert "--fabricator" in out
+
+    import sys
+
+    sys.path.insert(0, str(SRC_DIR))
+    try:
+        from jbom.config.fabricators import get_available_fabricators
+
+        for fab in get_available_fabricators():
+            assert fab in out
+    finally:
+        sys.path.remove(str(SRC_DIR))

--- a/tests/unit/test_fabricator_config_schema.py
+++ b/tests/unit/test_fabricator_config_schema.py
@@ -13,7 +13,7 @@ from jbom.config.fabricators import (
 )
 
 
-def test_load_generic_parses_field_synonyms_and_tier_rules() -> None:
+def test_load_generic_parses_field_synonyms_tier_rules_and_suppliers() -> None:
     fab = load_fabricator("generic")
 
     assert isinstance(fab.field_synonyms, dict)
@@ -27,6 +27,10 @@ def test_load_generic_parses_field_synonyms_and_tier_rules() -> None:
     assert fab.tier_rules[0].conditions
     assert isinstance(fab.tier_rules[0].conditions[0], TierCondition)
 
+    assert isinstance(fab.suppliers, list)
+    assert fab.suppliers
+    assert all(isinstance(s, str) for s in fab.suppliers)
+
 
 def test_resolve_field_synonym_is_forgiving() -> None:
     fab = load_fabricator("jlc")
@@ -34,6 +38,21 @@ def test_resolve_field_synonym_is_forgiving() -> None:
     assert fab.resolve_field_synonym(" Lcsc Part # ") == "fab_pn"
     assert fab.resolve_field_synonym("fab_pn") == "fab_pn"
     assert fab.resolve_field_synonym("unknown_field") is None
+
+
+def test_from_yaml_dict_warns_on_unknown_supplier_ids(caplog) -> None:
+    data = {
+        "name": "Example",
+        "pos_columns": {"Designator": "reference"},
+        "suppliers": ["definitely-not-a-real-supplier"],
+    }
+
+    caplog.clear()
+    fab = FabricatorConfig.from_yaml_dict(data, default_id="example")
+    assert fab.suppliers == ["definitely-not-a-real-supplier"]
+
+    # Advisory validation: unknown supplier IDs should warn but not error.
+    assert any("Unknown supplier" in r.message for r in caplog.records)
 
 
 def test_from_yaml_dict_rejects_deprecated_priority_fields() -> None:


### PR DESCRIPTION
Closes #105.

Summary
- Add `suppliers:` ordered list to all fab profiles and parse into `FabricatorConfig.suppliers` with advisory validation (warn on truly unknown supplier IDs).
- Add minimal stub supplier profiles for `farnell` and `newark` so fab YAML can reference them without warning noise.
- Extend `jbom inventory-search` with optional fabricator selection and Phase-1 fab-relative sparseness filtering (opt-in only when fabricator explicitly selected).
- Default inventory-search provider by walking `fab.suppliers` in order and choosing the first supported provider (currently Mouser), with `--provider` override preserved.
- Make fabricator shorthand flags (`--jlc`, `--generic`, etc.) dynamically generated from discovered fab profiles (help text uses fab display name).

Testing
- `python -m pytest -q`
- `python -m behave --format progress`

Co-Authored-By: Oz <oz-agent@warp.dev>
