### PR TITLE
fix: connector classifier ordering and category-gated typed decode (#145, #146)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - LCSC/JLCPCB provider architecture documented in `docs/dev/architecture/adr/0002-jlcpcb-lcsc-provider.md`; user reference at `docs/lcsc-provider.md`.
 
 ### Changed
+- Component classifier heuristic now checks connector/specific-name patterns before generic single-letter prefixes, preventing `CONNECTOR_*` symbols from being misclassified as capacitors (#145).
+- Typed parametric decode is now category-gated in both project inventory generation and inventory CSV intake: only the category-matching typed field is decoded, with UNK/Unknown/blank promotion only when exactly one typed attribute is present; ambiguous typed attributes now log a warning and decode none (#146).
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.
 - LCSC supplier profile now uses `jlcpcb_api` (live API) instead of the `jlcparts_sqlite` stub.
 - `inventory-search` now deduplicates identical queries within a run to reduce provider API calls.

--- a/src/jbom/common/component_classification.py
+++ b/src/jbom/common/component_classification.py
@@ -149,6 +149,10 @@ def _get_component_type_heuristic(lib_id: str, footprint: str = "") -> Optional[
         return ComponentType.INTEGRATED_CIRCUIT
     if component_upper.startswith("74"):  # Logic IC family (74HC00, etc.)
         return ComponentType.INTEGRATED_CIRCUIT
+    if "CONN" in component_upper or "J" in component_upper:
+        return ComponentType.CONNECTOR
+    if "INDUCTOR" in component_upper or "FERRITE" in component_upper:
+        return ComponentType.INDUCTOR
     if component_upper.startswith("R") and not _has_ic_indicators(
         component_upper, footprint_upper
     ):
@@ -169,8 +173,6 @@ def _get_component_type_heuristic(lib_id: str, footprint: str = "") -> Optional[
         return ComponentType.TRANSISTOR
     if component_upper.startswith("U"):  # U prefix typically means IC
         return ComponentType.INTEGRATED_CIRCUIT
-    if "CONN" in component_upper or "J" in component_upper:
-        return ComponentType.CONNECTOR
     if "SW" in component_upper:
         return ComponentType.SWITCH
 

--- a/src/jbom/common/value_parsing.py
+++ b/src/jbom/common/value_parsing.py
@@ -32,6 +32,8 @@ __all__ = [
     "henry_to_eia",
     "canonical_value",
     "decode_typed_parametric",
+    "TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY",
+    "UNCLASSIFIED_CATEGORIES",
 ]
 
 _OHM_RE = re.compile(r"^\s*([0-9]*\.?[0-9]+)\s*([kKmMrR]?)\s*\+?\s*$")
@@ -438,6 +440,12 @@ _NORMALIZERS: dict[str, _Normalizer] = {
     "CAP": _Normalizer(parse_cap_to_farad, farad_to_eia, "Capacitance"),
     "IND": _Normalizer(parse_ind_to_henry, henry_to_eia, "Inductance"),
 }
+
+# Shared typed-field metadata used by inventory intake/generation services.
+TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {
+    category: normalizer.column for category, normalizer in _NORMALIZERS.items()
+}
+UNCLASSIFIED_CATEGORIES: frozenset[str] = frozenset({"", "UNK", "UNKNOWN"})
 
 
 def canonical_value(category: str, text: str) -> str:

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -17,7 +17,11 @@ from typing import List, Dict, Optional, Union
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.component_id import is_current_version, make_component_id
 from jbom.common.types import InventoryItem, DEFAULT_PRIORITY
-from jbom.common.value_parsing import decode_typed_parametric
+from jbom.common.value_parsing import (
+    TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY,
+    UNCLASSIFIED_CATEGORIES,
+    decode_typed_parametric,
+)
 from jbom.config.defaults import get_defaults
 from jbom.services.jlc_loader import JLCPrivateInventoryLoader
 
@@ -26,12 +30,6 @@ _DEFAULTS_PROFILE = get_defaults("generic")
 
 _ROW_TYPE_ITEM = "ITEM"
 _ROW_TYPE_COMPONENT = "COMPONENT"
-_TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {
-    "RES": "Resistance",
-    "CAP": "Capacitance",
-    "IND": "Inductance",
-}
-_UNCLASSIFIED_CATEGORIES = {"", "UNK", "UNKNOWN"}
 
 
 # Suppress specific Numbers version warning
@@ -447,14 +445,14 @@ class InventoryReader:
         """Return (effective_category, decode_category) for typed decode gating."""
 
         normalized_category = normalize_component_type(source_category)
-        if normalized_category in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
+        if normalized_category in TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
             return source_category, normalized_category
-        if normalized_category not in _UNCLASSIFIED_CATEGORIES:
+        if normalized_category not in UNCLASSIFIED_CATEGORIES:
             return source_category, None
 
         populated_categories = [
             category
-            for category, column in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
+            for category, column in TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
             if str(row.get(column, "")).strip()
         ]
 
@@ -464,7 +462,7 @@ class InventoryReader:
 
         if len(populated_categories) > 1:
             populated_columns = ", ".join(
-                _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
+                TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
                 for category in populated_categories
             )
             log.warning(

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import List, Dict, Optional, Union
 
 # warnings imported at line 12 already
+from jbom.common.component_classification import normalize_component_type
 from jbom.common.component_id import is_current_version, make_component_id
 from jbom.common.types import InventoryItem, DEFAULT_PRIORITY
 from jbom.common.value_parsing import decode_typed_parametric
@@ -25,6 +26,12 @@ _DEFAULTS_PROFILE = get_defaults("generic")
 
 _ROW_TYPE_ITEM = "ITEM"
 _ROW_TYPE_COMPONENT = "COMPONENT"
+_TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {
+    "RES": "Resistance",
+    "CAP": "Capacitance",
+    "IND": "Inductance",
+}
+_UNCLASSIFIED_CATEGORIES = {"", "UNK", "UNKNOWN"}
 
 
 # Suppress specific Numbers version warning
@@ -343,10 +350,25 @@ class InventoryReader:
             # No need to parse stocking info - Priority column handles all ranking
             category = row.get("Category", "")
             value = row.get("Value", "")
+            row_context = (
+                ipn
+                or str(row.get("ComponentID", "")).strip()
+                or str(row.get("UUID", "")).strip()
+                or str(value).strip()
+                or "<row>"
+            )
+            (
+                effective_category,
+                decode_category,
+            ) = self._resolve_category_for_typed_decode(
+                source_category=category,
+                row=row,
+                context=row_context,
+            )
             item = InventoryItem(
                 ipn=ipn,
                 keywords=row.get("Keywords", ""),
-                category=category,
+                category=effective_category,
                 description=row.get("Description", ""),
                 smd=row.get("SMD", ""),
                 value=value,
@@ -393,15 +415,66 @@ class InventoryReader:
                 # Typed parametric fields decoded at intake (#90).
                 # Each call passes the TARGET field's category so the helper knows
                 # which column to look in and which parse function to apply.
-                resistance=decode_typed_parametric("RES", value, row),
-                capacitance=decode_typed_parametric("CAP", value, row),
-                inductance=decode_typed_parametric("IND", value, row),
+                resistance=(
+                    decode_typed_parametric("RES", value, row)
+                    if decode_category == "RES"
+                    else None
+                ),
+                capacitance=(
+                    decode_typed_parametric("CAP", value, row)
+                    if decode_category == "CAP"
+                    else None
+                ),
+                inductance=(
+                    decode_typed_parametric("IND", value, row)
+                    if decode_category == "IND"
+                    else None
+                ),
                 name=(row.get("Name") or "").strip(),
                 source=source,
                 source_file=source_file,
                 raw_data=row,
             )
             self.inventory.append(item)
+
+    def _resolve_category_for_typed_decode(
+        self,
+        *,
+        source_category: str,
+        row: Dict[str, str],
+        context: str,
+    ) -> tuple[str, Optional[str]]:
+        """Return (effective_category, decode_category) for typed decode gating."""
+
+        normalized_category = normalize_component_type(source_category)
+        if normalized_category in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
+            return source_category, normalized_category
+        if normalized_category not in _UNCLASSIFIED_CATEGORIES:
+            return source_category, None
+
+        populated_categories = [
+            category
+            for category, column in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
+            if str(row.get(column, "")).strip()
+        ]
+
+        if len(populated_categories) == 1:
+            promoted_category = populated_categories[0]
+            return promoted_category, promoted_category
+
+        if len(populated_categories) > 1:
+            populated_columns = ", ".join(
+                _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
+                for category in populated_categories
+            )
+            log.warning(
+                "Ambiguous typed parametric promotion for unclassified inventory row '%s': "
+                "multiple typed attributes set (%s). Skipping typed decode.",
+                context,
+                populated_columns,
+            )
+
+        return source_category, None
 
     def _get_canonical_electrical_value(
         self, row: Dict[str, str], *, canonical: str

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -12,16 +12,13 @@ from jbom.common.component_utils import (
 )
 from jbom.common.constants import CommonFields
 from jbom.common.packages import PackageType
-from jbom.common.value_parsing import decode_typed_parametric
+from jbom.common.value_parsing import (
+    TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY,
+    UNCLASSIFIED_CATEGORIES,
+    decode_typed_parametric,
+)
 
 log = logging.getLogger(__name__)
-
-_TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {
-    "RES": "Resistance",
-    "CAP": "Capacitance",
-    "IND": "Inductance",
-}
-_UNCLASSIFIED_CATEGORIES = {"", "UNK", "UNKNOWN"}
 
 
 class ProjectInventoryGenerator:
@@ -276,14 +273,14 @@ class ProjectInventoryGenerator:
         """Return (effective_category, decode_category, category_was_promoted)."""
 
         normalized_category = normalize_component_type(source_category)
-        if normalized_category in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
+        if normalized_category in TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
             return source_category, normalized_category, False
-        if normalized_category not in _UNCLASSIFIED_CATEGORIES:
+        if normalized_category not in UNCLASSIFIED_CATEGORIES:
             return source_category, None, False
 
         populated_categories = [
             category
-            for category, column in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
+            for category, column in TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
             if str(row_for_decode.get(column, "")).strip()
         ]
 
@@ -293,7 +290,7 @@ class ProjectInventoryGenerator:
 
         if len(populated_categories) > 1:
             populated_columns = ", ".join(
-                _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
+                TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
                 for category in populated_categories
             )
             log.warning(

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -1,6 +1,7 @@
 """Loader for generating inventory from KiCad project components."""
 
-from typing import List, Tuple, Dict, Set
+import logging
+from typing import Dict, List, Optional, Set, Tuple
 
 from jbom.common.component_classification import normalize_component_type
 from jbom.common.component_id import make_component_id
@@ -12,6 +13,15 @@ from jbom.common.component_utils import (
 from jbom.common.constants import CommonFields
 from jbom.common.packages import PackageType
 from jbom.common.value_parsing import decode_typed_parametric
+
+log = logging.getLogger(__name__)
+
+_TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {
+    "RES": "Resistance",
+    "CAP": "Capacitance",
+    "IND": "Inductance",
+}
+_UNCLASSIFIED_CATEGORIES = {"", "UNK", "UNKNOWN"}
 
 
 class ProjectInventoryGenerator:
@@ -132,16 +142,23 @@ class ProjectInventoryGenerator:
 
         return self.inventory, sorted(list(self.inventory_fields))
 
-    def _generate_group_key(self, component: Component) -> str:
+    def _generate_group_key(
+        self,
+        component: Component,
+        category_override: Optional[str] = None,
+    ) -> str:
         """Generate deterministic requirement identity via make_component_id().
 
         Always delegates to ``make_component_id`` — never constructs the
         ComponentID string directly.
         """
-        category_raw = (
-            get_component_type(component.lib_id, component.footprint) or "UNK"
-        )
-        category = normalize_component_type(category_raw)
+        if category_override is None:
+            category_raw = (
+                get_component_type(component.lib_id, component.footprint) or "UNK"
+            )
+        else:
+            category_raw = category_override
+        category = normalize_component_type(category_raw) or "UNK"
         props = component.properties or {}
 
         return make_component_id(
@@ -169,17 +186,28 @@ class ProjectInventoryGenerator:
 
         # Map properties to InventoryItem fields
         props = component.properties
+        # Decode typed parametric fields from schematic properties.
+        # props acts as the row: it may carry an explicit Resistance/Capacitance/
+        # Inductance property; Value is the fallback.
+        row_for_decode: dict[str, str] = dict(props)
+        (
+            category,
+            decode_category,
+            category_was_promoted,
+        ) = self._resolve_category_for_typed_decode(
+            source_category=category,
+            row_for_decode=row_for_decode,
+            context=f"{component.reference}:{component.lib_id}",
+        )
 
         # IPN must only come from an explicit 'IPN' schematic property.
         # jBOM has no knowledge of IPN structure or naming conventions.
         # Leave blank so the user can assign their own IPNs.
         ipn = props.get("IPN", "")
-
-        component_id = self._generate_group_key(component)
-        # Decode typed parametric fields from schematic properties.
-        # props acts as the row: it may carry an explicit Resistance/Capacitance/
-        # Inductance property; Value is the fallback.
-        row_for_decode: dict[str, str] = dict(props)
+        component_id = self._generate_group_key(
+            component,
+            category_override=category if category_was_promoted else None,
+        )
         return InventoryItem(
             row_type="COMPONENT",
             component_id=component_id,
@@ -212,9 +240,21 @@ class ProjectInventoryGenerator:
             package=package,
             uuid=uuid_str,
             priority=DEFAULT_PRIORITY,
-            resistance=decode_typed_parametric("RES", component.value, row_for_decode),
-            capacitance=decode_typed_parametric("CAP", component.value, row_for_decode),
-            inductance=decode_typed_parametric("IND", component.value, row_for_decode),
+            resistance=(
+                decode_typed_parametric("RES", component.value, row_for_decode)
+                if decode_category == "RES"
+                else None
+            ),
+            capacitance=(
+                decode_typed_parametric("CAP", component.value, row_for_decode)
+                if decode_category == "CAP"
+                else None
+            ),
+            inductance=(
+                decode_typed_parametric("IND", component.value, row_for_decode)
+                if decode_category == "IND"
+                else None
+            ),
             source="Project",
             raw_data={
                 **props,
@@ -225,6 +265,45 @@ class ProjectInventoryGenerator:
                 "ki_keywords": props.get("Keywords", ""),
             },
         )
+
+    def _resolve_category_for_typed_decode(
+        self,
+        *,
+        source_category: str,
+        row_for_decode: Dict[str, str],
+        context: str,
+    ) -> Tuple[str, Optional[str], bool]:
+        """Return (effective_category, decode_category, category_was_promoted)."""
+
+        normalized_category = normalize_component_type(source_category)
+        if normalized_category in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY:
+            return source_category, normalized_category, False
+        if normalized_category not in _UNCLASSIFIED_CATEGORIES:
+            return source_category, None, False
+
+        populated_categories = [
+            category
+            for category, column in _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY.items()
+            if str(row_for_decode.get(column, "")).strip()
+        ]
+
+        if len(populated_categories) == 1:
+            promoted_category = populated_categories[0]
+            return promoted_category, promoted_category, True
+
+        if len(populated_categories) > 1:
+            populated_columns = ", ".join(
+                _TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY[category]
+                for category in populated_categories
+            )
+            log.warning(
+                "Ambiguous typed parametric promotion for unclassified component '%s': "
+                "multiple typed attributes set (%s). Skipping typed decode.",
+                context,
+                populated_columns,
+            )
+
+        return source_category, None, False
 
     def _extract_package(self, footprint: str) -> str:
         """Extract package name from footprint.

--- a/tests/unit/test_component_classification.py
+++ b/tests/unit/test_component_classification.py
@@ -79,6 +79,16 @@ def test_get_component_type_detects_lm_prefix_as_ic() -> None:
     )
 
 
+def test_get_component_type_connector_name_not_misclassified_as_cap() -> None:
+    assert (
+        get_component_type(
+            lib_id="SPCoast:CONNECTOR_01X04_V",
+            footprint="SPCoast:Connector_01x04_V",
+        )
+        == "CON"
+    )
+
+
 def test_get_component_type_unknown_returns_none() -> None:
     assert get_component_type(lib_id="Custom:Thing", footprint="") is None
     assert get_component_type(lib_id="", footprint="Whatever") is None

--- a/tests/unit/test_typed_parametric_fields.py
+++ b/tests/unit/test_typed_parametric_fields.py
@@ -24,8 +24,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SRC_DIR = PROJECT_ROOT / "src"
 sys.path.insert(0, str(SRC_DIR))
 
-from jbom.common.types import InventoryItem  # noqa: E402
+from jbom.common.types import Component, InventoryItem  # noqa: E402
 from jbom.services.inventory_reader import InventoryReader  # noqa: E402
+from jbom.services.project_inventory import ProjectInventoryGenerator  # noqa: E402
 from jbom.services.search.inventory_search_service import (
     InventorySearchService,
 )  # noqa: E402
@@ -237,6 +238,103 @@ class TestInventoryReaderDisagreementWarning:
         assert not any(
             "conflict" in r.message.lower() or "disagree" in r.message.lower()
             for r in caplog.records
+        )
+
+
+class TestInventoryReaderCategoryGatedDecode:
+    def test_resistor_category_does_not_decode_capacitance_column(self) -> None:
+        csv = _INV_HEADER + "R1,,RES,RES,SMD,10K,,,,10K,100nF,,0603,1%,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].category == "RES"
+        assert items[0].resistance == pytest.approx(10_000.0)
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+
+    def test_unknown_category_promotes_when_single_typed_attr_present(self) -> None:
+        csv = _INV_HEADER + "X1,,UNK,Unknown,SMD,N/A,,,,47K,,,0603,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].category == "RES"
+        assert items[0].resistance == pytest.approx(47_000.0)
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+
+    def test_unknown_category_ambiguity_logs_warning_and_decodes_none(
+        self, caplog
+    ) -> None:
+        csv = _INV_HEADER + "X1,,UNK,Unknown,SMD,N/A,,,,10K,100nF,,0603,,,,,1,,,,\n"
+        with caplog.at_level(logging.WARNING, logger="jbom.services.inventory_reader"):
+            items = _csv_reader(csv)
+        assert items[0].category == "Unknown"
+        assert items[0].resistance is None
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+        assert any(
+            "ambiguous typed parametric promotion" in record.message.lower()
+            for record in caplog.records
+        )
+
+    def test_non_unknown_category_is_not_promoted_by_typed_attrs(self) -> None:
+        csv = _INV_HEADER + "J1,,CON,CON,SMD,0.100,,,,10K,100nF,,1X04,,,,,1,,,,\n"
+        items = _csv_reader(csv)
+        assert items[0].category == "CON"
+        assert items[0].resistance is None
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+
+
+class TestProjectInventoryCategoryGatedDecode:
+    def test_resistor_category_does_not_decode_capacitance_attr(self) -> None:
+        component = Component(
+            reference="R1",
+            lib_id="Device:R",
+            value="10K",
+            footprint="Resistor_SMD:R_0603_1608Metric",
+            properties={"Capacitance": "100nF"},
+        )
+        items, _ = ProjectInventoryGenerator([component]).load()
+        item = items[0]
+        assert item.category == "RES"
+        assert item.resistance == pytest.approx(10_000.0)
+        assert item.capacitance is None
+        assert item.inductance is None
+        assert item.raw_data["Capacitance"] == "100nF"
+
+    def test_unknown_category_promotes_when_single_typed_attr_present(self) -> None:
+        component = Component(
+            reference="X1",
+            lib_id="Custom:Widget",
+            value="N/A",
+            footprint="Custom:Footprint",
+            properties={"Resistance": "47K"},
+        )
+        items, _ = ProjectInventoryGenerator([component]).load()
+        item = items[0]
+        assert item.category == "RES"
+        assert item.resistance == pytest.approx(47_000.0)
+        assert item.capacitance is None
+        assert item.inductance is None
+        assert "CAT=RES" in item.component_id
+
+    def test_unknown_category_ambiguity_logs_warning_and_decodes_none(
+        self, caplog
+    ) -> None:
+        component = Component(
+            reference="X1",
+            lib_id="Custom:Widget",
+            value="N/A",
+            footprint="Custom:Footprint",
+            properties={"Resistance": "10K", "Capacitance": "100nF"},
+        )
+        with caplog.at_level(logging.WARNING, logger="jbom.services.project_inventory"):
+            items, _ = ProjectInventoryGenerator([component]).load()
+        item = items[0]
+        assert item.category == "Unknown"
+        assert item.resistance is None
+        assert item.capacitance is None
+        assert item.inductance is None
+        assert any(
+            "ambiguous typed parametric promotion" in record.message.lower()
+            for record in caplog.records
         )
 
 


### PR DESCRIPTION
## Summary
- Fix classifier ordering so connector-specific checks run before generic single-letter prefix checks, preventing `CONNECTOR_*` symbols from being classified as capacitors (#145).
- Gate typed parametric decode by effective category in both project inventory generation and inventory CSV intake (#146).
- For source categories that are `UNK`/`Unknown`/blank, promote category only when exactly one typed attribute is present (`Resistance`, `Capacitance`, or `Inductance`).
- When multiple typed attributes are present for an unclassified source row/component, log an ambiguity warning and decode none.
- Preserve raw attributes unchanged in `raw_data`.

## Validation
- `pytest tests/unit/test_component_classification.py tests/unit/test_typed_parametric_fields.py`
- `pytest` (full suite): 441 passed

Closes #145
Closes #146

Co-Authored-By: Oz <oz-agent@warp.dev>