### PR TITLE
docs: issue #123 inventory-search batch validation findings

### DIFF
--- a/docs/dev/validation/issue-123/findings-AltmillSwitches.md
+++ b/docs/dev/validation/issue-123/findings-AltmillSwitches.md
@@ -1,0 +1,65 @@
+# Issue #123 Findings: AltmillSwitchController + AltmillSwitchRemote
+## Why combined
+Issue #123 referenced `AltmillSwitches`. In this workspace, the equivalent projects are `AltmillSwitchController` and `AltmillSwitchRemote`, so findings are reported together.
+
+## Sparse detection
+### AltmillSwitchController
+- Inventory rows: 18
+- Searchable rows (`--dry-run`): 10
+- Searchable by category: `CAP=5`, `IC=1`, `RES=4`
+- Excluded rows: 8 (`UNKNOWN=7`, `SWI=1`)
+
+### AltmillSwitchRemote
+- Inventory rows: 6
+- Searchable rows (`--dry-run`): 4
+- Searchable by category: `CAP=2`, `RES=2`
+- Excluded rows: 2 (`UNKNOWN=1`, `SWI=1`)
+
+Interpretation:
+- Expected exclusion behavior held for non-search categories (`UNKNOWN`, `SWI`).
+- No obvious “already filled LCSC” suppression appeared in these fresh `jbom inventory` outputs.
+
+## Query quality and hit rate (LCSC)
+### AltmillSwitchController
+- Total searchable: 10
+- Successes: 4 (40.0%)
+- Failures: 6 (60.0%)
+- Category hit rates:
+  - `RES`: 3/4 (75.0%)
+  - `CAP`: 1/5 (20.0%)
+  - `IC`: 0/1 (0.0%)
+
+Representative successful query:
+- `10K resistor 0603 5%` → candidates returned, high match score.
+
+Representative failure queries:
+- `DCJ0202 capacitor DCJ0202` (power jack treated as capacitor)
+- `Conn_01x02 capacitor ...` (connector symbol treated as capacitor)
+- `4N28SM IC SMDIP-6_W7.62mm` (no candidates)
+
+### AltmillSwitchRemote
+- Total searchable: 4
+- Successes: 2 (50.0%)
+- Failures: 2 (50.0%)
+- Category hit rates:
+  - `RES`: 2/2 (100.0%)
+  - `CAP`: 0/2 (0.0%)
+
+Failure examples:
+- `Conn_6P6C capacitor RJ12_TOP`
+- `1e+03uF capacitor CP_Elec_10x10`
+
+## Ranking quality observations
+- Multi-candidate rows reviewed:
+  - Controller: 4
+  - Remote: 2
+- Pattern:
+  - `RES` rows often produce ranked candidates, but top-1 repeatedly includes `CC0603KRX7R9BB104` for multiple resistor values, suggesting ranking/scoring instability or category/value mismatch leakage.
+  - Valid-looking resistor rankings also appear (`10K` query returning resistor-family parts with descending relevance).
+
+## False positives and intentional sparseness
+- Intentional exclusions (`SWI`, `UNKNOWN`) were correctly excluded.
+- Main false-positive pattern was not excluded items; it was searchable items with connector/power-jack semantics encoded as `CAP`, leading to low-quality capacitor queries.
+
+## Project-level conclusion
+The AltmillSwitch family supports the issue premise: sparse detection itself is mostly acceptable, but query construction and ranking quality are not yet reliable outside straightforward resistor cases.

--- a/docs/dev/validation/issue-123/findings-Core-wt32-eth0.md
+++ b/docs/dev/validation/issue-123/findings-Core-wt32-eth0.md
@@ -1,0 +1,46 @@
+# Issue #123 Findings: Core-wt32-eth0
+## Sparse detection
+- Inventory rows: 23
+- Searchable rows (`--dry-run`): 14
+- Searchable by category: `CAP=10`, `RES=4`
+- Excluded rows: 9 (`UNKNOWN=8`, `SWI=1`)
+
+Interpretation:
+- Exclusions are consistent with expected non-search categories.
+- Searchable set is dominated by passives, which is useful for baseline quality measurement.
+
+## Query quality and hit rate (LCSC)
+- Total searchable: 14
+- Unique queries: 13
+- Successes: 6 (42.9%)
+- Failures: 8 (57.1%)
+- Category hit rates:
+  - `RES`: 4/4 (100.0%)
+  - `CAP`: 2/10 (20.0%)
+
+Representative successful queries:
+- `10K resistor 0603 5%`
+- `10uF capacitor 1206`
+
+Representative failed queries:
+- `IO capacitor Connector_PlexiData`
+- `FTDI Programmer capacitor Connector_FTDI-DEVICE-SIDE`
+- `Conn_01x02 capacitor PinHeader_1x02_P2.54mm_Vertical`
+
+Interpretation:
+- Many failures are connector-like semantics mapped into `CAP` rows, not pure passive capacitor value lookups.
+
+## Ranking quality observations
+- Multi-candidate rows reviewed: 6 (all available)
+- For resistor rows:
+  - Rankings are consistent in shape but sometimes repeat top candidates across distinct resistor values.
+- For capacitor rows:
+  - Some high-confidence results look plausible (`10uF 1206` family).
+  - `100nF capacitor 0603` produced top-1 `CC0603KRX7R9BB104`, likely not the intended capacitor-family match.
+
+## False positives and intentional sparseness
+- `UNKNOWN` and `SWI` were excluded as expected.
+- Operational false positives are mostly “searchable but semantically wrong” rows (connector/function labels mapped as `CAP`) rather than excluded-category leakage.
+
+## Project-level conclusion
+`Core-wt32-eth0` confirms strong `RES` behavior but weak mixed `CAP` behavior due to category/value semantics. This supports prioritizing query/category normalization before interactive UX work.

--- a/docs/dev/validation/issue-123/findings-LEDStripDriver.md
+++ b/docs/dev/validation/issue-123/findings-LEDStripDriver.md
@@ -1,0 +1,54 @@
+# Issue #123 Findings: LEDStripDriver
+## Sparse detection
+- Inventory rows: 20
+- Searchable rows (`--dry-run`): 11
+- Searchable by category: `CAP=4`, `CON=4`, `IC=2`, `RES=1`
+- Excluded rows: 9 (`UNKNOWN=9`)
+
+Interpretation:
+- Expected exclusion behavior held for `UNKNOWN`.
+- This project is useful because it includes connector and IC categories directly in the searchable set.
+
+## Query quality and hit rate (LCSC)
+- Total searchable: 11
+- Unique queries: 10
+- Successes: 6 (54.5%)
+- Failures: 5 (45.5%)
+- Category hit rates:
+  - `CAP`: 4/4 (100.0%)
+  - `RES`: 1/1 (100.0%)
+  - `IC`: 1/2 (50.0%)
+  - `CON`: 0/4 (0.0%)
+
+Representative successful queries:
+- `150uF capacitor CP_Elec_8x10`
+- `DMN4468 IC soic`
+
+Representative failed queries:
+- `CONNECTOR-M02MSTBA2 connector ...`
+- `GROVE-4P-2.0 connector 4P-2.0`
+- `PCA9685PW IC tssop`
+- `CONNECTOR-M045.08 connector ...`
+
+## Ranking quality observations
+- Multi-candidate rows reviewed: 6 (all available)
+- `IC_DMN4468` ranked plausibly with two close MPN variants.
+- `RES_10k` and `CAP_0.1uF` again show repeated top-1 candidate patterns that do not consistently reflect expected part-family distinctions.
+- Connector rows had no candidates, so rank quality is undefined there.
+
+## Optional provider comparison (Mouser)
+Same project, same sparse inventory:
+- LCSC: 6/11 successes (54.5%)
+- Mouser: 7/11 successes (63.6%)
+
+By category:
+- `CON`: 0/4 for both providers
+- `CAP`: 4/4 for both providers
+- `IC`: LCSC 1/2 vs Mouser 2/2
+
+Interpretation:
+- Connector failure appears query/category-shaping related, not provider-specific.
+- Some IC misses may be provider-specific or provider-coverage-sensitive.
+
+## Project-level conclusion
+`LEDStripDriver` is the clearest signal that connector handling must improve before building interactive flows. Provider choice alone does not address the dominant connector miss pattern.

--- a/docs/dev/validation/issue-123/methodology.md
+++ b/docs/dev/validation/issue-123/methodology.md
@@ -1,0 +1,55 @@
+# Issue #123 Methodology: inventory-search batch validation
+## Scope
+This validation tests whether the current batch `inventory-search` pipeline is strong enough to justify follow-on interaction work in #99, #100, #101, and #102.
+
+Projects evaluated:
+- `AltmillSwitchController`
+- `AltmillSwitchRemote`
+- `Core-wt32-eth0`
+- `LEDStripDriver`
+
+Primary provider:
+- `lcsc` (JLCPCB/LCSC alignment for tutorial and fabrication workflow relevance)
+
+Secondary comparison:
+- `mouser` on `LEDStripDriver` only, to separate provider effects from query-construction effects.
+
+## Commands run
+For each project:
+```bash
+jbom inventory <project-path> -o /tmp/jbom-issue-123/<project>-sparse.csv -F
+jbom inventory-search /tmp/jbom-issue-123/<project>-sparse.csv --provider lcsc --dry-run
+jbom inventory-search /tmp/jbom-issue-123/<project>-sparse.csv --provider lcsc \
+  -o /tmp/jbom-issue-123/<project>-candidates-lcsc.csv \
+  --report /tmp/jbom-issue-123/<project>-report-lcsc.txt -F
+```
+
+Optional comparison run:
+```bash
+jbom inventory-search /tmp/jbom-issue-123/LEDStripDriver-sparse.csv --provider mouser \
+  -o /tmp/jbom-issue-123/LEDStripDriver-candidates-mouser.csv \
+  --report /tmp/jbom-issue-123/LEDStripDriver-report-mouser.txt -F
+```
+
+## Measurement approach
+- Sparse detection:
+  - `inventory_rows` from generated sparse CSV
+  - `dry_run_searchable` and searchable category counts from `--dry-run`
+  - excluded count/category inferred as `inventory_by_category - searchable_by_category`
+- Query quality and hit rate:
+  - Overall and by-category hit rate from report files (`success/total`)
+  - Representative success/failure query samples from enhanced candidate CSV
+- Ranking quality:
+  - Multi-candidate rows only (`Candidate 2 MPN` present)
+  - Stratified review policy requested for this issue:
+    - categories expected to work well (`RES`, `CAP`)
+    - vocabulary-risk categories (`CON`, `IC`)
+    - zero-result rows
+  - Because all categories had fewer than 10 multi-candidate rows per project, all available multi-candidate rows were reviewed.
+- Intentional sparseness correctness:
+  - `UNKNOWN` and `SWI` rows were treated as expected exclusions.
+  - False-positive focus was placed on connector-like and non-passive symbols that landed in searchable categories.
+
+## Notes
+- Raw CSV/report artifacts were intentionally kept local under `/tmp/jbom-issue-123/` to avoid noisy repository diffs.
+- Repository artifacts for this issue capture analysis and recommendations only.

--- a/docs/dev/validation/issue-123/summary.md
+++ b/docs/dev/validation/issue-123/summary.md
@@ -1,0 +1,54 @@
+# Issue #123 Summary and recommendations
+## Cross-project metrics (LCSC primary)
+Projects measured:
+- `AltmillSwitchController`
+- `AltmillSwitchRemote`
+- `Core-wt32-eth0`
+- `LEDStripDriver`
+
+Total searchable rows across runs: 39
+Total successful searches: 17 (43.6%)
+
+Category hit rates:
+- `RES`: 10/11 (90.9%)
+- `CAP`: 7/21 (33.3%)
+- `IC`: 1/3 (33.3%)
+- `CON`: 0/4 (0.0%)
+
+## What the data says
+1. Sparse detection is mostly calibrated.
+- Expected non-search rows (`UNKNOWN`, `SWI`) were excluded consistently in these projects.
+- The dominant issue is not excluded-category leakage; it is semantically weak rows in searchable categories.
+
+2. Query quality is uneven and category-dependent.
+- `RES` performs strongly.
+- `CAP` quality is mixed because connector/function-like values and footprints can be pulled into capacitor-style queries.
+- `CON` is currently non-viable in this sample (0% hit rate).
+
+3. Ranking quality is not yet dependable.
+- Multi-candidate rows reviewed: 18 (all available under the requested sampling policy).
+- Several rows show repeated top-1 candidates across materially different values/categories, indicating scoring/ranking is not robust enough for confident interactive “pick best” workflows.
+
+4. Provider choice is a secondary factor.
+- Optional Mouser comparison (`LEDStripDriver`) improved overall success modestly (63.6% vs 54.5%) and IC outcomes, but connector failures remained 0/4 in both providers.
+- This points to query/category normalization as the first-order problem.
+
+## Recommendations for #99, #100, #101, #102
+## #99 interactive model
+Do not prioritize full interactive mode yet. Current connector and mixed-category quality means the operator would spend time rejecting bad/noisy rows, reducing UX value.
+
+## #100 multi-candidate write-back
+Prioritize the non-interactive “batch candidate rows + spreadsheet delete” stepping stone first. It fits current pipeline quality better and allows rapid human triage without new UI complexity.
+
+## #101 explain output
+Proceed partially now. Adding score/query rationale to existing batch output is useful immediately for diagnosing bad category/value mappings and ranking anomalies.
+
+## #102 smart query batching
+Defer. Batching efficiency gains should follow query quality fixes; optimizing dispatch over low-quality queries compounds noise faster.
+
+## Suggested near-term execution order
+1. Improve query/category normalization for connector-like and mislabeled capacitor rows.
+2. Strengthen ranking/scoring to reduce repeated top-1 anomalies across different values.
+3. Extend explainability output (#101) to make per-row decisions auditable.
+4. Add `--top N` batch write-back mode from #100 as the first workflow enhancement.
+5. Re-run this validation suite; only then reconsider #99 interactive flow as default.


### PR DESCRIPTION
## Summary
Adds Issue #123 validation artifacts for `inventory-search` batch quality across real KiCad projects, using LCSC as primary provider and one Mouser comparison pass.

## What was added
- `docs/dev/validation/issue-123/methodology.md`
- `docs/dev/validation/issue-123/findings-AltmillSwitches.md`
- `docs/dev/validation/issue-123/findings-Core-wt32-eth0.md`
- `docs/dev/validation/issue-123/findings-LEDStripDriver.md`
- `docs/dev/validation/issue-123/summary.md`

## Highlights
- Cross-project LCSC hit rates: RES 90.9%, CAP 33.3%, IC 33.3%, CON 0.0%
- Sparse exclusion behavior mostly calibrated (`UNKNOWN`/`SWI` excluded as expected)
- Main weakness is query/category semantics and ranking consistency, not just provider selection
- Optional LEDStripDriver Mouser comparison improved IC hit rate but did not improve connectors

## Validation
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m pytest tests/ -q --tb=short`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress`

Closes #123

Co-Authored-By: Oz <oz-agent@warp.dev>