### PR TITLE
feat: fix jbom parts electro-mechanical aggregation with Refs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jbom pos MyProject.kicad_sch --jlc
 jbom inventory MyProject/ -o my_new_inventory.csv
 ```
 
-**Generate Parts List** (one row per component, no aggregation):
+**Generate Parts List** (electro-mechanical aggregation with collapsed `Refs`):
 ```bash
 jbom parts MyProject/ -o parts.csv
 ```

--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -175,7 +175,7 @@ Generates an initial inventory template from schematic components. The output is
 jbom parts [PROJECT] [-o OUTPUT] [OPTIONS]
 ```
 
-Generates an unaggregated parts list — one row per component reference — from schematics. Unlike `bom`, `parts` does not aggregate by value+package and does not require an inventory file. Useful for checking component counts or exporting for use in another tool.
+Generates an electro-mechanically aggregated parts list from schematics. `parts` groups by value/package/type/tolerance/voltage/dielectric and emits a `Refs` column containing collapsed reference designators. Unlike `bom`, this aggregation excludes supply-chain fields and does not require an inventory file.
 
 **PROJECT** (optional, default: current directory)
 : Path to .kicad_sch file, project directory, or base name.
@@ -302,7 +302,7 @@ Bulk-searches distributor catalogs using items from an existing inventory file t
 : Default name `part-inventory.csv` (written in the current working directory when `-o` is omitted). Template with IPN, Category, Value, Package, and related columns.
 
 **Parts CSV**
-: Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per component reference, not aggregated. Use `-o -` for CSV to stdout.
+: Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per electro-mechanical group with a `Refs` column of collapsed references. Use `-o -` for CSV to stdout.
 
 **Exit Codes**
 : 0 — success
@@ -386,7 +386,7 @@ Show only components not yet in an existing inventory:
 jbom inventory MyProject/ --inventory existing.csv --filter-matches -o new_parts.csv
 ```
 
-Parts list (one row per reference, no aggregation):
+Parts list (electro-mechanical groups with collapsed Refs):
 ```
 jbom parts MyProject/ -o parts.csv
 ```

--- a/features/cli/parts_output.feature
+++ b/features/cli/parts_output.feature
@@ -30,11 +30,11 @@ Feature: CLI Parts Output Semantics
     When I run jbom command "parts -o -"
     Then the command should succeed
     And the output should contain these fields:
-      | Reference | Value | Footprint |
+      | Refs | Value | Footprint | Package |
     And the CSV output has rows where:
-      | Reference | Value | Footprint   |
-      | R1        | 10K   | R_0805_2012 |
-      | C1        | 100nF | C_0603_1608 |
+      | Refs      | Value | Footprint   |
+      | R1,R2,R10 | 10K   | R_0805_2012 |
+      | C1,C20    | 100nF | C_0603_1608 |
 
   Scenario: Explicit console output uses -o console
     When I run jbom command "parts -o console"

--- a/features/parts/README.md
+++ b/features/parts/README.md
@@ -1,10 +1,10 @@
 # Parts Domain
 
 ## Use Case
-As a hardware engineer, I want to generate a complete parts list from my KiCad project showing individual components (not aggregated like BOMs), so I can understand exactly which physical parts I need to procure or validate in my design.
+As a hardware engineer, I want to generate a complete parts list from my KiCad project showing electro-mechanical groups with collapsed references, so I can validate design identity without supply-chain splitting.
 
 ## Core User Needs
-1. "I want to see every individual component from my schematic in a simple list"
+1. "I want to see electro-mechanical groups with a clear `Refs` list from my schematic"
 2. "I want to exclude components that shouldn't be manufactured (DNP, excluded from BOM)"
 3. "I want to exclude KiCad's internal virtual symbols unless I specifically need them for debugging"
 4. "I want control over what gets included without having to understand KiCad's internal implementation"

--- a/features/parts/core.feature
+++ b/features/parts/core.feature
@@ -1,7 +1,7 @@
 Feature: Parts List Generation (Core Functionality)
   As a hardware developer
   I want to generate a Parts List from KiCad schematics
-  So that I can see every component instance for PCB assembly
+  So that I can see electro-mechanically grouped components for PCB assembly
 
   Background:
     Given a jBOM CSV sandbox
@@ -19,24 +19,35 @@ Feature: Parts List Generation (Core Functionality)
     When I run jbom command "parts"
     Then the command should succeed
     And the output should contain these fields:
-      | Reference | Value | Footprint |
+      | Refs | Value | Footprint | Package |
     And the CSV output has rows where:
-      | Reference | Value | Footprint   |
-      | R1        | 10K   | R_0805_2012 |
-      | C1        | 100nF | C_0603_1608 |
+      | Refs      | Value | Footprint   |
+      | R1,R2,R10 | 10K   | R_0805_2012 |
+      | C1,C20    | 100nF | C_0603_1608 |
 
-  Scenario: Parts list shows individual components (no aggregation)
+  Scenario: Parts list aggregates electro-mechanically identical components
     When I run jbom command "parts"
     Then the command should succeed
-    And the output should contain "R1"
-    And the output should contain "R2"
-    And the output should contain "R10"
-    And the output should not contain "R1, R2"
-    And the output should not contain "Quantity"
+    And the CSV output row count is 3
+    And the CSV output has rows where:
+      | Refs      | Value | Footprint   |
+      | R1,R2,R10 | 10K   | R_0805_2012 |
 
-  Scenario: Natural reference sorting in parts list
+  Scenario: Natural reference sorting within aggregated refs
     When I run jbom command "parts"
     Then the command should succeed
-    And R1 appears before R2 in the output
-    And R2 appears before R10 in the output
-    And C1 appears before C20 in the output
+    And the output should contain "R1,R2,R10"
+    And the output should contain "C1,C20"
+
+  Scenario: Parts list does not aggregate when package differs
+    Given a schematic that contains:
+      | Reference | Value | Footprint   | Package |
+      | R1        | 10K   | R_0805_2012 | 0603    |
+      | R2        | 10K   | R_0805_2012 | 0805    |
+    When I run jbom command "parts"
+    Then the command should succeed
+    And the CSV output row count is 2
+    And the CSV output has rows where:
+      | Refs | Value | Footprint   | Package |
+      | R1   | 10K   | R_0805_2012 | 0603    |
+      | R2   | 10K   | R_0805_2012 | 0805    |

--- a/features/parts/filtering.feature
+++ b/features/parts/filtering.feature
@@ -16,12 +16,12 @@ Feature: Parts List Filtering
     When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | C1        | 100nF |
+      | Refs | Value |
+      | R1   | 10K   |
+      | C1   | 100nF |
     And the CSV output does not contain components where:
-      | Reference |
-      | R2        |
+      | Refs |
+      | R2   |
 
   Scenario: Include DNP components when requested
     Given a schematic that contains:
@@ -32,10 +32,9 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-dnp"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | R2        | 10K   |
-      | C1        | 100nF |
+      | Refs  | Value |
+      | R1,R2 | 10K   |
+      | C1    | 100nF |
 
   Scenario: Exclude components marked as excluded from BOM by default
     Given a schematic that contains:
@@ -46,12 +45,12 @@ Feature: Parts List Filtering
     When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | C1        | 100nF |
+      | Refs | Value |
+      | R1   | 10K   |
+      | C1   | 100nF |
     And the CSV output does not contain components where:
-      | Reference |
-      | R2        |
+      | Refs |
+      | R2   |
 
   Scenario: Include excluded components when requested
     Given a schematic that contains:
@@ -62,10 +61,9 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | R2        | 10K   |
-      | C1        | 100nF |
+      | Refs  | Value |
+      | R1,R2 | 10K   |
+      | C1    | 100nF |
 
   Scenario: Exclude virtual symbols automatically
     Given a schematic that contains:
@@ -77,13 +75,13 @@ Feature: Parts List Filtering
     When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | C1        | 100nF |
+      | Refs | Value |
+      | R1   | 10K   |
+      | C1   | 100nF |
     And the CSV output does not contain components where:
-      | Reference |
-      | #PWR01    |
-      | #PWR02    |
+      | Refs  |
+      | #PWR01 |
+      | #PWR02 |
 
   Scenario: Include virtual symbols with --include-all
     Given a schematic that contains:
@@ -95,11 +93,11 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-all"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | C1        | 100nF |
-      | #PWR01    | GND   |
-      | #PWR02    | VCC   |
+      | Refs   | Value |
+      | R1     | 10K   |
+      | C1     | 100nF |
+      | #PWR01 | GND   |
+      | #PWR02 | VCC   |
 
   Scenario: Test both DNP and ExcludeFromBOM flags work independently
     Given a schematic that contains:
@@ -111,11 +109,9 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-dnp --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | R2        | 10K   |
-      | R3        | 10K   |
-      | C1        | 100nF |
+      | Refs     | Value |
+      | R1,R2,R3 | 10K   |
+      | C1       | 100nF |
 
   Scenario: Include only DNP components (exclude ExcludeFromBOM)
     Given a schematic that contains:
@@ -126,12 +122,11 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-dnp"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | R2        | 10K   |
+      | Refs  | Value |
+      | R1,R2 | 10K   |
     And the CSV output does not contain components where:
-      | Reference |
-      | R3        |
+      | Refs |
+      | R3   |
 
   Scenario: Include only ExcludeFromBOM components (exclude DNP)
     Given a schematic that contains:
@@ -142,9 +137,8 @@ Feature: Parts List Filtering
     When I run jbom command "parts --include-excluded"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value |
-      | R1        | 10K   |
-      | R3        | 10K   |
+      | Refs  | Value |
+      | R1,R3 | 10K   |
     And the CSV output does not contain components where:
-      | Reference |
-      | R2        |
+      | Refs |
+      | R2   |

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -264,21 +264,21 @@ def _print_console_table(parts_data: PartsListData) -> None:
         return
 
     # Simple table formatting
-    print(f"{'Reference':<12} {'Value':<12} {'Footprint':<20}")
+    print(f"{'Refs':<20} {'Value':<12} {'Package':<14}")
     print("-" * 60)
 
     for entry in parts_data.entries:
-        ref = entry.reference[:11] if len(entry.reference) > 11 else entry.reference
+        refs_value = entry.refs_csv
+        refs = refs_value[:19] + "..." if len(refs_value) > 19 else refs_value
         value = entry.value[:11] + "..." if len(entry.value) > 11 else entry.value
-        footprint = (
-            entry.footprint[:19] + "..."
-            if len(entry.footprint) > 19
-            else entry.footprint
-        )
+        package = entry.package or entry.footprint
+        package_display = package[:13] + "..." if len(package) > 13 else package
 
-        print(f"{ref:<12} {value:<12} {footprint:<20}")
+        print(f"{refs:<20} {value:<12} {package_display:<14}")
 
-    print(f"\nTotal: {parts_data.total_components} components")
+    print(
+        f"\nTotal: {parts_data.total_components} components in {parts_data.total_groups} groups"
+    )
 
     # Show inventory enhancement info if available
     if "matched_entries" in parts_data.metadata:
@@ -294,7 +294,16 @@ def _print_csv(parts_data: PartsListData, *, out: TextIO) -> None:
     writer = csv.writer(out)
 
     # Headers
-    headers = ["Reference", "Value", "Footprint"]
+    headers = [
+        "Refs",
+        "Value",
+        "Footprint",
+        "Package",
+        "Type",
+        "Tolerance",
+        "Voltage",
+        "Dielectric",
+    ]
 
     # Add inventory headers if present
     if parts_data.entries and parts_data.entries[0].attributes.get("inventory_matched"):
@@ -304,7 +313,16 @@ def _print_csv(parts_data: PartsListData, *, out: TextIO) -> None:
 
     # Data rows
     for entry in parts_data.entries:
-        row = [entry.reference, entry.value, entry.footprint]
+        row = [
+            entry.refs_csv,
+            entry.value,
+            entry.footprint,
+            entry.package,
+            entry.part_type,
+            entry.tolerance,
+            entry.voltage,
+            entry.dielectric,
+        ]
 
         # Add inventory data if present
         if entry.attributes.get("inventory_matched"):

--- a/src/jbom/services/parts_list_generator.py
+++ b/src/jbom/services/parts_list_generator.py
@@ -1,4 +1,4 @@
-"""Pure Parts List generator service that converts components to individual entries."""
+"""Pure Parts List generator service with electro-mechanical aggregation."""
 
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
@@ -9,13 +9,23 @@ from jbom.common.component_filters import apply_component_filters
 
 @dataclass
 class PartsListEntry:
-    """Individual component entry for parts list (1:1 with components)."""
+    """Aggregated component entry for parts list output."""
 
-    reference: str  # Single component reference (e.g., "R1")
+    refs: List[str]  # Component references collapsed into one row
     value: str  # Component value
     footprint: str  # Footprint identifier
+    package: str = ""  # Normalized package identity (falls back to footprint)
+    part_type: str = ""  # Electrical type (e.g., X7R, Thick Film)
+    tolerance: str = ""  # Tolerance field if present
+    voltage: str = ""  # Voltage rating if present
+    dielectric: str = ""  # Dielectric field if present
     lib_id: str = ""  # Library ID for component type
     attributes: Dict[str, Any] = field(default_factory=dict)  # Component properties
+
+    @property
+    def refs_csv(self) -> str:
+        """Return comma-separated reference designators for CSV output."""
+        return ",".join(self.refs)
 
 
 @dataclass
@@ -23,12 +33,17 @@ class PartsListData:
     """Complete Parts List dataset."""
 
     project_name: str  # Project name for output files
-    entries: List[PartsListEntry]  # Individual parts list entries (no aggregation)
+    entries: List[PartsListEntry]  # Aggregated parts entries
     metadata: Dict[str, Any] = field(default_factory=dict)  # Additional metadata
 
     @property
     def total_components(self) -> int:
-        """Total number of components in the parts list."""
+        """Total number of component references represented in the parts list."""
+        return sum(len(entry.refs) for entry in self.entries)
+
+    @property
+    def total_groups(self) -> int:
+        """Total number of electro-mechanical groups in the parts list."""
         return len(self.entries)
 
 
@@ -53,16 +68,15 @@ class PartsListGenerator:
             filters: Optional filtering criteria
 
         Returns:
-            PartsListData object with individual component entries
+            PartsListData object with electro-mechanically aggregated entries
         """
         # Apply filters using common logic
         filtered_components = apply_component_filters(components, filters or {})
+        # Create grouped entries by electro-mechanical identity
+        entries = self._create_grouped_entries(filtered_components)
 
-        # Create individual entries (no aggregation)
-        entries = self._create_individual_entries(filtered_components)
-
-        # Sort entries by reference in natural order
-        entries.sort(key=lambda e: self._natural_sort_key(e.reference))
+        # Sort groups by first reference in natural order
+        entries.sort(key=lambda e: self._natural_sort_key(e.refs[0] if e.refs else ""))
 
         return PartsListData(
             project_name=project_name,
@@ -70,37 +84,91 @@ class PartsListGenerator:
             metadata={
                 "total_input_components": len(components),
                 "filtered_components": len(filtered_components),
+                "aggregated_groups": len(entries),
             },
         )
 
-    def _create_individual_entries(
+    def _create_grouped_entries(
         self, components: List[Component]
     ) -> List[PartsListEntry]:
-        """Create individual PartsListEntry objects (1:1 with unique components).
+        """Create aggregated PartsListEntry objects from unique components.
 
         Multi-unit components (e.g. dual op-amps) produce multiple symbol
         instances with the same reference. We deduplicate by reference so
         each physical component appears only once.
         """
-        seen_refs: set[str] = set()
-        entries = []
-
+        unique_components: Dict[str, Component] = {}
         for component in components:
-            if component.reference in seen_refs:
-                continue
-            seen_refs.add(component.reference)
+            unique_components.setdefault(component.reference, component)
+
+        grouped_components: Dict[
+            tuple[str, str, str, str, str, str], List[Component]
+        ] = {}
+        for component in unique_components.values():
+            key = self._electro_mechanical_key(component)
+            grouped_components.setdefault(key, []).append(component)
+
+        entries: List[PartsListEntry] = []
+        for group in grouped_components.values():
+            representative = group[0]
+            refs = sorted(
+                [component.reference for component in group],
+                key=self._natural_sort_key,
+            )
             entry = PartsListEntry(
-                reference=component.reference,
-                value=component.value,
-                footprint=component.footprint,
-                lib_id=component.lib_id,
-                attributes=component.properties.copy(),
+                refs=refs,
+                value=representative.value,
+                footprint=representative.footprint,
+                package=self._component_property(
+                    representative, ["Package"], fallback=representative.footprint
+                ),
+                part_type=self._component_property(representative, ["Type"]),
+                tolerance=self._component_property(representative, ["Tolerance"]),
+                voltage=self._component_property(representative, ["Voltage", "V"]),
+                dielectric=self._component_property(representative, ["Dielectric"]),
+                lib_id=representative.lib_id,
+                attributes=representative.properties.copy(),
             )
             entries.append(entry)
 
         return entries
 
-    def _natural_sort_key(self, reference: str):
+    def _electro_mechanical_key(
+        self, component: Component
+    ) -> tuple[str, str, str, str, str, str]:
+        """Create normalized grouping key for electro-mechanical identity."""
+        value = component.value.strip().casefold()
+        package = (
+            self._component_property(
+                component, ["Package"], fallback=component.footprint
+            )
+            .strip()
+            .casefold()
+        )
+        part_type = self._component_property(component, ["Type"]).strip().casefold()
+        tolerance = (
+            self._component_property(component, ["Tolerance"]).strip().casefold()
+        )
+        voltage = (
+            self._component_property(component, ["Voltage", "V"]).strip().casefold()
+        )
+        dielectric = (
+            self._component_property(component, ["Dielectric"]).strip().casefold()
+        )
+        return (value, package, part_type, tolerance, voltage, dielectric)
+
+    def _component_property(
+        self, component: Component, keys: List[str], fallback: str = ""
+    ) -> str:
+        """Fetch a component property by case-insensitive key with fallback."""
+        property_map = {k.casefold(): v for k, v in component.properties.items()}
+        for key in keys:
+            value = property_map.get(key.casefold())
+            if value:
+                return value
+        return fallback
+
+    def _natural_sort_key(self, reference: str) -> List[Any]:
         """Generate natural sort key for references (R1, R2, R10 not R1, R10, R2)."""
         import re
 

--- a/tests/unit/test_parts_list_generator.py
+++ b/tests/unit/test_parts_list_generator.py
@@ -1,0 +1,115 @@
+"""Unit tests for PartsListGenerator electro-mechanical aggregation behavior."""
+
+from __future__ import annotations
+
+from jbom.common.types import Component
+from jbom.services.parts_list_generator import PartsListGenerator
+
+
+def _component(
+    reference: str,
+    value: str,
+    footprint: str,
+    *,
+    package: str = "",
+    part_type: str = "",
+    tolerance: str = "",
+    voltage: str = "",
+    dielectric: str = "",
+    manufacturer: str = "",
+) -> Component:
+    properties: dict[str, str] = {}
+    if package:
+        properties["Package"] = package
+    if part_type:
+        properties["Type"] = part_type
+    if tolerance:
+        properties["Tolerance"] = tolerance
+    if voltage:
+        properties["Voltage"] = voltage
+    if dielectric:
+        properties["Dielectric"] = dielectric
+    if manufacturer:
+        properties["Manufacturer"] = manufacturer
+
+    return Component(
+        reference=reference,
+        lib_id="Device:Generic",
+        value=value,
+        footprint=footprint,
+        properties=properties,
+    )
+
+
+def test_parts_are_aggregated_by_electro_mechanical_identity() -> None:
+    components = [
+        _component(
+            "R1",
+            "10K",
+            "R_0603_1608",
+            package="0603",
+            part_type="ThickFilm",
+            tolerance="1%",
+            voltage="50V",
+            manufacturer="Yageo",
+        ),
+        _component(
+            "R2",
+            "10K",
+            "R_0603_1608",
+            package="0603",
+            part_type="ThickFilm",
+            tolerance="1%",
+            voltage="50V",
+            manufacturer="Vishay",
+        ),
+        _component(
+            "C1",
+            "100nF",
+            "C_0603_1608",
+            package="0603",
+            part_type="Ceramic",
+            tolerance="10%",
+            voltage="25V",
+            dielectric="X7R",
+        ),
+    ]
+
+    data = PartsListGenerator().generate_parts_list_data(
+        components, project_name="Test"
+    )
+
+    assert len(data.entries) == 2
+    resistors = [e for e in data.entries if e.value == "10K"]
+    assert len(resistors) == 1
+    assert resistors[0].refs == ["R1", "R2"]
+
+
+def test_parts_do_not_aggregate_when_package_differs() -> None:
+    components = [
+        _component("R1", "10K", "R_0805_2012", package="0603"),
+        _component("R2", "10K", "R_0805_2012", package="0805"),
+    ]
+
+    data = PartsListGenerator().generate_parts_list_data(
+        components, project_name="Test"
+    )
+
+    assert len(data.entries) == 2
+    assert data.entries[0].refs == ["R1"]
+    assert data.entries[1].refs == ["R2"]
+
+
+def test_refs_are_sorted_naturally_within_aggregated_row() -> None:
+    components = [
+        _component("R10", "10K", "R_0603_1608"),
+        _component("R2", "10K", "R_0603_1608"),
+        _component("R1", "10K", "R_0603_1608"),
+    ]
+
+    data = PartsListGenerator().generate_parts_list_data(
+        components, project_name="Test"
+    )
+
+    assert len(data.entries) == 1
+    assert data.entries[0].refs == ["R1", "R2", "R10"]


### PR DESCRIPTION
## Summary
Implements Issue #127 Scope B by changing `jbom parts` from per-reference rows to electro-mechanical aggregation with collapsed references.

## Changes
- Updated `PartsListGenerator` to group components by electro-mechanical identity: Value, Package, Type, Tolerance, Voltage, Dielectric (excluding supply-chain fields).
- Added `Refs` support in the parts data model, with natural reference ordering inside each aggregated row.
- Updated `jbom parts` CSV output to emit `Refs,Value,Footprint,Package,Type,Tolerance,Voltage,Dielectric`.
- Updated console output to render grouped rows and summary counts (`components` + `groups`).
- Added new unit coverage in `tests/unit/test_parts_list_generator.py` for aggregation, package-split behavior, and natural ref ordering.
- Updated BDD expectations for parts core/filtering/CLI output features to validate grouped `Refs` behavior.
- Updated user-facing docs in `README.md` and `docs/README.man1.md` for the new parts semantics.

## Verification
- `pre-commit run --all-files`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src pytest tests/unit/test_parts_list_generator.py tests/unit/test_cli_help.py -q`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress features/parts/core.feature features/parts/filtering.feature features/cli/parts_output.feature`

## Architecture impact
The parts pipeline now intentionally diverges from BOM aggregation by representing electro-mechanical identity groups (`Refs`) while keeping supply-chain splitting in BOM only.

Closes #127

Co-Authored-By: Oz <oz-agent@warp.dev>