### PR TITLE
refactor: extract _provider_choices to list_searchable_suppliers in providers.py

### DIFF
--- a/src/jbom/cli/inventory_search.py
+++ b/src/jbom/cli/inventory_search.py
@@ -21,28 +21,12 @@ from jbom.common.cli_fabricator import (
     resolve_fabricator_selection_from_args,
 )
 from jbom.config.fabricators import load_fabricator
-from jbom.config.providers import get_provider
-from jbom.config.suppliers import list_suppliers, load_supplier, resolve_supplier_by_id
+from jbom.config.providers import get_provider, list_searchable_suppliers
+from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
 from jbom.services.inventory_reader import InventoryReader
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.inventory_search_service import InventorySearchService
 from jbom.services.search.provider import SearchProvider
-
-
-def _provider_choices() -> list[str]:
-    """Return supplier IDs that declare at least one search provider."""
-
-    out: list[str] = []
-    for sid in list_suppliers():
-        try:
-            supplier = load_supplier(sid)
-        except ValueError:
-            continue
-
-        if supplier.search_providers:
-            out.append(supplier.id)
-
-    return sorted(set(out))
 
 
 def _default_provider_for_fabricator(fabricator_id: str, *, api_key: str | None) -> str:
@@ -99,7 +83,7 @@ def register_command(subparsers) -> None:
 
     parser.add_argument(
         "--provider",
-        choices=_provider_choices(),
+        choices=list_searchable_suppliers(),
         default=None,
         help="Search provider to use (default: derived from fabricator supplier priority)",
     )

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -18,8 +18,8 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
-from jbom.config.providers import get_provider
-from jbom.config.suppliers import list_suppliers, load_supplier, resolve_supplier_by_id
+from jbom.config.providers import get_provider, list_searchable_suppliers
+from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.filtering import (
     SearchFilter,
@@ -125,22 +125,6 @@ _FIELD_REGISTRY: dict[str, _FieldDef] = {
 }
 
 
-def _provider_choices() -> list[str]:
-    """Return supplier IDs that declare at least one search provider."""
-
-    out: list[str] = []
-    for sid in list_suppliers():
-        try:
-            supplier = load_supplier(sid)
-        except ValueError:
-            continue
-
-        if supplier.search_providers:
-            out.append(supplier.id)
-
-    return sorted(set(out))
-
-
 def register_command(subparsers) -> None:
     """Register search command with argument parser."""
 
@@ -155,7 +139,7 @@ def register_command(subparsers) -> None:
     )
 
     # Provider is selected by supplier ID, discovered from supplier YAML profiles.
-    provider_choices = _provider_choices()
+    provider_choices = list_searchable_suppliers()
     default_provider = "mouser" if "mouser" in provider_choices else None
     if default_provider is None and provider_choices:
         default_provider = provider_choices[0]

--- a/src/jbom/config/providers.py
+++ b/src/jbom/config/providers.py
@@ -84,4 +84,23 @@ def get_provider(
     return provider_cls.from_config(cfg, cache=cache)
 
 
-__all__ = ["SearchProviderConfig", "get_provider"]
+def list_searchable_suppliers() -> list[str]:
+    """Return supplier IDs that declare at least one search provider, sorted.
+
+    Used to populate --provider choices in CLI commands.
+    """
+
+    from jbom.config.suppliers import list_suppliers, load_supplier
+
+    out: list[str] = []
+    for sid in list_suppliers():
+        try:
+            supplier = load_supplier(sid)
+        except ValueError:
+            continue
+        if supplier.search_providers:
+            out.append(supplier.id)
+    return sorted(set(out))
+
+
+__all__ = ["SearchProviderConfig", "get_provider", "list_searchable_suppliers"]


### PR DESCRIPTION
## Summary

Eliminates the duplicated `_provider_choices()` function that existed identically in both `cli/search.py` and `cli/inventory_search.py` by extracting it to `config/providers.py` as the public utility function `list_searchable_suppliers()`.

## Changes

- Added `list_searchable_suppliers()` to `src/jbom/config/providers.py` and exported via `__all__`
- Removed `_provider_choices()` from `src/jbom/cli/search.py`; replaced call-sites with `list_searchable_suppliers()`
- Removed `_provider_choices()` from `src/jbom/cli/inventory_search.py`; replaced call-sites with `list_searchable_suppliers()`
- Removed now-unused `list_suppliers` / `load_supplier` imports from the two CLI modules (or trimmed to only what's still needed)

## Testing

- `pytest tests/` — 327 passed
- `python -m behave --format progress` — 192 scenarios passed, 0 failed

Co-Authored-By: Oz <oz-agent@warp.dev>