### PR TITLE
docs: ADR 0002 JLCPCB/LCSC provider decisions + user reference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Mouser search fixtures and offline contract/integration test scaffolding.
 - Persistent disk-backed search cache (default, 24h TTL) with `--no-cache` and `--clear-cache` flags.
 - LCSC keyword search provider using the public JLCPCB live parts API (`jlcpcb_api`).
+- LCSC/JLCPCB provider architecture documented in `docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md`; user reference at `docs/lcsc-provider.md`.
 
 ### Changed
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.

--- a/docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md
+++ b/docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md
@@ -1,0 +1,133 @@
+# ADR 0002: JLCPCB/LCSC Provider — Live API over Local Database
+Date: 2026-03-04
+Status: Accepted
+
+Closes: #93, #115, #116, #103
+
+## Context
+
+jBOM needs a search provider for LCSC/JLCPCB parts to fill sparse inventory items
+(missing supplier part numbers). Two architectural options were evaluated.
+
+### Option A — Local SQLite database (jlcparts)
+
+The yaqwsx/jlcparts project maintained a canonical LCSC component database (~1 GB
+SQLite, FTS5-indexed). However, since July 2025, JLCPCB throttled their catalog API
+so severely that a full download cannot complete within GitHub Actions' 6-hour timeout.
+The canonical database is now frozen with **missing descriptions** — not just stale but
+structurally incomplete. All downstream projects (Bouni/kicad-jlcpcb-tools,
+CDFER/jlcpcb-parts-database) inherit this degraded data.
+
+References: https://github.com/yaqwsx/jlcparts/issues/151
+
+### Option B — Live JLCPCB parts API
+
+An apparently-open JLCPCB search API was discovered via sleemanj's active fork
+(https://sleemanj.github.io/jlcparts/). The endpoint:
+
+```
+POST https://jlcpcb.com/api/overseas-pcb-order/v1/shoppingCart/smtGood/selectSmtComponentList/v2
+```
+
+accepts category + attribute filters, returns up to 1024 results per call with current
+stock and price data, and requires no authentication or API key.
+
+## Decision
+
+**Option B (live API) was chosen.**
+
+Key decision factors:
+
+1. **Data quality**: The local DB is structurally broken upstream. The live API returns
+   current stock and price on every query.
+2. **No credentials or local setup required**: The live endpoint is unauthenticated.
+   Users get LCSC search working immediately without downloading a ~1 GB database.
+3. **Cache handles cold-start**: `DiskSearchCache` with a 30-day TTL on taxonomy
+   responses eliminates repeated calls. The cold-start problem the local DB was meant
+   to solve is already addressed by the cache layer.
+4. **API ethics**: jBOM issues targeted per-item queries only (one call per unique
+   component type per session). This is qualitatively equivalent to a user manually
+   searching jlcpcb.com/parts and does not constitute bulk catalog extraction.
+   Rate limiting: 2 seconds default between calls, configurable in `lcsc.supplier.yaml`.
+
+## Architecture
+
+```
+JlcpcbProvider  (src/jbom/services/search/jlcpcb_provider.py)
+├── JlcpcbPartsApi  (src/jbom/services/search/jlcpcb_api.py)
+│     └── responses cached via DiskSearchCache (24h TTL)
+└── build_phase4_parametric_query_plan()
+      (src/jbom/services/search/jlcpcb_phase4_heuristics.py)
+      └── config-driven via DefaultsConfig / generic.defaults.yaml
+
+JlcpartsProvider  (src/jbom/services/search/jlcparts_provider.py)
+└── stub only — available() → False
+    preserved for potential future air-gapped use; no implementation planned
+```
+
+Provider type identifiers in `lcsc.supplier.yaml`:
+- `jlcpcb_api` → `JlcpcbProvider` (active)
+- `jlcparts_sqlite` → `JlcpartsProvider` stub (inactive)
+
+## MPN Routing Split
+
+`InventorySearchService.search(item)` routes based on whether a manufacturer part
+number is present (design notes from issue #116):
+
+```
+InventorySearchService.search(item)
+│
+├── item.mpn is set   →  JlcpcbProvider.lookup_by_mpn()
+│                         Deterministic lookup. Highest-stock C-number wins on
+│                         multiple matches. No candidate ranking needed.
+│
+└── item.mpn absent   →  build_phase4_parametric_query_plan()
+                          Parametric search using category-based attribute filtering.
+                          Category-aware heuristics select relevant API filters.
+```
+
+Well-specified items (MPN present) never touch parametric search. The two paths have
+a clean boundary and are independently deliverable.
+
+## Phase 4 Parametric Heuristics
+
+Category-specific query shaping in `jlcpcb_phase4_heuristics.py`, driven by
+`DefaultsConfig` loaded from `generic.defaults.yaml` (overridable at project level).
+
+| Category | Parametric support | Key attributes |
+|---|---|---|
+| RES | ✅ Full | Resistance, Tolerance, Package, Technology, Power |
+| CAP | ✅ Full | Capacitance, Tolerance, Voltage, Dielectric, Package |
+| IND | ❌ Keyword fallback | Phase 4 heuristics not yet implemented |
+| CON | ❌ Keyword fallback | Connector taxonomy mismatch; low hit rate |
+| Others | ❌ Keyword fallback | — |
+
+Key defaults (all overridable via `generic.defaults.yaml`):
+- Resistor tolerance: `5%`
+- Capacitor tolerance: `10%`
+- Capacitor dielectric: `X7R`
+- Sort order: stock-descending (`sortMode=STOCK_SORT`) — high stock correlates with
+  commodity availability and price. Applied as default for generic/underspecified items.
+
+## Consequences
+
+### Positive
+- No local database download or maintenance required
+- Works out of the box with no user configuration beyond the supplier YAML
+- Current stock and price data on every non-cached query
+- Cache layer handles repeated queries efficiently (24h TTL)
+- MPN routing eliminates expensive catalog search for well-specified items
+- Phase 4 heuristics are config-driven and overridable without code changes
+
+### Negative / Risks
+- Dependent on JLCPCB API availability (mitigated by cache; cached results serve
+  offline sessions)
+- API is unofficial and undocumented; endpoint URL or schema may change without notice
+- CON (connector) category not yet viable for parametric search — keyword fallback
+  has ~0% hit rate in current validation (see `docs/dev/validation/issue-123/`)
+- IND (inductor) falls through to keyword search; Phase 4 heuristics planned in a
+  follow-on issue
+
+### Neutral
+- `jlcparts_sqlite` stub preserved in provider registry for forward compatibility
+- POC script and API recording fixtures retained in `scripts/` for reference

--- a/docs/lcsc-provider.md
+++ b/docs/lcsc-provider.md
@@ -1,0 +1,85 @@
+# LCSC / JLCPCB Search Provider
+
+jBOM searches the LCSC/JLCPCB parts catalog using the live JLCPCB parts API.
+No local database download, no account, and no API key are required.
+
+## How it works
+
+### Items with a known Manufacturer Part Number (MPN)
+
+If an inventory item has `Manufacturer` and `MPN` fields populated, jBOM performs a
+**deterministic lookup** via `JlcpcbProvider.lookup_by_mpn()`. This returns the
+corresponding LCSC C-number directly — no keyword search, no candidate ranking.
+When multiple C-numbers exist for the same MPN (batch/warehouse variants), the
+highest-stock result is selected.
+
+### Generic / underspecified items (no MPN)
+
+If an inventory item has no MPN, jBOM uses **Phase 4 parametric heuristics** to build
+a structured query from the item's category and attributes:
+
+| Category | Mode | Notes |
+|---|---|---|
+| RES | Parametric | Resistance, Tolerance, Package, Technology, Power |
+| CAP | Parametric | Capacitance, Tolerance, Voltage, Dielectric, Package |
+| IND | Keyword fallback | Parametric heuristics not yet implemented |
+| CON | Keyword fallback | Connector taxonomy mismatch; expect low hit rate |
+| Others | Keyword fallback | — |
+
+Results are sorted stock-descending by default: high stock correlates with commodity
+availability and price, naturally surfacing the parts experienced designers reach for.
+
+## Configuration
+
+The LCSC provider is configured in `src/jbom/config/suppliers/lcsc.supplier.yaml`:
+
+```yaml
+search:
+  cache:
+    ttl_hours: 24
+
+  api:
+    timeout_seconds: 20.0
+    max_retries: 3
+    retry_delay_seconds: 1.0
+
+  providers:
+    - type: jlcpcb_api
+      rate_limit_seconds: 2
+```
+
+`rate_limit_seconds` controls the delay between API calls. The default of 2 seconds
+is conservative; reducing it risks throttling by the JLCPCB endpoint.
+
+To override defaults for RES/CAP parametric queries (tolerance, dielectric, package
+power ratings), create a `jbom-defaults.yaml` in your project directory. See
+`src/jbom/config/defaults/generic.defaults.yaml` for the available keys.
+
+## Cache
+
+Search results are cached to disk at `~/.cache/jbom/` with a 24-hour TTL.
+Repeated queries within the TTL window make no API calls.
+
+```bash
+jbom inventory-search --no-cache    # bypass cache for this run
+jbom inventory-search --clear-cache # delete cached results and re-query
+```
+
+## Known limitations
+
+- **CON (connectors)**: keyword search only; ~0% hit rate observed in batch validation
+  because KiCad connector attribute vocabulary does not map to JLCPCB's connector
+  taxonomy. Manual search via `jbom search --query "..."` is the current workaround.
+- **IND (inductors)**: keyword search only; Phase 4 heuristics for inductors are
+  planned in a follow-on issue.
+- **Unofficial API**: The JLCPCB endpoint is undocumented and may change without
+  notice. Cached results continue to work offline if the endpoint becomes unavailable.
+- **Rate limiting**: Aggressive polling will trigger throttling. The 2s default is
+  intentional. Do not reduce `rate_limit_seconds` below 1.0.
+
+## See also
+
+- Architecture decision: `docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md`
+- Batch validation findings: `docs/dev/validation/issue-123/summary.md`
+- Phase 4 heuristics: `src/jbom/services/search/jlcpcb_phase4_heuristics.py`
+- Default config: `src/jbom/config/defaults/generic.defaults.yaml`


### PR DESCRIPTION
## Summary

Closes out the LCSC/JLCPCB provider epic by capturing architectural decisions in a permanent, findable home before closing the source issues.

## Changes

- `docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md` — ADR covering:
  - Why live API was chosen over jlcparts local SQLite (broken since July 2025)
  - API ethics policy (targeted queries only, not bulk dumps)
  - Provider architecture and component diagram
  - MPN routing split (MPN present → deterministic lookup; absent → parametric)
  - Phase 4 heuristics status by category (RES/CAP full; IND/CON keyword fallback)
  - Known limitations and risks
- `docs/lcsc-provider.md` — User-facing quick reference (configuration, cache, limitations)
- `docs/CHANGELOG.md` — One line added pointing to new docs

## Issues closed

Closes #93
Closes #115
Closes #116
Closes #103

Co-Authored-By: Oz <oz-agent@warp.dev>