### PR TITLE
feat(audit): jbom audit — field quality + inventory coverage (Issue #154 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # CHANGELOG
 
 
+## Unreleased — feat/154-jbom-audit (PR 1)
+
+### Features
+
+* feat(audit): add `jbom audit` command — field quality + inventory coverage (#154 PR 1)
+
+New `jbom audit` command implementing the diagnostic half of the
+audit/annotate symmetric pair described in issue #154.
+
+Project mode (`jbom audit <proj> [--inventory cat.csv] [-o report.csv]`):
+- Local heuristics: checks every in-BOM component against the jBOM field
+  taxonomy (REQUIRED: Value, Footprint → ERROR; BEST_PRACTICE: Manufacturer,
+  MFGPN, and category-specific fields → WARN with SuggestedValue)
+- Coverage dry-run (when --inventory provided): runs match() for each
+  component and emits COVERAGE_GAP (ERROR), MATCH_HEURISTIC (WARN),
+  MATCH_AMBIGUOUS (INFO), or silent (exact single / IPN/MPN exclusive match)
+
+Inventory mode (`jbom audit cat.csv [--requirements req.csv] [-o report.csv]`):
+- Coverage check against COMPONENT rows from a requirements CSV
+- UNUSED_ITEM (INFO) for catalog items not satisfied by any requirement
+
+New modules:
+- `src/jbom/common/field_taxonomy.py`: FieldSeverity, FieldSpec, per-category
+  REQUIRED/BEST_PRACTICE definitions — no CLI deps, KiCad plugin callable
+- `src/jbom/services/audit_service.py`: pure service layer with AuditService,
+  AuditReport, AuditRow, CheckType, Severity; stable report.csv schema
+  including PR-2 stub columns (Supplier, SupplierPN, ApprovedValue, Action)
+- `src/jbom/cli/audit.py`: thin CLI wrapper with automatic mode detection
+
+Tests: +64 unit tests (test_field_taxonomy, test_audit_service,
+test_audit_cli); all 611 tests green.
+
+PR 2 will add: `--supplier` validation (SUPPLIER_MISS, INVENTORY_GAP rows),
+`jbom annotate --repairs`, and `jbom inventory-search` retirement.
+
+Co-Authored-By: Oz <oz-agent@warp.dev>
+
+
 ## v6.32.0 (2026-03-09)
 
 ### Bug Fixes

--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -8,6 +8,7 @@ jbom — generate Bill of Materials, Placement Files, and Parts Lists from KiCad
 
 ```
 jbom [-q] [--version]
+jbom audit PATH [PATH ...] [--inventory CATALOG_CSV] [--requirements REQ_CSV] [-o REPORT_CSV] [--strict]
 jbom bom [PROJECT] [--inventory FILE ...] [-o OUTPUT] [BOM OPTIONS]
 jbom pos [PROJECT] [-o OUTPUT] [POS OPTIONS]
 jbom inventory [PROJECT] [-o OUTPUT] [INVENTORY OPTIONS]
@@ -18,8 +19,9 @@ jbom inventory-search INVENTORY_FILE [OPTIONS]
 
 ## DESCRIPTION
 
-jBOM (version 7) provides six subcommands:
+jBOM (version 7) provides seven subcommands:
 
+- `audit` — diagnose field-quality issues and inventory coverage gaps in KiCad projects or catalog files
 - `bom` — generate a procurement BOM from KiCad schematics matched against an inventory file
 - `pos` — generate component placement files (CPL/POS) from KiCad PCB files
 - `inventory` — generate an initial inventory template from schematic components
@@ -38,6 +40,78 @@ The BOM workflow keeps designs supplier-neutral: components carry generic values
 
 **--version**
 : Print jBOM version and exit.
+
+## AUDIT COMMAND
+
+```
+jbom audit PATH [PATH ...]  [--inventory CATALOG_CSV]  [-o REPORT_CSV]  [--strict]
+jbom audit CAT.CSV [...]    [--requirements REQ_CSV]   [-o REPORT_CSV]  [--strict]
+```
+
+Diagnoses field-quality issues and inventory coverage gaps. Mode is detected automatically from the positional arguments:
+
+- **Project mode** — positionals are KiCad project directories or schematic files.
+- **Inventory mode** — all positionals end with `.csv`.
+
+### Checks performed
+
+**Local heuristics (project mode, always)**
+: For every in-BOM component, the jBOM field taxonomy is checked:
+  - `REQUIRED` (Value, Footprint) — `QUALITY_ISSUE` row with `Severity=ERROR` when absent.
+  - `BEST_PRACTICE` (Manufacturer, MFGPN, and category-specific fields such as Tolerance for resistors) — `QUALITY_ISSUE` row with `Severity=WARN` when absent; the `SuggestedValue` column carries an example.
+
+**Coverage dry-run (project mode + `--inventory`)**
+: Runs `match()` for every component against the catalog without generating a BOM:
+  - No match → `COVERAGE_GAP / ERROR`
+  - Match only via heuristics → `MATCH_HEURISTIC / WARN`
+  - Multiple equally-qualified candidates → `MATCH_AMBIGUOUS / INFO`
+  - Single exact match or IPN/MPN exclusive match → silent
+
+**Coverage check (inventory mode + `--requirements`)**
+: Same four-outcome model applied to COMPONENT rows from the requirements file against catalog ITEM rows.
+: Catalog items not matched by any requirement → `UNUSED_ITEM / INFO`
+
+### Arguments
+
+**PATH** (one or more, required)
+: KiCad project directories, `.kicad_sch` files (project mode), or inventory `.csv` files (inventory mode).
+
+**--inventory CATALOG_CSV**
+: Inventory catalog for a coverage dry-run (project mode only).
+
+**--requirements REQ_CSV**
+: Requirements CSV (output of `jbom inventory proj`) for a coverage check (inventory mode only).
+
+**-o, --output REPORT_CSV**
+: Write the audit report to this file. If omitted, CSV is written to stdout.
+
+**--strict**
+: Treat `WARN`-severity rows as failures: exit code is 1 even if there are no `ERROR` rows.
+
+### report.csv schema (stable)
+
+Columns: `CheckType`, `Severity`, `ProjectPath`, `RefDes`, `UUID`, `CatalogFile`, `IPN`, `Category`, `Field`, `CurrentValue`, `SuggestedValue`, `ApprovedValue`, `Action`, `Supplier`, `SupplierPN`, `Description`.
+
+The `ApprovedValue` and `Action` columns are blank in `audit` output. Open the file in a spreadsheet, fill in `ApprovedValue` and set `Action` to `SET` / `SKIP` / `IGNORE` for each `QUALITY_ISSUE` row, then pass it to `jbom annotate proj --repairs report.csv` (available in PR 2).
+
+### Exit codes
+
+- `0` — no `ERROR`-severity rows (default)
+- `1` — one or more `ERROR`-severity rows; or any `WARN`-severity rows when `--strict` is passed
+
+### Example workflow
+
+```sh
+# 1. Check field quality and inventory coverage for a project
+jbom audit ./my_project --inventory catalog.csv -o report.csv
+
+# 2. Review QUALITY_ISSUE rows, fill ApprovedValue + Action, then annotate (PR 2)
+jbom annotate ./my_project --repairs report.csv
+
+# 3. Audit catalog coverage against project requirements
+jbom inventory ./my_project -o requirements.csv
+jbom audit catalog.csv --requirements requirements.csv -o catalog_report.csv
+```
 
 ## BOM COMMAND
 

--- a/src/jbom/cli/audit.py
+++ b/src/jbom/cli/audit.py
@@ -1,0 +1,199 @@
+"""audit command — field quality checks and inventory coverage analysis.
+
+Usage
+-----
+Project mode (positionals resolve to KiCad project directories or schematics)::
+
+    jbom audit <proj> [<proj> ...]  \\
+        [--inventory cat.csv]       \\
+        [-o report.csv]             \\
+        [--strict]
+
+Inventory mode (positionals are ``.csv`` files)::
+
+    jbom audit <cat.csv> [<cat.csv> ...]  \\
+        [--requirements req.csv]           \\
+        [-o report.csv]                    \\
+        [--strict]
+
+Mode is detected automatically: if every positional argument ends with
+``.csv`` the command operates in inventory mode; otherwise it operates in
+project mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from jbom.services.audit_service import AuditService
+
+
+def register_command(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the audit sub-command with the top-level argument parser."""
+
+    parser = subparsers.add_parser(
+        "audit",
+        help="Audit component fields and inventory coverage",
+        description=(
+            "Diagnose field-quality issues and inventory coverage gaps.\n\n"
+            "PROJECT MODE  — pass KiCad project directories or schematic files.\n"
+            "INVENTORY MODE — pass inventory CSV files (mode detected automatically)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        metavar="PATH",
+        help=(
+            "One or more KiCad project directories (project mode) "
+            "or inventory CSV files (inventory mode)"
+        ),
+    )
+
+    # Project mode option
+    parser.add_argument(
+        "--inventory",
+        metavar="CATALOG_CSV",
+        type=Path,
+        default=None,
+        help=(
+            "Inventory catalog CSV for coverage dry-run "
+            "(project mode only; triggers COVERAGE_GAP / MATCH_* rows)"
+        ),
+    )
+
+    # Inventory mode option
+    parser.add_argument(
+        "--requirements",
+        metavar="REQ_CSV",
+        type=Path,
+        default=None,
+        help=(
+            "Requirements CSV (output of 'jbom inventory proj') for coverage check "
+            "(inventory mode only; triggers COVERAGE_GAP / UNUSED_ITEM rows)"
+        ),
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="REPORT_CSV",
+        type=Path,
+        default=None,
+        help="Write report to this CSV file (default: stdout)",
+    )
+
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with non-zero status when WARN-severity rows exist (default: only on ERROR)",
+    )
+
+    parser.set_defaults(handler=handle_audit)
+
+
+def handle_audit(args: argparse.Namespace) -> int:
+    """Handle the ``jbom audit`` command.
+
+    Returns:
+        Exit code: 0 on success (no ERROR/WARN depending on ``--strict``), 1 otherwise.
+    """
+    try:
+        inputs = [Path(p) for p in args.inputs]
+
+        # Mode detection: all .csv → inventory mode; anything else → project mode.
+        if all(p.suffix.lower() == ".csv" for p in inputs):
+            return _run_inventory_mode(args, inputs)
+        else:
+            return _run_project_mode(args, inputs)
+
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _run_project_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
+    """Execute audit in project mode."""
+    if args.requirements is not None:
+        print(
+            "Error: --requirements is only valid in inventory mode "
+            "(positional arguments must be .csv files for inventory mode)",
+            file=sys.stderr,
+        )
+        return 1
+
+    service = AuditService()
+    report = service.audit_project(
+        project_paths=inputs,
+        inventory_path=getattr(args, "inventory", None),
+    )
+
+    _write_report(args, report)
+    _print_summary(report)
+
+    return report.exit_code_strict() if args.strict else report.exit_code
+
+
+def _run_inventory_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
+    """Execute audit in inventory mode."""
+    if args.inventory is not None:
+        print(
+            "Error: --inventory is only valid in project mode "
+            "(pass KiCad project directories for project mode)",
+            file=sys.stderr,
+        )
+        return 1
+
+    service = AuditService()
+    report = service.audit_inventory(
+        catalog_paths=inputs,
+        requirements_path=getattr(args, "requirements", None),
+    )
+
+    _write_report(args, report)
+    _print_summary(report)
+
+    return report.exit_code_strict() if args.strict else report.exit_code
+
+
+def _write_report(args: argparse.Namespace, report) -> None:
+    """Write the audit report to the configured output destination."""
+    import io
+
+    output_path: Path | None = getattr(args, "output", None)
+
+    if output_path is not None:
+        with output_path.open("w", encoding="utf-8", newline="") as f:
+            report.write_csv(f)
+        print(f"Audit report written to {output_path}", file=sys.stderr)
+    else:
+        # Write CSV to stdout.
+        buf = io.StringIO()
+        report.write_csv(buf)
+        print(buf.getvalue(), end="")
+
+
+def _print_summary(report) -> None:
+    """Print a one-line count summary to stderr."""
+    total = len(report.rows)
+    if total == 0:
+        print("Audit complete: no issues found.", file=sys.stderr)
+    else:
+        parts = []
+        if report.error_count:
+            parts.append(f"{report.error_count} error(s)")
+        if report.warn_count:
+            parts.append(f"{report.warn_count} warning(s)")
+        if report.info_count:
+            parts.append(f"{report.info_count} info(s)")
+        print(f"Audit complete: {', '.join(parts)}.", file=sys.stderr)

--- a/src/jbom/cli/main.py
+++ b/src/jbom/cli/main.py
@@ -5,7 +5,16 @@ import sys
 from typing import List, Optional
 
 from jbom import __version__
-from jbom.cli import annotate, bom, inventory, pos, parts, search, inventory_search
+from jbom.cli import (
+    annotate,
+    audit,
+    bom,
+    inventory,
+    pos,
+    parts,
+    search,
+    inventory_search,
+)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -36,6 +45,7 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     # Direct command registration - no registry needed!
+    audit.register_command(subparsers)
     bom.register_command(subparsers)
     annotate.register_command(subparsers)
     inventory.register_command(subparsers)

--- a/src/jbom/common/field_taxonomy.py
+++ b/src/jbom/common/field_taxonomy.py
@@ -1,0 +1,236 @@
+"""Field taxonomy for jBOM audit diagnostics.
+
+Defines which schematic component fields are REQUIRED, BEST_PRACTICE, or
+OPTIONAL per component category.  This module has no CLI dependencies and
+is safe to import from the KiCad Python plugin scripting environment.
+
+Severity levels
+---------------
+REQUIRED
+    Hard error when absent.  The component will produce poor or no matches
+    and cannot be reliably sourced without this field.
+BEST_PRACTICE
+    Informational warning when absent.  Missing this field is not fatal
+    but weakens match quality and supplier search accuracy.  The taxonomy
+    provides a human-readable suggestion for each best-practice field.
+OPTIONAL
+    Silent.  Useful when present but not checked by the auditor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from jbom.common.constants import ComponentType
+
+
+# ---------------------------------------------------------------------------
+# Core data types
+# ---------------------------------------------------------------------------
+
+
+class FieldSeverity(str, Enum):
+    """Severity level for a component field in the jBOM taxonomy."""
+
+    REQUIRED = "REQUIRED"
+    BEST_PRACTICE = "BEST_PRACTICE"
+    OPTIONAL = "OPTIONAL"
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """A single field specification in the taxonomy.
+
+    Attributes:
+        name: Canonical KiCad property name (case-sensitive, matches the schematic).
+        severity: How important this field is for the given category.
+        suggestion: Human-readable hint shown in ``BEST_PRACTICE`` audit rows.
+            Empty for ``REQUIRED`` and ``OPTIONAL`` specs.
+    """
+
+    name: str
+    severity: FieldSeverity
+    suggestion: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Universal required fields (apply to every component, every category)
+# ---------------------------------------------------------------------------
+
+UNIVERSAL_REQUIRED_FIELDS: list[FieldSpec] = [
+    FieldSpec("Value", FieldSeverity.REQUIRED),
+    FieldSpec("Footprint", FieldSeverity.REQUIRED),
+]
+
+# ---------------------------------------------------------------------------
+# Universal best-practice fields (apply to every component)
+# ---------------------------------------------------------------------------
+
+_UNIVERSAL_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec(
+        "Manufacturer",
+        FieldSeverity.BEST_PRACTICE,
+        "e.g. Vishay, Murata, Texas Instruments",
+    ),
+    FieldSpec(
+        "MFGPN",
+        FieldSeverity.BEST_PRACTICE,
+        "Manufacturer part number; enables unambiguous supplier search",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Category-specific best-practice fields
+# ---------------------------------------------------------------------------
+
+_RESISTOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Tolerance", FieldSeverity.BEST_PRACTICE, "e.g. 1%, 5%, 10%"),
+    FieldSpec("Power", FieldSeverity.BEST_PRACTICE, "e.g. 0.1W, 0.25W, 0.5W, 1W"),
+]
+
+_CAPACITOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "e.g. 10V, 16V, 25V, 50V"),
+    FieldSpec("Tolerance", FieldSeverity.BEST_PRACTICE, "e.g. 10%, 20%"),
+]
+
+_INDUCTOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Current", FieldSeverity.BEST_PRACTICE, "e.g. 100mA, 1A, 3A"),
+    FieldSpec("Power", FieldSeverity.BEST_PRACTICE, "e.g. 0.5W, 1W"),
+]
+
+_DIODE_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "e.g. 30V, 60V, 100V"),
+    FieldSpec("Current", FieldSeverity.BEST_PRACTICE, "e.g. 100mA, 1A, 3A"),
+]
+
+_LED_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec(
+        "Voltage", FieldSeverity.BEST_PRACTICE, "Forward voltage, e.g. 2.0V, 3.2V"
+    ),
+    FieldSpec("Current", FieldSeverity.BEST_PRACTICE, "e.g. 5mA, 20mA"),
+    FieldSpec("Wavelength", FieldSeverity.BEST_PRACTICE, "e.g. 470nm, 625nm"),
+]
+
+_IC_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "Supply voltage, e.g. 3.3V, 5V"),
+]
+
+_TRANSISTOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "Vce/Vds max, e.g. 30V, 60V"),
+    FieldSpec("Current", FieldSeverity.BEST_PRACTICE, "Ic/Id max, e.g. 100mA, 1A"),
+]
+
+_CONNECTOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Pitch", FieldSeverity.BEST_PRACTICE, "e.g. 2.54mm, 1.25mm"),
+]
+
+_REGULATOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "Output voltage, e.g. 3.3V, 5V"),
+    FieldSpec(
+        "Current", FieldSeverity.BEST_PRACTICE, "Max output current, e.g. 1A, 3A"
+    ),
+]
+
+_OSCILLATOR_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec("Frequency", FieldSeverity.BEST_PRACTICE, "e.g. 8MHz, 16MHz, 25MHz"),
+    FieldSpec("Stability", FieldSeverity.BEST_PRACTICE, "e.g. ±20ppm, ±50ppm"),
+]
+
+_FUSE_BEST_PRACTICE: list[FieldSpec] = [
+    FieldSpec(
+        "Current", FieldSeverity.BEST_PRACTICE, "Rated current, e.g. 500mA, 1A, 3A"
+    ),
+    FieldSpec("Voltage", FieldSeverity.BEST_PRACTICE, "Rated voltage, e.g. 32V, 125V"),
+]
+
+# ---------------------------------------------------------------------------
+# Mapping: category -> extra best-practice fields (in addition to universal)
+# ---------------------------------------------------------------------------
+
+CATEGORY_BEST_PRACTICE: dict[str, list[FieldSpec]] = {
+    ComponentType.RESISTOR: _RESISTOR_BEST_PRACTICE,
+    ComponentType.CAPACITOR: _CAPACITOR_BEST_PRACTICE,
+    ComponentType.INDUCTOR: _INDUCTOR_BEST_PRACTICE,
+    ComponentType.DIODE: _DIODE_BEST_PRACTICE,
+    ComponentType.LED: _LED_BEST_PRACTICE,
+    ComponentType.INTEGRATED_CIRCUIT: _IC_BEST_PRACTICE,
+    ComponentType.MICROCONTROLLER: _IC_BEST_PRACTICE,
+    ComponentType.TRANSISTOR: _TRANSISTOR_BEST_PRACTICE,
+    ComponentType.CONNECTOR: _CONNECTOR_BEST_PRACTICE,
+    ComponentType.REGULATOR: _REGULATOR_BEST_PRACTICE,
+    ComponentType.OSCILLATOR: _OSCILLATOR_BEST_PRACTICE,
+    ComponentType.FUSE: _FUSE_BEST_PRACTICE,
+    ComponentType.SWITCH: [],
+    ComponentType.RELAY: [],
+    ComponentType.ANALOG: _IC_BEST_PRACTICE,
+    ComponentType.SILK_SCREEN: [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_field_specs(category: Optional[str]) -> list[FieldSpec]:
+    """Return all field specs applicable to the given component category.
+
+    The returned list starts with the universal required fields, followed by
+    universal best-practice fields, then category-specific best-practice
+    fields.  The ordering puts the most critical fields first.
+
+    Args:
+        category: Component category string (e.g. ``ComponentType.RESISTOR``).
+            ``None`` or unrecognised categories return only the universal fields.
+
+    Returns:
+        Ordered list of :class:`FieldSpec` objects.
+    """
+    specs: list[FieldSpec] = list(UNIVERSAL_REQUIRED_FIELDS)
+    specs.extend(_UNIVERSAL_BEST_PRACTICE)
+
+    cat_key = (category or "").upper()
+    extra = CATEGORY_BEST_PRACTICE.get(cat_key, [])
+    specs.extend(extra)
+
+    return specs
+
+
+def get_required_fields() -> list[FieldSpec]:
+    """Return the universal required field specs (Value + Footprint).
+
+    Returns:
+        List of :class:`FieldSpec` objects with ``severity=REQUIRED``.
+    """
+    return list(UNIVERSAL_REQUIRED_FIELDS)
+
+
+def get_best_practice_fields(category: Optional[str]) -> list[FieldSpec]:
+    """Return only best-practice field specs for the given category.
+
+    Includes both universal best-practice fields (Manufacturer, MFGPN) and
+    category-specific best-practice fields.
+
+    Args:
+        category: Component category string.
+
+    Returns:
+        List of :class:`FieldSpec` objects with ``severity=BEST_PRACTICE``.
+    """
+    specs: list[FieldSpec] = list(_UNIVERSAL_BEST_PRACTICE)
+    cat_key = (category or "").upper()
+    specs.extend(CATEGORY_BEST_PRACTICE.get(cat_key, []))
+    return specs
+
+
+__all__ = [
+    "FieldSeverity",
+    "FieldSpec",
+    "UNIVERSAL_REQUIRED_FIELDS",
+    "CATEGORY_BEST_PRACTICE",
+    "get_field_specs",
+    "get_required_fields",
+    "get_best_practice_fields",
+]

--- a/src/jbom/services/audit_service.py
+++ b/src/jbom/services/audit_service.py
@@ -1,0 +1,737 @@
+"""Audit service for jBOM — field quality checks and inventory coverage analysis.
+
+This module is a pure service layer: no argparse imports, no printing, no
+subprocess calls.  It may be called directly from the KiCad Python plugin.
+
+Two top-level operations are exposed:
+
+``AuditService.audit_project``
+    Given one or more KiCad project paths, check every in-BOM schematic
+    component for field quality (local heuristics) and, if an inventory is
+    provided, perform a coverage dry-run against that inventory.
+
+``AuditService.audit_inventory``
+    Given one or more inventory catalog CSVs, check catalog quality and, if a
+    requirements file is provided, report coverage gaps and unused catalog items.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional, Sequence
+
+from jbom.common.component_classification import get_component_type
+from jbom.common.component_filters import apply_component_filters
+from jbom.common.field_taxonomy import (
+    get_best_practice_fields,
+    get_required_fields,
+)
+from jbom.common.types import Component, InventoryItem
+from jbom.services.inventory_reader import InventoryReader
+from jbom.services.schematic_reader import SchematicReader
+from jbom.services.sophisticated_inventory_matcher import (
+    MatchingOptions,
+    SophisticatedInventoryMatcher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public constants / enums
+# ---------------------------------------------------------------------------
+
+
+class CheckType(str, Enum):
+    """Type of audit finding.
+
+    PR-1 types
+    ----------
+    QUALITY_ISSUE
+        A field is missing or sub-optimal per the jBOM field taxonomy.
+    MATCH_AMBIGUOUS
+        Multiple inventory items satisfy all provided attributes exactly.
+        The inventory maintainer should add priority values to disambiguate.
+    MATCH_HEURISTIC
+        A match was found only via heuristics (fuzzy logic).  Specs should
+        be tightened or a more-precise inventory item should be added.
+    COVERAGE_GAP
+        No inventory item matched at all.
+    UNUSED_ITEM
+        An inventory catalog item was not matched by any project requirement.
+
+    PR-2 stub types (schema reserved, not populated in PR 1)
+    --------------------------------------------------------
+    SUPPLIER_MISS
+        Component was not found in the supplier catalog.
+    INVENTORY_GAP
+        Component was found in the supplier catalog but is absent from the
+        local inventory.
+    """
+
+    QUALITY_ISSUE = "QUALITY_ISSUE"
+    MATCH_AMBIGUOUS = "MATCH_AMBIGUOUS"
+    MATCH_HEURISTIC = "MATCH_HEURISTIC"
+    COVERAGE_GAP = "COVERAGE_GAP"
+    UNUSED_ITEM = "UNUSED_ITEM"
+    SUPPLIER_MISS = "SUPPLIER_MISS"  # PR-2: supplier validation
+    INVENTORY_GAP = "INVENTORY_GAP"  # PR-2: supplier validation
+
+
+class Severity(str, Enum):
+    """Severity level of an audit finding."""
+
+    ERROR = "ERROR"
+    WARN = "WARN"
+    INFO = "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Stable report schema
+# ---------------------------------------------------------------------------
+
+#: Ordered CSV column headers for report.csv (stable across PR 1 and PR 2).
+REPORT_CSV_COLUMNS: list[str] = [
+    "CheckType",
+    "Severity",
+    "ProjectPath",
+    "RefDes",
+    "UUID",
+    "CatalogFile",
+    "IPN",
+    "Category",
+    "Field",
+    "CurrentValue",
+    "SuggestedValue",
+    "ApprovedValue",  # designer fills in (blank in audit output)
+    "Action",  # designer fills in: SET / SKIP / IGNORE / ADD
+    "Supplier",  # PR-2
+    "SupplierPN",  # PR-2
+    "Description",
+]
+
+
+@dataclass(frozen=True)
+class AuditRow:
+    """One finding row in the audit report.
+
+    All fields that do not apply to a given check type are left as empty
+    strings.  The stable column set allows PR-2 to add SUPPLIER_MISS /
+    INVENTORY_GAP rows without changing the schema.
+    """
+
+    check_type: str
+    severity: str
+    # Project mode identification
+    project_path: str = ""
+    ref_des: str = ""
+    uuid: str = ""
+    # Inventory mode identification
+    catalog_file: str = ""
+    ipn: str = ""
+    # Common
+    category: str = ""
+    # QUALITY_ISSUE specific
+    field: str = ""
+    current_value: str = ""
+    suggested_value: str = ""
+    # Designer-editable columns (blank in audit output; consumer fills in)
+    approved_value: str = ""
+    action: str = ""
+    # Supplier columns (PR-2; blank in PR 1)
+    supplier: str = ""
+    supplier_pn: str = ""
+    # Human description
+    description: str = ""
+
+    def to_csv_row(self) -> dict[str, str]:
+        """Return a dict keyed by :data:`REPORT_CSV_COLUMNS` for DictWriter."""
+        return {
+            "CheckType": self.check_type,
+            "Severity": self.severity,
+            "ProjectPath": self.project_path,
+            "RefDes": self.ref_des,
+            "UUID": self.uuid,
+            "CatalogFile": self.catalog_file,
+            "IPN": self.ipn,
+            "Category": self.category,
+            "Field": self.field,
+            "CurrentValue": self.current_value,
+            "SuggestedValue": self.suggested_value,
+            "ApprovedValue": self.approved_value,
+            "Action": self.action,
+            "Supplier": self.supplier,
+            "SupplierPN": self.supplier_pn,
+            "Description": self.description,
+        }
+
+
+@dataclass
+class AuditReport:
+    """Aggregate result of an audit run.
+
+    Attributes:
+        rows: All findings.
+        error_count: Number of ERROR-severity rows.
+        warn_count: Number of WARN-severity rows.
+        info_count: Number of INFO-severity rows.
+        exit_code: 0 if no ERROR rows; 1 otherwise.
+            Callers passing ``--strict`` should promote non-zero on any WARN.
+    """
+
+    rows: list[AuditRow] = field(default_factory=list)
+    error_count: int = 0
+    warn_count: int = 0
+    info_count: int = 0
+
+    @property
+    def exit_code(self) -> int:
+        """Return 0 when no ERROR rows exist, 1 otherwise."""
+        return 1 if self.error_count > 0 else 0
+
+    def exit_code_strict(self) -> int:
+        """Return 1 when any WARN or ERROR rows exist (--strict mode)."""
+        return 1 if (self.error_count > 0 or self.warn_count > 0) else 0
+
+    def write_csv(self, dest: io.TextIOBase | io.StringIO) -> None:
+        """Write the report as CSV to *dest*.
+
+        Args:
+            dest: Writable text stream.
+        """
+        writer = csv.DictWriter(dest, fieldnames=REPORT_CSV_COLUMNS)
+        writer.writeheader()
+        for row in self.rows:
+            writer.writerow(row.to_csv_row())
+
+
+# ---------------------------------------------------------------------------
+# Match quality threshold
+# ---------------------------------------------------------------------------
+
+# Minimum score considered an "exact attribute-set match".
+# Scoring: type(50) + value(40) = 90. A component providing both type and
+# value but no package hint should still reach this threshold for a solid
+# catalog item. Matches below this threshold are classified as heuristic.
+_EXACT_THRESHOLD = 90
+
+
+# ---------------------------------------------------------------------------
+# AuditService
+# ---------------------------------------------------------------------------
+
+
+class AuditService:
+    """Runs field-quality and coverage audits over KiCad projects or inventories.
+
+    This class has no state beyond its construction-time options.  All
+    inputs are passed as arguments to :meth:`audit_project` and
+    :meth:`audit_inventory`.
+    """
+
+    def __init__(self, *, include_debug_info: bool = False) -> None:
+        """Create an AuditService.
+
+        Args:
+            include_debug_info: When True, pass debug mode to the matcher so
+                match debug strings appear in the ``Description`` column.
+        """
+        self._include_debug_info = include_debug_info
+        self._reader = SchematicReader()
+        self._matcher = SophisticatedInventoryMatcher(
+            MatchingOptions(include_debug_info=include_debug_info)
+        )
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+
+    def audit_project(
+        self,
+        project_paths: Sequence[Path],
+        inventory_path: Optional[Path] = None,
+        project_path_override: Optional[str] = None,
+    ) -> AuditReport:
+        """Audit KiCad project(s) for field quality and optional inventory coverage.
+
+        Args:
+            project_paths: Paths to KiCad project directories or schematic files.
+            inventory_path: Optional inventory CSV. When provided, a coverage
+                dry-run is performed for every in-BOM component.
+            project_path_override: When set, this string is used as
+                ``ProjectPath`` in every row instead of the resolved path.
+                Useful for testing deterministic output.
+
+        Returns:
+            :class:`AuditReport` with all findings.
+        """
+        report = AuditReport()
+
+        # Load all components across all project paths.
+        components: list[tuple[str, Component]] = []
+        for proj_path in project_paths:
+            resolved_pro, sch_files = _resolve_project(proj_path)
+            pro_str = project_path_override or str(resolved_pro)
+            for sch_file in sch_files:
+                raw = self._reader.load_components(sch_file)
+                filtered = apply_component_filters(
+                    raw,
+                    {
+                        "exclude_dnp": True,
+                        "include_only_bom": True,
+                        "include_virtual_symbols": False,
+                    },
+                )
+                for comp in filtered:
+                    components.append((pro_str, comp))
+
+        # Load inventory for coverage checks (once, outside component loop).
+        inventory_items: list[InventoryItem] = []
+        if inventory_path is not None:
+            reader = InventoryReader(inventory_path)
+            all_items, _ = reader.load()
+            inventory_items = [i for i in all_items if i.row_type.upper() == "ITEM"]
+
+        for pro_str, comp in components:
+            category = (
+                get_component_type(comp.lib_id, comp.footprint, comp.reference) or ""
+            )
+
+            # --- Local heuristics ---
+            for row in self._check_field_quality(comp, category, pro_str):
+                report.rows.append(row)
+                _increment_counter(report, row.severity)
+
+            # --- Coverage dry-run (only when inventory provided) ---
+            if inventory_path is not None:
+                match_row = self._classify_coverage(
+                    comp, category, pro_str, inventory_items
+                )
+                if match_row is not None:
+                    report.rows.append(match_row)
+                    _increment_counter(report, match_row.severity)
+
+        return report
+
+    def audit_inventory(
+        self,
+        catalog_paths: Sequence[Path],
+        requirements_path: Optional[Path] = None,
+    ) -> AuditReport:
+        """Audit inventory catalog(s) for coverage and quality.
+
+        Args:
+            catalog_paths: Paths to inventory CSV catalog files (ITEM rows).
+            requirements_path: Optional CSV output of ``jbom inventory proj``
+                (COMPONENT rows).  When provided, coverage checks are run
+                for each requirement against the catalog.
+
+        Returns:
+            :class:`AuditReport` with all findings.
+        """
+        report = AuditReport()
+
+        # Load catalog ITEM rows.
+        catalog_items: list[InventoryItem] = []
+        catalog_file_str = str(catalog_paths[0]) if catalog_paths else ""
+        for cat_path in catalog_paths:
+            reader = InventoryReader(cat_path)
+            items, _ = reader.load()
+            catalog_items.extend(i for i in items if i.row_type.upper() == "ITEM")
+
+        # No requirements? Nothing to check (yet — supplier checks are PR 2).
+        if requirements_path is None:
+            return report
+
+        # Load requirement COMPONENT rows.
+        req_reader = InventoryReader(requirements_path)
+        all_req, _ = req_reader.load()
+        requirements = [r for r in all_req if r.row_type.upper() == "COMPONENT"]
+
+        # Track which catalog items satisfy at least one requirement.
+        covered_ipns: set[str] = set()
+
+        for req in requirements:
+            category = (req.category or "").strip()
+            ref_des = req.component_id or req.uuid or req.ipn
+            catalog_file_for_row = catalog_file_str
+
+            match_row = self._classify_inventory_coverage(
+                req,
+                category,
+                ref_des,
+                catalog_file_for_row,
+                str(requirements_path),
+                catalog_items,
+                covered_ipns=covered_ipns,
+            )
+            if match_row is not None:
+                report.rows.append(match_row)
+                _increment_counter(report, match_row.severity)
+
+        # Unused catalog items.
+        for item in catalog_items:
+            if item.ipn and item.ipn not in covered_ipns:
+                row = AuditRow(
+                    check_type=CheckType.UNUSED_ITEM,
+                    severity=Severity.INFO,
+                    catalog_file=catalog_file_str,
+                    ipn=item.ipn,
+                    category=item.category or "",
+                    description=(
+                        f"Catalog item {item.ipn!r} was not matched by any project requirement"
+                    ),
+                )
+                report.rows.append(row)
+                report.info_count += 1
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Private helpers — field quality
+    # ------------------------------------------------------------------
+
+    def _check_field_quality(
+        self,
+        comp: Component,
+        category: str,
+        pro_str: str,
+    ) -> list[AuditRow]:
+        """Return QUALITY_ISSUE rows for *comp*."""
+        rows: list[AuditRow] = []
+
+        # Gather current component properties (include top-level fields).
+        present: dict[str, str] = {
+            "Value": comp.value or "",
+            "Footprint": comp.footprint or "",
+        }
+        present.update(comp.properties or {})
+
+        # Check required fields.
+        for spec in get_required_fields():
+            current = present.get(spec.name, "")
+            if _is_blank(current):
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.QUALITY_ISSUE,
+                        severity=Severity.ERROR,
+                        project_path=pro_str,
+                        ref_des=comp.reference,
+                        uuid=comp.uuid,
+                        category=category,
+                        field=spec.name,
+                        current_value=current,
+                        suggested_value=spec.suggestion,
+                        description=f"{comp.reference}: required field '{spec.name}' is missing",
+                    )
+                )
+
+        # Check best-practice fields.
+        for spec in get_best_practice_fields(category):
+            current = present.get(spec.name, "")
+            if _is_blank(current):
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.QUALITY_ISSUE,
+                        severity=Severity.WARN,
+                        project_path=pro_str,
+                        ref_des=comp.reference,
+                        uuid=comp.uuid,
+                        category=category,
+                        field=spec.name,
+                        current_value=current,
+                        suggested_value=spec.suggestion,
+                        description=(
+                            f"{comp.reference}: best-practice field '{spec.name}' is missing"
+                            + (f" — {spec.suggestion}" if spec.suggestion else "")
+                        ),
+                    )
+                )
+
+        return rows
+
+    # ------------------------------------------------------------------
+    # Private helpers — coverage classification (project mode)
+    # ------------------------------------------------------------------
+
+    def _classify_coverage(
+        self,
+        comp: Component,
+        category: str,
+        pro_str: str,
+        inventory_items: list[InventoryItem],
+    ) -> Optional[AuditRow]:
+        """Return a coverage finding for *comp*, or ``None`` if coverage is exact.
+
+        Exclusive attribute check (IPN / MPN) is tried first because these
+        provide unambiguous, high-confidence identification that does not need
+        scoring.
+        """
+        if not inventory_items:
+            return AuditRow(
+                check_type=CheckType.COVERAGE_GAP,
+                severity=Severity.ERROR,
+                project_path=pro_str,
+                ref_des=comp.reference,
+                uuid=comp.uuid,
+                category=category,
+                description=f"{comp.reference}: no inventory items to match against (empty catalog)",
+            )
+
+        # --- Exclusive attribute (IPN / MPN) ---
+        comp_ipn = _prop(comp, "IPN")
+        comp_mpn = _prop(comp, "MFGPN") or _prop(comp, "MPN")
+        if comp_ipn:
+            if any(i.ipn == comp_ipn for i in inventory_items):
+                return None  # exact exclusive match — silent
+        if comp_mpn:
+            if any(i.mfgpn == comp_mpn for i in inventory_items):
+                return None  # exact exclusive match — silent
+
+        # --- Attribute-set matching via SophisticatedInventoryMatcher ---
+        matches = self._matcher.find_matches(comp, inventory_items)
+
+        if not matches:
+            return AuditRow(
+                check_type=CheckType.COVERAGE_GAP,
+                severity=Severity.ERROR,
+                project_path=pro_str,
+                ref_des=comp.reference,
+                uuid=comp.uuid,
+                category=category,
+                description=f"{comp.reference}: no matching inventory item found",
+            )
+
+        # Partition into exact vs. heuristic.
+        exact = [m for m in matches if m.score >= _EXACT_THRESHOLD]
+        heuristic = [m for m in matches if m.score < _EXACT_THRESHOLD]
+
+        if not exact:
+            # All matches are heuristic only.
+            best = heuristic[0]
+            debug = f" (best candidate: {best.inventory_item.ipn}, score={best.score})"
+            return AuditRow(
+                check_type=CheckType.MATCH_HEURISTIC,
+                severity=Severity.WARN,
+                project_path=pro_str,
+                ref_des=comp.reference,
+                uuid=comp.uuid,
+                category=category,
+                description=(
+                    f"{comp.reference}: matched only via heuristics{debug}. "
+                    "Tighten specs or add a more precise inventory item."
+                ),
+            )
+
+        if len(exact) == 1:
+            return None  # single exact match — silent
+
+        # Multiple exact candidates — ambiguous.
+        candidates = ", ".join(m.inventory_item.ipn for m in exact[:5])
+        return AuditRow(
+            check_type=CheckType.MATCH_AMBIGUOUS,
+            severity=Severity.INFO,
+            project_path=pro_str,
+            ref_des=comp.reference,
+            uuid=comp.uuid,
+            category=category,
+            description=(
+                f"{comp.reference}: {len(exact)} equally-qualified candidates ({candidates}). "
+                "Set Priority values in the inventory to disambiguate."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers — coverage classification (inventory mode)
+    # ------------------------------------------------------------------
+
+    def _classify_inventory_coverage(
+        self,
+        req: InventoryItem,
+        category: str,
+        ref_des: str,
+        catalog_file: str,
+        req_file: str,
+        catalog_items: list[InventoryItem],
+        *,
+        covered_ipns: set[str],
+    ) -> Optional[AuditRow]:
+        """Return a coverage finding for requirement *req*, updating *covered_ipns*.
+
+        A synthetic :class:`Component` is constructed from the COMPONENT row
+        so the existing :class:`SophisticatedInventoryMatcher` can be reused
+        without modification.
+        """
+        synthetic = _component_from_inventory_item(req)
+
+        # Exclusive attribute check.
+        req_ipn = req.ipn
+        if req_ipn:
+            matched = [i for i in catalog_items if i.ipn == req_ipn]
+            if matched:
+                covered_ipns.update(i.ipn for i in matched)
+                return None
+
+        matches = self._matcher.find_matches(synthetic, catalog_items)
+
+        if not matches:
+            return AuditRow(
+                check_type=CheckType.COVERAGE_GAP,
+                severity=Severity.ERROR,
+                catalog_file=req_file,
+                ipn=req_ipn,
+                category=category,
+                ref_des=ref_des,
+                description=f"Requirement {ref_des!r}: no matching catalog item found",
+            )
+
+        exact = [m for m in matches if m.score >= _EXACT_THRESHOLD]
+        heuristic = [m for m in matches if m.score < _EXACT_THRESHOLD]
+
+        # Mark all matched items as covered.
+        for m in matches:
+            if m.inventory_item.ipn:
+                covered_ipns.add(m.inventory_item.ipn)
+
+        if not exact:
+            best = heuristic[0]
+            debug = f" (best: {best.inventory_item.ipn}, score={best.score})"
+            return AuditRow(
+                check_type=CheckType.MATCH_HEURISTIC,
+                severity=Severity.WARN,
+                catalog_file=req_file,
+                ipn=req_ipn,
+                category=category,
+                ref_des=ref_des,
+                description=(
+                    f"Requirement {ref_des!r}: matched only via heuristics{debug}. "
+                    "Tighten specs or add a more precise catalog item."
+                ),
+            )
+
+        if len(exact) == 1:
+            return None  # single exact match — silent
+
+        candidates = ", ".join(m.inventory_item.ipn for m in exact[:5])
+        return AuditRow(
+            check_type=CheckType.MATCH_AMBIGUOUS,
+            severity=Severity.INFO,
+            catalog_file=req_file,
+            ipn=req_ipn,
+            category=category,
+            ref_des=ref_des,
+            description=(
+                f"Requirement {ref_des!r}: {len(exact)} equally-qualified candidates "
+                f"({candidates}). Set Priority values to disambiguate."
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_blank(value: str) -> bool:
+    """Return True when a field value is absent or a KiCad no-value sentinel."""
+    s = (value or "").strip()
+    return s == "" or s == "~"
+
+
+def _prop(comp: Component, name: str) -> str:
+    """Return a component property value, stripping whitespace."""
+    return ((comp.properties or {}).get(name) or "").strip()
+
+
+def _increment_counter(report: AuditReport, severity: str) -> None:
+    """Increment the appropriate severity counter on *report*."""
+    if severity == Severity.ERROR:
+        report.error_count += 1
+    elif severity == Severity.WARN:
+        report.warn_count += 1
+    else:
+        report.info_count += 1
+
+
+def _resolve_project(path: Path) -> tuple[str, list[Path]]:
+    """Resolve a project path to (project_path_str, list_of_schematic_files).
+
+    Supports:
+    - A directory containing a ``.kicad_pro`` file
+    - A ``.kicad_sch`` file directly
+    - A ``.kicad_pro`` file
+
+    Returns:
+        Tuple of (project canonical string, list of schematic paths to audit).
+    """
+    from jbom.services.project_file_resolver import ProjectFileResolver
+
+    p = Path(path).resolve()
+
+    if p.is_file() and p.suffix == ".kicad_sch":
+        return str(p.parent), [p]
+
+    if p.is_file() and p.suffix == ".kicad_pro":
+        resolver = ProjectFileResolver(target_file_type="schematic")
+        resolved = resolver.resolve_input(p.parent)
+        sch_files = resolved.get_hierarchical_files()
+        return str(p), sch_files
+
+    if p.is_dir():
+        resolver = ProjectFileResolver(target_file_type="schematic")
+        resolved = resolver.resolve_input(p)
+        sch_files = resolved.get_hierarchical_files()
+        # Try to find .kicad_pro for canonical path
+        pro_files = list(p.glob("*.kicad_pro"))
+        pro_str = str(pro_files[0]) if pro_files else str(p)
+        return pro_str, sch_files
+
+    # Unknown — assume it's a schematic
+    return str(p.parent), [p]
+
+
+def _component_from_inventory_item(item: InventoryItem) -> Component:
+    """Build a synthetic :class:`Component` from a COMPONENT inventory row.
+
+    This allows :class:`SophisticatedInventoryMatcher` to be reused for
+    inventory-mode coverage checks without any code duplication.
+    """
+    from jbom.common.types import Component
+
+    # Map InventoryItem fields to Component fields as faithfully as possible.
+    props: dict[str, str] = {}
+    if item.tolerance:
+        props["Tolerance"] = item.tolerance
+    if item.voltage:
+        props["Voltage"] = item.voltage
+    if item.amperage:
+        props["Current"] = item.amperage
+    if item.wattage:
+        props["Power"] = item.wattage
+    if item.mfgpn:
+        props["MFGPN"] = item.mfgpn
+    if item.ipn:
+        props["IPN"] = item.ipn
+
+    return Component(
+        reference=item.component_id or item.uuid or item.ipn or "",
+        lib_id=item.symbol_lib + ":" + item.symbol_name
+        if item.symbol_name
+        else item.category or "",
+        value=item.value or "",
+        footprint=item.footprint_full or item.package or "",
+        uuid=item.uuid or "",
+        properties=props,
+    )
+
+
+__all__ = [
+    "CheckType",
+    "Severity",
+    "AuditRow",
+    "AuditReport",
+    "AuditService",
+    "REPORT_CSV_COLUMNS",
+]

--- a/tests/unit/test_audit_cli.py
+++ b/tests/unit/test_audit_cli.py
@@ -1,0 +1,299 @@
+"""Unit tests for jbom.cli.audit — argument parsing and exit code behaviour.
+
+These tests invoke the handler directly rather than through subprocess to keep
+them fast and independent of the installed entry point.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jbom.cli.audit import handle_audit
+from jbom.cli.main import create_parser
+from jbom.services.audit_service import AuditReport, AuditRow, CheckType, Severity
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+
+def test_audit_command_registered_in_parser() -> None:
+    parser = create_parser()
+    # --help raises SystemExit(0); that confirms 'audit' is a known subcommand.
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["audit", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_audit_command_registered() -> None:
+    """audit subcommand should be parseable without error."""
+    parser = create_parser()
+    # Using a non-existent path is fine for parser-level validation
+    args = parser.parse_args(["audit", "."])
+    assert args.command == "audit"
+    assert args.inputs == ["."]
+
+
+def test_audit_strict_flag_parsed() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["audit", ".", "--strict"])
+    assert args.strict is True
+
+
+def test_audit_inventory_flag_parsed() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["audit", ".", "--inventory", "cat.csv"])
+    assert args.inventory == Path("cat.csv")
+
+
+def test_audit_requirements_flag_parsed() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["audit", "cat.csv", "--requirements", "req.csv"])
+    assert args.requirements == Path("req.csv")
+
+
+def test_audit_output_flag_parsed() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["audit", ".", "-o", "report.csv"])
+    assert args.output == Path("report.csv")
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a mock AuditReport and a fake args namespace
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs):
+    """Build a minimal argparse.Namespace for handle_audit."""
+    import argparse
+
+    defaults = {
+        "inputs": ["."],
+        "inventory": None,
+        "requirements": None,
+        "output": None,
+        "strict": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _mock_report(*, error_count=0, warn_count=0, info_count=0, rows=None):
+    report = AuditReport(
+        rows=rows or [],
+        error_count=error_count,
+        warn_count=warn_count,
+        info_count=info_count,
+    )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Mode detection
+# ---------------------------------------------------------------------------
+
+
+def test_audit_csv_input_triggers_inventory_mode(tmp_path: Path) -> None:
+    """All-CSV inputs should call audit_inventory, not audit_project."""
+    cat = tmp_path / "catalog.csv"
+    cat.write_text("RowType,IPN,Category\nITEM,R001,RES\n", encoding="utf-8")
+
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_inventory.return_value = _mock_report()
+
+        args = _make_args(inputs=[str(cat)])
+        handle_audit(args)
+
+        instance.audit_inventory.assert_called_once()
+        instance.audit_project.assert_not_called()
+
+
+def test_audit_directory_input_triggers_project_mode(tmp_path: Path) -> None:
+    """Non-CSV inputs should call audit_project, not audit_inventory."""
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report()
+
+        args = _make_args(inputs=[str(tmp_path)])
+        handle_audit(args)
+
+        instance.audit_project.assert_called_once()
+        instance.audit_inventory.assert_not_called()
+
+
+def test_audit_mixed_inputs_treated_as_project_mode(tmp_path: Path) -> None:
+    """If any input is not .csv the command must use project mode."""
+    csv_file = tmp_path / "catalog.csv"
+    csv_file.write_text("RowType,IPN,Category\n", encoding="utf-8")
+
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report()
+
+        # Mix: one .csv and one directory
+        args = _make_args(inputs=[str(tmp_path), str(csv_file)])
+        handle_audit(args)
+
+        instance.audit_project.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# --requirements in project mode is an error
+# ---------------------------------------------------------------------------
+
+
+def test_requirements_flag_in_project_mode_returns_1(tmp_path: Path) -> None:
+    args = _make_args(inputs=[str(tmp_path)], requirements=Path("req.csv"))
+    result = handle_audit(args)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# --inventory in inventory mode is an error
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_flag_in_inventory_mode_returns_1(tmp_path: Path) -> None:
+    cat = tmp_path / "catalog.csv"
+    cat.write_text("RowType,IPN,Category\n", encoding="utf-8")
+
+    args = _make_args(inputs=[str(cat)], inventory=Path("cat.csv"))
+    result = handle_audit(args)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# Exit code behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_0_when_no_errors(tmp_path: Path) -> None:
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report(warn_count=2)
+
+        args = _make_args(inputs=[str(tmp_path)])
+        result = handle_audit(args)
+
+    assert result == 0
+
+
+def test_exit_code_1_when_errors(tmp_path: Path) -> None:
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report(error_count=1)
+
+        args = _make_args(inputs=[str(tmp_path)])
+        result = handle_audit(args)
+
+    assert result == 1
+
+
+def test_strict_exit_code_1_when_only_warnings(tmp_path: Path) -> None:
+    """With --strict, warnings should raise exit code to 1."""
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report(warn_count=3)
+
+        args = _make_args(inputs=[str(tmp_path)], strict=True)
+        result = handle_audit(args)
+
+    assert result == 1
+
+
+def test_strict_exit_code_0_when_no_issues(tmp_path: Path) -> None:
+    """With --strict and no issues, exit code should still be 0."""
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report()
+
+        args = _make_args(inputs=[str(tmp_path)], strict=True)
+        result = handle_audit(args)
+
+    assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# -o output file writing
+# ---------------------------------------------------------------------------
+
+
+def test_output_file_is_written(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.csv"
+
+    error_row = AuditRow(
+        check_type=CheckType.QUALITY_ISSUE,
+        severity=Severity.ERROR,
+        project_path=str(tmp_path),
+        ref_des="R1",
+        uuid="uuid-r1",
+        field="Value",
+        description="R1: required field 'Value' is missing",
+    )
+
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report(
+            error_count=1, rows=[error_row]
+        )
+
+        args = _make_args(inputs=[str(tmp_path)], output=report_path)
+        handle_audit(args)
+
+    assert report_path.exists(), "Report file should be created at -o path"
+    content = report_path.read_text(encoding="utf-8")
+    assert "QUALITY_ISSUE" in content
+    assert "R1" in content
+
+
+def test_output_file_has_all_csv_columns(tmp_path: Path) -> None:
+    from jbom.services.audit_service import REPORT_CSV_COLUMNS
+
+    report_path = tmp_path / "report.csv"
+
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report()
+
+        args = _make_args(inputs=[str(tmp_path)], output=report_path)
+        handle_audit(args)
+
+    assert report_path.exists()
+    with report_path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert set(reader.fieldnames or []) == set(REPORT_CSV_COLUMNS)
+
+
+def test_output_to_stdout_contains_csv_header(tmp_path: Path, capsys) -> None:
+    """When -o is not specified, CSV should be written to stdout."""
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report()
+
+        args = _make_args(inputs=[str(tmp_path)])
+        handle_audit(args)
+
+    captured = capsys.readouterr()
+    assert "CheckType" in captured.out, "CSV header should appear in stdout"
+
+
+# ---------------------------------------------------------------------------
+# Error handling: FileNotFoundError
+# ---------------------------------------------------------------------------
+
+
+def test_handle_audit_returns_1_on_file_not_found(tmp_path: Path) -> None:
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.side_effect = FileNotFoundError("not found")
+
+        args = _make_args(inputs=[str(tmp_path)])
+        result = handle_audit(args)
+
+    assert result == 1

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -1,0 +1,730 @@
+"""Unit tests for jbom.services.audit_service.
+
+These tests use minimal in-memory fixtures (synthetic schematics and CSVs
+written to tmp_path) to avoid touching real KiCad project structures.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from pathlib import Path
+
+from jbom.services.audit_service import (
+    AuditReport,
+    AuditRow,
+    AuditService,
+    CheckType,
+    REPORT_CSV_COLUMNS,
+    Severity,
+    _is_blank,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for writing minimal fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_schematic(
+    path: Path,
+    components: list[dict],
+) -> None:
+    """Write a minimal .kicad_sch with one or more symbol nodes."""
+    symbols_sexp = ""
+    for comp in components:
+        ref = comp.get("reference", "R1")
+        value = comp.get("value", "10K")
+        footprint = comp.get("footprint", "Resistor_SMD:R_0603_1608Metric")
+        lib_id = comp.get("lib_id", "Device:R")
+        uuid = comp.get("uuid", f"uuid-{ref.lower()}")
+        props = comp.get("extra_props", {})
+
+        # Build extra property s-expressions
+        extra_sexp = ""
+        for i, (key, val) in enumerate(props.items(), start=10):
+            extra_sexp += f'    (property "{key}" "{val}" (id {i}) (at 0 0 0))\n'
+
+        symbols_sexp += f"""  (symbol (lib_id "{lib_id}") (at 50 50 0)
+    (uuid "{uuid}")
+    (in_bom yes) (on_board yes) (dnp no)
+    (property "Reference" "{ref}" (id 0) (at 50 48 0))
+    (property "Value" "{value}" (id 1) (at 50 52 0))
+    (property "Footprint" "{footprint}" (id 2) (at 50 54 0))
+{extra_sexp}  )
+"""
+
+    content = f"""(kicad_sch (version 20211123) (generator eeschema)
+{symbols_sexp})
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_kicad_pro(path: Path) -> None:
+    """Write a minimal .kicad_pro file."""
+    path.write_text("{}", encoding="utf-8")
+
+
+def _write_inventory_csv(path: Path, rows: list[dict]) -> None:
+    """Write a minimal inventory CSV with RowType, IPN, Category, Value, Package columns."""
+    fieldnames = [
+        "RowType",
+        "IPN",
+        "Category",
+        "Value",
+        "Package",
+        "Manufacturer",
+        "MFGPN",
+        "Tolerance",
+        "Voltage",
+        "Current",
+        "Power",
+        "Description",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({**{k: "" for k in fieldnames}, **row})
+
+
+def _write_requirements_csv(path: Path, rows: list[dict]) -> None:
+    """Write a COMPONENT-type requirements CSV."""
+    fieldnames = [
+        "RowType",
+        "ComponentID",
+        "Category",
+        "Value",
+        "Package",
+        "Tolerance",
+        "Voltage",
+        "Current",
+        "Power",
+        "IPN",
+        "UUID",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {**{k: "" for k in fieldnames}, "RowType": "COMPONENT", **row}
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helper: create a minimal KiCad project dir
+# ---------------------------------------------------------------------------
+
+
+def _make_project(
+    tmp_path: Path,
+    components: list[dict],
+    name: str = "proj",
+) -> Path:
+    """Create a minimal KiCad project directory and return its path."""
+    proj_dir = tmp_path / name
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    _write_kicad_pro(proj_dir / f"{name}.kicad_pro")
+    _write_schematic(proj_dir / f"{name}.kicad_sch", components)
+    return proj_dir
+
+
+# ---------------------------------------------------------------------------
+# _is_blank helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_blank_empty_string() -> None:
+    assert _is_blank("") is True
+
+
+def test_is_blank_whitespace() -> None:
+    assert _is_blank("   ") is True
+
+
+def test_is_blank_tilde() -> None:
+    assert _is_blank("~") is True
+
+
+def test_is_blank_tilde_with_spaces() -> None:
+    assert _is_blank("  ~  ") is True
+
+
+def test_is_blank_non_empty() -> None:
+    assert _is_blank("10K") is False
+
+
+# ---------------------------------------------------------------------------
+# AuditReport.write_csv
+# ---------------------------------------------------------------------------
+
+
+def test_audit_report_write_csv_has_all_columns() -> None:
+    report = AuditReport()
+    buf = io.StringIO()
+    report.write_csv(buf)
+    buf.seek(0)
+    reader = csv.DictReader(buf)
+    assert set(reader.fieldnames or []) == set(REPORT_CSV_COLUMNS)
+
+
+def test_audit_report_write_csv_with_rows() -> None:
+    row = AuditRow(
+        check_type=CheckType.QUALITY_ISSUE,
+        severity=Severity.ERROR,
+        project_path="/proj",
+        ref_des="R1",
+        uuid="uuid-r1",
+        category="RES",
+        field="Value",
+        description="R1: required field 'Value' is missing",
+    )
+    report = AuditReport(rows=[row], error_count=1)
+    buf = io.StringIO()
+    report.write_csv(buf)
+    buf.seek(0)
+    rows = list(csv.DictReader(buf))
+    assert len(rows) == 1
+    assert rows[0]["CheckType"] == "QUALITY_ISSUE"
+    assert rows[0]["Severity"] == "ERROR"
+    assert rows[0]["RefDes"] == "R1"
+
+
+# ---------------------------------------------------------------------------
+# AuditReport.exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_zero_when_no_errors() -> None:
+    report = AuditReport(warn_count=2, info_count=3)
+    assert report.exit_code == 0
+
+
+def test_exit_code_one_when_errors() -> None:
+    report = AuditReport(error_count=1)
+    assert report.exit_code == 1
+
+
+def test_exit_code_strict_zero_when_no_issues() -> None:
+    report = AuditReport()
+    assert report.exit_code_strict() == 0
+
+
+def test_exit_code_strict_one_when_only_warnings() -> None:
+    report = AuditReport(warn_count=1)
+    assert report.exit_code_strict() == 1
+
+
+# ---------------------------------------------------------------------------
+# audit_project — local heuristics: REQUIRED field checks
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_required_value_missing(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    quality_errors = [
+        r
+        for r in report.rows
+        if r.check_type == CheckType.QUALITY_ISSUE
+        and r.severity == Severity.ERROR
+        and r.field == "Value"
+    ]
+    assert quality_errors, "Expected QUALITY_ISSUE/ERROR for missing Value"
+    assert quality_errors[0].ref_des == "R1"
+
+
+def test_audit_project_required_footprint_missing(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [{"reference": "R1", "value": "10K", "footprint": "", "lib_id": "Device:R"}],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    quality_errors = [
+        r
+        for r in report.rows
+        if r.check_type == CheckType.QUALITY_ISSUE
+        and r.severity == Severity.ERROR
+        and r.field == "Footprint"
+    ]
+    assert quality_errors, "Expected QUALITY_ISSUE/ERROR for missing Footprint"
+
+
+def test_audit_project_required_tilde_treated_as_missing(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "~",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    quality_errors = [
+        r
+        for r in report.rows
+        if r.check_type == CheckType.QUALITY_ISSUE
+        and r.severity == Severity.ERROR
+        and r.field == "Value"
+    ]
+    assert quality_errors, "Tilde value should be treated as missing (ERROR)"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — local heuristics: BEST_PRACTICE field checks
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_resistor_missing_tolerance_is_warn(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    tolerance_warns = [
+        r
+        for r in report.rows
+        if r.check_type == CheckType.QUALITY_ISSUE
+        and r.severity == Severity.WARN
+        and r.field == "Tolerance"
+    ]
+    assert (
+        tolerance_warns
+    ), "Expected QUALITY_ISSUE/WARN for missing Tolerance on resistor"
+
+
+def test_audit_project_capacitor_missing_voltage_is_warn(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "C1",
+                "value": "100nF",
+                "footprint": "Capacitor_SMD:C_0603_1608Metric",
+                "lib_id": "Device:C",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    voltage_warns = [
+        r
+        for r in report.rows
+        if r.check_type == CheckType.QUALITY_ISSUE
+        and r.severity == Severity.WARN
+        and r.field == "Voltage"
+    ]
+    assert voltage_warns, "Expected QUALITY_ISSUE/WARN for missing Voltage on capacitor"
+
+
+def test_audit_project_component_with_all_fields_no_required_errors(
+    tmp_path: Path,
+) -> None:
+    """A component with Value, Footprint, and all universal best-practice fields set should
+    produce no REQUIRED-severity errors."""
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+                "extra_props": {
+                    "Manufacturer": "Vishay",
+                    "MFGPN": "CRCW060310K0FKEA",
+                    "Tolerance": "1%",
+                    "Power": "0.1W",
+                },
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    errors = [r for r in report.rows if r.severity == Severity.ERROR]
+    assert not errors, f"Unexpected errors for well-specified component: {errors}"
+
+
+def test_audit_project_warns_do_not_affect_exit_code_default(tmp_path: Path) -> None:
+    """WARN rows alone should not set exit_code to 1 (only ERRORs do by default)."""
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    assert report.warn_count > 0, "Expected at least one WARN (missing Tolerance etc.)"
+    assert report.exit_code == 0, "WARNs alone should not trigger exit_code=1"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — suggested values populated
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_quality_issue_has_suggested_value(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    service = AuditService()
+    report = service.audit_project([proj])
+
+    tolerance_row = next((r for r in report.rows if r.field == "Tolerance"), None)
+    assert tolerance_row is not None
+    assert (
+        tolerance_row.suggested_value.strip() != ""
+    ), "SuggestedValue should be populated for BEST_PRACTICE rows"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — coverage dry-run: COVERAGE_GAP
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_coverage_gap_when_no_inventory_match(tmp_path: Path) -> None:
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "100K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    # Inventory has a totally different component (capacitor, not matching R1)
+    inv = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        inv,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "CAP001",
+                "Category": "CAP",
+                "Value": "100nF",
+                "Package": "0603",
+                "Manufacturer": "Murata",
+                "MFGPN": "GRM188R71C104KA01D",
+            }
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_project([proj], inventory_path=inv)
+
+    gap_rows = [r for r in report.rows if r.check_type == CheckType.COVERAGE_GAP]
+    assert gap_rows, "Expected COVERAGE_GAP for unmatched resistor"
+    assert gap_rows[0].severity == Severity.ERROR
+    assert gap_rows[0].ref_des == "R1"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — coverage dry-run: silent exact match
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_no_coverage_row_for_exact_match(tmp_path: Path) -> None:
+    """When inventory has an exact match, no COVERAGE_* row should appear."""
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    inv = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        inv,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "RES001",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+                "Manufacturer": "Vishay",
+                "MFGPN": "CRCW060310K0FKEA",
+            }
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_project([proj], inventory_path=inv)
+
+    coverage_rows = [
+        r
+        for r in report.rows
+        if r.check_type
+        in (
+            CheckType.COVERAGE_GAP,
+            CheckType.MATCH_HEURISTIC,
+            CheckType.MATCH_AMBIGUOUS,
+        )
+    ]
+    assert (
+        not coverage_rows
+    ), f"Expected no coverage rows for exact match, got: {coverage_rows}"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — coverage dry-run: IPN exact exclusive match (silent)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_ipn_match_is_silent(tmp_path: Path) -> None:
+    """A component with a matching IPN should produce no coverage rows."""
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+                "extra_props": {"IPN": "RES001"},
+            }
+        ],
+    )
+    inv = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        inv,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "RES001",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+            }
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_project([proj], inventory_path=inv)
+
+    coverage_rows = [
+        r
+        for r in report.rows
+        if r.check_type
+        in (
+            CheckType.COVERAGE_GAP,
+            CheckType.MATCH_HEURISTIC,
+            CheckType.MATCH_AMBIGUOUS,
+        )
+    ]
+    assert not coverage_rows, "IPN exact match should be silent (no coverage rows)"
+
+
+# ---------------------------------------------------------------------------
+# audit_project — coverage dry-run: MATCH_AMBIGUOUS
+# ---------------------------------------------------------------------------
+
+
+def test_audit_project_match_ambiguous_multiple_exact_candidates(
+    tmp_path: Path,
+) -> None:
+    """Multiple high-score catalog items should produce MATCH_AMBIGUOUS."""
+    proj = _make_project(
+        tmp_path,
+        [
+            {
+                "reference": "R1",
+                "value": "10K",
+                "footprint": "Resistor_SMD:R_0603_1608Metric",
+                "lib_id": "Device:R",
+            }
+        ],
+    )
+    inv = tmp_path / "catalog.csv"
+    # Two identical-scoring 10K 0603 resistors from different manufacturers
+    _write_inventory_csv(
+        inv,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "RES001",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+                "Manufacturer": "Vishay",
+                "MFGPN": "CRCW060310K0FKEA",
+            },
+            {
+                "RowType": "ITEM",
+                "IPN": "RES002",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+                "Manufacturer": "Yageo",
+                "MFGPN": "RC0603FR-0710KL",
+            },
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_project([proj], inventory_path=inv)
+
+    ambiguous = [r for r in report.rows if r.check_type == CheckType.MATCH_AMBIGUOUS]
+    assert ambiguous, "Expected MATCH_AMBIGUOUS for multiple equally-scored candidates"
+    assert ambiguous[0].severity == Severity.INFO
+
+
+# ---------------------------------------------------------------------------
+# audit_inventory — UNUSED_ITEM
+# ---------------------------------------------------------------------------
+
+
+def test_audit_inventory_unused_item(tmp_path: Path) -> None:
+    """Catalog items not matched by any requirement should be UNUSED_ITEM."""
+    catalog = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        catalog,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "RES001",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+            },
+            {
+                "RowType": "ITEM",
+                "IPN": "CAP001",
+                "Category": "CAP",
+                "Value": "100nF",
+                "Package": "0402",
+            },
+        ],
+    )
+
+    req = tmp_path / "requirements.csv"
+    _write_requirements_csv(
+        req,
+        [
+            # Only asks for the resistor
+            {"Category": "RES", "Value": "10K", "Package": "0603"},
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_inventory([catalog], requirements_path=req)
+
+    unused = [r for r in report.rows if r.check_type == CheckType.UNUSED_ITEM]
+    unused_ipns = {r.ipn for r in unused}
+    assert "CAP001" in unused_ipns, "CAP001 should be UNUSED_ITEM"
+    assert "RES001" not in unused_ipns, "RES001 was matched and should not be UNUSED"
+
+
+# ---------------------------------------------------------------------------
+# audit_inventory — COVERAGE_GAP
+# ---------------------------------------------------------------------------
+
+
+def test_audit_inventory_coverage_gap_for_unmatched_requirement(tmp_path: Path) -> None:
+    catalog = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        catalog,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "CAP001",
+                "Category": "CAP",
+                "Value": "100nF",
+                "Package": "0603",
+            }
+        ],
+    )
+
+    req = tmp_path / "requirements.csv"
+    _write_requirements_csv(
+        req,
+        [
+            {"Category": "RES", "Value": "100K", "Package": "0603"},  # not in catalog
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_inventory([catalog], requirements_path=req)
+
+    gaps = [r for r in report.rows if r.check_type == CheckType.COVERAGE_GAP]
+    assert gaps, "Expected COVERAGE_GAP for unmatched requirement"
+    assert gaps[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# audit_inventory — no requirements returns empty report
+# ---------------------------------------------------------------------------
+
+
+def test_audit_inventory_no_requirements_returns_empty(tmp_path: Path) -> None:
+    catalog = tmp_path / "catalog.csv"
+    _write_inventory_csv(
+        catalog,
+        [
+            {
+                "RowType": "ITEM",
+                "IPN": "RES001",
+                "Category": "RES",
+                "Value": "10K",
+                "Package": "0603",
+            }
+        ],
+    )
+
+    service = AuditService()
+    report = service.audit_inventory([catalog], requirements_path=None)
+
+    assert not report.rows, "Without requirements, no rows should be generated"
+    assert report.exit_code == 0

--- a/tests/unit/test_field_taxonomy.py
+++ b/tests/unit/test_field_taxonomy.py
@@ -1,0 +1,270 @@
+"""Unit tests for jbom.common.field_taxonomy."""
+
+from __future__ import annotations
+
+import pytest
+
+from jbom.common.constants import ComponentType
+from jbom.common.field_taxonomy import (
+    CATEGORY_BEST_PRACTICE,
+    UNIVERSAL_REQUIRED_FIELDS,
+    FieldSeverity,
+    FieldSpec,
+    get_best_practice_fields,
+    get_field_specs,
+    get_required_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# FieldSpec dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_fieldspec_is_frozen() -> None:
+    spec = FieldSpec("Value", FieldSeverity.REQUIRED)
+    with pytest.raises((AttributeError, TypeError)):
+        spec.name = "Changed"  # type: ignore[misc]
+
+
+def test_fieldspec_default_suggestion_is_empty() -> None:
+    spec = FieldSpec("Value", FieldSeverity.REQUIRED)
+    assert spec.suggestion == ""
+
+
+def test_fieldspec_with_suggestion() -> None:
+    spec = FieldSpec("Tolerance", FieldSeverity.BEST_PRACTICE, "e.g. 1%, 5%")
+    assert spec.suggestion == "e.g. 1%, 5%"
+
+
+# ---------------------------------------------------------------------------
+# Universal required fields
+# ---------------------------------------------------------------------------
+
+
+def test_universal_required_contains_value() -> None:
+    names = [s.name for s in UNIVERSAL_REQUIRED_FIELDS]
+    assert "Value" in names
+
+
+def test_universal_required_contains_footprint() -> None:
+    names = [s.name for s in UNIVERSAL_REQUIRED_FIELDS]
+    assert "Footprint" in names
+
+
+def test_universal_required_all_have_required_severity() -> None:
+    for spec in UNIVERSAL_REQUIRED_FIELDS:
+        assert (
+            spec.severity == FieldSeverity.REQUIRED
+        ), f"{spec.name} should be REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# get_required_fields()
+# ---------------------------------------------------------------------------
+
+
+def test_get_required_fields_returns_copy() -> None:
+    r1 = get_required_fields()
+    r2 = get_required_fields()
+    assert r1 is not r2
+
+
+def test_get_required_fields_contains_value_and_footprint() -> None:
+    names = [s.name for s in get_required_fields()]
+    assert "Value" in names
+    assert "Footprint" in names
+
+
+# ---------------------------------------------------------------------------
+# get_field_specs() — structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ComponentType.RESISTOR,
+        ComponentType.CAPACITOR,
+        ComponentType.INDUCTOR,
+        ComponentType.LED,
+        ComponentType.INTEGRATED_CIRCUIT,
+        ComponentType.CONNECTOR,
+        ComponentType.TRANSISTOR,
+        ComponentType.OSCILLATOR,
+        ComponentType.FUSE,
+        None,
+        "",
+        "UNKNOWN_CATEGORY",
+    ],
+)
+def test_get_field_specs_always_includes_required_fields(category: str) -> None:
+    specs = get_field_specs(category)
+    names = [s.name for s in specs]
+    assert "Value" in names, f"Value missing for category={category!r}"
+    assert "Footprint" in names, f"Footprint missing for category={category!r}"
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ComponentType.RESISTOR,
+        ComponentType.CAPACITOR,
+        ComponentType.INTEGRATED_CIRCUIT,
+        None,
+    ],
+)
+def test_get_field_specs_always_includes_universal_best_practice(category: str) -> None:
+    specs = get_field_specs(category)
+    names = [s.name for s in specs]
+    assert "Manufacturer" in names, f"Manufacturer missing for category={category!r}"
+    assert "MFGPN" in names, f"MFGPN missing for category={category!r}"
+
+
+def test_get_field_specs_required_before_best_practice() -> None:
+    """Required fields should come before best-practice fields in the list."""
+    specs = get_field_specs(ComponentType.RESISTOR)
+    required_indices = [
+        i for i, s in enumerate(specs) if s.severity == FieldSeverity.REQUIRED
+    ]
+    best_practice_indices = [
+        i for i, s in enumerate(specs) if s.severity == FieldSeverity.BEST_PRACTICE
+    ]
+    assert required_indices, "No REQUIRED specs found"
+    assert best_practice_indices, "No BEST_PRACTICE specs found"
+    assert max(required_indices) < min(
+        best_practice_indices
+    ), "All REQUIRED specs should appear before any BEST_PRACTICE spec"
+
+
+# ---------------------------------------------------------------------------
+# get_field_specs() — category-specific best-practice fields
+# ---------------------------------------------------------------------------
+
+
+def test_resistor_has_tolerance_best_practice() -> None:
+    specs = get_field_specs(ComponentType.RESISTOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Tolerance" in bp_names
+
+
+def test_resistor_has_power_best_practice() -> None:
+    specs = get_field_specs(ComponentType.RESISTOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Power" in bp_names
+
+
+def test_capacitor_has_voltage_best_practice() -> None:
+    specs = get_field_specs(ComponentType.CAPACITOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Voltage" in bp_names
+
+
+def test_capacitor_has_tolerance_best_practice() -> None:
+    specs = get_field_specs(ComponentType.CAPACITOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Tolerance" in bp_names
+
+
+def test_inductor_has_current_best_practice() -> None:
+    specs = get_field_specs(ComponentType.INDUCTOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Current" in bp_names
+
+
+def test_led_has_wavelength_best_practice() -> None:
+    specs = get_field_specs(ComponentType.LED)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Wavelength" in bp_names
+
+
+def test_connector_has_pitch_best_practice() -> None:
+    specs = get_field_specs(ComponentType.CONNECTOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Pitch" in bp_names
+
+
+def test_oscillator_has_frequency_best_practice() -> None:
+    specs = get_field_specs(ComponentType.OSCILLATOR)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Frequency" in bp_names
+
+
+def test_fuse_has_current_best_practice() -> None:
+    specs = get_field_specs(ComponentType.FUSE)
+    bp_names = {s.name for s in specs if s.severity == FieldSeverity.BEST_PRACTICE}
+    assert "Current" in bp_names
+
+
+def test_unknown_category_returns_only_universal_fields() -> None:
+    specs = get_field_specs("COMPLETELY_UNKNOWN")
+    # Should have universal required + universal best-practice only
+    names = {s.name for s in specs}
+    assert names == {"Value", "Footprint", "Manufacturer", "MFGPN"}
+
+
+# ---------------------------------------------------------------------------
+# get_best_practice_fields()
+# ---------------------------------------------------------------------------
+
+
+def test_get_best_practice_fields_returns_only_best_practice_severity() -> None:
+    for category in [ComponentType.RESISTOR, ComponentType.CAPACITOR, None]:
+        specs = get_best_practice_fields(category)
+        for spec in specs:
+            assert (
+                spec.severity == FieldSeverity.BEST_PRACTICE
+            ), f"Expected BEST_PRACTICE, got {spec.severity} for {spec.name}"
+
+
+def test_get_best_practice_fields_excludes_required_fields() -> None:
+    specs = get_best_practice_fields(ComponentType.RESISTOR)
+    names = {s.name for s in specs}
+    assert "Value" not in names
+    assert "Footprint" not in names
+
+
+# ---------------------------------------------------------------------------
+# Suggestions are populated for best-practice fields
+# ---------------------------------------------------------------------------
+
+
+def test_resistor_tolerance_has_non_empty_suggestion() -> None:
+    specs = get_field_specs(ComponentType.RESISTOR)
+    tol = next((s for s in specs if s.name == "Tolerance"), None)
+    assert tol is not None
+    assert tol.suggestion.strip() != ""
+
+
+def test_capacitor_voltage_has_non_empty_suggestion() -> None:
+    specs = get_field_specs(ComponentType.CAPACITOR)
+    v = next((s for s in specs if s.name == "Voltage"), None)
+    assert v is not None
+    assert v.suggestion.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# CATEGORY_BEST_PRACTICE dict completeness
+# ---------------------------------------------------------------------------
+
+
+def test_category_best_practice_covers_major_categories() -> None:
+    """All commonly-used categories should be in the mapping (even if empty list)."""
+    expected = {
+        ComponentType.RESISTOR,
+        ComponentType.CAPACITOR,
+        ComponentType.INDUCTOR,
+        ComponentType.DIODE,
+        ComponentType.LED,
+        ComponentType.INTEGRATED_CIRCUIT,
+        ComponentType.TRANSISTOR,
+        ComponentType.CONNECTOR,
+        ComponentType.REGULATOR,
+        ComponentType.OSCILLATOR,
+        ComponentType.FUSE,
+        ComponentType.SWITCH,
+        ComponentType.RELAY,
+        ComponentType.ANALOG,
+    }
+    missing = expected - set(CATEGORY_BEST_PRACTICE.keys())
+    assert not missing, f"Missing categories in CATEGORY_BEST_PRACTICE: {missing}"


### PR DESCRIPTION
## Summary

PR 1 of 2 for issue #154 — delivers `jbom audit`, the diagnostic half of the audit/annotate symmetric pair.

## What's new

### `jbom audit` command

Two modes, detected automatically from positional argument types:

**Project mode** (`jbom audit <proj-dir> [--inventory cat.csv] [-o report.csv] [--strict]`)
- **Local heuristics** (always): checks every in-BOM component against the new `field_taxonomy`
  - `REQUIRED` (Value, Footprint) → `QUALITY_ISSUE / ERROR`
  - `BEST_PRACTICE` (Manufacturer, MFGPN, + category-specific: Tolerance/Power for resistors, Voltage/Tolerance for caps, etc.) → `QUALITY_ISSUE / WARN` with `SuggestedValue` populated
- **Coverage dry-run** (when `--inventory` provided): runs `match()` against the catalog without generating a BOM
  - No match → `COVERAGE_GAP / ERROR`
  - Heuristic-only match → `MATCH_HEURISTIC / WARN`
  - Multiple equally-qualified candidates → `MATCH_AMBIGUOUS / INFO`
  - Single exact match or IPN/MPN exclusive match → silent

**Inventory mode** (`jbom audit cat.csv [--requirements req.csv] [-o report.csv] [--strict]`)
- Same four-outcome coverage model applied to COMPONENT rows in the requirements file against catalog ITEM rows
- Catalog items unmatched by any requirement → `UNUSED_ITEM / INFO`

### `src/jbom/common/field_taxonomy.py` (new)

No CLI dependencies — safe to import from the KiCad Python plugin. Defines:
- `FieldSeverity` enum (REQUIRED, BEST_PRACTICE, OPTIONAL)
- `FieldSpec` frozen dataclass
- `get_field_specs(category)`, `get_required_fields()`, `get_best_practice_fields(category)`

### `src/jbom/services/audit_service.py` (new)

Pure service layer. Defines `CheckType`, `Severity`, `AuditRow`, `AuditReport`, `AuditService`.

**Stable `report.csv` schema** (designed for PR 2's `annotate --repairs` consumer):
`CheckType, Severity, ProjectPath, RefDes, UUID, CatalogFile, IPN, Category, Field, CurrentValue, SuggestedValue, ApprovedValue, Action, Supplier, SupplierPN, Description`

`ApprovedValue`, `Action`, `Supplier`, `SupplierPN` are blank in audit output; PR 2 fills/uses them.

### `src/jbom/cli/audit.py` (new)

Thin wrapper. Automatic mode detection: all-CSV positionals → inventory mode; otherwise project mode.

## Tests

+64 unit tests across 3 new test files. **All 611 tests green.**

## What PR 2 adds

- `--supplier` flag (SUPPLIER_MISS, INVENTORY_GAP rows via supplier catalog API)
- `jbom annotate --repairs report.csv` (clean break from current `annotate` behavior)
- `jbom inventory-search` retirement

Closes #154 (partially — PR 1 of 2)

Co-Authored-By: Oz <oz-agent@warp.dev>