### PR TITLE
test: lock LED/non-RCL stopgap behavior (#147)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Component classifier heuristic now checks connector/specific-name patterns before generic single-letter prefixes, preventing `CONNECTOR_*` symbols from being misclassified as capacitors (#145).
 - Typed parametric decode is now category-gated in both project inventory generation and inventory CSV intake: only the category-matching typed field is decoded, with UNK/Unknown/blank promotion only when exactly one typed attribute is present; ambiguous typed attributes now log a warning and decode none (#146).
+- Added LED/non-RCL regression coverage to lock stopgap behavior: C-prefixed LED-like symbols are guarded from CAP misclassification, LED attributes (`Vf`, `If`, `Color`, `Wavelength`) pass through unchanged, and no R/C/L typed fields are populated for LED categories (#147).
 - Mouser provider now supports configurable timeout + retry/backoff for transient failures.
 - LCSC supplier profile now uses `jlcpcb_api` (live API) instead of the `jlcparts_sqlite` stub.
 - `inventory-search` now deduplicates identical queries within a run to reduce provider API calls.

--- a/src/jbom/common/component_classification.py
+++ b/src/jbom/common/component_classification.py
@@ -139,7 +139,7 @@ def _get_component_type_heuristic(lib_id: str, footprint: str = "") -> Optional[
         return ComponentType.INTEGRATED_CIRCUIT
 
     # Pattern-based detection - check specific patterns before generic prefixes
-    if "LED" in component_upper:  # Check LED before L prefix
+    if "LED" in component_upper:  # Guard before generic C*/L* prefix rules (#147)
         return ComponentType.LED
     if component_upper.startswith("LM"):  # Common IC prefix (LM358, etc.)
         return ComponentType.INTEGRATED_CIRCUIT

--- a/src/jbom/common/value_parsing.py
+++ b/src/jbom/common/value_parsing.py
@@ -440,6 +440,12 @@ _NORMALIZERS: dict[str, _Normalizer] = {
     "CAP": _Normalizer(parse_cap_to_farad, farad_to_eia, "Capacitance"),
     "IND": _Normalizer(parse_ind_to_henry, henry_to_eia, "Inductance"),
 }
+"""R/C/L-only typed normalizer registry.
+
+This registry intentionally handles only single-dominant numeric categories
+(resistance/capacitance/inductance). Non-RCL categories (LED, CON, etc.) are
+passthrough at this layer until scoring-based classification work lands (#149).
+"""
 
 # Shared typed-field metadata used by inventory intake/generation services.
 TYPED_PARAMETRIC_COLUMNS_BY_CATEGORY: dict[str, str] = {

--- a/tests/unit/test_component_classification.py
+++ b/tests/unit/test_component_classification.py
@@ -89,6 +89,16 @@ def test_get_component_type_connector_name_not_misclassified_as_cap() -> None:
     )
 
 
+def test_get_component_type_c_prefixed_led_name_not_misclassified_as_cap() -> None:
+    assert (
+        get_component_type(
+            lib_id="Custom:CLED_RGB",
+            footprint="LED_SMD:LED_0603_1608Metric",
+        )
+        == "LED"
+    )
+
+
 def test_get_component_type_unknown_returns_none() -> None:
     assert get_component_type(lib_id="Custom:Thing", footprint="") is None
     assert get_component_type(lib_id="", footprint="Whatever") is None

--- a/tests/unit/test_typed_parametric_fields.py
+++ b/tests/unit/test_typed_parametric_fields.py
@@ -281,6 +281,17 @@ class TestInventoryReaderCategoryGatedDecode:
         assert items[0].capacitance is None
         assert items[0].inductance is None
 
+    def test_led_category_does_not_decode_rcl_columns(self) -> None:
+        csv = (
+            _INV_HEADER
+            + "D1,,LED,LED,SMD,Green,,,CLED_RGB,10K,100nF,10uH,0603,,,,,1,,,,\n"
+        )
+        items = _csv_reader(csv)
+        assert items[0].category == "LED"
+        assert items[0].resistance is None
+        assert items[0].capacitance is None
+        assert items[0].inductance is None
+
 
 class TestProjectInventoryCategoryGatedDecode:
     def test_resistor_category_does_not_decode_capacitance_attr(self) -> None:
@@ -336,6 +347,33 @@ class TestProjectInventoryCategoryGatedDecode:
             "ambiguous typed parametric promotion" in record.message.lower()
             for record in caplog.records
         )
+
+    def test_c_prefixed_led_attributes_passthrough_and_no_typed_decode(self) -> None:
+        component = Component(
+            reference="D1",
+            lib_id="Custom:CLED_RGB",
+            value="Green",
+            footprint="LED_SMD:LED_0603_1608Metric",
+            properties={
+                "Vf": "2.1V",
+                "If": "20mA",
+                "Color": "Green",
+                "Wavelength": "525nm",
+            },
+        )
+        items, fields = ProjectInventoryGenerator([component]).load()
+        item = items[0]
+        assert item.category == "LED"
+        assert item.resistance is None
+        assert item.capacitance is None
+        assert item.inductance is None
+        assert "Resistance" not in fields
+        assert "Capacitance" not in fields
+        assert "Inductance" not in fields
+        assert item.raw_data["Vf"] == "2.1V"
+        assert item.raw_data["If"] == "20mA"
+        assert item.raw_data["Color"] == "Green"
+        assert item.raw_data["Wavelength"] == "525nm"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Lock in stopgap LED/non-RCL behavior for the current first-match classifier architecture.
- Add explicit regression coverage for C-prefixed LED-like names (e.g., `CLED_RGB`) to ensure LED classification wins over generic C-prefix CAP heuristics.
- Add regression coverage ensuring LED category items do not populate typed R/C/L fields during CSV intake.
- Add regression coverage ensuring project inventory generation preserves LED attributes (`Vf`, `If`, `Color`, `Wavelength`) in output/raw data and does not emit typed R/C/L fields.
- Add `_NORMALIZERS` inline documentation clarifying current R/C/L-only scope and pointing to scoring-classifier follow-up issue #149 as the long-term fix direction.

## Validation
- `pytest tests/unit/test_component_classification.py tests/unit/test_typed_parametric_fields.py tests/unit/test_value_parsing.py`
- `pytest` (full suite): 444 passed

## Sequencing note
This PR intentionally keeps #147 as a stopgap test-and-guard close-out and does not attempt broader per-category decode architecture changes before #149.

Closes #147
Related: #149

Co-Authored-By: Oz <oz-agent@warp.dev>