### PR TITLE
fix: LED-prefix ref signal and ComponentID category consistency

### DIFF
--- a/src/jbom/common/component_classification.py
+++ b/src/jbom/common/component_classification.py
@@ -205,6 +205,9 @@ _SIGNALS: list[ClassificationSignal] = [
     ClassificationSignal(
         "CON", 5.0, lambda n, f, r: r[:3] == "CON" and r[3:4].isdigit()
     ),
+    ClassificationSignal(
+        "LED", 4.0, lambda n, f, r: r[:3] == "LED" and r[3:4].isdigit()
+    ),
     ClassificationSignal("CON", 5.0, lambda n, f, r: r[:1] == "J" and r[1:2].isdigit()),
     ClassificationSignal(
         "IND", 6.0, lambda n, f, r: r[:2] == "FB" and r[2:3].isdigit()

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -328,9 +328,19 @@ class ProjectInventoryGenerator:
         # jBOM has no knowledge of IPN structure or naming conventions.
         # Leave blank so the user can assign their own IPNs.
         ipn = props.get("IPN", "")
+        # Use the multi-pass category_override when available so the ComponentID
+        # reflects the same category that was used to group this component.
+        # category_was_promoted is only True for typed-parametric RES/CAP/IND
+        # promotion; for LED and other categories promoted by Phase 2 value
+        # consensus, category_override carries the correct answer.
+        id_category = (
+            category_override
+            if category_override is not None
+            else (category if category_was_promoted else None)
+        )
         component_id = self._generate_group_key(
             component,
-            category_override=category if category_was_promoted else None,
+            category_override=id_category,
         )
         # Parse KiCad lib_id (always NICKNAME:ENTRY_NAME for valid components)
         lib_id_parts = component.lib_id.split(":", 1)

--- a/tests/unit/test_component_classification.py
+++ b/tests/unit/test_component_classification.py
@@ -434,3 +434,40 @@ def test_l_refdes_beats_ne_in_generic_lib_id() -> None:
     assert (
         result == "IND"
     ), f"Device:Generic + L1 should classify as IND (not IC), got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# LED-prefix reference designator (issue follow-up to #166)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["LED1", "LED2", "LED10", "LED20", "LED32"],
+)
+def test_led_prefix_ref_classifies_as_led(reference: str) -> None:
+    """LED* reference designators (e.g. LED1, LED20) must classify as LED.
+
+    Components like WS2812B5050 using 'LED' prefix refs had zero primary signals,
+    leaving them all unclassified and blocking Phase 2 value-consensus propagation.
+    """
+    result = get_component_type(
+        lib_id="SPCoast:WS2812B5050",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference=reference,
+    )
+    assert (
+        result == "LED"
+    ), f"reference={reference!r} should classify as LED, got {result!r}"
+
+
+def test_led_prefix_ref_does_not_fire_on_led_without_digit() -> None:
+    """'LED' alone (no trailing digit) must not fire the LED ref signal."""
+    # No digit after 'LED' → signal does not fire; other signals (LED in name) still win.
+    result = get_component_type(
+        lib_id="Device:LED",
+        footprint="LED_SMD:LED_0603_1608Metric",
+        reference="LED",
+    )
+    # Device:LED has LED in name (3.0) + LED in footprint (4.0) → LED wins regardless
+    assert result == "LED"

--- a/tests/unit/test_project_inventory.py
+++ b/tests/unit/test_project_inventory.py
@@ -138,3 +138,74 @@ def test_load_aggregated_propagates_category_to_unknown_sibling() -> None:
     # Both components have same value+footprint+category after propagation → one group
     assert len(items) == 1
     assert items[0].category == "LED"
+
+
+# ---------------------------------------------------------------------------
+# LED-prefix reference signal (follow-up to #166)
+# ---------------------------------------------------------------------------
+
+
+def test_led_ref_prefix_classifies_ws2812b_with_no_description() -> None:
+    """WS2812B5050 with 'LED1' reference and no description classifies as LED via ref signal."""
+    comp = _comp(
+        lib_id="SPCoast:WS2812B5050",
+        value="WS2812B5050",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED1",
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load_per_instance()
+    assert (
+        items[0].category == "LED"
+    ), f"expected LED via LED-ref, got {items[0].category!r}"
+
+
+def test_led_ref_prefix_component_id_matches_category() -> None:
+    """ComponentID must reflect the classified LED category, not 'UNK'.
+
+    Regression for the bug where _create_inventory_item() re-derived the
+    ComponentID from scratch (ignoring the multi-pass category_override),
+    producing CAT=UNK even when the category field was correctly LED.
+    """
+    comp = _comp(
+        lib_id="SPCoast:WS2812B5050",
+        value="WS2812B5050",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED1",
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load_per_instance()
+    assert items[0].category == "LED"
+    assert (
+        "CAT=LED" in items[0].component_id
+    ), f"ComponentID should contain CAT=LED, got {items[0].component_id!r}"
+    assert "CAT=UNK" not in items[0].component_id
+
+
+def test_phase2_propagated_category_reflected_in_component_id() -> None:
+    """ComponentID reflects Phase-2-propagated category, not the re-derived UNK.
+
+    When Phase 2 value-consensus promotes a component from Unknown to LED,
+    the ComponentID must show CAT=LED to match the category field and the
+    grouping key used in load().
+    """
+    comp_with_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        description="RGB LED Neopixel",
+    )
+    comp_without_desc = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+    )
+    gen = ProjectInventoryGenerator([comp_with_desc, comp_without_desc])
+    items, _ = gen.load_per_instance()
+
+    for item in items:
+        assert item.category == "LED"
+        assert "CAT=LED" in item.component_id, (
+            f"component_id should contain CAT=LED after Phase-2 propagation, "
+            f"got {item.component_id!r}"
+        )


### PR DESCRIPTION
## Root cause (found via debug tracing)

Two bugs, both visible in the `WS2812B5050` / `LED1`-ref case:

### Bug 1 — Missing `LED`-prefix reference designator signal

Components with `LED1`, `LED2`, `LED32`... reference designators fired **zero** primary signals in Phase 1. No description → no text signal fallback either. Result: `value→cat map: {}` in Phase 2, so value-consensus propagation had no seed and all WS2812B components remained `Unknown`.

Fix: added `ClassificationSignal("LED", 4.0, lambda n, f, r: r[:3] == "LED" and r[3:4].isdigit())` to `_SIGNALS`, mirroring the existing `CON`-prefix signal at the same weight tier.

### Bug 2 — ComponentID regeneration ignored the multi-pass category override

`_create_inventory_item()` called `_generate_group_key(..., category_override=None)` unless `category_was_promoted` was `True`. But `category_was_promoted` is only `True` for typed-parametric RES/CAP/IND promotion — never for LED or any Phase-2-promoted category. This re-derived the ComponentID from scratch, producing `CAT=UNK` even when `category='LED'`.

Fix: when `category_override is not None` (i.e. the multi-pass pipeline supplied a category), use it directly for the ComponentID; only fall through to `category_was_promoted` for the typed-parametric RES/CAP/IND case.

## Tests: 757/757 pass (9 new)

Co-Authored-By: Oz <oz-agent@warp.dev>