### PR TITLE
feat: Issue #115 Phase 4 foundation - RES/CAP decision-tree query shaping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Search parametric filtering now supports category-aware value normalization for RES/CAP/IND/REG and uses canonical values as a tertiary sort key.
 - `inventory-search` query construction now supports per-supplier `search.type_query_keywords` with a safe hardcoded fallback.
 - `jbom search` console output now includes Description plus up to 2 heuristic parametric columns.
+- LCSC `inventory-search` now applies Issue #115 Phase 4 foundation heuristics for RES/CAP parametric query shaping (category/spec/attribute payloads with static defaults and safe keyword fallback).
 
 ## [7.0.0] - 2026-02-27
 

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -380,6 +380,15 @@ class InventorySearchService:
         # Phase 6.3 behavior: limit is purely service configuration.
         provider_limit = max(10, self._candidate_limit * 3)
 
+        jlc_provider = None
+        try:
+            from jbom.services.search.jlcpcb_provider import JlcpcbProvider
+
+            if isinstance(self._provider, JlcpcbProvider):
+                jlc_provider = self._provider
+        except Exception:
+            jlc_provider = None
+
         query_groups: dict[str, list[tuple[InventoryItem, str]]] = defaultdict(list)
         per_item_query: list[tuple[InventoryItem, str, str]] = []
 
@@ -398,11 +407,19 @@ class InventorySearchService:
         for key, group in query_groups.items():
             # Keep the original (non-normalized) query string for the provider call.
             provider_query = group[0][1]
+            representative_item = group[0][0]
 
             try:
-                raw_results = self._provider.search(
-                    provider_query, limit=provider_limit
-                )
+                if jlc_provider is not None:
+                    raw_results = jlc_provider.search_for_inventory_item(
+                        representative_item,
+                        query=provider_query,
+                        limit=provider_limit,
+                    )
+                else:
+                    raw_results = self._provider.search(
+                        provider_query, limit=provider_limit
+                    )
                 filtered = apply_default_filters(raw_results)
                 ranked_by_query[key] = SearchSorter.rank(filtered)
             except Exception as exc:

--- a/src/jbom/services/search/jlcpcb_api.py
+++ b/src/jbom/services/search/jlcpcb_api.py
@@ -143,6 +143,86 @@ class JlcpcbPartsApi:
 
         return self._post_json(self.SEARCH_URL, payload)
 
+    def search_parametric(
+        self,
+        *,
+        query: str,
+        first_sort_name: str,
+        second_sort_name: str | None = None,
+        component_specification_list: list[str] | None = None,
+        component_attribute_list: list[dict[str, list[str]]] | None = None,
+        page: int = 1,
+        page_size: int = 50,
+        presale_type: str = "stock",
+        sort_mode: str = "STOCK_SORT",
+        sort_asc: str = "DESC",
+    ) -> dict[str, Any]:
+        """Search using category/spec/attribute filters (Issue #115 Phase 4).
+
+        Args:
+            query: Keyword context merged from inventory-derived terms.
+            first_sort_name: Top-level JLCPCB category name (e.g. "Resistors").
+            second_sort_name: Optional subcategory name.
+            component_specification_list: Optional package/spec filters.
+            component_attribute_list: Optional attribute filters as
+                ``[{attribute_name: [value1, value2]}, ...]``.
+            page: 1-indexed page.
+            page_size: Requested page size (max 1024 observed).
+            presale_type: Observed default is "stock".
+            sort_mode: Browser-observed sort mode, default "STOCK_SORT".
+            sort_asc: "DESC" or "ASC".
+
+        Returns:
+            Raw decoded JSON response.
+        """
+
+        specs = [
+            str(v).strip()
+            for v in (component_specification_list or [])
+            if str(v).strip()
+        ]
+
+        attrs: list[dict[str, list[str]]] = []
+        for group in component_attribute_list or []:
+            if not isinstance(group, dict):
+                continue
+            for name, values in group.items():
+                key = str(name).strip()
+                if not key:
+                    continue
+                cleaned_values = [
+                    str(v).strip() for v in (values or []) if str(v).strip()
+                ]
+                if cleaned_values:
+                    attrs.append({key: cleaned_values})
+
+        payload: dict[str, Any] = {
+            "currentPage": int(page),
+            "pageSize": int(page_size),
+            "keyword": (query or "").strip() or None,
+            "componentLibraryType": "",
+            "preferredComponentFlag": False,
+            "stockFlag": "",
+            "presaleType": str(presale_type or "stock"),
+            "searchType": 2,
+            "stockSort": None,
+            "firstSortName": str(first_sort_name or "").strip(),
+            "firstSortNameList": [str(first_sort_name or "").strip()]
+            if str(first_sort_name or "").strip()
+            else [],
+            "secondSortName": str(second_sort_name or "").strip() or None,
+            "componentSpecificationList": specs,
+            "componentAttributeList": attrs,
+            "componentBrandList": [],
+            "sortMode": str(sort_mode or "").strip(),
+            "sortASC": str(sort_asc or "").strip(),
+        }
+
+        if self._cfg.rate_limit_seconds > 0:
+            time.sleep(self._cfg.rate_limit_seconds)
+
+        return self._post_json(self.SEARCH_URL, payload)
+
     def _post_json(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
         headers = {
             "Accept": "application/json, text/plain, */*",

--- a/src/jbom/services/search/jlcpcb_phase4_heuristics.py
+++ b/src/jbom/services/search/jlcpcb_phase4_heuristics.py
@@ -1,0 +1,329 @@
+"""Phase 4 decision-tree query shaping for JLCPCB/LCSC search.
+
+This module provides data-first, YAML-shaped constants and deterministic helper
+logic used by Issue #115 Phase 4 foundation work. It intentionally avoids
+interactive prompting (Mode A / #99) and avoids configuration loader work (#98).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jbom.common.types import InventoryItem
+from jbom.common.value_parsing import farad_to_eia, ohms_to_eia
+from jbom.services.search.cache import normalize_query
+
+# YAML-shaped constants (kept in code for Phase 4 foundation only).
+PARAMETRIC_QUERY_FIELDS: dict[str, list[str]] = {
+    "resistor": ["resistance", "tolerance", "package", "power_rating", "technology"],
+    "capacitor": [
+        "capacitance",
+        "tolerance",
+        "package",
+        "voltage_rating",
+        "dielectric",
+    ],
+}
+
+CATEGORY_ROUTE_RULES: dict[str, dict[str, str]] = {
+    "resistor": {
+        "first_sort": "Resistors",
+        "second_sort_smd": "Chip Resistor - Surface Mount",
+        "second_sort_pth": "Through Hole Resistors",
+    },
+    "capacitor": {
+        "first_sort": "Capacitors",
+    },
+}
+
+DOMAIN_DEFAULTS: dict[str, dict[str, str]] = {
+    "resistor": {
+        "tolerance": "5%",
+    },
+    "capacitor": {
+        "tolerance": "10%",
+        "dielectric": "X7R",
+    },
+}
+
+PACKAGE_POWER_DEFAULTS: dict[str, str] = {
+    "0402": "63mW",
+    "0603": "100mW",
+    "0805": "125mW",
+    "1206": "250mW",
+    "2512": "1W",
+}
+
+PACKAGE_VOLTAGE_DEFAULTS: dict[str, str] = {
+    "0402": "10V",
+    "0603": "25V",
+    "0805": "50V",
+    "1206": "50V",
+}
+
+
+@dataclass(frozen=True)
+class JlcpcbParametricQueryPlan:
+    """Planned JLCPCB query shape for one inventory item."""
+
+    use_parametric: bool
+    base_query: str
+    keyword_query: str
+    reason: str
+    first_sort_name: str | None = None
+    second_sort_name: str | None = None
+    component_specification_list: tuple[str, ...] = ()
+    component_attribute_list: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    def component_attribute_payload(self) -> list[dict[str, list[str]]]:
+        """Return API-ready attribute payload."""
+
+        payload: list[dict[str, list[str]]] = []
+        for name, values in self.component_attribute_list:
+            payload.append({name: list(values)})
+        return payload
+
+    def cache_fingerprint(self) -> str:
+        """Return deterministic cache fingerprint for this plan."""
+
+        specs = ",".join(self.component_specification_list)
+        attrs = ";".join(f"{k}={','.join(v)}" for k, v in self.component_attribute_list)
+        return (
+            "phase4"
+            f"|first={self.first_sort_name or ''}"
+            f"|second={self.second_sort_name or ''}"
+            f"|spec={specs}"
+            f"|attr={attrs}"
+            f"|q={normalize_query(self.keyword_query)}"
+        )
+
+
+def build_phase4_parametric_query_plan(
+    item: InventoryItem, *, base_query: str
+) -> JlcpcbParametricQueryPlan:
+    """Build a Phase 4 query plan for one inventory item.
+
+    Supported categories:
+    - RES (resistor)
+    - CAP (capacitor)
+    """
+
+    category = _normalize_category(item.category)
+    if category == "RES":
+        return _build_resistor_plan(item, base_query=base_query)
+    if category == "CAP":
+        return _build_capacitor_plan(item, base_query=base_query)
+
+    return JlcpcbParametricQueryPlan(
+        use_parametric=False,
+        base_query=base_query,
+        keyword_query=base_query,
+        reason=f"unsupported category: {category or '(missing)'}",
+    )
+
+
+def _build_resistor_plan(
+    item: InventoryItem, *, base_query: str
+) -> JlcpcbParametricQueryPlan:
+    first_sort = CATEGORY_ROUTE_RULES["resistor"]["first_sort"]
+    second_sort = _resistor_second_sort(item)
+
+    specs: list[str] = []
+    package = _normalize_token(item.package)
+    if package:
+        specs.append(package)
+
+    resistance = _resistance_attribute_value(item)
+    if not resistance:
+        return JlcpcbParametricQueryPlan(
+            use_parametric=False,
+            base_query=base_query,
+            keyword_query=base_query,
+            reason="missing resistance value for resistor parametric search",
+        )
+
+    tolerance = _normalize_tolerance(
+        item.tolerance, default=DOMAIN_DEFAULTS["resistor"]["tolerance"]
+    )
+
+    attributes: list[tuple[str, tuple[str, ...]]] = [("Resistance", (resistance,))]
+    if tolerance:
+        attributes.append(("Tolerance", (tolerance,)))
+
+    power_rating = _normalize_token(item.wattage) or _package_default(
+        PACKAGE_POWER_DEFAULTS, package
+    )
+    technology = _resistor_technology_token(item.type)
+
+    keyword_query = _merge_keyword_tokens(base_query, [technology, power_rating])
+
+    return JlcpcbParametricQueryPlan(
+        use_parametric=True,
+        base_query=base_query,
+        keyword_query=keyword_query,
+        reason="resistor parametric query plan",
+        first_sort_name=first_sort,
+        second_sort_name=second_sort,
+        component_specification_list=tuple(specs),
+        component_attribute_list=tuple(attributes),
+    )
+
+
+def _build_capacitor_plan(
+    item: InventoryItem, *, base_query: str
+) -> JlcpcbParametricQueryPlan:
+    first_sort = CATEGORY_ROUTE_RULES["capacitor"]["first_sort"]
+
+    specs: list[str] = []
+    package = _normalize_token(item.package)
+    if package:
+        specs.append(package)
+
+    capacitance = _capacitance_attribute_value(item)
+    if not capacitance:
+        return JlcpcbParametricQueryPlan(
+            use_parametric=False,
+            base_query=base_query,
+            keyword_query=base_query,
+            reason="missing capacitance value for capacitor parametric search",
+        )
+
+    tolerance = _normalize_tolerance(
+        item.tolerance, default=DOMAIN_DEFAULTS["capacitor"]["tolerance"]
+    )
+    voltage = _normalize_voltage(item.voltage) or _package_default(
+        PACKAGE_VOLTAGE_DEFAULTS, package
+    )
+    dielectric = (
+        _dielectric_token(item.type) or DOMAIN_DEFAULTS["capacitor"]["dielectric"]
+    )
+
+    attributes: list[tuple[str, tuple[str, ...]]] = [("Capacitance", (capacitance,))]
+    if tolerance:
+        attributes.append(("Tolerance", (tolerance,)))
+
+    keyword_query = _merge_keyword_tokens(base_query, [dielectric, voltage])
+
+    return JlcpcbParametricQueryPlan(
+        use_parametric=True,
+        base_query=base_query,
+        keyword_query=keyword_query,
+        reason="capacitor parametric query plan",
+        first_sort_name=first_sort,
+        second_sort_name=None,
+        component_specification_list=tuple(specs),
+        component_attribute_list=tuple(attributes),
+    )
+
+
+def _normalize_category(text: str) -> str:
+    return _normalize_token(text).upper()
+
+
+def _normalize_token(text: str) -> str:
+    return " ".join((text or "").strip().split())
+
+
+def _normalize_tolerance(text: str, *, default: str) -> str:
+    t = _normalize_token(text)
+    if not t or t.upper() == "N/A":
+        t = default
+    if not t:
+        return ""
+    if t.endswith("%"):
+        return t
+    if t.replace(".", "", 1).isdigit():
+        return f"{t}%"
+    return t
+
+
+def _normalize_voltage(text: str) -> str:
+    v = _normalize_token(text).upper()
+    if not v or v == "N/A":
+        return ""
+    if v.endswith("V"):
+        return v
+    if v.replace(".", "", 1).isdigit():
+        return f"{v}V"
+    return v
+
+
+def _package_default(mapping: dict[str, str], package: str) -> str:
+    p = _normalize_token(package).upper()
+    if not p:
+        return ""
+    return mapping.get(p, "")
+
+
+def _resistance_attribute_value(item: InventoryItem) -> str:
+    raw = ""
+    if item.resistance is not None:
+        raw = ohms_to_eia(item.resistance)
+    elif _normalize_token(item.value):
+        raw = _normalize_token(item.value)
+
+    if not raw:
+        return ""
+
+    out = raw.replace(" ", "").replace("ohm", "Ω").replace("OHM", "Ω")
+    if "Ω" not in out:
+        out = f"{out}Ω"
+    return out
+
+
+def _capacitance_attribute_value(item: InventoryItem) -> str:
+    if item.capacitance is not None:
+        return _normalize_token(farad_to_eia(item.capacitance))
+    return _normalize_token(item.value)
+
+
+def _resistor_second_sort(item: InventoryItem) -> str | None:
+    smd = _normalize_token(item.smd).upper()
+    if smd == "SMD":
+        return CATEGORY_ROUTE_RULES["resistor"]["second_sort_smd"]
+    if smd == "PTH":
+        return CATEGORY_ROUTE_RULES["resistor"]["second_sort_pth"]
+
+    type_token = _normalize_token(item.type).lower()
+    if any(t in type_token for t in ("wirewound", "metal film", "carbon film")):
+        return CATEGORY_ROUTE_RULES["resistor"]["second_sort_pth"]
+    return None
+
+
+def _resistor_technology_token(text: str) -> str:
+    t = _normalize_token(text).lower()
+    if "wirewound" in t:
+        return "wirewound resistor"
+    if "metal film" in t:
+        return "metal film resistor"
+    if "carbon film" in t:
+        return "carbon film resistor"
+    return ""
+
+
+def _dielectric_token(text: str) -> str:
+    t = _normalize_token(text).upper()
+    for candidate in ("X7R", "X5R", "C0G", "NP0", "Y5V"):
+        if candidate in t:
+            return candidate
+    return ""
+
+
+def _merge_keyword_tokens(base_query: str, extras: list[str]) -> str:
+    tokens: list[str] = []
+    for token in [base_query, *extras]:
+        cleaned = _normalize_token(token)
+        if cleaned and cleaned not in tokens:
+            tokens.append(cleaned)
+    return " ".join(tokens).strip()
+
+
+__all__ = [
+    "CATEGORY_ROUTE_RULES",
+    "DOMAIN_DEFAULTS",
+    "JlcpcbParametricQueryPlan",
+    "PACKAGE_POWER_DEFAULTS",
+    "PACKAGE_VOLTAGE_DEFAULTS",
+    "PARAMETRIC_QUERY_FIELDS",
+    "build_phase4_parametric_query_plan",
+]

--- a/src/jbom/services/search/jlcpcb_provider.py
+++ b/src/jbom/services/search/jlcpcb_provider.py
@@ -18,10 +18,14 @@ from typing import TYPE_CHECKING, Any
 from jbom.services.search.cache import SearchCache, SearchCacheKey
 from jbom.services.search import jlcpcb_api
 from jbom.services.search.jlcpcb_api import JlcpcbPartsApi
+from jbom.services.search.jlcpcb_phase4_heuristics import (
+    build_phase4_parametric_query_plan,
+)
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
 
 if TYPE_CHECKING:
+    from jbom.common.types import InventoryItem
     from jbom.config.providers import SearchProviderConfig
 
 
@@ -130,6 +134,59 @@ class JlcpcbProvider(SearchProvider):
         results = self._parse_results(data)
 
         # Store raw provider results (the CLI applies filters/ranking).
+        self._cache.set(cache_key, results)
+        return list(results)
+
+    def search_for_inventory_item(
+        self, item: "InventoryItem", *, query: str, limit: int = 10
+    ) -> list[SearchResult]:
+        """Search using Phase 4 item-aware parametric planning when available.
+
+        Falls back to keyword search when:
+        - Category is unsupported by the Phase 4 planner
+        - Required parametric fields are missing (e.g. no RES/CAP value)
+        - Parametric API call fails or returns no results
+        """
+
+        if self._api is None:
+            raise RuntimeError(self.unavailable_reason())
+
+        plan = build_phase4_parametric_query_plan(item, base_query=query)
+        if not plan.use_parametric or not plan.first_sort_name:
+            return self.search(query, limit=limit)
+
+        cache_key = SearchCacheKey.create(
+            provider_id=self.provider_id,
+            query=plan.cache_fingerprint(),
+            limit=limit,
+        )
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return list(cached)
+
+        page_size = max(1, min(1024, int(limit)))
+
+        try:
+            data = self._api.search_parametric(
+                query=plan.keyword_query,
+                first_sort_name=plan.first_sort_name,
+                second_sort_name=plan.second_sort_name,
+                component_specification_list=list(plan.component_specification_list),
+                component_attribute_list=plan.component_attribute_payload(),
+                page=1,
+                page_size=page_size,
+                sort_mode="STOCK_SORT",
+                sort_asc="DESC",
+            )
+            results = self._parse_results(data)
+        except Exception:
+            results = []
+
+        if not results:
+            fallback = self.search(query, limit=limit)
+            self._cache.set(cache_key, fallback)
+            return list(fallback)
+
         self._cache.set(cache_key, results)
         return list(results)
 

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from jbom.common.types import InventoryItem
+from jbom.config.providers import SearchProviderConfig
 from jbom.config.fabricators import load_fabricator
 from jbom.config.suppliers import SupplierConfig
+from jbom.services.search.cache import InMemorySearchCache
 from jbom.services.search.inventory_search_service import InventorySearchService
+from jbom.services.search.jlcpcb_provider import JlcpcbProvider
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
 
@@ -269,3 +272,51 @@ def test_inventory_search_service_fans_out_provider_errors_to_all_items() -> Non
 
     assert by_ipn["R1K-1"].candidates
     assert by_ipn["R1K-1"].error is None
+
+
+def test_inventory_search_service_uses_item_aware_lcsc_dispatch(monkeypatch) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    search_for_inventory_item = Mock(
+        return_value=[_sr(distributor="lcsc", distributor_part_number="C25231")]
+    )
+    monkeypatch.setattr(
+        provider, "search_for_inventory_item", search_for_inventory_item
+    )
+
+    search_keyword_only = Mock(
+        side_effect=AssertionError(
+            "provider.search should not be used for JLC inventory item queries"
+        )
+    )
+    monkeypatch.setattr(provider, "search", search_keyword_only)
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+
+    items = [
+        _inv_item(
+            ipn="R10K-1",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+        ),
+        _inv_item(
+            ipn="R10K-2",
+            category="RES",
+            value="10K",
+            package="0603",
+            tolerance="1%",
+        ),
+    ]
+
+    records = svc.search(items)
+    assert [r.inventory_item.ipn for r in records] == ["R10K-1", "R10K-2"]
+    assert all(r.candidates for r in records)
+    assert search_for_inventory_item.call_count == 1

--- a/tests/services/search/test_jlcpcb_phase4_heuristics.py
+++ b/tests/services/search/test_jlcpcb_phase4_heuristics.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from jbom.common.types import InventoryItem
+from jbom.services.search.jlcpcb_phase4_heuristics import (
+    PARAMETRIC_QUERY_FIELDS,
+    build_phase4_parametric_query_plan,
+)
+
+
+def _inv_item(
+    *,
+    category: str,
+    value: str,
+    package: str = "",
+    tolerance: str = "",
+    voltage: str = "",
+    smd: str = "SMD",
+    type_: str = "",
+    resistance: float | None = None,
+    capacitance: float | None = None,
+) -> InventoryItem:
+    return InventoryItem(
+        ipn="I-1",
+        keywords="",
+        category=category,
+        description="",
+        smd=smd,
+        value=value,
+        type=type_,
+        tolerance=tolerance,
+        voltage=voltage,
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer="",
+        mfgpn="",
+        datasheet="",
+        package=package,
+        resistance=resistance,
+        capacitance=capacitance,
+        raw_data={},
+    )
+
+
+def test_phase4_constants_are_yaml_shaped_for_resistor_and_capacitor() -> None:
+    assert PARAMETRIC_QUERY_FIELDS["resistor"] == [
+        "resistance",
+        "tolerance",
+        "package",
+        "power_rating",
+        "technology",
+    ]
+    assert PARAMETRIC_QUERY_FIELDS["capacitor"] == [
+        "capacitance",
+        "tolerance",
+        "package",
+        "voltage_rating",
+        "dielectric",
+    ]
+
+
+def test_resistor_plan_uses_static_default_tolerance_and_routing() -> None:
+    item = _inv_item(
+        category="RES",
+        value="10K",
+        package="0603",
+        tolerance="",
+        smd="SMD",
+        resistance=10_000.0,
+    )
+    plan = build_phase4_parametric_query_plan(item, base_query="10K resistor 0603")
+
+    assert plan.use_parametric is True
+    assert plan.first_sort_name == "Resistors"
+    assert plan.second_sort_name == "Chip Resistor - Surface Mount"
+    assert plan.component_specification_list == ("0603",)
+    assert ("Tolerance", ("5%",)) in plan.component_attribute_list
+
+
+def test_capacitor_plan_uses_static_defaults_in_keyword_context() -> None:
+    item = _inv_item(
+        category="CAP",
+        value="100nF",
+        package="0603",
+        tolerance="",
+        voltage="",
+        type_="",
+        capacitance=100e-9,
+    )
+    plan = build_phase4_parametric_query_plan(item, base_query="100nF capacitor 0603")
+
+    assert plan.use_parametric is True
+    assert plan.first_sort_name == "Capacitors"
+    assert "X7R" in plan.keyword_query
+    assert "25V" in plan.keyword_query
+    assert ("Tolerance", ("10%",)) in plan.component_attribute_list
+
+
+def test_unknown_category_returns_keyword_fallback_plan() -> None:
+    item = _inv_item(category="IC", value="LM358D")
+    plan = build_phase4_parametric_query_plan(item, base_query="LM358D IC")
+
+    assert plan.use_parametric is False
+    assert plan.keyword_query == "LM358D IC"

--- a/tests/services/search/test_jlcpcb_provider.py
+++ b/tests/services/search/test_jlcpcb_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from unittest.mock import Mock
+from jbom.common.types import InventoryItem
 
 from jbom.config.providers import SearchProviderConfig
 from jbom.services.search.cache import InMemorySearchCache
@@ -93,6 +94,42 @@ def test_jlcpcb_provider_uses_cache(monkeypatch) -> None:
     assert search_keyword.call_count == 1
 
 
+def _inv_item(
+    *,
+    category: str = "RES",
+    value: str = "10K",
+    tolerance: str = "",
+    package: str = "0603",
+    smd: str = "SMD",
+    resistance: float | None = 10_000.0,
+    capacitance: float | None = None,
+    voltage: str = "",
+    wattage: str = "",
+    type_: str = "",
+) -> InventoryItem:
+    return InventoryItem(
+        ipn="TEST-1",
+        keywords="",
+        category=category,
+        description="",
+        smd=smd,
+        value=value,
+        type=type_,
+        tolerance=tolerance,
+        voltage=voltage,
+        amperage="",
+        wattage=wattage,
+        lcsc="",
+        manufacturer="",
+        mfgpn="",
+        datasheet="",
+        package=package,
+        resistance=resistance,
+        capacitance=capacitance,
+        raw_data={},
+    )
+
+
 def test_jlcpcb_provider_lookup_by_mpn_picks_highest_stock(monkeypatch) -> None:
     import jbom.services.search.jlcpcb_api as api_mod
 
@@ -166,3 +203,62 @@ def test_jlcpcb_provider_lookup_by_mpn_picks_highest_stock(monkeypatch) -> None:
     _args, kwargs = search_keyword.call_args
     assert kwargs.get("query") == "RC0603FR-0710KL"
     assert kwargs.get("manufacturer") == "Yageo"
+
+
+def test_jlcpcb_provider_uses_parametric_search_for_resistor_item(
+    monkeypatch,
+) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    assert provider._api is not None
+    search_parametric = Mock(return_value=_fake_api_response())
+    search_keyword = Mock(return_value={"data": {"componentPageInfo": {"list": []}}})
+    monkeypatch.setattr(provider._api, "search_parametric", search_parametric)
+    monkeypatch.setattr(provider._api, "search_keyword", search_keyword)
+
+    item = _inv_item(category="RES", value="10K", tolerance="", package="0603")
+    results = provider.search_for_inventory_item(
+        item, query="10K resistor 0603", limit=5
+    )
+
+    assert len(results) == 1
+    assert search_parametric.call_count == 1
+    assert search_keyword.call_count == 0
+
+    _args, kwargs = search_parametric.call_args
+    assert kwargs["first_sort_name"] == "Resistors"
+    payload_attrs = kwargs["component_attribute_list"]
+    assert {"Tolerance": ["5%"]} in payload_attrs
+
+
+def test_jlcpcb_provider_parametric_search_falls_back_to_keyword_when_empty(
+    monkeypatch,
+) -> None:
+    import jbom.services.search.jlcpcb_api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+
+    assert provider._api is not None
+    search_parametric = Mock(return_value={"data": {"componentPageInfo": {"list": []}}})
+    search_keyword = Mock(return_value=_fake_api_response())
+    monkeypatch.setattr(provider._api, "search_parametric", search_parametric)
+    monkeypatch.setattr(provider._api, "search_keyword", search_keyword)
+
+    item = _inv_item(category="RES", value="10K", tolerance="1%", package="0603")
+    results = provider.search_for_inventory_item(
+        item, query="10K resistor 0603", limit=5
+    )
+
+    assert len(results) == 1
+    assert search_parametric.call_count == 1
+    assert search_keyword.call_count == 1


### PR DESCRIPTION
## Summary
Implements Issue #115 **Phase 4 foundation only** for LCSC/JLCPCB query construction.

This PR improves query quality for underspecified generic inventory items by adding deterministic, static-default heuristics for RES/CAP and using structured parametric payloads where confidence is high, with safe fallback to existing keyword search.

## Scope boundaries
- Included: query-construction quality improvements for Issue #115 Phase 4 foundation
- Excluded: interactive Camp 2 prompting / Mode A workflow (#99)
- Excluded: config-loader/YAML externalization work (#98)

## What changed
- Added `src/jbom/services/search/jlcpcb_phase4_heuristics.py`
  - Python constant mappings (YAML-shaped): parametric fields, category routing, static domain defaults
  - Planner to build deterministic RES/CAP parametric query plans
- Extended `JlcpcbPartsApi` with `search_parametric(...)`
  - Supports category/spec/attribute payload dispatch to `selectSmtComponentList/v2`
- Extended `JlcpcbProvider` with `search_for_inventory_item(...)`
  - Uses Phase 4 planner when supported
  - Uses deterministic cache fingerprinting for parametric plans
  - Falls back to keyword search when unsupported/low-confidence/empty-result
- Updated `InventorySearchService` dispatch
  - Uses item-aware LCSC provider path while preserving existing behavior for other providers
- Added tests for
  - heuristic plan shape/defaults/fallback gating
  - provider parametric dispatch + fallback behavior
  - inventory-search integration dedup with item-aware LCSC dispatch
- Updated `docs/CHANGELOG.md` unreleased section

## Validation
- `python -m pytest tests/services/search/test_jlcpcb_phase4_heuristics.py tests/services/search/test_jlcpcb_provider.py tests/services/search/test_inventory_search_dedup.py`
- `python -m pytest` (340 passed)
- `python -m behave --format progress` (37 features passed, 0 failed)
- `pre-commit run --all-files`

## Issue linkage
- Addresses #115 (Phase 4 foundation)

Co-Authored-By: Oz <oz-agent@warp.dev>