### PR TITLE
feat: add verbose progress feedback for supplier search (issue #167)

### DIFF
--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -498,7 +498,10 @@ def _build_inventory_supplier_service(
             api_key=api_key,
             cache=None,  # default DiskSearchCache
         )
-        service = InventorySearchService(provider, request_delay_seconds=0.2)
+        verbose = getattr(args, "verbose", False)
+        service = InventorySearchService(
+            provider, request_delay_seconds=0.2, verbose=verbose
+        )
         return service, supplier_config, supplier_id
     except (ValueError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -36,6 +36,9 @@ class ProjectInventoryGenerator:
         Returns a mapping of ``id(component)`` → category token (e.g. "LED",
         "RES") or ``None`` when the component cannot be classified.
         """
+        log.debug(
+            "[classify] Phase 0+1: classifying %d components", len(self.components)
+        )
         result: Dict[int, Optional[str]] = {}
         for comp in self.components:
             props = comp.properties or {}
@@ -47,6 +50,12 @@ class ProjectInventoryGenerator:
                 keywords=props.get("Keywords", ""),
             )  # None when no signals match
             result[id(comp)] = cat
+        n_classified = sum(1 for v in result.values() if v is not None)
+        log.debug(
+            "[classify] Phase 0+1 complete: %d/%d classified",
+            n_classified,
+            len(self.components),
+        )
         return result
 
     def _propagate_categories_by_value(
@@ -59,6 +68,10 @@ class ProjectInventoryGenerator:
         maps to exactly one category, adopt that category.  Ambiguous values
         (two or more distinct categories) are left unresolved.
         """
+        n_unknown = sum(1 for v in comp_categories.values() if v is None)
+        log.debug(
+            "[classify] Phase 2: value-consensus propagation (%d unknown)", n_unknown
+        )
         # Build value → set of categories (ignoring unclassified)
         value_categories: Dict[str, set] = {}
         for comp in self.components:
@@ -84,6 +97,14 @@ class ProjectInventoryGenerator:
                     val,
                     resolved,
                 )
+        n_promoted = sum(
+            1
+            for cid, v in result.items()
+            if v is not None and comp_categories.get(cid) is None
+        )
+        log.debug(
+            "[classify] Phase 2 complete: %d promoted by value consensus", n_promoted
+        )
         return result
 
     def load(self) -> Tuple[List[InventoryItem], List[str]]:
@@ -92,6 +113,10 @@ class ProjectInventoryGenerator:
         Returns:
             Tuple of (inventory items list, field names list)
         """
+        log.debug(
+            "[load] Starting inventory generation for %d components",
+            len(self.components),
+        )
         # Multi-pass classification: Phase 0+1 (signals) then Phase 2 (value consensus).
         comp_categories = self._propagate_categories_by_value(
             self._classify_all_components()
@@ -157,6 +182,11 @@ class ProjectInventoryGenerator:
             if any(getattr(item, attr) is not None for item in self.inventory):
                 self.inventory_fields.add(field)
 
+        log.debug(
+            "[load] Done: %d unique groups from %d components",
+            len(self.inventory),
+            len(self.components),
+        )
         return self.inventory, sorted(list(self.inventory_fields))
 
     def load_per_instance(self) -> Tuple[List[InventoryItem], List[str]]:
@@ -165,6 +195,9 @@ class ProjectInventoryGenerator:
         Returns:
             Tuple of (inventory items list, field names list)
         """
+        log.debug(
+            "[load_per_instance] Starting for %d components", len(self.components)
+        )
         self.inventory = []
         self.inventory_fields = {
             "RowType",
@@ -207,6 +240,7 @@ class ProjectInventoryGenerator:
             for prop in component.properties.keys():
                 self.inventory_fields.add(prop)
 
+        log.debug("[load_per_instance] Done: %d items", len(self.inventory))
         return self.inventory, sorted(list(self.inventory_fields))
 
     def _generate_group_key(

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -12,6 +12,7 @@ Design goals:
 from __future__ import annotations
 
 import re
+import sys
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -165,11 +166,13 @@ class InventorySearchService:
         candidate_limit: int = 3,
         request_delay_seconds: float = 0.0,
         defaults: DefaultsConfig | None = None,
+        verbose: bool = False,
     ) -> None:
         self._provider = provider
         self._candidate_limit = max(1, int(candidate_limit))
         self._request_delay_seconds = max(0.0, float(request_delay_seconds))
         self._matcher = SophisticatedInventoryMatcher(MatchingOptions())
+        self._verbose = verbose
         # Load defaults once at construction time (injectable for tests / library users).
         self._defaults: DefaultsConfig = (
             defaults if defaults is not None else get_defaults()
@@ -335,7 +338,14 @@ class InventorySearchService:
         mpn_results: dict[str, SearchResult | None] = {}
         mpn_errors: dict[str, str] = {}
 
-        for key, (mfg, mpn, _indices) in mpn_groups.items():
+        n_mpn_groups = len(mpn_groups)
+        for i, (key, (mfg, mpn, _indices)) in enumerate(mpn_groups.items(), 1):
+            if self._verbose:
+                label = f"{mfg} {mpn}".strip() or mpn
+                print(
+                    f"  [MPN lookup {i}/{n_mpn_groups}] {label}",
+                    file=sys.stderr,
+                )
             try:
                 mpn_results[key] = self._provider.lookup_by_mpn(mfg, mpn)
             except Exception as exc:
@@ -414,10 +424,17 @@ class InventorySearchService:
         ranked_by_query: dict[str, list[SearchResult]] = {}
         error_by_query: dict[str, str] = {}
 
-        for key, group in query_groups.items():
+        n_queries = len(query_groups)
+        for i, (key, group) in enumerate(query_groups.items(), 1):
             # Keep the original (non-normalized) query string for the provider call.
             provider_query = group[0][1]
             representative_item = group[0][0]
+
+            if self._verbose:
+                print(
+                    f"  [keyword search {i}/{n_queries}] {provider_query!r}",
+                    file=sys.stderr,
+                )
 
             try:
                 raw_results = self._provider.search_for_item(

--- a/tests/services/search/test_inventory_search_verbose.py
+++ b/tests/services/search/test_inventory_search_verbose.py
@@ -1,0 +1,249 @@
+"""Tests for verbose progress output in InventorySearchService (issue #167)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from jbom.common.types import InventoryItem
+from jbom.config.providers import SearchProviderConfig
+from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.inventory_search_service import InventorySearchService
+from jbom.services.search.models import SearchResult
+from jbom.services.search.provider import SearchProvider
+from jbom.suppliers.lcsc.provider import JlcpcbProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _inv_item(
+    *,
+    ipn: str,
+    category: str = "RES",
+    value: str = "10K",
+    package: str = "0603",
+    manufacturer: str = "",
+    mfgpn: str = "",
+) -> InventoryItem:
+    return InventoryItem(
+        ipn=ipn,
+        keywords="",
+        category=category,
+        description="",
+        smd="",
+        value=value,
+        type="",
+        tolerance="1%",
+        voltage="",
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer=manufacturer,
+        mfgpn=mfgpn,
+        datasheet="",
+        package=package,
+        raw_data={},
+    )
+
+
+def _sr(**kw) -> SearchResult:
+    base = dict(
+        manufacturer="Mfg",
+        mpn="MPN",
+        description="desc",
+        datasheet="",
+        distributor="mouser",
+        distributor_part_number="123",
+        availability="100 In Stock",
+        price="$0.10",
+        details_url="",
+        raw_data={},
+        lifecycle_status="Active",
+        min_order_qty=1,
+        attributes={},
+        stock_quantity=100,
+    )
+    base.update(kw)
+    return SearchResult(**base)
+
+
+# ---------------------------------------------------------------------------
+# verbose=False (default): no progress lines emitted
+# ---------------------------------------------------------------------------
+
+
+def test_no_verbose_output_by_default_keyword_search(capsys) -> None:
+    """With verbose=False (default), keyword search produces no stderr output."""
+    provider = Mock(spec=SearchProvider)
+    provider.search_for_item = Mock(return_value=[_sr()])
+    provider.provider_id = "generic"
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0)
+    svc.search([_inv_item(ipn="R1")])
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_no_verbose_output_by_default_mpn_lookup(capsys, monkeypatch) -> None:
+    """With verbose=False (default), MPN lookup produces no stderr output."""
+    import jbom.suppliers.lcsc.api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+    monkeypatch.setattr(
+        provider,
+        "lookup_by_mpn",
+        Mock(
+            return_value=_sr(
+                distributor_part_number="C100",
+                manufacturer="Yageo",
+                mpn="RC0603FR-0710KL",
+            )
+        ),
+    )
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0)
+    svc.search([_inv_item(ipn="R1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL")])
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# verbose=True: progress lines emitted to stderr
+# ---------------------------------------------------------------------------
+
+
+def test_verbose_keyword_search_prints_query_progress(capsys) -> None:
+    """With verbose=True, each unique query is reported to stderr."""
+    provider = Mock(spec=SearchProvider)
+    provider.search_for_item = Mock(return_value=[_sr()])
+    provider.provider_id = "generic"
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0, verbose=True)
+    items = [
+        _inv_item(ipn="R1", value="10K"),
+        _inv_item(ipn="R2", value="1K"),
+    ]
+    svc.search(items)
+
+    captured = capsys.readouterr()
+    # Two distinct queries → two progress lines
+    assert "[keyword search 1/2]" in captured.err
+    assert "[keyword search 2/2]" in captured.err
+
+
+def test_verbose_keyword_search_dedup_shows_unique_count(capsys) -> None:
+    """Deduplication: 5 identical items → 1 query → progress shows 1/1."""
+    provider = Mock(spec=SearchProvider)
+    provider.search_for_item = Mock(return_value=[_sr()])
+    provider.provider_id = "generic"
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0, verbose=True)
+    items = [_inv_item(ipn=f"R{i}", value="10K") for i in range(5)]
+    svc.search(items)
+
+    captured = capsys.readouterr()
+    assert "[keyword search 1/1]" in captured.err
+    # Should only appear once (deduplicated)
+    assert captured.err.count("[keyword search") == 1
+
+
+def test_verbose_mpn_lookup_prints_progress(capsys, monkeypatch) -> None:
+    """With verbose=True, each MPN lookup is reported to stderr."""
+    import jbom.suppliers.lcsc.api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+    monkeypatch.setattr(
+        provider,
+        "lookup_by_mpn",
+        Mock(
+            return_value=_sr(
+                distributor_part_number="C100",
+                manufacturer="Yageo",
+                mpn="RC0603FR-0710KL",
+            )
+        ),
+    )
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0, verbose=True)
+    svc.search([_inv_item(ipn="R1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL")])
+
+    captured = capsys.readouterr()
+    assert "[MPN lookup 1/1]" in captured.err
+    assert "Yageo" in captured.err
+    assert "RC0603FR-0710KL" in captured.err
+
+
+def test_verbose_mpn_lookup_dedup_shows_unique_count(capsys, monkeypatch) -> None:
+    """Two items with the same MPN → one lookup → progress shows 1/1."""
+    import jbom.suppliers.lcsc.api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+    monkeypatch.setattr(
+        provider,
+        "lookup_by_mpn",
+        Mock(
+            return_value=_sr(
+                distributor_part_number="C100",
+                manufacturer="Yageo",
+                mpn="RC0603FR-0710KL",
+            )
+        ),
+    )
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0, verbose=True)
+    items = [
+        _inv_item(ipn="R1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL"),
+        _inv_item(ipn="R2", manufacturer="Yageo", mfgpn="RC0603FR-0710KL"),
+    ]
+    svc.search(items)
+
+    captured = capsys.readouterr()
+    # Deduplicated: only 1 MPN lookup
+    assert "[MPN lookup 1/1]" in captured.err
+    assert captured.err.count("[MPN lookup") == 1
+
+
+def test_verbose_mixed_mpn_and_keyword_search(capsys, monkeypatch) -> None:
+    """Items with MPN use lookup path; items without use keyword path; both report progress."""
+    import jbom.suppliers.lcsc.api as api_mod
+
+    monkeypatch.setattr(api_mod, "requests", Mock())
+    cache = InMemorySearchCache()
+    cfg = SearchProviderConfig(type="jlcpcb_api", extra={"rate_limit_seconds": 0})
+    provider = JlcpcbProvider.from_config(cfg, cache=cache)
+    monkeypatch.setattr(
+        provider,
+        "lookup_by_mpn",
+        Mock(
+            return_value=_sr(
+                distributor_part_number="C100",
+                manufacturer="Yageo",
+                mpn="RC0603FR-0710KL",
+            )
+        ),
+    )
+    monkeypatch.setattr(provider, "search_for_item", Mock(return_value=[_sr()]))
+
+    svc = InventorySearchService(provider, request_delay_seconds=0.0, verbose=True)
+    items = [
+        _inv_item(ipn="R1", manufacturer="Yageo", mfgpn="RC0603FR-0710KL"),
+        _inv_item(ipn="R2", value="1K"),
+    ]
+    svc.search(items)
+
+    captured = capsys.readouterr()
+    assert "[MPN lookup 1/1]" in captured.err
+    assert "[keyword search 1/1]" in captured.err


### PR DESCRIPTION
## Summary

Closes #167

Adds R&D-level progress visibility when `jbom inventory -v --supplier <id>` is running. Previously, long-running supplier API searches gave no feedback, making it hard to tell whether the process was stuck or just slow.

## Changes

### `src/jbom/services/search/inventory_search_service.py`
- Added `verbose: bool = False` parameter to `__init__`; stored as `self._verbose`
- MPN-lookup phase: prints `[MPN lookup i/N] <manufacturer> <mpn>` to stderr before each API call (dedup count reflects unique lookups, not total items)
- Keyword-search phase: prints `[keyword search i/N] '<query>'` to stderr before each API call (again, deduplicated count)

### `src/jbom/cli/inventory.py`
- `_build_inventory_supplier_service()`: threads `--verbose` flag through to `InventorySearchService(verbose=verbose)`

### `src/jbom/services/project_inventory.py`
- Added `log.debug()` markers at phase boundaries in `_classify_all_components()`, `_propagate_categories_by_value()`, `load()`, and `load_per_instance()` — visible when Python logging is configured at DEBUG level

### `tests/services/search/test_inventory_search_verbose.py` (new)
- 7 tests covering `verbose=False` (no stderr output) and `verbose=True` for both MPN lookup and keyword search paths, including deduplication count verification

## Example output with `-v --supplier lcsc`

```
Enriching 12 item(s) with supplier PN ('lcsc')...
  [MPN lookup 1/3] Yageo RC0603FR-0710KL
  [MPN lookup 2/3] Murata GRM188R71H104KA93D
  [MPN lookup 3/3] TI LM358DR
  [keyword search 1/7] '10K resistor 0603 1%'
  [keyword search 2/7] '100nF capacitor 0603 10%'
  ...
```

## Test results

748/748 tests pass.

Co-Authored-By: Oz <oz-agent@warp.dev>