### PR TITLE
Fix/console output ux

### DIFF
--- a/src/jbom/cli/formatting.py
+++ b/src/jbom/cli/formatting.py
@@ -261,42 +261,51 @@ def print_tabular_data(
         print(summary_line)
 
 
-def print_inventory_table(items: Iterable[dict], fieldnames: List[str]) -> None:
-    """Pretty-print inventory rows as a compact table to stdout.
+# (preferred_width, wrap) hints for inventory console display.
+# Path/ID fields are kept narrow and non-wrapping so they truncate cleanly;
+# content fields wrap so descriptions/values are fully visible.
+_INVENTORY_FIELD_WIDTHS: dict[str, tuple[int, bool]] = {
+    "Project": (25, False),
+    "ProjectName": (15, False),
+    "UUID": (20, False),
+    "SourceFile": (25, False),
+    "Refs": (8, False),
+    "Category": (10, False),
+    "IPN": (20, False),
+    "Value": (15, True),
+    "Description": (35, True),
+    "Package": (14, True),
+    "Manufacturer": (16, True),
+    "MFGPN": (16, False),
+    "LCSC": (10, False),
+    "Datasheet": (20, False),
+}
 
-    Shows a curated subset if available; otherwise falls back to CSV to stdout.
+
+def print_inventory_table(items: Iterable[dict], fieldnames: List[str]) -> None:
+    """Pretty-print inventory rows as a formatted table to stdout.
+
+    Renders every field in *fieldnames* order; terminal width constrains
+    column widths automatically.  Falls back to raw CSV if fieldnames is empty.
     """
 
     items_list = list(items)
 
-    subset = [
-        f
-        for f in ("IPN", "Category", "Value", "Description", "Package")
-        if f in fieldnames
-    ]
-    if not subset:
+    if not fieldnames:
         writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
         writer.writeheader()
         for row in items_list:
             writer.writerow(row)
         return
 
-    width_defaults = {
-        "IPN": 20,
-        "Category": 15,
-        "Value": 15,
-        "Description": 40,
-        "Package": 15,
-    }
-
     cols = [
         Column(
             header=f,
             key=f,
-            preferred_width=width_defaults.get(f, 15),
-            wrap=True,
+            preferred_width=_INVENTORY_FIELD_WIDTHS.get(f, (15, True))[0],
+            wrap=_INVENTORY_FIELD_WIDTHS.get(f, (15, True))[1],
         )
-        for f in subset
+        for f in fieldnames
     ]
 
     print(f"\nInventory: {len(items_list)} items")

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -1,8 +1,14 @@
 import io
 import unittest
 from contextlib import redirect_stdout
+from unittest.mock import patch
 
-from jbom.cli.formatting import Column, print_table, print_tabular_data
+from jbom.cli.formatting import (
+    Column,
+    print_inventory_table,
+    print_table,
+    print_tabular_data,
+)
 
 
 class TestConsoleFormatting(unittest.TestCase):
@@ -178,6 +184,42 @@ class TestConsoleFormatting(unittest.TestCase):
         # Check title appears
         title_idx = next(i for i, line in enumerate(lines) if "Test Title" in line)
         self.assertEqual(lines[title_idx], "Test Title")
+
+    def test_print_inventory_table_renders_all_fieldnames(self):
+        """print_inventory_table must show every field in fieldnames, not a hardcoded subset."""
+        fieldnames = [
+            "Project",
+            "UUID",
+            "SourceFile",
+            "Refs",
+            "Category",
+            "IPN",
+            "Value",
+        ]
+        rows = [
+            {
+                "Project": "/some/path",
+                "UUID": "uuid-r1",
+                "SourceFile": "/some/path/top.kicad_sch",
+                "Refs": "R1",
+                "Category": "RES",
+                "IPN": "",
+                "Value": "10K",
+            }
+        ]
+        buf = io.StringIO()
+        # Use a wide terminal so no column shrinks below its header width.
+        with patch("jbom.cli.formatting.get_terminal_width", return_value=400):
+            with redirect_stdout(buf):
+                print_inventory_table(rows, fieldnames)
+        out = buf.getvalue()
+        # Every field name must appear as a column header (no whitelist truncation).
+        for field in fieldnames:
+            self.assertIn(field, out, f"Column '{field}' missing from console output")
+        # Data values must also be present.
+        self.assertIn("uuid-r1", out)
+        self.assertIn("RES", out)
+        self.assertIn("10K", out)
 
     def test_row_separator_emitted_after_each_data_row(self):
         """A -+- row separator must appear after every data row."""


### PR DESCRIPTION
Issue #127 supposidly added --no-aggregate and the extraction of REFDES, project and UUID info into a new inventory file:
> jbom inventory project.kicad_sch --no-aggregate > fixit-sparse.csv

When I run the latest jbom with that command, I don't see those columns
```
(.venv) √  [jplocher@ultra]~/Dropbox/KiCad/projects/AltmillSwitchController% jbom inventory -o console               

Inventory: 9 items
IPN                  | Category        | Value           | Description                              | Package        
---------------------+-----------------+-----------------+------------------------------------------+----------------
                     | RES             | 330R            | Resistor, US symbol                      | 0603           
---------------------+-----------------+-----------------+------------------------------------------+----------------
```

Root cause: print_inventory_table had a hardcoded tuple ("IPN", "Category", "Value", "Description", "Package") that acted as a whitelist — anything not in those 5 names was silently dropped. The --no-aggregate columns (Project, ProjectName, UUID, SourceFile, Refs) were in the data and went to CSV correctly, but were invisible in console output.

Fix: The hardcoded whitelist is replaced by _INVENTORY_FIELD_WIDTHS — a module-level dict of (preferred_width, wrap) hints for all known fields. print_inventory_table now builds Column objects from every name in fieldnames, with auto-sizing (15 wide, wrapping) for any field not in the hints dict. The existing terminal-width constraint still applies.

Side note on basics.feature:29: The failure (jbom: No such file or directory) is a pre-existing environment issue — that step runs jbom as a bare subprocess, which only works when the .venv is activated. It fails identically with and without our changes.