### PR TITLE
feat: MPN cross-reference lookup for LCSC inventory-search

### DIFF
--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -266,9 +266,116 @@ class InventorySearchService:
     def search(self, items: list[InventoryItem]) -> list[InventorySearchRecord]:
         """Search for candidates for each inventory item.
 
-        This implementation deduplicates provider calls by normalized query so that
-        repeated inventory rows do not burn additional API quota.
+        Deduplicates provider calls by normalized query so repeated inventory rows
+        do not burn additional API quota.
+
+        Issue #106 routing:
+        - When the provider is LCSC (JlcpcbProvider) and the inventory item has an
+          explicit MPN (`InventoryItem.mfgpn`), attempt a deterministic MPN lookup
+          first (MPN → best available LCSC C-number).
+        - If the lookup returns a match, emit it as Candidate 1 and skip catalog
+          search for that item.
+        - If no match is found, fall back to the existing keyword-based search.
         """
+
+        if not items:
+            return []
+
+        jlc_provider = None
+        try:
+            from jbom.services.search.jlcpcb_provider import JlcpcbProvider
+
+            if isinstance(self._provider, JlcpcbProvider):
+                jlc_provider = self._provider
+        except Exception:
+            jlc_provider = None
+
+        deterministic_score = 1000
+
+        records_by_index: list[InventorySearchRecord | None] = [None] * len(items)
+        remaining_items: list[InventoryItem] = []
+        remaining_indices: list[int] = []
+
+        # Group MPN lookups to avoid redundant API calls.
+        mpn_groups: dict[str, tuple[str, str, list[int]]] = {}
+
+        for idx, item in enumerate(items):
+            mpn = (item.mfgpn or "").strip()
+            if jlc_provider is None or not mpn:
+                remaining_items.append(item)
+                remaining_indices.append(idx)
+                continue
+
+            mfg = (item.manufacturer or "").strip()
+            key = normalize_query(f"mpn:{mpn} manufacturer:{mfg}")
+            if key not in mpn_groups:
+                mpn_groups[key] = (mfg, mpn, [])
+            mpn_groups[key][2].append(idx)  # type: ignore[index]
+
+        # Resolve each unique (manufacturer, mpn) once.
+        mpn_results: dict[str, SearchResult | None] = {}
+        mpn_errors: dict[str, str] = {}
+
+        for key, (mfg, mpn, _indices) in mpn_groups.items():
+            try:
+                mpn_results[key] = jlc_provider.lookup_by_mpn(mfg, mpn)
+            except Exception as exc:
+                mpn_errors[key] = str(exc)
+
+            if self._request_delay_seconds > 0:
+                time.sleep(self._request_delay_seconds)
+
+        # Fan out deterministic matches; queue misses for fallback.
+        for key, (mfg, mpn, indices) in mpn_groups.items():
+            query = f"{mfg} {mpn}".strip()
+
+            if key in mpn_errors:
+                for idx in indices:
+                    records_by_index[idx] = InventorySearchRecord(
+                        inventory_item=items[idx],
+                        query=query,
+                        candidates=[],
+                        error=mpn_errors[key],
+                    )
+                continue
+
+            res = mpn_results.get(key)
+            if res is not None:
+                for idx in indices:
+                    records_by_index[idx] = InventorySearchRecord(
+                        inventory_item=items[idx],
+                        query=query,
+                        candidates=[
+                            InventorySearchCandidate(
+                                result=res, match_score=deterministic_score
+                            )
+                        ],
+                    )
+                continue
+
+            # Miss: fall back to keyword-based search.
+            for idx in indices:
+                remaining_items.append(items[idx])
+                remaining_indices.append(idx)
+
+        keyword_records: list[InventorySearchRecord] = []
+        if remaining_items:
+            keyword_records = self._search_by_keyword(remaining_items)
+
+        for idx, rec in zip(remaining_indices, keyword_records, strict=True):
+            records_by_index[idx] = rec
+
+        # Preserve input ordering.
+        out: list[InventorySearchRecord] = []
+        for rec in records_by_index:
+            if rec is not None:
+                out.append(rec)
+        return out
+
+    def _search_by_keyword(
+        self, items: list[InventoryItem]
+    ) -> list[InventorySearchRecord]:
+        """Original keyword-based search implementation (Phase 6.3)."""
 
         # Phase 6.3 behavior: limit is purely service configuration.
         provider_limit = max(10, self._candidate_limit * 3)

--- a/src/jbom/services/search/jlcpcb_api.py
+++ b/src/jbom/services/search/jlcpcb_api.py
@@ -95,6 +95,7 @@ class JlcpcbPartsApi:
         presale_type: str = "stock",
         sort_mode: str = "STOCK_SORT",
         sort_asc: str = "DESC",
+        manufacturer: str | None = None,
     ) -> dict[str, Any]:
         """Search by keyword across the catalog.
 
@@ -105,10 +106,17 @@ class JlcpcbPartsApi:
             presale_type: Observed default is "stock".
             sort_mode: Browser-observed sort mode, default "STOCK_SORT".
             sort_asc: "DESC" or "ASC".
+            manufacturer: Optional manufacturer/brand filter. When provided, sent
+                as `componentBrandList` to reduce irrelevant results at the source.
 
         Returns:
             Raw decoded JSON response.
         """
+
+        mfg = (manufacturer or "").strip()
+        component_brand_list: list[dict[str, Any]] = []
+        if mfg:
+            component_brand_list = [{"brandName": mfg}]
 
         payload: dict[str, Any] = {
             "currentPage": int(page),
@@ -124,7 +132,7 @@ class JlcpcbPartsApi:
             "secondSortName": None,
             "componentSpecificationList": [],
             "componentAttributeList": [],
-            "componentBrandList": [],
+            "componentBrandList": component_brand_list,
             "sortMode": str(sort_mode or "").strip(),
             "sortASC": str(sort_asc or "").strip(),
         }

--- a/src/jbom/services/search/jlcpcb_provider.py
+++ b/src/jbom/services/search/jlcpcb_provider.py
@@ -11,6 +11,7 @@ Notes:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,27 @@ class _Config:
 
 class JlcpcbProvider(SearchProvider):
     """LCSC search via JLCPCB's public parts API."""
+
+    _DETERMINISTIC_MPN_MATCH_SCORE = 1000
+
+    @staticmethod
+    def _normalize_mpn(text: str) -> str:
+        """Normalize an MPN for exact-match comparisons.
+
+        Notes:
+        - JLCPCB API data is usually consistent, but LCSC can list multiple C-numbers
+          for a single MPN (batch/warehouse/sub-variant distinctions).
+        - For #106, we treat MPN lookup as "best available C-number right now" and
+          use highest stock as the selection criterion.
+        """
+
+        t = (text or "").strip().upper()
+        t = re.sub(r"\s+", "", t)
+        return t
+
+    @staticmethod
+    def _normalize_manufacturer(text: str) -> str:
+        return " ".join((text or "").strip().upper().split())
 
     def __init__(
         self, *, cache: SearchCache, rate_limit_seconds: float | None = None
@@ -110,6 +132,70 @@ class JlcpcbProvider(SearchProvider):
         # Store raw provider results (the CLI applies filters/ranking).
         self._cache.set(cache_key, results)
         return list(results)
+
+    def lookup_by_mpn(self, manufacturer: str, mpn: str) -> SearchResult | None:
+        """Deterministically resolve an MPN to the best available LCSC C-number.
+
+        This is a *lookup*, not a ranked search. We:
+        1) Query the live API using keyword=MPN and componentBrandList=manufacturer
+           (when manufacturer is known)
+        2) Filter to exact-MPN matches
+        3) If multiple C-numbers match the same MPN, pick the highest-stock result
+
+        Returns:
+            The best matching SearchResult, or None if no exact match is found.
+        """
+
+        mpn_norm = (mpn or "").strip()
+        if not mpn_norm:
+            return None
+
+        mfg_norm = (manufacturer or "").strip()
+
+        cache_query = f"mpn:{mpn_norm} manufacturer:{mfg_norm}".strip()
+        cache_key = SearchCacheKey.create(
+            provider_id=self.provider_id, query=cache_query, limit=50
+        )
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            results = list(cached)
+        else:
+            if self._api is None:
+                raise RuntimeError(self.unavailable_reason())
+
+            data = self._api.search_keyword(
+                query=mpn_norm,
+                page=1,
+                page_size=50,
+                sort_mode="STOCK_SORT",
+                sort_asc="DESC",
+                manufacturer=mfg_norm or None,
+            )
+            results = self._parse_results(data)
+            self._cache.set(cache_key, results)
+
+        want_mpn = self._normalize_mpn(mpn_norm)
+        want_mfg = self._normalize_manufacturer(mfg_norm) if mfg_norm else ""
+
+        matches: list[SearchResult] = []
+        for r in results:
+            if self._normalize_mpn(r.mpn) != want_mpn:
+                continue
+            if want_mfg and self._normalize_manufacturer(r.manufacturer) != want_mfg:
+                continue
+            matches.append(r)
+
+        if not matches:
+            return None
+
+        # Deterministic selection: highest stock, then stable tie-break.
+        matches.sort(
+            key=lambda r: (
+                -int(r.stock_quantity or 0),
+                str(r.distributor_part_number or ""),
+            )
+        )
+        return matches[0]
 
     def _parse_results(self, data: dict[str, Any]) -> list[SearchResult]:
         payload = data.get("data")

--- a/tests/services/search/test_inventory_search_mpn_lookup.py
+++ b/tests/services/search/test_inventory_search_mpn_lookup.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from jbom.common.types import InventoryItem
+from jbom.config.providers import SearchProviderConfig
+from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.inventory_search_service import InventorySearchService
+from jbom.services.search.jlcpcb_provider import JlcpcbProvider
+from jbom.services.search.models import SearchResult
+
+
+def _inv_item(*, ipn: str, manufacturer: str, mfgpn: str) -> InventoryItem:
+    return InventoryItem(
+        ipn=ipn,
+        keywords="",
+        category="RES",
+        description="",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="1%",
+        voltage="",
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer=manufacturer,
+        mfgpn=mfgpn,
+        datasheet="",
+        package="0603",
+        raw_data={},
+    )
+
+
+def _sr(*, cnum: str, manufacturer: str, mpn: str, stock: int) -> SearchResult:
+    return SearchResult(
+        manufacturer=manufacturer,
+        mpn=mpn,
+        description="RES",
+        datasheet="",
+        distributor="lcsc",
+        distributor_part_number=cnum,
+        availability=f"{stock} In Stock",
+        price="$0.01",
+        details_url="",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        attributes={},
+        stock_quantity=stock,
+    )
+
+
+def test_inventory_search_service_uses_mpn_lookup_when_available(monkeypatch) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    # Replace lookup/search with mocks so we don't touch the network.
+    lookup = Mock(
+        return_value=_sr(
+            cnum="C222", manufacturer="Yageo", mpn="RC0603FR-0710KL", stock=500
+        )
+    )
+    monkeypatch.setattr(provider, "lookup_by_mpn", lookup)
+
+    search = Mock(
+        side_effect=AssertionError(
+            "provider.search should not be called when lookup succeeds"
+        )
+    )
+    monkeypatch.setattr(provider, "search", search)
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+
+    item = _inv_item(ipn="R10K-1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL")
+    records = svc.search([item])
+
+    assert len(records) == 1
+    assert records[0].candidates
+    assert records[0].candidates[0].result.distributor_part_number == "C222"
+
+    lookup.assert_called_once_with("Yageo", "RC0603FR-0710KL")
+
+
+def test_inventory_search_service_deduplicates_mpn_lookup_calls(monkeypatch) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    lookup = Mock(
+        return_value=_sr(
+            cnum="C222", manufacturer="Yageo", mpn="RC0603FR-0710KL", stock=500
+        )
+    )
+    monkeypatch.setattr(provider, "lookup_by_mpn", lookup)
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+
+    items = [
+        _inv_item(ipn="R10K-1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL"),
+        _inv_item(ipn="R10K-2", manufacturer="Yageo", mfgpn="RC0603FR-0710KL"),
+    ]
+
+    records = svc.search(items)
+    assert [r.inventory_item.ipn for r in records] == ["R10K-1", "R10K-2"]
+    assert all(r.candidates for r in records)
+
+    assert lookup.call_count == 1

--- a/tests/services/search/test_jlcpcb_provider.py
+++ b/tests/services/search/test_jlcpcb_provider.py
@@ -91,3 +91,78 @@ def test_jlcpcb_provider_uses_cache(monkeypatch) -> None:
     provider.search("10k 0603", limit=1)
 
     assert search_keyword.call_count == 1
+
+
+def test_jlcpcb_provider_lookup_by_mpn_picks_highest_stock(monkeypatch) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    assert provider._api is not None
+
+    api_response = {
+        "code": 200,
+        "data": {
+            "componentPageInfo": {
+                "list": [
+                    {
+                        "componentCode": "C111",
+                        "componentModelEn": "RC0603FR-0710KL",
+                        "componentBrandEn": "Yageo",
+                        "describe": "RES SMD 10k 1% 0603",
+                        "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C111.html",
+                        "dataManualUrl": "https://example.com/datasheet.pdf",
+                        "stockCount": 10,
+                        "minBuyNumber": 1,
+                        "componentPrices": [
+                            {"productPrice": "0.10", "productNumber": 1}
+                        ],
+                        "attributes": [],
+                    },
+                    {
+                        "componentCode": "C222",
+                        "componentModelEn": "RC0603FR-0710KL",
+                        "componentBrandEn": "Yageo",
+                        "describe": "RES SMD 10k 1% 0603 (alt)",
+                        "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C222.html",
+                        "dataManualUrl": "https://example.com/datasheet.pdf",
+                        "stockCount": 500,
+                        "minBuyNumber": 1,
+                        "componentPrices": [
+                            {"productPrice": "0.09", "productNumber": 1}
+                        ],
+                        "attributes": [],
+                    },
+                    {
+                        "componentCode": "C333",
+                        "componentModelEn": "NOT-THE-SAME",
+                        "componentBrandEn": "Yageo",
+                        "describe": "noise",
+                        "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C333.html",
+                        "dataManualUrl": "",
+                        "stockCount": 999,
+                        "minBuyNumber": 1,
+                        "componentPrices": [],
+                        "attributes": [],
+                    },
+                ]
+            }
+        },
+    }
+
+    search_keyword = Mock(return_value=api_response)
+    monkeypatch.setattr(provider._api, "search_keyword", search_keyword)
+
+    best = provider.lookup_by_mpn("Yageo", "RC0603FR-0710KL")
+    assert best is not None
+    assert best.distributor_part_number == "C222"
+    assert best.stock_quantity == 500
+
+    assert search_keyword.call_count == 1
+    _args, kwargs = search_keyword.call_args
+    assert kwargs.get("query") == "RC0603FR-0710KL"
+    assert kwargs.get("manufacturer") == "Yageo"


### PR DESCRIPTION
Closes #106

## Summary
Adds a deterministic MPN cross-reference path for LCSC (JLCPCB live API): when an inventory item has `Manufacturer` + `MFGPN`, jBOM now attempts an MPN lookup to resolve the best available LCSC C-number before falling back to keyword catalog search.

## Design
- LCSC-specific capability is implemented on `JlcpcbProvider` (not on the base `SearchProvider` interface):
  - `lookup_by_mpn(manufacturer, mpn) -> SearchResult | None`
- API call uses server-side `componentBrandList` when manufacturer is known (reduces noise at the source).
- Exact MPN matches are filtered client-side.
- If multiple C-numbers match a single MPN (expected LCSC behavior), we deterministically select the highest-stock result (tie-broken by C-number).
- `InventorySearchService.search()` routing:
  - If provider is `JlcpcbProvider` and `item.mfgpn` is set: try MPN lookup first
  - If found: emit it as Candidate 1 (no new output columns)
  - If not found: fall back to existing keyword search
  - MPN lookups are deduplicated by (manufacturer, mpn) to avoid redundant API calls.

## Tests
- Added unit tests for `lookup_by_mpn` and `InventorySearchService` routing/deduplication.
- Full test runs (local):
  - `python -m pytest`
  - `python -m behave --format progress`

Co-Authored-By: Oz <oz-agent@warp.dev>