### PR TITLE
fix: align tilde matching constraints with literal annotate write-back

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `inventory-search` query construction now supports per-supplier `search.type_query_keywords` with a safe hardcoded fallback.
 - `jbom search` console output now includes Description plus up to 2 heuristic parametric columns.
 - LCSC `inventory-search` now applies Issue #115 Phase 4 foundation heuristics for RES/CAP parametric query shaping (category/spec/attribute payloads with static defaults and safe keyword fallback).
+- Matching now treats component-side `~` attribute values as blank/no-constraint during primary filtering and property scoring.
+- Documentation now clarifies that `annotate` writes non-blank CSV values literally (including `~`) while matching interprets component `~` as unconstrained.
 
 ## [7.0.0] - 2026-02-27
 

--- a/docs/README.man5.md
+++ b/docs/README.man5.md
@@ -143,14 +143,23 @@ jbom bom project --inventory inventory.csv -f "Reference,Value,I:Package,C:Toler
 
 jBOM matches schematic components to inventory items through:
 
+**Blank fields = no constraint**: A blank value in any component attribute means the designer
+chose not to constrain that attribute. Blank is not "unknown" — it is an explicit non-requirement.
+Blank fields are excluded from filtering and scoring; any inventory item is acceptable on
+that attribute. This applies to Tolerance, Voltage, Current, Power, Dielectric, and all
+other optional attributes. For matching only, KiCad's `~` placeholder in component attributes
+is treated as blank/no-constraint.
+
 1. **Primary filtering** (must match all):
    - Category must match component type
    - Package must match footprint extraction
    - Value must match numerically (for RES/CAP/IND)
+   - Blank component attributes are excluded from primary filtering
 
 2. **Scoring** (selection when multiple match):
    - Priority ranking (1 preferred over 2, etc.)
-   - Technical score from property matches (Tolerance, V, A, W, etc.)
+   - Technical score from property matches (Tolerance, Voltage, Current, Power, etc.)
+   - Blank component attributes contribute zero to scoring (no constraint, no influence)
    - Tolerance-aware substitution: exact tolerance matches are preferred; tighter tolerances substitute only when exact match is unavailable
      - Exact match preferred: Schematic requires 10kΩ 10% and 10% is available → 10% part is selected (full scoring bonus)
      - Next-tighter preferred over tightest: Schematic requires 10kΩ 10%, inventory has only 5% and 1% → 5% is ranked higher (tolerance gap 5% vs 9%, closer to requirement gets higher score)

--- a/docs/inventory-field-semantics.md
+++ b/docs/inventory-field-semantics.md
@@ -1,25 +1,40 @@
 # Inventory field semantics
 This document defines the current v7 semantics for inventory cell values used by `jbom annotate` and related CSV workflows.
 
-## Three-state value model
-Each inventory cell is interpreted as one of three states:
+## Two-state value model
+Each inventory cell is interpreted as one of two states:
 
-- blank (`""`)
-  - meaning: not yet determined by the designer
+- blank (or schematic `~`)
+  - meaning: designer chose not to constrain this attribute
   - annotate behavior: do not write this field to the schematic
-- `~`
-  - meaning: explicit don't-care decision by the designer
-  - annotate behavior: write literal `~` to the schematic property
+  - matching behavior: match any inventory item on this attribute (no filter applied)
 - explicit non-blank value
   - meaning: designer-provided requirement/value
   - annotate behavior: write the value to the schematic property
+  - matching behavior: must match this value in the inventory
+
+### How `~` is interpreted
+KiCad uses `~` as a legacy format-level placeholder for empty fields. jBOM does not
+assign custom sentinel semantics to `~`.
+
+- Matching semantics: component-side `~` is treated as blank/no-constraint.
+- Annotate semantics: non-blank CSV cells are written literally, including `~`.
+- Export/round-trip semantics: `inventory --no-aggregate` preserves literal field values,
+  and `annotate` writes user-edited non-blank values as provided.
+
+### Why blank is unambiguous
+The design workflow is: create project → audit (B1) → optional repair (B2) → fab.
+After B1/B2 the designer has reviewed every blank field and chosen to leave it blank.
+That choice is the data. jBOM trusts the workflow — no sentinel is needed to encode
+"designer chose generic."
 
 ## Annotate write-back rules
 `jbom annotate` processes inventory rows by UUID and applies the following rules:
 
 - rows with `Project = "Project"` are treated as header/sub-header sentinel rows and skipped
 - data rows with blank cells skip write-back for those fields
-- data rows with non-blank cells write values as-is (including `~`)
+- data rows with non-blank cells write values as-is
+- if a data cell contains `~`, annotate writes `~` literally
 - write-back mapping is direct column-to-property:
   - `Package` column writes `Package` property
   - `Footprint` column writes `Footprint` property

--- a/src/jbom/services/sophisticated_inventory_matcher.py
+++ b/src/jbom/services/sophisticated_inventory_matcher.py
@@ -91,6 +91,19 @@ class SophisticatedInventoryMatcher:
         t = re.sub(r"\s+", "", t)
         return t
 
+    @staticmethod
+    def _is_blank_constraint(value: str | None) -> bool:
+        """Return True when a component constraint should be treated as blank.
+
+        KiCad may encode empty user fields as "~" in schematic data. For
+        matching semantics, this is equivalent to blank/no-constraint.
+        """
+
+        if value is None:
+            return True
+        stripped = value.strip()
+        return stripped == "" or stripped == "~"
+
     def _passes_primary_filters(
         self, component: Component, item: InventoryItem
     ) -> bool:
@@ -112,7 +125,9 @@ class SophisticatedInventoryMatcher:
         comp_type = get_component_type(component.lib_id, component.footprint)
         comp_pkg = extract_package_from_footprint(component.footprint)
         comp_val_norm = (
-            self._normalize_value(component.value) if component.value else ""
+            ""
+            if self._is_blank_constraint(component.value)
+            else self._normalize_value(component.value)
         )
 
         # 1) Type/category must match if we could determine it.
@@ -226,7 +241,8 @@ class SophisticatedInventoryMatcher:
         properties = component.properties or {}
 
         # Tolerance matching.
-        if (tol := properties.get("Tolerance")) and item.tolerance:
+        tol = properties.get("Tolerance")
+        if not self._is_blank_constraint(tol) and item.tolerance:
             comp_tol = self._parse_tolerance_percent(tol)
             item_tol = self._parse_tolerance_percent(item.tolerance)
             if comp_tol is not None and item_tol is not None:
@@ -237,14 +253,16 @@ class SophisticatedInventoryMatcher:
 
         # Voltage matching.
         for field in ("Voltage", "V"):
-            if (v := properties.get(field)) and item.voltage:
+            v = properties.get(field)
+            if not self._is_blank_constraint(v) and item.voltage:
                 if v in item.voltage:
                     score += 10
                     break
 
         # Power / wattage matching.
         for field in ("Wattage", "Power", "W", "P"):
-            if (w := properties.get(field)) and item.wattage:
+            w = properties.get(field)
+            if not self._is_blank_constraint(w) and item.wattage:
                 if w in item.wattage:
                     score += 10
                     break

--- a/tests/unit/test_sophisticated_inventory_matcher_primary_filtering.py
+++ b/tests/unit/test_sophisticated_inventory_matcher_primary_filtering.py
@@ -91,6 +91,19 @@ def test_resistor_value_filter_numeric_equality() -> None:
     assert matcher._passes_primary_filters(component, bad) is False
 
 
+def test_tilde_component_value_is_treated_as_blank_constraint() -> None:
+    matcher = SophisticatedInventoryMatcher(MatchingOptions())
+
+    component = _make_component(
+        lib_id="Device:R", value="~", footprint="R_0603_1608Metric"
+    )
+    item = _make_inventory_item(category="RES", value="47K", package="0603")
+
+    # "~" means no value constraint from component side, so this passes
+    # even though item.value differs.
+    assert matcher._passes_primary_filters(component, item) is True
+
+
 def test_capacitor_value_filter_numeric_equivalence_across_units() -> None:
     matcher = SophisticatedInventoryMatcher(MatchingOptions())
 

--- a/tests/unit/test_sophisticated_inventory_matcher_scoring_and_ordering.py
+++ b/tests/unit/test_sophisticated_inventory_matcher_scoring_and_ordering.py
@@ -185,3 +185,27 @@ def test_debug_info_optional() -> None:
     results = matcher.find_matches(component, [item])
     assert results
     assert results[0].debug_info
+
+
+def test_tilde_property_constraint_is_ignored_for_scoring_bonus() -> None:
+    matcher = SophisticatedInventoryMatcher(MatchingOptions())
+
+    component = _make_component(
+        lib_id="Device:R",
+        value="10K",
+        footprint="R_0603_1608Metric",
+        properties={"Voltage": "~", "Power": "~", "Tolerance": "~"},
+    )
+    item = _make_inventory_item(
+        ipn="IPN-1",
+        category="RES",
+        value="10K",
+        package="0603",
+        priority=1,
+        tolerance="5%",
+        voltage="50V",
+        wattage="0.1W",
+    )
+
+    # Base score only (type + value + package), with no property bonus from "~".
+    assert matcher._calculate_match_score(component, item) == 120


### PR DESCRIPTION
Closes #139

## Summary
- Treat component-side `~` values as blank/no-constraint during matching primary filtering and property scoring.
- Preserve literal annotate behavior: non-blank CSV cells are written as-is, including `~`.
- Align docs and changelog with the finalized semantics.

## Verification
- `pytest tests/unit/test_sophisticated_inventory_matcher_primary_filtering.py tests/unit/test_sophisticated_inventory_matcher_scoring_and_ordering.py tests/unit/test_annotation_service.py tests/unit/test_inventory_tilde_semantics.py`
- `pre-commit run --files src/jbom/services/sophisticated_inventory_matcher.py tests/unit/test_sophisticated_inventory_matcher_primary_filtering.py tests/unit/test_sophisticated_inventory_matcher_scoring_and_ordering.py docs/inventory-field-semantics.md docs/README.man5.md docs/CHANGELOG.md`

## Architecture impact
- No architectural restructuring; this is a localized matcher semantics update plus documentation/test alignment.

Co-Authored-By: Oz <oz-agent@warp.dev>