### PR TITLE
Fix Seeed fab_pn derivation with seeed supplier stub profile

### DIFF
--- a/src/jbom/config/fabricators/seeed.fab.yaml
+++ b/src/jbom/config/fabricators/seeed.fab.yaml
@@ -5,6 +5,7 @@ website: "https://www.seeedstudio.com/fusion_pcb.html"
 
 # Ordered supplier profile IDs (position encodes priority).
 suppliers:
+  - seeed
   - mouser
   - digikey
   - farnell

--- a/src/jbom/config/suppliers/seeed.supplier.yaml
+++ b/src/jbom/config/suppliers/seeed.supplier.yaml
@@ -1,0 +1,26 @@
+id: "seeed"
+name: "Seeed Studio"
+
+# Canonical inventory column name used for the Seeed native catalog.
+# `inventory_column_synonyms` captures the real-world header variants we accept.
+inventory_column: "Seeed"
+inventory_column_synonyms:
+  - "Seeed Part Number"
+  - "Seeed Part"
+  - "Seeed Part #"
+  - "Seeed Studio"
+  - "Seeed SKU"
+  - "SKU"
+
+# Optional metadata (kept minimal for the stub profile).
+description: "Seeed Studio Fusion PCBA parts catalog"
+website: "https://www.seeedstudio.com"
+
+url_template: null
+search_url_template: null
+
+part_number: {}
+
+search:
+  cache:
+    ttl_hours: 24

--- a/tests/unit/test_supplier_config_schema.py
+++ b/tests/unit/test_supplier_config_schema.py
@@ -20,6 +20,7 @@ def test_list_suppliers_includes_builtin_profiles() -> None:
     assert "lcsc" in suppliers
     assert "mouser" in suppliers
     assert "digikey" in suppliers
+    assert "seeed" in suppliers
 
 
 def test_get_available_suppliers_is_non_empty() -> None:


### PR DESCRIPTION
Closes #110

## Fix
- Added `src/jbom/config/suppliers/seeed.supplier.yaml` with `inventory_column_synonyms` for Seeed SKU/part-number headers.
- Updated `src/jbom/config/fabricators/seeed.fab.yaml` to put `seeed` first in `suppliers:` so `fab_pn` derives from Seeed’s native catalog, not Mouser.

## Testing
- `python -m pytest`
- `python -m behave --format progress`

Co-Authored-By: Oz <oz-agent@warp.dev>