### PR TITLE
feat: multi-pass iterative component classification (issue #166)

### DIFF
--- a/src/jbom/common/component_classification.py
+++ b/src/jbom/common/component_classification.py
@@ -54,6 +54,52 @@ class ClassificationSignal:
     match: Callable[[str, str, str], bool]
 
 
+@dataclass(frozen=True)
+class TextClassificationSignal:
+    """A weighted classification signal operating on free-text fields (Description, Keywords).
+
+    Attributes:
+        category: The ComponentType identifier this signal votes for.
+        weight: How strongly this signal votes.
+        match: Callable ``(text_upper,) -> bool`` operating on the uppercased combined
+            description + keywords string.
+    """
+
+    category: str
+    weight: float
+    match: Callable[[str], bool]
+
+
+# ---------------------------------------------------------------------------
+# Text-based signal table (Description + Keywords)
+# ---------------------------------------------------------------------------
+# These operate on a combined uppercase string of the KiCad component\'s
+# Description and Keywords properties.  They supplement the primary
+# lib_id/footprint/reference signals; a strong primary signal (e.g. IC
+# footprint at 6.0) will always outweigh a weak text hint (3.0).
+# ---------------------------------------------------------------------------
+
+_TEXT_SIGNALS: list[TextClassificationSignal] = [
+    # Neopixel is brand-specific → very high confidence
+    TextClassificationSignal("LED", 4.0, lambda t: "NEOPIXEL" in t),
+    TextClassificationSignal("LED", 3.0, lambda t: "LED" in t),
+    TextClassificationSignal("RLY", 3.0, lambda t: "RELAY" in t),
+    TextClassificationSignal("IND", 3.0, lambda t: "INDUCTOR" in t),
+    TextClassificationSignal("IND", 3.0, lambda t: "FERRITE" in t),
+    TextClassificationSignal("OSC", 3.0, lambda t: "CRYSTAL" in t),
+    TextClassificationSignal("OSC", 3.0, lambda t: "OSCILLATOR" in t),
+    TextClassificationSignal("OSC", 3.0, lambda t: "XTAL" in t),
+    TextClassificationSignal("FUS", 3.0, lambda t: "FUSE" in t),
+    TextClassificationSignal("CON", 3.0, lambda t: "CONNECTOR" in t),
+    TextClassificationSignal("DIO", 3.0, lambda t: "DIODE" in t),
+    TextClassificationSignal("RES", 3.0, lambda t: "RESISTOR" in t),
+    TextClassificationSignal("CAP", 3.0, lambda t: "CAPACITOR" in t),
+    TextClassificationSignal("Q", 3.0, lambda t: "TRANSISTOR" in t),
+    TextClassificationSignal("SWI", 3.0, lambda t: "SWITCH" in t),
+    TextClassificationSignal("REG", 3.0, lambda t: "REGULATOR" in t),
+]
+
+
 def _is_ic_footprint(footprint_upper: str) -> bool:
     """Return True if the footprint indicates an integrated circuit."""
 
@@ -189,7 +235,11 @@ _SIGNALS: list[ClassificationSignal] = [
 
 
 def _classify_by_score(
-    component_upper: str, footprint_upper: str, ref_upper: str
+    component_upper: str,
+    footprint_upper: str,
+    ref_upper: str,
+    description_upper: str = "",
+    keywords_upper: str = "",
 ) -> Optional[str]:
     """Score all active signals and return the highest-scoring category.
 
@@ -197,6 +247,8 @@ def _classify_by_score(
         component_upper: Uppercased component name (lib_id part after ``:``)
         footprint_upper: Uppercased KiCad footprint string.
         ref_upper: Uppercased reference designator (e.g. ``"R1"``, ``"U3"``).
+        description_upper: Uppercased KiCad Description property (optional).
+        keywords_upper: Uppercased KiCad Keywords property (optional).
 
     Returns:
         The winning category string, or ``None`` if no signals matched.
@@ -206,6 +258,19 @@ def _classify_by_score(
     for signal in _SIGNALS:
         if signal.match(component_upper, footprint_upper, ref_upper):
             scores[signal.category] = scores.get(signal.category, 0.0) + signal.weight
+
+    # Description + Keywords fallback: activated only when the primary signals
+    # (name / footprint / reference) yield no winner.  This prevents description
+    # text from additively inflating scores for components already classified by
+    # more authoritative signals.
+    if not scores:
+        extra_text = f"{description_upper} {keywords_upper}".strip()
+        if extra_text:
+            for text_signal in _TEXT_SIGNALS:
+                if text_signal.match(extra_text):
+                    scores[text_signal.category] = (
+                        scores.get(text_signal.category, 0.0) + text_signal.weight
+                    )
 
     if not scores:
         _logger.debug(
@@ -232,7 +297,12 @@ class ComponentClassifier(Protocol):
     """Classify a schematic component into a standardized component type."""
 
     def classify(
-        self, lib_id: str, footprint: str = "", reference: str = ""
+        self,
+        lib_id: str,
+        footprint: str = "",
+        reference: str = "",
+        description: str = "",
+        keywords: str = "",
     ) -> Optional[str]:
         """Return a standardized component type (e.g., "RES", "CAP") or None."""
 
@@ -250,12 +320,21 @@ class HeuristicComponentClassifier:
     """
 
     def classify(
-        self, lib_id: str, footprint: str = "", reference: str = ""
+        self,
+        lib_id: str,
+        footprint: str = "",
+        reference: str = "",
+        description: str = "",
+        keywords: str = "",
     ) -> Optional[str]:
         """Classify a component by scoring weighted signals."""
 
         return _get_component_type_heuristic(
-            lib_id=lib_id, footprint=footprint, reference=reference
+            lib_id=lib_id,
+            footprint=footprint,
+            reference=reference,
+            description=description,
+            keywords=keywords,
         )
 
 
@@ -306,6 +385,8 @@ def get_component_type(
     footprint: str = "",
     reference: str = "",
     *,
+    description: str = "",
+    keywords: str = "",
     classifier: ComponentClassifier = DEFAULT_COMPONENT_CLASSIFIER,
 ) -> Optional[str]:
     """Determine component type from library ID, footprint, and reference designator.
@@ -315,6 +396,10 @@ def get_component_type(
         footprint: KiCad footprint name.
         reference: KiCad reference designator (e.g., "R1", "U3", "J2").
             When provided, IPC reference designator prefix signals are active.
+        description: KiCad component Description property (optional).  Used as
+            a supplementary scored signal when primary signals yield no winner.
+        keywords: KiCad component Keywords property (optional).  Same role as
+            *description*.
         classifier: The classifier to use.
 
     Returns:
@@ -326,11 +411,15 @@ def get_component_type(
     if not lib_id:
         return None
 
-    return classifier.classify(lib_id, footprint, reference)
+    return classifier.classify(lib_id, footprint, reference, description, keywords)
 
 
 def _get_component_type_heuristic(
-    lib_id: str, footprint: str = "", reference: str = ""
+    lib_id: str,
+    footprint: str = "",
+    reference: str = "",
+    description: str = "",
+    keywords: str = "",
 ) -> Optional[str]:
     """Scoring-based implementation of component type detection.
 
@@ -351,6 +440,8 @@ def _get_component_type_heuristic(
     component_upper = component_part.upper()
     footprint_upper = footprint.upper() if footprint else ""
     ref_upper = reference.upper() if reference else ""
+    description_upper = description.upper() if description else ""
+    keywords_upper = keywords.upper() if keywords else ""
 
     # Fast path: exact name lookup beats any heuristic.
     if component_upper in COMPONENT_TYPE_MAPPING:
@@ -364,4 +455,6 @@ def _get_component_type_heuristic(
         )
         return result
 
-    return _classify_by_score(component_upper, footprint_upper, ref_upper)
+    return _classify_by_score(
+        component_upper, footprint_upper, ref_upper, description_upper, keywords_upper
+    )

--- a/src/jbom/common/component_utils.py
+++ b/src/jbom/common/component_utils.py
@@ -34,7 +34,12 @@ def derive_package_from_footprint(footprint: str) -> str:
 
 
 def get_component_type(
-    lib_id: str, footprint: str = "", reference: str = ""
+    lib_id: str,
+    footprint: str = "",
+    reference: str = "",
+    *,
+    description: str = "",
+    keywords: str = "",
 ) -> Optional[str]:
     """Determine component type from library ID, footprint, and reference designator.
 
@@ -42,9 +47,17 @@ def get_component_type(
         lib_id: KiCad library ID (e.g., "Device:R")
         footprint: Component footprint (e.g., "R_0603")
         reference: KiCad reference designator (e.g., "R1", "U3")
+        description: KiCad component Description property (optional).
+        keywords: KiCad component Keywords property (optional).
 
     Returns:
         Component type string or None if unknown
     """
 
-    return _get_component_type(lib_id=lib_id, footprint=footprint, reference=reference)
+    return _get_component_type(
+        lib_id=lib_id,
+        footprint=footprint,
+        reference=reference,
+        description=description,
+        keywords=keywords,
+    )

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -30,22 +30,80 @@ class ProjectInventoryGenerator:
         self.inventory: List[InventoryItem] = []
         self.inventory_fields: Set[str] = set()
 
+    def _classify_all_components(self) -> Dict[int, Optional[str]]:
+        """Phase 0+1: classify every component using all available signal sources.
+
+        Returns a mapping of ``id(component)`` → category token (e.g. "LED",
+        "RES") or ``None`` when the component cannot be classified.
+        """
+        result: Dict[int, Optional[str]] = {}
+        for comp in self.components:
+            props = comp.properties or {}
+            cat = get_component_type(
+                comp.lib_id,
+                comp.footprint,
+                comp.reference,
+                description=props.get("Description", ""),
+                keywords=props.get("Keywords", ""),
+            )  # None when no signals match
+            result[id(comp)] = cat
+        return result
+
+    def _propagate_categories_by_value(
+        self, comp_categories: Dict[int, Optional[str]]
+    ) -> Dict[int, Optional[str]]:
+        """Phase 2: propagate category to unclassified components via value consensus.
+
+        Builds a ``value -> set[category]`` map from already-classified
+        components.  For each still-unclassified component whose ``value``
+        maps to exactly one category, adopt that category.  Ambiguous values
+        (two or more distinct categories) are left unresolved.
+        """
+        # Build value → set of categories (ignoring unclassified)
+        value_categories: Dict[str, set] = {}
+        for comp in self.components:
+            cat = comp_categories[id(comp)]
+            if cat is None:
+                continue
+            val = (comp.value or "").strip()
+            if val:
+                value_categories.setdefault(val, set()).add(cat)
+
+        result: Dict[int, Optional[str]] = dict(comp_categories)
+        for comp in self.components:
+            if result[id(comp)] is not None:
+                continue  # already classified
+            val = (comp.value or "").strip()
+            cats = value_categories.get(val, set())
+            if len(cats) == 1:
+                resolved = next(iter(cats))
+                result[id(comp)] = resolved
+                log.debug(
+                    "category propagated by value: %s %r -> %s",
+                    comp.reference or comp.lib_id,
+                    val,
+                    resolved,
+                )
+        return result
+
     def load(self) -> Tuple[List[InventoryItem], List[str]]:
         """Generate COMPONENT rows from project requirements.
 
         Returns:
             Tuple of (inventory items list, field names list)
         """
+        # Multi-pass classification: Phase 0+1 (signals) then Phase 2 (value consensus).
+        comp_categories = self._propagate_categories_by_value(
+            self._classify_all_components()
+        )
+
         # Group by explicit requirement identity so identical requirements collapse.
         grouped_components: Dict[str, List[Component]] = {}
 
         for comp in self.components:
-            # Skip components not in BOM or DNP if desired?
-            # Usually we want all components to be in inventory even if DNP in this specific project,
-            # but if they are DNP, maybe they aren't "inventory candidates"?
-            # For now, include everything.
-
-            key = self._generate_group_key(comp)
+            key = self._generate_group_key(
+                comp, category_override=comp_categories[id(comp)]
+            )
             if key not in grouped_components:
                 grouped_components[key] = []
             grouped_components[key].append(comp)
@@ -79,7 +137,11 @@ class ProjectInventoryGenerator:
             uuids = [c.uuid for c in comps if c.uuid]
             uuid_str = ",".join(uuids)
 
-            item = self._create_inventory_item(representative, uuid_str)
+            item = self._create_inventory_item(
+                representative,
+                uuid_str,
+                category_override=comp_categories[id(representative)],
+            )
             self.inventory.append(item)
 
             # Add any extra fields found in properties
@@ -126,8 +188,16 @@ class ProjectInventoryGenerator:
             "ki_keywords",
         }
 
+        comp_categories = self._propagate_categories_by_value(
+            self._classify_all_components()
+        )
+
         for component in self.components:
-            item = self._create_inventory_item(component, component.uuid)
+            item = self._create_inventory_item(
+                component,
+                component.uuid,
+                category_override=comp_categories[id(component)],
+            )
             item.raw_data = dict(item.raw_data)
             item.raw_data["Footprint"] = component.footprint
             item.raw_data["Symbol"] = component.lib_id
@@ -150,14 +220,19 @@ class ProjectInventoryGenerator:
         ComponentID string directly.
         """
         if category_override is None:
+            props = component.properties or {}
             category_raw = (
                 get_component_type(
-                    component.lib_id, component.footprint, component.reference
+                    component.lib_id,
+                    component.footprint,
+                    component.reference,
+                    description=props.get("Description", ""),
+                    keywords=props.get("Keywords", ""),
                 )
                 or "UNK"
             )
         else:
-            category_raw = category_override
+            category_raw = category_override or "UNK"
         category = normalize_component_type(category_raw) or "UNK"
         props = component.properties or {}
 
@@ -173,14 +248,27 @@ class ProjectInventoryGenerator:
         )
 
     def _create_inventory_item(
-        self, component: Component, uuid_str: str = ""
+        self,
+        component: Component,
+        uuid_str: str = "",
+        *,
+        category_override: Optional[str] = None,
     ) -> InventoryItem:
         """Create an InventoryItem from a Component."""
 
-        # Determine category
-        comp_type = get_component_type(
-            component.lib_id, component.footprint, component.reference
-        )
+        # Determine category: use pre-computed override when available so the
+        # full multi-pass result is respected; fall back to direct classification.
+        if category_override is not None:
+            comp_type: Optional[str] = category_override if category_override else None
+        else:
+            props_early = component.properties or {}
+            comp_type = get_component_type(
+                component.lib_id,
+                component.footprint,
+                component.reference,
+                description=props_early.get("Description", ""),
+                keywords=props_early.get("Keywords", ""),
+            )
         category = comp_type if comp_type else "Unknown"
 
         # Extract package from footprint

--- a/tests/unit/test_component_classification.py
+++ b/tests/unit/test_component_classification.py
@@ -311,6 +311,66 @@ def test_fuse_category_type_constant() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phase 1 — Description and Keywords as additional classification signal sources
+# (issue #166)
+# ---------------------------------------------------------------------------
+
+
+def test_get_component_type_uses_description_when_name_and_footprint_fail() -> None:
+    """WS2812B: zero signals from name/footprint; Description='RGB LED Neopixel' → LED."""
+    result = get_component_type(
+        lib_id="SPCoast:WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        description="RGB LED Neopixel",
+    )
+    assert result == "LED", f"expected LED from description, got {result!r}"
+
+
+def test_get_component_type_neopixel_in_description_classifies_as_led() -> None:
+    """'Neopixel' keyword in description is a high-confidence LED signal.
+
+    Uses a component name and footprint that fire zero primary signals so the
+    description fallback is the sole signal source.
+    """
+    result = get_component_type(
+        lib_id="Custom:WS2812B",  # zero primary signals: no LED/IC/etc in name or footprint
+        footprint="Custom:5050",
+        description="Neopixel addressable LED",
+    )
+    assert result == "LED", f"expected LED, got {result!r}"
+
+
+def test_get_component_type_uses_keywords_for_relay() -> None:
+    """Unknown part with Keywords='relay SPST' classifies as RLY."""
+    result = get_component_type(
+        lib_id="Custom:XYZ123",
+        footprint="",
+        keywords="relay SPST",
+    )
+    assert result == "RLY", f"expected RLY, got {result!r}"
+
+
+def test_get_component_type_description_does_not_override_strong_primary_signal() -> (
+    None
+):
+    """Primary signals (IC footprint 6.0) still win over a weak LED in description (3.0)."""
+    result = get_component_type(
+        lib_id="Custom:LEDDRIVER",
+        footprint="Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+        description="LED driver IC",
+    )
+    assert (
+        result == "IC"
+    ), f"IC footprint should outweigh description LED hint, got {result!r}"
+
+
+def test_classify_by_score_uses_description_upper_dimension() -> None:
+    """_classify_by_score with description_upper='RGB LED NEOPIXEL' returns LED."""
+    result = _classify_by_score("WS2812B", "", "", description_upper="RGB LED NEOPIXEL")
+    assert result == "LED", f"expected LED, got {result!r}"
+
+
+# ---------------------------------------------------------------------------
 # RefDes precision: prefix+digit constraint prevents false positives
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_project_inventory.py
+++ b/tests/unit/test_project_inventory.py
@@ -1,0 +1,140 @@
+"""Unit tests for ProjectInventoryGenerator multi-pass classification (issue #166)."""
+
+from __future__ import annotations
+
+from jbom.common.types import Component
+from jbom.services.project_inventory import ProjectInventoryGenerator
+
+
+def _comp(
+    lib_id: str,
+    value: str,
+    footprint: str = "",
+    reference: str = "",
+    description: str = "",
+    keywords: str = "",
+) -> Component:
+    props: dict[str, str] = {}
+    if description:
+        props["Description"] = description
+    if keywords:
+        props["Keywords"] = keywords
+    return Component(
+        reference=reference,
+        lib_id=lib_id,
+        value=value,
+        footprint=footprint,
+        uuid="",
+        properties=props,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 integration: description/keywords reach the classifier at harvest time
+# ---------------------------------------------------------------------------
+
+
+def test_load_per_instance_uses_description_to_classify() -> None:
+    """WS2812B with Description='RGB LED Neopixel' in schematic properties → category LED."""
+    comp = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        description="RGB LED Neopixel",
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load_per_instance()
+    assert len(items) == 1
+    assert items[0].category == "LED", f"expected LED, got {items[0].category!r}"
+
+
+def test_load_per_instance_no_description_stays_unknown() -> None:
+    """WS2812B with no Description and no other signals stays Unknown (pre-Phase-2)."""
+    comp = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load_per_instance()
+    # No description, no other signals → still Unknown (Phase 2 has no peer to propagate from)
+    assert items[0].category == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: value-consensus propagation
+# ---------------------------------------------------------------------------
+
+
+def test_load_per_instance_propagates_category_to_descriptionless_sibling() -> None:
+    """WS2812B without Description inherits LED from same-value sibling that has one."""
+    comp_with_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        description="RGB LED Neopixel",
+    )
+    comp_without_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+    )
+    gen = ProjectInventoryGenerator([comp_with_desc, comp_without_desc])
+    items, _ = gen.load_per_instance()
+
+    categories = {item.category for item in items}
+    assert categories == {
+        "LED"
+    }, f"expected all LED after propagation, got {categories}"
+
+
+def test_load_per_instance_does_not_propagate_already_classified_items() -> None:
+    """Classified items keep their category; propagation only fills Unknown slots."""
+    res = _comp("Device:R", "10K", "Resistor_SMD:R_0603_1608Metric", "R1")
+    unknown = _comp("Custom:XYZZY", "SOMETHING_UNIQUE_9999")
+
+    gen = ProjectInventoryGenerator([res, unknown])
+    items, _ = gen.load_per_instance()
+
+    res_item = next(i for i in items if i.value == "10K")
+    unk_item = next(i for i in items if i.value == "SOMETHING_UNIQUE_9999")
+    assert res_item.category == "RES"
+    assert unk_item.category == "Unknown"  # no classified peer → stays Unknown
+
+
+def test_load_per_instance_skips_propagation_when_value_is_ambiguous() -> None:
+    """When a value maps to two distinct categories, Unknown siblings are not promoted."""
+    comp_res = _comp("Device:R", "AMBIG", "Resistor_SMD:R_0603_1608Metric", "R1")
+    comp_cap = _comp("Device:C", "AMBIG", "Capacitor_SMD:C_0603_1608Metric", "C1")
+    comp_unk = _comp("Custom:AMBIG_PART", "AMBIG")
+
+    gen = ProjectInventoryGenerator([comp_res, comp_cap, comp_unk])
+    items, _ = gen.load_per_instance()
+
+    unk_item = next(
+        i for i in items if i.symbol_lib == "Custom" and i.symbol_name == "AMBIG_PART"
+    )
+    assert (
+        unk_item.category == "Unknown"
+    ), f"ambiguous value should not be propagated, got {unk_item.category!r}"
+
+
+def test_load_aggregated_propagates_category_to_unknown_sibling() -> None:
+    """In aggregated load(), value propagation correctly merges Unknown into LED group."""
+    comp_with_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        description="RGB LED Neopixel",
+    )
+    comp_without_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+    )
+    gen = ProjectInventoryGenerator([comp_with_desc, comp_without_desc])
+    items, _ = gen.load()
+
+    # Both components have same value+footprint+category after propagation → one group
+    assert len(items) == 1
+    assert items[0].category == "LED"


### PR DESCRIPTION
## Summary

Fixes #166 — WS2812B RGB LEDs (and similar parts) were classified as `Unknown` and silently excluded from supplier search because all available clues were ignored.

## Two-pass "pachinko" classification pipeline

### Phase 1: Description + Keywords as fallback signals

`get_component_type()` previously only used `lib_id`, `footprint`, and `reference`. For WS2812B:
- Component name `WS2812B` → zero primary signals
- Footprint `WS2812B5050` → zero primary signals
- **`Description = "RGB LED Neopixel"`** → ignored

Now: when primary signals score nothing, a second set of `TextClassificationSignal` entries checks the combined Description + Keywords text. `"LED"` in description fires at weight 3.0; `"NEOPIXEL"` at 4.0. WS2812B Row 1 → `LED`.

Critical design choice: text signals are a **pure fallback** — they only activate when primary signals yield nothing. A component with `SOIC` footprint (IC 6.0) + description `"LED driver IC"` still classifies as `IC`, not `LED`.

### Phase 2: Value-consensus propagation

WS2812B Row 2 has no `Description` property set in KiCad — Phase 1 alone can't help it. But it shares `VALUE=WS2812B` with Row 1.

`ProjectInventoryGenerator` now runs a two-pass pipeline before grouping:
1. `_classify_all_components()` — Phase 0+1 for every component
2. `_propagate_categories_by_value()` — build `value → category` consensus from classified components; apply to unclassified siblings with unambiguous value→category mapping; skip ambiguous values

Row 2 inherits `LED` from Row 1. Both now searchable.

**Bonus**: because propagation happens before `_generate_group_key()`, both rows get `CAT=LED` in their ComponentID and merge into a single aggregated group in `load()` mode.

## Files changed

| File | Change |
|------|--------|
| `component_classification.py` | `TextClassificationSignal`, `_TEXT_SIGNALS`, extended `_classify_by_score()` / `get_component_type()` / protocol |
| `component_utils.py` | Pass-through shim updated |
| `project_inventory.py` | `_classify_all_components()`, `_propagate_categories_by_value()`, pipeline in `load()` + `load_per_instance()` |
| `test_component_classification.py` | 5 new Phase 1 tests |
| `test_project_inventory.py` | New file — 6 Phase 1+2 integration tests |

## Test coverage

- `test_get_component_type_uses_description_when_name_and_footprint_fail` — WS2812B + description → LED
- `test_get_component_type_neopixel_in_description_classifies_as_led` — Neopixel brand name → LED
- `test_get_component_type_uses_keywords_for_relay` — Keywords → RLY
- `test_get_component_type_description_does_not_override_strong_primary_signal` — SOIC + description still → IC
- `test_classify_by_score_uses_description_upper_dimension` — direct scorer API
- `test_load_per_instance_uses_description_to_classify` — Phase 1 integration
- `test_load_per_instance_no_description_stays_unknown` — no false positives
- `test_load_per_instance_propagates_category_to_descriptionless_sibling` — Phase 2 core case
- `test_load_per_instance_does_not_propagate_already_classified_items` — no side effects
- `test_load_per_instance_skips_propagation_when_value_is_ambiguous` — ambiguous safe
- `test_load_aggregated_propagates_category_to_unknown_sibling` — merged into one group

741/741 tests passing.

Co-authored-by: Oz <oz-agent@warp.dev>