### PR TITLE
feat: implement issue #127 scope A (annotate + ~ semantics + docs)

### DIFF
--- a/docs/dev/validation/JohnExample.csv
+++ b/docs/dev/validation/JohnExample.csv
@@ -1,0 +1,60 @@
+Project,UUID,Category,IPN,SMD,Value,Type,Description,Resistance,Capacitance,Inductance,Package,Form,Pins,Pitch,Tolerance,V,A,W,Color,Angle,Wavelength,mcd,Frequency,Symbol,Footprint
+Project,UUID,Category,"(OPTIONAL)
+IPN",SMD,Value,Type,Description,,Capacitance,,Package,,,,"(Optional)
+Tolerance",V,,,,,,,,Symbol,Footprint
+,,CAP,CAP_0.01uF_X7R_0603_25V,SMD,0.01uF,X7R,25V 10nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,0.01uF,,0603,,,,10%,25V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_0.01uF_X5R_0603_50V,SMD,0.01uF,X5R,50V 10nF X5R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,0.01uF,,0603,,,,10%,50V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_0.01uF_X7R_0603_50V,SMD,0.01uF,X7R,50V 10nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,0.01uF,,0603,,,,10%,50V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_0.1uF_X5R_0603_25V,SMD,0.1uF,X5R,25V 100nF X5R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,0.1uF,,0603,,,,10%,25V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_0.1uF_X7R_0603_50V,SMD,0.1uF,X7R,50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,0.1uF,,0603,,,,10%,50V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_1uF_X5R_0603_25V,SMD,1uF,X5R,35V 1uF X5R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,1uF,,0603,,,,10%,25V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_1uF_X5R_0603_50V,SMD,1uF,X5R,50V 1uF X5R ±10% 0603 Multilayer Ceramic Capacitors MLCC,,1uF,,0603,,,,10%,50V,,,,,,,,Device:C,SPCoast:0603-CAP
+,,CAP,CAP_10uF_X5R_1206_50V,SMD,10uF,X5R,50V 10uF X5R ±10% 1206 Multilayer Ceramic Capacitors MLCC,,10uF,,1206,,,,10%,50V,,,,,,,,Device:C,SPCoast:1206-CAP
+,,CAP,CAP_220uF_Electrolytic_8x10,SMD,220uF,Electrolytic,220uF 35V 300mA@120Hz ±20% SMD D8xL10mm Aluminum Electrolytic Capacitor,,220uF,,8x10,,,,20%,35V,,,,,,,,Device:C_Polarized_US,SPCoast:CP_Elec_8x10
+,,CAP,CAP_1000uF_Electrolytic_8x11.5,PTH,1000uF,Electrolytic,Aluminum Electrolytic Capacitors - Radial Leaded 1000uF 6.3V 85c,,1000uF,,8x11.5,,,,20%,6.3V,,,,,,,,Device:C_Polarized_US,
+,,CAP,CAP_1000uF_Electrolytic_10x10.2,SMD,1000uF,Electrolytic,Aluminum Electrolytic Capacitors - Radial Leaded 1000uF 16V -55-105c 347mA@120hz 20% D10xL10.2,,1000uF,,10x10.2,,,,20%,16V,,,,,,,,Device:C_Polarized_US,Capacitor_SMD:CP_Elec_10x10
+Project,UUID,Category,"(OPTIONAL)
+IPN",SMD,Value,"(Optional)
+Type",Description,,,,Package,,,,,"(Optional)
+V","(Optional)
+A",,,"(Optional)
+Angle","(Optional)
+Wavelength","(Optional)
+mcd",,Symbol,Footprint
+,,LED,LED_Blue_0603_20mA,SMD,Blue,clear,20mA 240mcd Colorless and transparent -20℃~+85℃ Positive Stick 455nm~475nm Blue 120° 70mW 3.3V 0603 LED Indication,,,,0603,,,,,3.3V,20mA,,Blue,120°,455nm~475nm,240,,Device:LED,SPCoast:0603-LED
+,,LED,LED_White_0603_20mA,SMD,White,warm,20mA 13700K~33000K 130mcd WarmWhite -20℃~+85℃ Positive Stick White 120° 70mW 2.7V 0603 LED Indication,,,,0603,,,,,2.7V,20mA,,White,120°,13700 - 33000 K,130,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Green Emerald_0603_20mA,SMD,Green Emerald,clear,20mA 810mcd Colorless transparent  515nm~535nm -20℃~+85℃ Positive Stick Emerald Green 120° 70mW 3.3V 0603 LED Indication,,,,0603,,,,,3.3V,20mA,,Green Emerald,120°,515nm~535nm,810,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Yellow Green_0603_20mA,SMD,Yellow Green,clear,20mA 240mcd Colorless transparent 565nm~575nm -20℃~+85℃ Positive Stick Yellow Green 120° 50mW 2.4V 0603 LED Indication,,,,0603,,,,,2.4V,20mA,,Yellow Green,,565nm~575nm,240,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Orange_0603_10mA,SMD,Orange,clear,10mA Orange 0603 LED Indication,,,,0603,,,,,2.2V,10mA,,Orange,,600nm~612nm,70,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Orange_0603_20mA,SMD,Orange,clear,20mA 315mcd Colorless transparent -20℃~+85℃ 600nm~610nm Positive Stick Orange 120° 50mW 2.3V 0603 LED Indication,,,,0603,,,,,2.3V,20mA,,Orange,,,315,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Orange_0603_20mA,SMD,Orange,clear,20mA 315mcd Colorless transparent -20℃~+85℃ 600nm~610nm Positive Stick Orange 120° 50mW 2.3V 0603 LED Indication,,,,0603,,,,,2.3V,20mA,,Orange,120°,600nm~610nm,315,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Yellow_0603_20mA,SMD,Yellow,clear,20mA 450mcd Colorless transparent -20℃~+85℃ 585nm~595nm Positive Stick Yellow 120° 50mW 2.3V 0603 LED Indication,,,,0603,,,,,2.3V,20mA,,Yellow,120°,585nm~595nm,450,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Red_0603_20mA,SMD,Red,clear,20mA 150mcd 622nm Red 120° 2.2V 0603 LED Indication,,,,0603,,,,,2.2V,20mA,,Red,,,150,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Red_0603_20mA,SMD,Red,clear,20mA 330mcd Colorless transparent -20℃~+85℃ Positive Stick 620nm~630nm Red 120° 50mW 2.3V 0603 LED Indication,,,,0603,,,,,2.3V,20mA,,Red,,,330,,Device:LED,SPCoast:0603-LED
+,,LED,LED_Red_0603_20mA,SMD,Red,clear,20mA 360mcd Colorless transparent 615nm~625nm -20℃~+85℃ Positive Stick Red 120° 50mW 2.4V 0603 LED Indication,,,,0603,,,,,2.4V,20mA,,Red,120°,615nm~625nm,360,,Device:LED,SPCoast:0603-LED
+,,LED,LED_WS2812B_SMD5050,SMD,WS2812B,5050,SMD5050 RGB LEDs(Built-in IC) NeoPixel,,,,SMD5050,,,,,5v,12mA,,,,,,,SPCoast:WS2812B,SPCoast:WS2812B
+Project,UUID,Category,"(OPTIONAL)
+IPN",SMD,Value,"(Optional)
+Type",Description,Resistance,,,Package,,,,"(Optional)
+Tolerance",V,,W,,,,,,Symbol,Footprint
+,,RES,RES_5%_100mW_0603_200,SMD,200,thick film,200 100mW  75V ±100ppm/℃ ±5% 0603,200,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_1%_100mW_0603_220,SMD,220,thick film,220 100mW s 150V ±100ppm/℃ ±1% 0603,220,,,0603,,,,1%,150V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_220,SMD,220,thick film,220 100mW  75V ±100ppm/℃ ±5% 0603,220,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_330,SMD,330,thick film,330 100mW  75V ±100ppm/℃ ±5% 0603,330,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_470,SMD,470,thick film,470 100mW  75V ±100ppm/℃ ±5% 0603,470,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_1K,SMD,1K,thick film,1k 100mW  75V ±100ppm/℃ ±5% 0603,1K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_2.2K,SMD,2.2K,thick film,2.2k 100mW  75V ±100ppm/℃ ±5% 0603,2.2K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_1%_100mW_0603_3.3K,SMD,3.3K,thick film,3.3k 100mW s 75V ±100ppm/℃ ±1% 0603,3.3K,,,0603,,,,1%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_3.3K,SMD,3.3K,thick film,3.3k 100mW  75V ±100ppm/℃ ±5% 0603,3.3K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_4.7K,SMD,4.7K,thick film,4.7k 100mW  75V ±100ppm/℃ ±5% 0603,4.7K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_5.6K,SMD,5.6K,thick film,5.6k 100mW  75V ±100ppm/℃ ±5% 0603,5.6K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_10K,SMD,10K,thick film,10k 100mW s 150V ±100ppm/℃ ±5% 0603,10K,,,0603,,,,5%,150V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_10K,SMD,10K,thick film,10k 100mW  75V ±100ppm/℃ ±5% 0603,10K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_10K,SMD,10K,thick film,10k 100mW  75V ±100ppm/℃ ±5% 0603,10K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_22K,SMD,22K,thick film,22k 100mW  75V ±100ppm/℃ ±5% 0603,22K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_100K,SMD,100K,thick film,100k 100mW  75V ±100ppm/℃ ±5% 0603,100K,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_1%_100mW_0603_1M,SMD,1M,thick film,1.0M 100mW  75V ±100ppm/℃ ±1% 0603,1M,,,0603,,,,1%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_1M,SMD,1M,thick film,1.0M 100mW  75V ±100ppm/℃ ±5% 0603,1M,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_2.2M,SMD,2.2M,thick film,2.2M 100mW  75V ±100ppm/℃ ±5% 0603,2.2M,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_2.2M,SMD,2.2M,thick film,2.2M 100mW  50V ±250ppm/℃ ±5% 0603,2.2M,,,0603,,,,5%,50V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES
+,,RES,RES_5%_100mW_0603_2.2M,SMD,2.2M,thick film,2.2M 100mW  75V ±100ppm/℃ ±5% 0603,2.2M,,,0603,,,,5%,75V,,100mW,,,,,,Device:R_US,SPCoast:0603-RES

--- a/docs/inventory-field-semantics.md
+++ b/docs/inventory-field-semantics.md
@@ -1,0 +1,48 @@
+# Inventory field semantics
+This document defines the current v7 semantics for inventory cell values used by `jbom annotate` and related CSV workflows.
+
+## Three-state value model
+Each inventory cell is interpreted as one of three states:
+
+- blank (`""`)
+  - meaning: not yet determined by the designer
+  - annotate behavior: do not write this field to the schematic
+- `~`
+  - meaning: explicit don't-care decision by the designer
+  - annotate behavior: write literal `~` to the schematic property
+- explicit non-blank value
+  - meaning: designer-provided requirement/value
+  - annotate behavior: write the value to the schematic property
+
+## Annotate write-back rules
+`jbom annotate` processes inventory rows by UUID and applies the following rules:
+
+- rows with `Project = "Project"` are treated as header/sub-header sentinel rows and skipped
+- data rows with blank cells skip write-back for those fields
+- data rows with non-blank cells write values as-is (including `~`)
+- write-back mapping is direct column-to-property:
+  - `Package` column writes `Package` property
+  - `Footprint` column writes `Footprint` property
+  - no `Package -> Footprint` mapping shim is applied in v7
+
+Required field warnings during annotate:
+
+- required fields are currently `Value` and `Package`
+- annotate emits warnings when required fields are blank in data rows
+
+## Triage behavior (`--triage`)
+`jbom annotate --triage` reports data rows with required blanks:
+
+- required fields checked: `Value`, `Package`
+- rows with `Project = "Project"` are skipped
+- output is focused on missing required fields only
+
+## Sub-header row sentinel format
+Inline sub-header rows are identified using:
+
+- `Project` column value exactly equal to `"Project"`
+
+This sentinel is used to skip both top-level header-like guide rows and per-category sub-header rows during annotate processing.
+
+## Scope note
+Defaults-driven required/optional/recommended category semantics are intentionally deferred to the `--defaults` design thread. Current triage/reporting behavior remains minimal and explicit for Issue #127 Scope A.

--- a/features/annotate/core.feature
+++ b/features/annotate/core.feature
@@ -1,0 +1,70 @@
+Feature: Annotate command core behavior
+  As a hardware designer
+  I want inventory CSV edits written back to schematic properties by UUID
+  So that I can run the KLC compliance loop safely
+
+  Background:
+    Given a schematic that contains:
+      | UUID    | Reference | Value | Footprint | Package | LibID    |
+      | uuid-r1 | R1        | 10K   | R_0603    | 0603    | Device:R |
+
+  Scenario: Annotate writes explicit values for matching UUID rows
+    Given an inventory file "fixit.csv" that contains:
+      | Project   | UUID    | Value | Package | Footprint | LCSC  |
+      | /tmp/demo | uuid-r1 | 11K   | 0805    | R_0805    | C9999 |
+    When I run jbom command "annotate -i fixit.csv"
+    Then the command should succeed
+    And the file "project.kicad_sch" should contain "\"Value\" \"11K\""
+    And the file "project.kicad_sch" should contain "\"Package\" \"0805\""
+    And the file "project.kicad_sch" should contain "\"Footprint\" \"R_0805\""
+    And the file "project.kicad_sch" should contain "\"LCSC\" \"C9999\""
+
+  Scenario: Annotate skips blank cells and preserves existing values
+    Given an inventory file "fixit.csv" that contains:
+      | Project   | UUID    | Value | Package | Footprint | LCSC |
+      | /tmp/demo | uuid-r1 |       |         |           |      |
+    When I run jbom command "annotate -i fixit.csv"
+    Then the command should succeed
+    And the file "project.kicad_sch" should contain "\"Value\" \"10K\""
+    And the file "project.kicad_sch" should contain "\"Package\" \"0603\""
+    And the file "project.kicad_sch" should contain "\"Footprint\" \"R_0603\""
+
+  Scenario: Annotate writes tilde literal for non-blank fields
+    Given an inventory file "fixit.csv" that contains:
+      | Project   | UUID    | Value | Package | Footprint | LCSC |
+      | /tmp/demo | uuid-r1 |       | ~       |           |      |
+    When I run jbom command "annotate -i fixit.csv"
+    Then the command should succeed
+    And the file "project.kicad_sch" should contain "\"Package\" \"~\""
+
+  Scenario: Annotate skips sub-header rows identified by Project sentinel
+    Given an inventory file "fixit.csv" that contains:
+      | Project | UUID    | Value             | Package           | Footprint         | LCSC             |
+      | Project | uuid-r1 | SHOULD_NOT_APPLY | SHOULD_NOT_APPLY | SHOULD_NOT_APPLY | SHOULD_NOT_APPLY |
+    When I run jbom command "annotate -i fixit.csv"
+    Then the command should succeed
+    And the file "project.kicad_sch" should contain "\"Value\" \"10K\""
+    And the file "project.kicad_sch" should contain "\"Package\" \"0603\""
+    And the file "project.kicad_sch" should contain "\"Footprint\" \"R_0603\""
+
+  Scenario: Annotate dry-run reports changes without writing schematic
+    Given an inventory file "fixit.csv" that contains:
+      | Project   | UUID    | Value | Package | Footprint | LCSC  |
+      | /tmp/demo | uuid-r1 | 22K   | 1206    | R_1206    | C7777 |
+    When I run jbom command "annotate -i fixit.csv --dry-run"
+    Then the command should succeed
+    And the output should contain "Dry run complete."
+    And the file "project.kicad_sch" should contain "\"Value\" \"10K\""
+    And the file "project.kicad_sch" should contain "\"Package\" \"0603\""
+    And the file "project.kicad_sch" should contain "\"Footprint\" \"R_0603\""
+
+  Scenario: Annotate triage reports required blanks for Value and Package
+    Given an inventory file "fixit.csv" that contains:
+      | Project   | UUID    | Value | Package | Footprint |
+      | /tmp/demo | uuid-r1 |       | 0603    | R_0603    |
+      | /tmp/demo | uuid-r2 | 10K   |         | R_0603    |
+    When I run jbom command "annotate -i fixit.csv --triage"
+    Then the command should succeed
+    And the output should contain "Triage report"
+    And the output should contain "missing Value"
+    And the output should contain "missing Package"

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -640,9 +640,10 @@ def step_file_should_contain(context, filename, text):
     file_path = Path(context.project_root) / filename
     assert file_path.exists(), f"File not found: {file_path}"
     content = file_path.read_text(encoding="utf-8")
+    expected_text = text.replace('\\"', '"')
     assert (
-        text in content
-    ), f"Text '{text}' not found in file {filename}\nContent:\n{content}"
+        expected_text in content
+    ), f"Text '{expected_text}' not found in file {filename}\nContent:\n{content}"
 
 
 @then('a file should exist that contains "{text}"')

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -26,6 +26,8 @@ def _write_schematic_local(
         ref = row.get("Reference", "U1")
         val = row.get("Value", "VAL")
         fp = row.get("Footprint", "")
+        package = row.get("Package", "")
+        uuid = row.get("UUID", "")
         lib = row.get("LibID", "Device:Generic")
         dnp = row.get("DNP", "No")
         exclude_from_bom = row.get("ExcludeFromBOM", "No")
@@ -38,6 +40,8 @@ def _write_schematic_local(
             symbol_parts.append("(dnp yes)")
         if exclude_from_bom.lower() in ["yes", "true", "1"]:
             symbol_parts.append("(in_bom no)")
+        if uuid:
+            symbol_parts.append(f'(uuid "{uuid}")')
 
         # Add properties
         symbol_parts.extend(
@@ -47,6 +51,10 @@ def _write_schematic_local(
                 f'(property "Footprint" "{fp}" (id 2) (at {x+2} 54 0))',
             ]
         )
+        if package:
+            symbol_parts.append(
+                f'(property "Package" "{package}" (id 3) (at {x+2} 56 0))'
+            )
 
         symbol_lines = [f"  {part}" for part in symbol_parts] + ["  )"]
         symbols.append("\n".join(symbol_lines))

--- a/src/jbom/cli/annotate.py
+++ b/src/jbom/cli/annotate.py
@@ -1,0 +1,114 @@
+"""Annotate command - back-annotate inventory values into schematic properties."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from jbom.services.annotation_service import annotate_schematic, triage_inventory
+from jbom.services.project_file_resolver import ProjectFileResolver
+
+
+def register_command(subparsers) -> None:
+    """Register annotate command with argument parser."""
+
+    parser = subparsers.add_parser(
+        "annotate",
+        help="Back-annotate inventory fields to schematic by UUID",
+        description="Back-annotate inventory fields to schematic by UUID",
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=".",
+        help="Path to .kicad_sch file or project directory (default: current directory)",
+    )
+    parser.add_argument(
+        "-i",
+        "--inventory",
+        required=True,
+        type=Path,
+        help="Path to inventory CSV used for annotation",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Show proposed changes without writing the schematic",
+    )
+    parser.add_argument(
+        "--triage",
+        action="store_true",
+        help="Report rows missing required fields (Value, Package)",
+    )
+    parser.set_defaults(handler=handle_annotate)
+
+
+def handle_annotate(args: argparse.Namespace) -> int:
+    """Handle annotate command execution."""
+
+    try:
+        resolver = ProjectFileResolver(prefer_pcb=False, target_file_type="schematic")
+        resolved = resolver.resolve_input(args.input)
+        schematic_path = resolved.resolved_path
+
+        if args.triage:
+            report = triage_inventory(args.inventory)
+            return _print_triage_report(report)
+
+        result = annotate_schematic(
+            schematic_path=schematic_path,
+            inventory_path=args.inventory,
+            dry_run=args.dry_run,
+        )
+        return _print_annotation_result(result, schematic_path)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _print_triage_report(report) -> int:
+    """Print triage report and return command exit code."""
+
+    if not report.rows_with_required_blanks:
+        print(
+            f"Triage complete: no required blanks found in {report.total_data_rows} rows."
+        )
+        return 0
+
+    print("Triage report (required blank fields: Value, Package):")
+    for issue in report.rows_with_required_blanks:
+        missing = ", ".join(issue.missing_required_fields)
+        print(
+            f"  row {issue.row_number} UUID {issue.uuid or '<blank>'}: missing {missing}"
+        )
+
+    print(
+        f"Rows with required blanks: {len(report.rows_with_required_blanks)}/{report.total_data_rows}"
+    )
+    return 0
+
+
+def _print_annotation_result(result, schematic_path: Path) -> int:
+    """Print annotation execution summary."""
+
+    for warning in result.warnings:
+        print(f"Warning: {warning}", file=sys.stderr)
+
+    if result.dry_run:
+        print(
+            f"Dry run complete. {result.updated_components} component(s) would be updated."
+        )
+    else:
+        print(
+            f"Annotation complete. Updated {result.updated_components} component(s) in {schematic_path}."
+        )
+
+    for change in result.changes:
+        print(
+            f"  row {change.row_number} UUID {change.uuid}: {change.field}: "
+            f"'{change.before}' -> '{change.after}'"
+        )
+
+    return 0

--- a/src/jbom/cli/main.py
+++ b/src/jbom/cli/main.py
@@ -5,7 +5,7 @@ import sys
 from typing import List, Optional
 
 from jbom import __version__
-from jbom.cli import bom, inventory, pos, parts, search, inventory_search
+from jbom.cli import annotate, bom, inventory, pos, parts, search, inventory_search
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -37,6 +37,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     # Direct command registration - no registry needed!
     bom.register_command(subparsers)
+    annotate.register_command(subparsers)
     inventory.register_command(subparsers)
     pos.register_command(subparsers)
     parts.register_command(subparsers)

--- a/src/jbom/services/annotation_service.py
+++ b/src/jbom/services/annotation_service.py
@@ -1,0 +1,326 @@
+"""Services for inventory-driven schematic annotation and triage."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import sexpdata
+
+from jbom.common.sexp_parser import load_kicad_file, walk_nodes
+
+_RESERVED_COLUMNS = {"project", "uuid"}
+_REQUIRED_FIELDS = ("Value", "Package")
+
+
+@dataclass(frozen=True)
+class AnnotationChange:
+    """Represents one proposed/applied schematic property change."""
+
+    uuid: str
+    field: str
+    before: str
+    after: str
+    row_number: int
+
+
+@dataclass(frozen=True)
+class AnnotationRow:
+    """One inventory row loaded for annotation."""
+
+    row_number: int
+    project: str
+    uuid: str
+    values: dict[str, str]
+
+
+@dataclass
+class AnnotationResult:
+    """Result summary for annotate execution."""
+
+    dry_run: bool
+    updated_components: int
+    changes: list[AnnotationChange] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TriageRowIssue:
+    """A CSV row with missing required fields for annotation."""
+
+    row_number: int
+    project: str
+    uuid: str
+    missing_required_fields: list[str]
+
+
+@dataclass
+class TriageReport:
+    """Triage report for required blanks in inventory rows."""
+
+    total_data_rows: int
+    rows_with_required_blanks: list[TriageRowIssue] = field(default_factory=list)
+
+
+def annotate_schematic(
+    schematic_path: Path,
+    inventory_path: Path,
+    *,
+    dry_run: bool = False,
+) -> AnnotationResult:
+    """Apply annotation values from inventory rows to schematic symbols by UUID."""
+
+    rows = _load_annotation_rows(inventory_path)
+    schematic = load_kicad_file(schematic_path)
+    symbols_by_uuid = _index_symbols_by_uuid(schematic)
+
+    changes: list[AnnotationChange] = []
+    warnings: list[str] = []
+    updated_components: set[str] = set()
+
+    for row in rows:
+        if _is_header_or_subheader_row(row):
+            continue
+
+        missing_required = _missing_required_fields(row.values)
+        if missing_required:
+            warnings.append(
+                f"Row {row.row_number} UUID {row.uuid or '<blank>'}: required blank field(s): "
+                + ", ".join(missing_required)
+            )
+
+        if not row.uuid:
+            continue
+
+        symbol = symbols_by_uuid.get(row.uuid)
+        if symbol is None:
+            continue
+
+        row_updates = _extract_row_updates(row.values)
+        if not row_updates:
+            continue
+
+        row_changed = False
+        for field_name, new_value in row_updates.items():
+            current = _get_property_value(symbol, field_name)
+            if current == new_value:
+                continue
+
+            changes.append(
+                AnnotationChange(
+                    uuid=row.uuid,
+                    field=field_name,
+                    before=current,
+                    after=new_value,
+                    row_number=row.row_number,
+                )
+            )
+            row_changed = True
+
+            if not dry_run:
+                _set_property_value(symbol, field_name, new_value)
+
+        if row_changed:
+            updated_components.add(row.uuid)
+
+    if not dry_run and changes:
+        schematic_path.write_text(sexpdata.dumps(schematic), encoding="utf-8")
+
+    return AnnotationResult(
+        dry_run=dry_run,
+        updated_components=len(updated_components),
+        changes=changes,
+        warnings=warnings,
+    )
+
+
+def triage_inventory(inventory_path: Path) -> TriageReport:
+    """Report rows with required blanks (Value/Package) for triage workflow."""
+
+    rows = _load_annotation_rows(inventory_path)
+
+    row_issues: list[TriageRowIssue] = []
+    total_data_rows = 0
+
+    for row in rows:
+        if _is_header_or_subheader_row(row):
+            continue
+
+        total_data_rows += 1
+        missing_required = _missing_required_fields(row.values)
+        if not missing_required:
+            continue
+
+        row_issues.append(
+            TriageRowIssue(
+                row_number=row.row_number,
+                project=row.project,
+                uuid=row.uuid,
+                missing_required_fields=missing_required,
+            )
+        )
+
+    return TriageReport(
+        total_data_rows=total_data_rows,
+        rows_with_required_blanks=row_issues,
+    )
+
+
+def _load_annotation_rows(inventory_path: Path) -> list[AnnotationRow]:
+    """Load annotation CSV rows as normalized row records."""
+
+    with inventory_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            return []
+
+        rows: list[AnnotationRow] = []
+        for index, row in enumerate(reader, start=2):
+            normalized = {str(k).strip(): _clean_cell(v) for k, v in row.items() if k}
+            rows.append(
+                AnnotationRow(
+                    row_number=index,
+                    project=normalized.get("Project", ""),
+                    uuid=normalized.get("UUID", ""),
+                    values=normalized,
+                )
+            )
+
+    return rows
+
+
+def _clean_cell(value: str | None) -> str:
+    """Normalize a CSV cell value to stripped string."""
+
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _is_header_or_subheader_row(row: AnnotationRow) -> bool:
+    """Return True when row is a header/sub-header sentinel row."""
+
+    return row.project == "Project"
+
+
+def _missing_required_fields(values: dict[str, str]) -> list[str]:
+    """Return required fields that are blank in a row."""
+
+    missing: list[str] = []
+    for field_name in _REQUIRED_FIELDS:
+        if values.get(field_name, "").strip():
+            continue
+        missing.append(field_name)
+    return missing
+
+
+def _extract_row_updates(values: dict[str, str]) -> dict[str, str]:
+    """Extract non-blank annotation updates from a row."""
+
+    updates: dict[str, str] = {}
+    for field_name, value in values.items():
+        if not value.strip():
+            continue
+        if field_name.lower() in _RESERVED_COLUMNS:
+            continue
+        updates[field_name] = value
+    return updates
+
+
+def _index_symbols_by_uuid(schematic: Any) -> dict[str, list[Any]]:
+    """Build UUID -> symbol-node map from parsed schematic data."""
+
+    indexed: dict[str, list[Any]] = {}
+    for symbol in walk_nodes(schematic, "symbol"):
+        symbol_uuid = _get_symbol_uuid(symbol)
+        if not symbol_uuid:
+            continue
+        indexed[symbol_uuid] = symbol
+    return indexed
+
+
+def _get_symbol_uuid(symbol: list[Any]) -> str:
+    """Extract UUID from a symbol node."""
+
+    for child in symbol[1:]:
+        if (
+            isinstance(child, list)
+            and child
+            and child[0] == sexpdata.Symbol("uuid")
+            and len(child) >= 2
+        ):
+            return str(child[1])
+    return ""
+
+
+def _find_property_node(symbol: list[Any], field_name: str) -> list[Any] | None:
+    """Find a property node by property name within a symbol node."""
+
+    for child in symbol[1:]:
+        if not (
+            isinstance(child, list)
+            and child
+            and child[0] == sexpdata.Symbol("property")
+            and len(child) >= 3
+        ):
+            continue
+
+        if str(child[1]) == field_name:
+            return child
+    return None
+
+
+def _get_property_value(symbol: list[Any], field_name: str) -> str:
+    """Get the current property value for a symbol field."""
+
+    node = _find_property_node(symbol, field_name)
+    if node is None:
+        return ""
+    return str(node[2])
+
+
+def _set_property_value(symbol: list[Any], field_name: str, value: str) -> None:
+    """Set or create a property value on a symbol node."""
+
+    node = _find_property_node(symbol, field_name)
+    if node is not None:
+        node[2] = value
+        return
+
+    next_id = _next_property_id(symbol)
+    symbol.append(
+        [
+            sexpdata.Symbol("property"),
+            field_name,
+            value,
+            [sexpdata.Symbol("id"), next_id],
+            [sexpdata.Symbol("at"), 0, 0, 0],
+        ]
+    )
+
+
+def _next_property_id(symbol: list[Any]) -> int:
+    """Return the next available property id for a symbol."""
+
+    highest = -1
+    for child in symbol[1:]:
+        if not (
+            isinstance(child, list)
+            and child
+            and child[0] == sexpdata.Symbol("property")
+        ):
+            continue
+
+        for token in child[3:]:
+            if (
+                isinstance(token, list)
+                and token
+                and token[0] == sexpdata.Symbol("id")
+                and len(token) >= 2
+            ):
+                try:
+                    highest = max(highest, int(token[1]))
+                except (TypeError, ValueError):
+                    continue
+
+    return highest + 1

--- a/tests/unit/test_annotation_service.py
+++ b/tests/unit/test_annotation_service.py
@@ -1,0 +1,213 @@
+"""Unit tests for Issue #127 annotation behavior in v7."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from jbom.services.annotation_service import annotate_schematic, triage_inventory
+
+
+def _write_schematic(path: Path) -> str:
+    """Write a minimal schematic with one UUID-addressable symbol."""
+
+    content = """(kicad_sch (version 20211123) (generator eeschema)
+  (symbol (lib_id "Device:R") (at 50 50 0)
+    (uuid "uuid-r1")
+    (property "Reference" "R1" (id 0) (at 52 48 0))
+    (property "Value" "10K" (id 1) (at 52 52 0))
+    (property "Footprint" "R_0603" (id 2) (at 52 54 0))
+    (property "Package" "0603" (id 3) (at 52 56 0))
+    (property "LCSC" "C1234" (id 4) (at 52 58 0))
+  )
+)
+"""
+    path.write_text(content, encoding="utf-8")
+    return content
+
+
+def _write_inventory(path: Path, rows: list[dict[str, str]]) -> None:
+    """Write annotation inventory rows to CSV."""
+
+    fieldnames = ["Project", "UUID", "Value", "Package", "Footprint", "LCSC"]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_annotate_writes_explicit_values_for_matching_uuid(tmp_path: Path) -> None:
+    schematic = tmp_path / "project.kicad_sch"
+    _write_schematic(schematic)
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r1",
+                "Value": "11K",
+                "Package": "0805",
+                "Footprint": "R_0805",
+                "LCSC": "C9999",
+            }
+        ],
+    )
+
+    result = annotate_schematic(schematic, inventory, dry_run=False)
+    updated = schematic.read_text(encoding="utf-8")
+
+    assert result.updated_components == 1
+    assert '"Value" "11K"' in updated
+    assert '"Package" "0805"' in updated
+    assert '"Footprint" "R_0805"' in updated
+    assert '"LCSC" "C9999"' in updated
+
+
+def test_annotate_skips_blank_cells_and_keeps_existing_values(tmp_path: Path) -> None:
+    schematic = tmp_path / "project.kicad_sch"
+    original = _write_schematic(schematic)
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r1",
+                "Value": "",
+                "Package": "",
+                "Footprint": "",
+                "LCSC": "",
+            }
+        ],
+    )
+
+    result = annotate_schematic(schematic, inventory, dry_run=False)
+    assert result.updated_components == 0
+    assert schematic.read_text(encoding="utf-8") == original
+
+
+def test_annotate_writes_tilde_literal_to_schematic_properties(tmp_path: Path) -> None:
+    schematic = tmp_path / "project.kicad_sch"
+    _write_schematic(schematic)
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r1",
+                "Value": "",
+                "Package": "~",
+                "Footprint": "",
+                "LCSC": "",
+            }
+        ],
+    )
+
+    result = annotate_schematic(schematic, inventory, dry_run=False)
+    updated = schematic.read_text(encoding="utf-8")
+
+    assert result.updated_components == 1
+    assert '"Package" "~"' in updated
+
+
+def test_annotate_skips_subheader_rows_where_project_equals_project(
+    tmp_path: Path,
+) -> None:
+    schematic = tmp_path / "project.kicad_sch"
+    original = _write_schematic(schematic)
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": "Project",
+                "UUID": "uuid-r1",
+                "Value": "SHOULD_NOT_APPLY",
+                "Package": "SHOULD_NOT_APPLY",
+                "Footprint": "SHOULD_NOT_APPLY",
+                "LCSC": "SHOULD_NOT_APPLY",
+            }
+        ],
+    )
+
+    result = annotate_schematic(schematic, inventory, dry_run=False)
+    assert result.updated_components == 0
+    assert schematic.read_text(encoding="utf-8") == original
+
+
+def test_annotate_dry_run_reports_changes_without_writing_file(tmp_path: Path) -> None:
+    schematic = tmp_path / "project.kicad_sch"
+    original = _write_schematic(schematic)
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r1",
+                "Value": "22K",
+                "Package": "1206",
+                "Footprint": "R_1206",
+                "LCSC": "C8888",
+            }
+        ],
+    )
+
+    result = annotate_schematic(schematic, inventory, dry_run=True)
+
+    assert result.updated_components == 1
+    assert result.dry_run is True
+    assert len(result.changes) >= 1
+    assert schematic.read_text(encoding="utf-8") == original
+
+
+def test_triage_reports_only_required_blank_fields_value_and_package(
+    tmp_path: Path,
+) -> None:
+    inventory = tmp_path / "fixit.csv"
+    _write_inventory(
+        inventory,
+        [
+            {
+                "Project": "Project",
+                "UUID": "UUID",
+                "Value": "Value",
+                "Package": "Package",
+                "Footprint": "Footprint",
+                "LCSC": "LCSC",
+            },
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r1",
+                "Value": "",
+                "Package": "0603",
+                "Footprint": "R_0603",
+                "LCSC": "",
+            },
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r2",
+                "Value": "10K",
+                "Package": "",
+                "Footprint": "R_0603",
+                "LCSC": "",
+            },
+            {
+                "Project": str(tmp_path),
+                "UUID": "uuid-r3",
+                "Value": "10K",
+                "Package": "0603",
+                "Footprint": "R_0603",
+                "LCSC": "",
+            },
+        ],
+    )
+
+    report = triage_inventory(inventory)
+    assert report.total_data_rows == 3
+    assert len(report.rows_with_required_blanks) == 2
+    assert report.rows_with_required_blanks[0].missing_required_fields == ["Value"]
+    assert report.rows_with_required_blanks[1].missing_required_fields == ["Package"]

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -73,6 +73,17 @@ def test_root_help_includes_inventory_search_command():
     assert "inventory-search" in out
 
 
+def test_root_help_includes_annotate_command():
+    out = run_help([]).lower()
+    assert "annotate" in out
+
+
+def test_annotate_help_shows_core_flags():
+    out = run_help(["annotate"]).lower()
+    for token in ["--inventory", "--dry-run", "--triage"]:
+        assert token in out
+
+
 def test_inventory_search_help_includes_fabricator_choices():
     out = run_help(["inventory-search"]).lower()
     assert "--fabricator" in out

--- a/tests/unit/test_inventory_tilde_semantics.py
+++ b/tests/unit/test_inventory_tilde_semantics.py
@@ -1,0 +1,91 @@
+"""Unit tests for Issue #127: inventory three-state (~) round-trip semantics."""
+
+from __future__ import annotations
+
+import csv
+import io
+import tempfile
+import textwrap
+from pathlib import Path
+
+from jbom.cli.inventory import _write_csv
+from jbom.services.inventory_reader import InventoryReader
+
+_ROUND_TRIP_FIELD_ORDER = [
+    "IPN",
+    "Category",
+    "Value",
+    "Description",
+    "Package",
+    "Manufacturer",
+    "MFGPN",
+    "LCSC",
+    "Datasheet",
+    "UUID",
+    "Tolerance",
+    "Footprint",
+]
+
+
+def _load_items_from_csv(csv_text: str) -> tuple[list, list[str]]:
+    """Load inventory items from a temporary CSV payload."""
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(textwrap.dedent(csv_text).lstrip())
+        temp_path = Path(handle.name)
+
+    try:
+        reader = InventoryReader(temp_path)
+        return reader.load()
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def test_tilde_round_trip_is_preserved_through_reader_and_writer() -> None:
+    """`~` should survive inventory reader -> writer round-trip unchanged."""
+
+    items, _ = _load_items_from_csv(
+        """
+        IPN,Category,Value,Package,Tolerance,Footprint,UUID
+        RES_10K,RES,~,~,~,~,uuid-r1
+        """
+    )
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.value == "~"
+    assert item.package == "~"
+    assert item.tolerance == "~"
+    assert item.raw_data["Footprint"] == "~"
+
+    out = io.StringIO()
+    _write_csv(items, _ROUND_TRIP_FIELD_ORDER, out=out)
+
+    rows = list(csv.DictReader(io.StringIO(out.getvalue())))
+    assert len(rows) == 1
+    assert rows[0]["Value"] == "~"
+    assert rows[0]["Package"] == "~"
+    assert rows[0]["Tolerance"] == "~"
+    assert rows[0]["Footprint"] == "~"
+
+
+def test_blank_cells_remain_blank_in_round_trip() -> None:
+    """Blank cells remain blank and are not coerced into a sentinel value."""
+
+    items, _ = _load_items_from_csv(
+        """
+        IPN,Category,Value,Package,Tolerance,Footprint,UUID
+        RES_10K,RES,,,,,uuid-r1
+        """
+    )
+
+    out = io.StringIO()
+    _write_csv(items, _ROUND_TRIP_FIELD_ORDER, out=out)
+    rows = list(csv.DictReader(io.StringIO(out.getvalue())))
+
+    assert rows[0]["Value"] == ""
+    assert rows[0]["Package"] == ""
+    assert rows[0]["Tolerance"] == ""
+    assert rows[0]["Footprint"] == ""


### PR DESCRIPTION
## Summary
Implements Issue #127 Scope A (the annotate gate) in v7:
- Promotes `jbom annotate` into the v7 CLI with `--inventory`, `--dry-run`, and `--triage`
- Adds UUID-based schematic annotation service with write-back rules:
  - skip blank cells
  - write non-blank values verbatim (including `~`)
  - skip header/sub-header sentinel rows where `Project = "Project"`
- Uses literal property mapping in v7:
  - `Package` column -> schematic `Package` property
  - `Footprint` column -> schematic `Footprint` property
- Adds required-field warnings/triage for `Value` and `Package`

## Tests
Added/updated test coverage:
- `tests/unit/test_annotation_service.py`
- `tests/unit/test_inventory_tilde_semantics.py`
- `tests/unit/test_cli_help.py` (annotate help/registration)
- `features/annotate/core.feature`

Validation run:
- `pytest tests/unit/test_annotation_service.py tests/unit/test_inventory_tilde_semantics.py tests/unit/test_cli_help.py`
- `python -m behave --format progress features/annotate/core.feature`

## Documentation
- Added `docs/inventory-field-semantics.md`
- Added `docs/dev/validation/JohnExample.csv` as referenced format/example artifact

## Issue linkage
Part of #127 (Scope A).
Follow-up scope for `inventory --no-aggregate` and `parts` aggregation remains for subsequent branch/PR.

Co-Authored-By: Oz <oz-agent@warp.dev>