### PR TITLE
feat: implement issue #127 scope C no-aggregate inventory export

### DIFF
--- a/docs/inventory-field-semantics.md
+++ b/docs/inventory-field-semantics.md
@@ -44,5 +44,27 @@ Inline sub-header rows are identified using:
 
 This sentinel is used to skip both top-level header-like guide rows and per-category sub-header rows during annotate processing.
 
+## `inventory --no-aggregate` (Scope C)
+`jbom inventory --no-aggregate` emits one row per component instance for sparse-fix workflows.
+
+Current schema prefix:
+
+- `Project` (absolute project directory path)
+- `UUID`
+- `Category`
+- `IPN`
+
+Rows are sorted/grouped by `Category`, and each category group is preceded by a sentinel sub-header row.
+
+Current minimal deterministic sub-header markers:
+
+- `Project` -> `Project`
+- `UUID` -> `UUID`
+- `Category` -> `Category`
+- `IPN` -> `(Optional)\nIPN`
+- `Value` -> `Value`
+- `Package` -> `Package`
+- all other columns -> blank
+
 ## Scope note
-Defaults-driven required/optional/recommended category semantics are intentionally deferred to the `--defaults` design thread. Current triage/reporting behavior remains minimal and explicit for Issue #127 Scope A.
+Defaults-driven required/optional/recommended category semantics are intentionally deferred to the `--defaults` design thread. Current annotate triage and no-aggregate sub-header behavior remain minimal and explicit for Issue #127 Scope A/C.

--- a/features/inventory/no_aggregate.feature
+++ b/features/inventory/no_aggregate.feature
@@ -1,0 +1,27 @@
+Feature: Inventory no-aggregate export
+  As a hardware designer
+  I want one inventory row per component instance
+  So that I can triage sparse metadata with category sub-headers
+
+  Background:
+    Given a schematic that contains:
+      | UUID    | Reference | Value | Footprint                           | LibID    |
+      | uuid-r2 | R2        | 10K   | Resistor_SMD:R_0603_1608Metric     | Device:R |
+      | uuid-c1 | C1        | 100nF | Capacitor_SMD:C_0603_1608Metric    | Device:C |
+      | uuid-r1 | R1        | 10K   | Resistor_SMD:R_0603_1608Metric     | Device:R |
+
+  Scenario: no-aggregate output uses Project UUID Category IPN leading columns
+    When I run jbom command "inventory --no-aggregate -o noagg.csv"
+    Then the command should succeed
+    And the file "noagg.csv" contains "Project,UUID,Category,IPN"
+
+  Scenario: no-aggregate output emits one data row per component instance
+    When I run jbom command "inventory --no-aggregate -o noagg.csv"
+    Then the command should succeed
+    And the file "noagg.csv" contains exactly 3 no-aggregate data rows
+
+  Scenario: no-aggregate output inserts category sub-header sentinel rows
+    When I run jbom command "inventory --no-aggregate -o noagg.csv"
+    Then the command should succeed
+    And the file "noagg.csv" contains a no-aggregate sub-header row for each category
+    And the no-aggregate sub-header row in "noagg.csv" marks required and optional fields

--- a/features/steps/inventory_steps.py
+++ b/features/steps/inventory_steps.py
@@ -279,3 +279,53 @@ def given_directory_readonly(context):
 
     # Store original permissions for cleanup
     context.original_permissions = current_permissions
+
+
+@then('the file "{filename}" contains exactly {n:d} no-aggregate data rows')
+def then_file_contains_n_no_aggregate_data_rows(context, filename: str, n: int) -> None:
+    """Count only non-sentinel data rows in a no-aggregate CSV."""
+
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    data_rows = [row for row in rows if row.get("Project", "") != "Project"]
+    assert len(data_rows) == n, f"Expected {n} no-aggregate rows, got {len(data_rows)}"
+
+
+@then('the file "{filename}" contains a no-aggregate sub-header row for each category')
+def then_file_contains_subheader_row_for_each_category(context, filename: str) -> None:
+    """Validate one sentinel sub-header row exists for each data category."""
+
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    data_categories = {
+        row.get("Category", "") for row in rows if row.get("Project") != "Project"
+    }
+    subheaders = [row for row in rows if row.get("Project") == "Project"]
+
+    assert len(subheaders) == len(
+        data_categories
+    ), f"Expected {len(data_categories)} sub-header rows, got {len(subheaders)}"
+
+
+@then(
+    'the no-aggregate sub-header row in "{filename}" marks required and optional fields'
+)
+def then_no_aggregate_subheader_marks_required_optional(context, filename: str) -> None:
+    """Validate minimal deterministic sub-header marker encoding."""
+
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    subheader = next((row for row in rows if row.get("Project") == "Project"), None)
+    assert subheader is not None, "Expected at least one no-aggregate sub-header row"
+
+    assert subheader.get("UUID", "") == "UUID"
+    assert subheader.get("Category", "") == "Category"
+    assert subheader.get("IPN", "") == "(Optional)\nIPN"
+    assert subheader.get("Value", "") == "Value"
+    assert subheader.get("Package", "") == "Package"

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -29,6 +29,38 @@ from jbom.services.sophisticated_inventory_matcher import (
     SophisticatedInventoryMatcher,
 )
 
+_NO_AGGREGATE_PREFIX_FIELDS = ["Project", "UUID", "Category", "IPN"]
+_NO_AGGREGATE_PREFERRED_FIELDS = [
+    "SMD",
+    "Value",
+    "Type",
+    "Description",
+    "Resistance",
+    "Capacitance",
+    "Inductance",
+    "Package",
+    "Form",
+    "Pins",
+    "Pitch",
+    "Tolerance",
+    "V",
+    "A",
+    "W",
+    "Color",
+    "Angle",
+    "Wavelength",
+    "mcd",
+    "Frequency",
+    "Symbol",
+    "Footprint",
+    "Manufacturer",
+    "MFGPN",
+    "LCSC",
+    "Datasheet",
+    "Keywords",
+    "Name",
+]
+
 
 def register_command(subparsers) -> None:
     """Register inventory command with argument parser."""
@@ -70,6 +102,11 @@ def register_command(subparsers) -> None:
         "--filter-matches",
         action="store_true",
         help="Filter out components that match existing inventory items",
+    )
+    parser.add_argument(
+        "--no-aggregate",
+        action="store_true",
+        help="Emit one inventory row per component instance with category sub-header rows",
     )
 
     # Safety options
@@ -174,14 +211,96 @@ def _handle_generate_inventory(args: argparse.Namespace) -> int:
             verbose=args.verbose,
         )
 
+    project_directory = (
+        resolved_input.project_context.project_directory
+        if resolved_input.project_context
+        else schematic_file.parent
+    )
+
     # Generate inventory
     generator = ProjectInventoryGenerator(components)
+
+    if args.no_aggregate:
+        rows, field_names = _generate_no_aggregate_inventory_rows(
+            components,
+            project_directory=project_directory,
+        )
+        return _output_inventory_rows(
+            rows, field_names, args.output, args.force, args.verbose
+        )
+
     inventory_items, field_names = generator.load()
 
     # Handle output using same pattern as BOM command
     return _output_inventory(
         inventory_items, field_names, args.output, args.force, args.verbose
     )
+
+
+def _generate_no_aggregate_inventory_rows(
+    components: list[Component], project_directory: Path
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Generate no-aggregate inventory rows grouped by category with sub-headers."""
+
+    generator = ProjectInventoryGenerator(components)
+    inventory_items, base_field_names = generator.load_no_aggregate()
+
+    field_names = _build_no_aggregate_field_order(base_field_names)
+    project_value = str(project_directory.resolve())
+
+    data_rows: list[dict[str, str]] = []
+    for item in inventory_items:
+        row = _inventory_item_to_row(item, field_names)
+        row["Project"] = project_value
+        row["UUID"] = item.uuid
+        row["Category"] = item.category
+        row["IPN"] = item.ipn
+        data_rows.append(row)
+
+    sorted_rows = sorted(
+        data_rows, key=lambda row: (row.get("Category", ""), row.get("UUID", ""))
+    )
+
+    grouped_rows: list[dict[str, str]] = []
+    current_category = ""
+    for row in sorted_rows:
+        category = row.get("Category", "")
+        if category != current_category:
+            grouped_rows.append(_build_no_aggregate_subheader_row(field_names))
+            current_category = category
+        grouped_rows.append(row)
+
+    return grouped_rows, field_names
+
+
+def _build_no_aggregate_field_order(base_field_names: list[str]) -> list[str]:
+    """Return deterministic field ordering for no-aggregate inventory output."""
+
+    base_set = set(base_field_names)
+    ordered_fields = list(_NO_AGGREGATE_PREFIX_FIELDS)
+
+    for field_name in _NO_AGGREGATE_PREFERRED_FIELDS:
+        if field_name in base_set and field_name not in ordered_fields:
+            ordered_fields.append(field_name)
+
+    extras = sorted(
+        field_name for field_name in base_set if field_name not in ordered_fields
+    )
+    ordered_fields.extend(extras)
+    return ordered_fields
+
+
+def _build_no_aggregate_subheader_row(field_names: list[str]) -> dict[str, str]:
+    """Build minimal deterministic sub-header marker row for no-aggregate output."""
+
+    row = {field_name: "" for field_name in field_names}
+    row["Project"] = "Project"
+    row["UUID"] = "UUID"
+    row["Category"] = "Category"
+    row["IPN"] = "(Optional)\nIPN"
+    row["Value"] = "Value"
+    row["Package"] = "Package"
+    return row
 
 
 def _filter_components_by_existing_inventory(
@@ -368,6 +487,68 @@ def _output_inventory(
     return 0
 
 
+def _output_inventory_rows(
+    rows: list[dict[str, str]],
+    field_names: list[str],
+    output,
+    force: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Output pre-built inventory row dictionaries in the requested format."""
+    default_path = Path("part-inventory.csv")
+
+    dest = resolve_output_destination(
+        output,
+        default_destination=OutputDestination(OutputKind.FILE, path=default_path),
+    )
+
+    if dest.kind == OutputKind.CONSOLE:
+        print_inventory_table(rows, field_names)
+        print(f"\nGenerated inventory with {_count_data_rows(rows)} items")
+        return 0
+
+    if dest.kind == OutputKind.STDOUT:
+        _write_csv_rows(rows, field_names, out=sys.stdout)
+        return 0
+
+    if not dest.path:
+        raise ValueError("Internal error: file output selected but no path provided")
+
+    output_path = dest.path
+    refused = (
+        f"Error: Output file '{output_path}' already exists. Use --force to overwrite."
+    )
+
+    def _backup(path: Path) -> Path | None:
+        backup_path = _create_backup(path, verbose)
+        if backup_path and verbose:
+            print(f"Created backup: {backup_path}", file=sys.stderr)
+        return backup_path
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+            make_backup=_backup,
+        ) as handle:
+            _write_csv_rows(rows, field_names, out=handle)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(
+        f"Generated inventory with {_count_data_rows(rows)} items written to {output_path}"
+    )
+    return 0
+
+
+def _count_data_rows(rows: list[dict[str, str]]) -> int:
+    """Count inventory data rows excluding no-aggregate sentinel sub-headers."""
+
+    return sum(1 for row in rows if row.get("Project", "") != "Project")
+
+
 def _create_backup(file_path: Path, verbose: bool = False) -> Path:
     """Create a timestamped backup of an existing file.
 
@@ -430,59 +611,54 @@ def _print_console_table(inventory_items, field_names) -> None:
 
 def _print_csv(inventory_items, field_names, *, out: TextIO) -> None:
     """Print inventory as CSV to a file-like object."""
-
-    writer = csv.DictWriter(out, fieldnames=field_names)
-    writer.writeheader()
-
-    for item in inventory_items:
-        row = {
-            "IPN": item.ipn,
-            "Category": item.category,
-            "Value": item.value,
-            "Description": item.description,
-            "Package": item.package,
-            "Manufacturer": item.manufacturer,
-            "MFGPN": item.mfgpn,
-            "LCSC": item.lcsc,
-            "Datasheet": item.datasheet,
-            "UUID": item.uuid,
-        }
-        # Add any extra fields from component properties
-        for field in field_names:
-            if (
-                field not in row
-                and hasattr(item, "raw_data")
-                and field in item.raw_data
-            ):
-                row[field] = item.raw_data[field]
-        writer.writerow(row)
+    rows = [_inventory_item_to_row(item, field_names) for item in inventory_items]
+    _write_csv_rows(rows, field_names, out=out)
 
 
 def _write_csv(inventory_items, field_names, *, out: TextIO) -> None:
     """Write inventory as CSV to a file-like object."""
+    rows = [_inventory_item_to_row(item, field_names) for item in inventory_items]
+    _write_csv_rows(rows, field_names, out=out)
+
+
+def _inventory_item_to_row(
+    item: InventoryItem, field_names: list[str]
+) -> dict[str, str]:
+    """Convert an InventoryItem to a CSV row dictionary."""
+
+    row = {
+        "IPN": item.ipn,
+        "Category": item.category,
+        "Value": item.value,
+        "Description": item.description,
+        "Package": item.package,
+        "Manufacturer": item.manufacturer,
+        "MFGPN": item.mfgpn,
+        "LCSC": item.lcsc,
+        "Datasheet": item.datasheet,
+        "UUID": item.uuid,
+    }
+
+    for field_name in field_names:
+        if (
+            field_name not in row
+            and hasattr(item, "raw_data")
+            and field_name in item.raw_data
+        ):
+            row[field_name] = item.raw_data[field_name]
+
+    for field_name in field_names:
+        row.setdefault(field_name, "")
+
+    return row
+
+
+def _write_csv_rows(
+    rows: list[dict[str, str]], field_names: list[str], *, out: TextIO
+) -> None:
+    """Write row dictionaries as CSV using the provided field order."""
 
     writer = csv.DictWriter(out, fieldnames=field_names)
     writer.writeheader()
-
-    for item in inventory_items:
-        row = {
-            "IPN": item.ipn,
-            "Category": item.category,
-            "Value": item.value,
-            "Description": item.description,
-            "Package": item.package,
-            "Manufacturer": item.manufacturer,
-            "MFGPN": item.mfgpn,
-            "LCSC": item.lcsc,
-            "Datasheet": item.datasheet,
-            "UUID": item.uuid,
-        }
-        # Add any extra fields from component properties
-        for field in field_names:
-            if (
-                field not in row
-                and hasattr(item, "raw_data")
-                and field in item.raw_data
-            ):
-                row[field] = item.raw_data[field]
+    for row in rows:
         writer.writerow(row)

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -71,6 +71,41 @@ class ProjectInventoryGenerator:
 
         return self.inventory, sorted(list(self.inventory_fields))
 
+    def load_no_aggregate(self) -> Tuple[List[InventoryItem], List[str]]:
+        """Generate one inventory item per component instance (no aggregation).
+
+        Returns:
+            Tuple of (inventory items list, field names list)
+        """
+        self.inventory = []
+        self.inventory_fields = {
+            "IPN",
+            "Category",
+            "Value",
+            "Package",
+            "Description",
+            "Keywords",
+            "Manufacturer",
+            "MFGPN",
+            "Datasheet",
+            "LCSC",
+            "UUID",
+            "Footprint",
+            "Symbol",
+        }
+
+        for component in self.components:
+            item = self._create_inventory_item(component, component.uuid)
+            item.raw_data = dict(item.raw_data)
+            item.raw_data["Footprint"] = component.footprint
+            item.raw_data["Symbol"] = component.lib_id
+
+            self.inventory.append(item)
+            for prop in component.properties.keys():
+                self.inventory_fields.add(prop)
+
+        return self.inventory, sorted(list(self.inventory_fields))
+
     def _generate_group_key(self, component: Component) -> str:
         """Generate a unique key for grouping components."""
         # We group by Value, Footprint, and relevant properties to deduplicate

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -58,7 +58,13 @@ def test_pos_help_shows_core_flags():
 def test_inventory_help_shows_inventory_interface_tokens():
     out = run_help(["inventory"]).lower()
     # Test current simplified interface with inventory matching flags
-    tokens_current = ["--inventory", "--filter-matches", "-o", "--output"]
+    tokens_current = [
+        "--inventory",
+        "--filter-matches",
+        "--no-aggregate",
+        "-o",
+        "--output",
+    ]
     for token in tokens_current:
         assert token in out
 

--- a/tests/unit/test_inventory_no_aggregate.py
+++ b/tests/unit/test_inventory_no_aggregate.py
@@ -1,0 +1,93 @@
+"""Unit tests for Issue #127 Scope C no-aggregate inventory output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jbom.cli.inventory import _generate_no_aggregate_inventory_rows
+from jbom.common.types import Component
+
+
+def _sample_components() -> list[Component]:
+    """Build sample components spanning two categories with deterministic UUIDs."""
+
+    return [
+        Component(
+            reference="R2",
+            lib_id="Device:R",
+            value="10K",
+            footprint="Resistor_SMD:R_0603_1608Metric",
+            uuid="uuid-r2",
+            properties={"Tolerance": "5%"},
+        ),
+        Component(
+            reference="C1",
+            lib_id="Device:C",
+            value="100nF",
+            footprint="Capacitor_SMD:C_0603_1608Metric",
+            uuid="uuid-c1",
+            properties={},
+        ),
+        Component(
+            reference="R1",
+            lib_id="Device:R",
+            value="10K",
+            footprint="Resistor_SMD:R_0603_1608Metric",
+            uuid="uuid-r1",
+            properties={"Tolerance": "5%"},
+        ),
+    ]
+
+
+def test_no_aggregate_schema_starts_with_project_uuid_category_ipn() -> None:
+    rows, field_names = _generate_no_aggregate_inventory_rows(
+        _sample_components(),
+        project_directory=Path("/tmp/example-project"),
+    )
+
+    assert field_names[:4] == ["Project", "UUID", "Category", "IPN"]
+
+    data_rows = [row for row in rows if row["Project"] != "Project"]
+    assert len(data_rows) == 3
+    assert {row["UUID"] for row in data_rows} == {"uuid-r1", "uuid-r2", "uuid-c1"}
+    expected_project_path = str(Path("/tmp/example-project").resolve())
+    assert all(row["Project"] == expected_project_path for row in data_rows)
+
+
+def test_no_aggregate_rows_are_grouped_by_category_with_subheaders() -> None:
+    rows, _ = _generate_no_aggregate_inventory_rows(
+        _sample_components(),
+        project_directory=Path("/tmp/example-project"),
+    )
+
+    # Expect pattern: subheader, CAP data..., subheader, RES data...
+    assert rows[0]["Project"] == "Project"
+    assert rows[1]["Category"] == "CAP"
+
+    # Find second subheader and verify it starts RES group.
+    second_subheader_index = next(
+        index
+        for index, row in enumerate(rows[2:], start=2)
+        if row["Project"] == "Project"
+    )
+    assert rows[second_subheader_index + 1]["Category"] == "RES"
+
+
+def test_subheader_row_uses_minimal_deterministic_markers() -> None:
+    rows, field_names = _generate_no_aggregate_inventory_rows(
+        _sample_components(),
+        project_directory=Path("/tmp/example-project"),
+    )
+
+    subheader = next(row for row in rows if row["Project"] == "Project")
+    assert subheader["Project"] == "Project"
+    assert subheader["UUID"] == "UUID"
+    assert subheader["Category"] == "Category"
+    assert subheader["IPN"] == "(Optional)\nIPN"
+    assert subheader["Value"] == "Value"
+    assert subheader["Package"] == "Package"
+
+    for field_name in field_names:
+        if field_name in {"Project", "UUID", "Category", "IPN", "Value", "Package"}:
+            continue
+        assert subheader[field_name] == ""


### PR DESCRIPTION
## Summary
Implements Issue #127 Scope C (`inventory --no-aggregate` + category sub-header rows).

### What this PR adds
- `jbom inventory --no-aggregate` option
- One output row per component instance (no aggregation)
- Output schema prefix: `Project, UUID, Category, IPN`
- `Project` column emitted as absolute project directory path
- Data rows sorted/grouped by `Category`
- Sentinel sub-header row inserted before each category group

### Sub-header marker content (minimal deterministic)
Per current design decision (intentionally not coupled to pending `--defaults` semantics):
- `Project` -> `Project`
- `UUID` -> `UUID`
- `Category` -> `Category`
- `IPN` -> `(Optional)\nIPN`
- `Value` -> `Value`
- `Package` -> `Package`
- all other columns blank

## Tests
Added/updated coverage:
- `tests/unit/test_inventory_no_aggregate.py`
- `tests/unit/test_cli_help.py` (inventory help now includes `--no-aggregate`)
- `features/inventory/no_aggregate.feature`
- `features/steps/inventory_steps.py` (no-aggregate CSV assertions)

Regression checks also rerun for Scope A paths:
- `tests/unit/test_annotation_service.py`
- `tests/unit/test_inventory_tilde_semantics.py`
- `features/annotate/core.feature`

Validation commands:
- `pre-commit run --all-files`
- `pytest tests/unit/test_inventory_no_aggregate.py tests/unit/test_cli_help.py tests/unit/test_annotation_service.py tests/unit/test_inventory_tilde_semantics.py`
- `python -m behave --format progress features/inventory/no_aggregate.feature features/annotate/core.feature`

## Documentation
- Updated `docs/inventory-field-semantics.md` with Scope C no-aggregate schema and marker details.

## Issue linkage
Part of #127 (Scope C).

Co-Authored-By: Oz <oz-agent@warp.dev>