### PR TITLE
feat: configurable ComponentID fields per category (issue #171)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- **Configurable ComponentID fields per category** (issue #171): optional fields in
+  a ComponentID (tolerance, voltage, current, wattage, type) are now controlled by a
+  per-category allowlist in `generic.defaults.yaml` under `component_id_fields`.  For
+  example, LED ComponentIDs no longer include `V=`/`A=`/`W=` — so two WS2812B
+  components where one schematic annotated `Voltage=5V` and the other did not are now
+  correctly treated as the same requirement.  Unlisted categories retain the previous
+  behavior (all non-empty optional fields included).  The table is overridable per
+  project via a `.jbom/generic.defaults.yaml` override without code changes.
+- **`OPTIONAL_ID_FIELD_DEFS` / `KNOWN_OPTIONAL_FIELD_NAMES`** in
+  `common/component_id.py`: single DRY authority mapping YAML profile names →
+  ComponentID keys → `make_component_id` parameter names.  Extending to a new field
+  (e.g. wavelength) requires one entry here plus a new `make_component_id` parameter.
+
+### Changed
+- `ProjectInventoryGenerator` accepts an optional `cwd: Path | None = None` kwarg;
+  the generic defaults profile is loaded lazily from the project directory's
+  `.jbom/` search path (no config injection required).
+
+### Migration note
+- **Stored ComponentIDs may change** for `led`, `cap`, `ind`, and `res` components
+  that previously had partial optional-field annotations in the schematic.  Re-run
+  `jbom inventory` to regenerate current IDs.
+
+### Added
 - **Catalog-driven supplier assignment** (issue #117): `NullSearchProvider` (`null_api` type) added as the built-in fixture-driven provider always available without credentials. `generic.supplier.yaml` wired with `null_api` as its search provider.
 - **Inventory freshness audit** (issue #117): `jbom audit inventory.csv --supplier NAME` checks each `ITEM` row's supplier PN against a fresh catalog search. Emits `STALE_PART / WARN` when the existing PN is no longer findable; `BETTER_AVAILABLE / WARN` when a different PN ranks higher than the recorded one; silent when the existing PN matches the best result.
 - **`jbom inventory --supplier NAME`** (issue #117): auto-populates `Supplier` and `SPN` columns when generating an inventory from a schematic. Rows that already have a supplier PN are preserved; new rows get the top search result filled in.

--- a/src/jbom/common/component_id.py
+++ b/src/jbom/common/component_id.py
@@ -30,11 +30,50 @@ Callers must never construct a ComponentID string directly.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from jbom.common.value_parsing import canonical_value as _canonical_value_fn
 
 _TILDE = "~"
 _VERSION = (
     1  # Bump when encoding rules change; existing IDs with other versions are stale.
+)
+
+
+@dataclass(frozen=True)
+class _OptionalIdFieldDef:
+    """Mapping between the three representations of one optional ComponentID field.
+
+    Attributes:
+        profile_name:     Name used in the defaults YAML config (e.g. ``"voltage"``).
+        component_id_key: Encoded key in the ComponentID string (e.g. ``"V"``).
+        param_name:       Keyword argument name in ``make_component_id()`` (e.g.
+                          ``"voltage"``).
+
+    Adding a new encodable field requires exactly one new entry in
+    ``OPTIONAL_ID_FIELD_DEFS`` plus a matching parameter in ``make_component_id``.
+    """
+
+    profile_name: str
+    component_id_key: str
+    param_name: str
+
+
+# ---------------------------------------------------------------------------
+# Canonical definition of every optional ComponentID field.
+# This is the single source of truth — do not repeat these names elsewhere.
+# ---------------------------------------------------------------------------
+OPTIONAL_ID_FIELD_DEFS: tuple[_OptionalIdFieldDef, ...] = (
+    _OptionalIdFieldDef("tolerance", "TOL", "tolerance"),
+    _OptionalIdFieldDef("voltage", "V", "voltage"),
+    _OptionalIdFieldDef("current", "A", "amperage"),
+    _OptionalIdFieldDef("wattage", "W", "wattage"),
+    _OptionalIdFieldDef("type", "TYPE", "component_type"),
+)
+
+# Derived convenience set of all valid profile_names — used for validation.
+KNOWN_OPTIONAL_FIELD_NAMES: frozenset[str] = frozenset(
+    d.profile_name for d in OPTIONAL_ID_FIELD_DEFS
 )
 
 # Keys used in a ComponentID, in alphabetical order (for documentation).
@@ -143,3 +182,14 @@ def make_component_id(
 
     parts = [f"{k}={v}" for k, v in sorted(fields.items()) if v or k == "CAT"]
     return "|".join([str(_VERSION)] + parts)
+
+
+__all__ = [
+    "OPTIONAL_ID_FIELD_DEFS",
+    "KNOWN_OPTIONAL_FIELD_NAMES",
+    "COLUMN_NORMALISE",
+    "COMPONENT_ROW_COLUMNS",
+    "is_current_version",
+    "is_null_value",
+    "make_component_id",
+]

--- a/src/jbom/config/defaults.py
+++ b/src/jbom/config/defaults.py
@@ -9,6 +9,7 @@ The defaults profile captures:
   - parametric_query_fields: JLCPCB/LCSC spec fields per category (Phase 4)
   - category_route_rules: JLCPCB taxonomy routing (Phase 4)
   - enrichment_attributes: Camp 2/3 attribute classification per category (#99)
+  - component_id_fields: optional ComponentID fields included per category
 
 See docs/dev/architecture/component-attribute-enrichment.md for the design model.
 """
@@ -22,6 +23,7 @@ from typing import Any
 
 import yaml
 
+from jbom.common.component_id import KNOWN_OPTIONAL_FIELD_NAMES
 from jbom.config.profile_search import find_profile
 
 log = logging.getLogger(__name__)
@@ -64,6 +66,7 @@ class DefaultsConfig:
     )
     field_synonyms: dict[str, FieldSynonymConfig] = field(default_factory=dict)
     search_excluded_categories: frozenset[str] = field(default_factory=frozenset)
+    component_id_fields: dict[str, frozenset[str]] = field(default_factory=dict)
 
     @staticmethod
     def from_yaml_dict(data: dict[str, Any], *, name: str) -> "DefaultsConfig":
@@ -137,6 +140,25 @@ class DefaultsConfig:
             str(c).upper().strip() for c in raw_excluded if str(c).strip()
         )
 
+        component_id_fields: dict[str, frozenset[str]] = {}
+        for category, fields_list in (data.get("component_id_fields") or {}).items():
+            if not isinstance(fields_list, list):
+                continue
+            validated: list[str] = []
+            for fname in fields_list:
+                fname_str = str(fname).strip().lower()
+                if fname_str in KNOWN_OPTIONAL_FIELD_NAMES:
+                    validated.append(fname_str)
+                else:
+                    log.warning(
+                        "component_id_fields[%r]: unknown field name %r "
+                        "(valid names: %s)",
+                        category,
+                        fname_str,
+                        ", ".join(sorted(KNOWN_OPTIONAL_FIELD_NAMES)),
+                    )
+            component_id_fields[str(category).lower()] = frozenset(validated)
+
         return DefaultsConfig(
             name=name,
             domain_defaults=domain_defaults,
@@ -147,6 +169,7 @@ class DefaultsConfig:
             enrichment_attributes=enrichment_attributes,
             field_synonyms=field_synonyms,
             search_excluded_categories=search_excluded_categories,
+            component_id_fields=component_id_fields,
         )
 
     def get_domain_default(
@@ -186,6 +209,23 @@ class DefaultsConfig:
         """Return the set of component categories excluded from supplier search."""
 
         return self.search_excluded_categories
+
+    def get_component_id_fields(self, category: str) -> frozenset[str] | None:
+        """Return the optional-field allowlist for *category*, or ``None``.
+
+        ``None`` means the category is not configured — the caller should fall
+        back to including all optional fields (conservative / backward-compatible).
+
+        Args:
+            category: Component category token, any case (e.g. ``"LED"``,
+                ``"res"``, ``"Cap"``).
+
+        Returns:
+            A ``frozenset`` of ``profile_name`` strings (e.g.
+            ``frozenset({"type"})``) when the category is explicitly configured,
+            or ``None`` when it is not.
+        """
+        return self.component_id_fields.get(category.lower())
 
 
 def load_defaults(name: str, *, cwd: Path | None = None) -> DefaultsConfig:

--- a/src/jbom/config/defaults/generic.defaults.yaml
+++ b/src/jbom/config/defaults/generic.defaults.yaml
@@ -48,6 +48,42 @@ package_voltage:
   "1206": "50V"
 
 # ---------------------------------------------------------------------------
+# Optional fields to include in the ComponentID hash per component category.
+#
+# CAT, VAL, and PKG are always present in every ComponentID.
+# The fields listed here are the OPTIONAL fields that contribute to identity.
+#
+# Categories NOT listed here fall back to including ALL optional fields
+# (conservative: no information is dropped for unrecognised categories).
+#
+# Available field names (see OPTIONAL_ID_FIELD_DEFS in common/component_id.py):
+#   tolerance  — Tolerance (TOL= in ComponentID)
+#   voltage    — Voltage rating (V= in ComponentID)
+#   current    — Current / Amperage rating (A= in ComponentID)
+#   wattage    — Power / Wattage rating (W= in ComponentID)
+#   type       — Component Type property (TYPE= in ComponentID)
+#
+# To extend: add a new _OptionalIdFieldDef entry in component_id.py first.
+# ---------------------------------------------------------------------------
+component_id_fields:
+  res:
+    - tolerance
+    - voltage    # derating spec
+    - wattage
+    - type
+  cap:
+    - tolerance
+    - voltage    # critical voltage rating
+    - type
+  ind:
+    - tolerance
+    - current    # saturation current
+    - type
+  led:
+    - type       # color / wavelength (encoded in Type field)
+                 # voltage/current/wattage omitted: part number is the identity
+
+# ---------------------------------------------------------------------------
 # Parametric spec fields to include in JLCPCB/LCSC search queries per category.
 # List order reflects preference for query construction.
 # ---------------------------------------------------------------------------

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -1,11 +1,13 @@
 """Loader for generating inventory from KiCad project components."""
 
 import logging
+from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 from jbom.common.component_classification import normalize_component_type
-from jbom.common.component_id import make_component_id
+from jbom.common.component_id import make_component_id, OPTIONAL_ID_FIELD_DEFS
 from jbom.common.types import Component, InventoryItem, DEFAULT_PRIORITY
+from jbom.config.defaults import DefaultsConfig, get_defaults
 from jbom.common.component_utils import (
     derive_package_from_footprint,
     get_component_type,
@@ -24,11 +26,31 @@ log = logging.getLogger(__name__)
 class ProjectInventoryGenerator:
     """Generates inventory items from project components."""
 
-    def __init__(self, components: List[Component]):
-        """Initialize with list of components from schematic."""
+    def __init__(
+        self,
+        components: List[Component],
+        *,
+        cwd: Optional[Path] = None,
+    ):
+        """Initialize with list of components from schematic.
+
+        Args:
+            components: Components loaded from a KiCad schematic.
+            cwd: Working directory for project-local profile search.  When
+                 ``None``, the built-in generic profile is used.  Pass the
+                 project directory to pick up any ``.jbom/`` overrides.
+        """
         self.components = components
+        self._cwd = cwd
+        self._defaults: Optional[DefaultsConfig] = None
         self.inventory: List[InventoryItem] = []
         self.inventory_fields: Set[str] = set()
+
+    def _get_defaults(self) -> DefaultsConfig:
+        """Return the loaded defaults profile, loading lazily on first call."""
+        if self._defaults is None:
+            self._defaults = get_defaults("generic", cwd=self._cwd)
+        return self._defaults
 
     def _classify_all_components(self) -> Dict[int, Optional[str]]:
         """Phase 0+1: classify every component using all available signal sources.
@@ -252,6 +274,12 @@ class ProjectInventoryGenerator:
 
         Always delegates to ``make_component_id`` — never constructs the
         ComponentID string directly.
+
+        Optional fields (tolerance, voltage, current, wattage, type) are
+        filtered by the per-category allowlist from the defaults profile.  When
+        a category is not explicitly listed in the profile the full set of
+        non-empty optional fields is included (conservative / backward-
+        compatible).
         """
         if category_override is None:
             props = component.properties or {}
@@ -270,15 +298,34 @@ class ProjectInventoryGenerator:
         category = normalize_component_type(category_raw) or "UNK"
         props = component.properties or {}
 
+        # Raw values for each optional field, keyed by profile_name.
+        _raw: Dict[str, str] = {
+            "tolerance": props.get(CommonFields.TOLERANCE, props.get("Tolerance", "")),
+            "voltage": props.get(CommonFields.VOLTAGE, props.get("Voltage", "")),
+            "current": props.get(CommonFields.AMPERAGE, props.get("Amperage", "")),
+            "wattage": props.get(CommonFields.WATTAGE, props.get("Wattage", "")),
+            "type": props.get("Type", ""),
+        }
+
+        # Per-category allowlist: None means "unlisted — include all fields".
+        allowed = self._get_defaults().get_component_id_fields(category)
+
+        kwargs: Dict[str, str] = {}
+        for field_def in OPTIONAL_ID_FIELD_DEFS:
+            raw_val = _raw[field_def.profile_name]
+            # Pass the real value when allowed (or when no restriction exists),
+            # empty string otherwise — make_component_id omits empty fields.
+            kwargs[field_def.param_name] = (
+                raw_val
+                if (allowed is None or field_def.profile_name in allowed)
+                else ""
+            )
+
         return make_component_id(
             category=category,
             value=component.value or "",
             package=self._extract_package(component.footprint),
-            tolerance=props.get(CommonFields.TOLERANCE, props.get("Tolerance", "")),
-            voltage=props.get(CommonFields.VOLTAGE, props.get("Voltage", "")),
-            amperage=props.get(CommonFields.AMPERAGE, props.get("Amperage", "")),
-            wattage=props.get(CommonFields.WATTAGE, props.get("Wattage", "")),
-            component_type=props.get("Type", ""),
+            **kwargs,
         )
 
     def _create_inventory_item(

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -8,6 +8,7 @@ Covers:
 - from_yaml_dict: all sections parsed correctly
 - Helper methods: get_domain_default, get_package_power, get_package_voltage, etc.
 - _deep_merge semantics
+- component_id_fields: parsing, get_component_id_fields(), validation
 """
 
 from __future__ import annotations
@@ -257,3 +258,121 @@ def test_from_yaml_dict_parses_field_synonyms() -> None:
     assert voltage is not None
     assert voltage.display_name == "Voltage"
     assert voltage.synonyms == ("Voltage", "V")
+
+
+# ---------------------------------------------------------------------------
+# component_id_fields: parsing and get_component_id_fields()
+# ---------------------------------------------------------------------------
+
+
+def test_generic_profile_has_component_id_fields_for_led() -> None:
+    """The built-in generic profile restricts LED ComponentIDs to 'type' only."""
+    cfg = load_defaults("generic")
+    allowed = cfg.get_component_id_fields("led")
+    assert allowed is not None
+    assert "type" in allowed
+    assert "voltage" not in allowed
+    assert "current" not in allowed
+    assert "wattage" not in allowed
+
+
+def test_generic_profile_has_component_id_fields_for_res() -> None:
+    """The built-in generic profile includes tolerance/voltage/wattage for RES."""
+    cfg = load_defaults("generic")
+    allowed = cfg.get_component_id_fields("res")
+    assert allowed is not None
+    assert "tolerance" in allowed
+    assert "voltage" in allowed
+    assert "wattage" in allowed
+    assert "current" not in allowed
+
+
+def test_generic_profile_has_component_id_fields_for_cap() -> None:
+    """The built-in generic profile includes tolerance/voltage for CAP (no wattage)."""
+    cfg = load_defaults("generic")
+    allowed = cfg.get_component_id_fields("cap")
+    assert allowed is not None
+    assert "tolerance" in allowed
+    assert "voltage" in allowed
+    assert "wattage" not in allowed
+
+
+def test_generic_profile_has_component_id_fields_for_ind() -> None:
+    """The built-in generic profile includes tolerance/current for IND (no voltage)."""
+    cfg = load_defaults("generic")
+    allowed = cfg.get_component_id_fields("ind")
+    assert allowed is not None
+    assert "tolerance" in allowed
+    assert "current" in allowed
+    assert "voltage" not in allowed
+
+
+def test_get_component_id_fields_returns_none_for_unlisted_category() -> None:
+    """A category not in the profile returns None — caller uses all fields."""
+    cfg = load_defaults("generic")
+    assert cfg.get_component_id_fields("ic") is None
+    assert cfg.get_component_id_fields("rly") is None
+    assert cfg.get_component_id_fields("totally_custom_cat") is None
+
+
+def test_get_component_id_fields_is_case_insensitive() -> None:
+    """Category lookup is case-insensitive: LED, led, Led all resolve."""
+    cfg = load_defaults("generic")
+    assert cfg.get_component_id_fields("LED") == cfg.get_component_id_fields("led")
+    assert cfg.get_component_id_fields("RES") == cfg.get_component_id_fields("res")
+
+
+def test_from_yaml_dict_parses_component_id_fields() -> None:
+    """from_yaml_dict parses component_id_fields into frozensets of profile names."""
+    data = {
+        "component_id_fields": {
+            "led": ["type"],
+            "res": ["tolerance", "voltage", "wattage"],
+        }
+    }
+    cfg = DefaultsConfig.from_yaml_dict(data, name="test")
+    assert cfg.get_component_id_fields("led") == frozenset({"type"})
+    assert cfg.get_component_id_fields("res") == frozenset(
+        {"tolerance", "voltage", "wattage"}
+    )
+    assert cfg.get_component_id_fields("cap") is None  # not listed
+
+
+def test_from_yaml_dict_warns_and_skips_unknown_field_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown profile names are warned about and omitted from the frozenset."""
+    import logging
+
+    data = {
+        "component_id_fields": {
+            "led": ["type", "wavelength"],  # 'wavelength' is not a known field
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        cfg = DefaultsConfig.from_yaml_dict(data, name="test")
+    allowed = cfg.get_component_id_fields("led")
+    assert allowed == frozenset({"type"})  # 'wavelength' was dropped
+    assert any("wavelength" in r.message for r in caplog.records)
+
+
+def test_component_id_fields_override_via_jbom_dir(tmp_path: Path) -> None:
+    """A project .jbom/ override can customize LED component_id_fields."""
+    jbom_dir = tmp_path / ".jbom"
+    jbom_dir.mkdir()
+    (jbom_dir / "custom.defaults.yaml").write_text(
+        "extends: generic\n"
+        "component_id_fields:\n"
+        "  led:\n"
+        "    - type\n"
+        "    - voltage\n"  # re-add voltage for this project
+    )
+    cfg = load_defaults("custom", cwd=tmp_path)
+    allowed = cfg.get_component_id_fields("led")
+    assert allowed is not None
+    assert "voltage" in allowed
+    assert "type" in allowed
+    # res still inherited from generic
+    res_allowed = cfg.get_component_id_fields("res")
+    assert res_allowed is not None
+    assert "tolerance" in res_allowed

--- a/tests/unit/test_project_inventory.py
+++ b/tests/unit/test_project_inventory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from jbom.common.types import Component
 from jbom.services.project_inventory import ProjectInventoryGenerator
 
@@ -13,12 +15,15 @@ def _comp(
     reference: str = "",
     description: str = "",
     keywords: str = "",
+    extra_props: dict[str, str] | None = None,
 ) -> Component:
     props: dict[str, str] = {}
     if description:
         props["Description"] = description
     if keywords:
         props["Keywords"] = keywords
+    if extra_props:
+        props.update(extra_props)
     return Component(
         reference=reference,
         lib_id=lib_id,
@@ -209,3 +214,109 @@ def test_phase2_propagated_category_reflected_in_component_id() -> None:
             f"component_id should contain CAT=LED after Phase-2 propagation, "
             f"got {item.component_id!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# component_id_fields: per-category optional field filtering
+# ---------------------------------------------------------------------------
+
+
+def test_led_with_and_without_voltage_produce_identical_component_ids() -> None:
+    """LED with V=5V and LED without V collapse to the same ComponentID.
+
+    Regression for the original WS2812B phantom-duplicate bug: inconsistent
+    schematic annotation of 'V=5V' caused two identical components to be
+    treated as different requirements.
+    """
+    comp_with_v = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED1",
+        extra_props={"Voltage": "5V"},
+    )
+    comp_without_v = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED2",
+    )
+    gen = ProjectInventoryGenerator([comp_with_v, comp_without_v])
+    items, _ = gen.load()
+
+    assert (
+        len(items) == 1
+    ), f"Expected 1 group (same LED), got {len(items)}: " + ", ".join(
+        i.component_id for i in items
+    )
+    assert (
+        "V=" not in items[0].component_id
+    ), f"LED ComponentID must not include voltage, got {items[0].component_id!r}"
+
+
+def test_res_voltage_still_included_in_component_id() -> None:
+    """Resistor with a Voltage property retains V= in the ComponentID.
+
+    Voltage is a meaningful derating spec for resistors — it must remain in
+    the ComponentID even after the LED voltage-exclusion change.
+    """
+    comp = _comp(
+        lib_id="Device:R",
+        value="10K",
+        footprint="Resistor_SMD:R_0603_1608Metric",
+        reference="R1",
+        extra_props={"Voltage": "100V"},
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load()
+
+    assert len(items) == 1
+    assert (
+        "V=100V" in items[0].component_id
+    ), f"Resistor ComponentID must include voltage, got {items[0].component_id!r}"
+
+
+def test_led_component_id_fields_overridable_via_jbom_dir(tmp_path: Path) -> None:
+    """A project .jbom/ generic override can re-add voltage to LED ComponentIDs.
+
+    Exercises the full profile-search path: a ``generic.defaults.yaml`` in the
+    project's ``.jbom/`` directory overrides the built-in generic profile.
+    ``ProjectInventoryGenerator(cwd=tmp_path)`` picks it up automatically.
+    """
+    jbom_dir = tmp_path / ".jbom"
+    jbom_dir.mkdir()
+    # Shadow the built-in 'generic' profile for this project directory.
+    # Note: do NOT use 'extends: generic' here — this file IS the 'generic' profile
+    # for this cwd, so extending 'generic' would create a circular reference.
+    # For this test we only need component_id_fields; other sections are omitted.
+    (jbom_dir / "generic.defaults.yaml").write_text(
+        "component_id_fields:\n"
+        "  led:\n"
+        "    - type\n"
+        "    - voltage\n"  # re-add voltage so these two LEDs produce different IDs
+    )
+
+    comp_with_v = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED1",
+        extra_props={"Voltage": "5V"},
+    )
+    comp_without_v = _comp(
+        lib_id="SPCoast:WS2812B",
+        value="WS2812B",
+        footprint="PCM_SPCoast:WS2812B5050",
+        reference="LED2",
+    )
+    # cwd=tmp_path → the generator discovers .jbom/generic.defaults.yaml and
+    # uses it automatically — no config injection required.
+    gen = ProjectInventoryGenerator([comp_with_v, comp_without_v], cwd=tmp_path)
+    items, _ = gen.load()
+
+    # With voltage back in, the two components now differ — two groups.
+    assert (
+        len(items) == 2
+    ), f"Expected 2 groups (voltage now discriminates), got {len(items)}"
+    cids = {i.component_id for i in items}
+    assert any("V=5V" in cid for cid in cids)


### PR DESCRIPTION
## Summary

Fixes the WS2812B phantom-duplicate bug: two LEDs where one schematic annotated `Voltage=5V` and the other didn't produced different ComponentIDs and were treated as different requirements.

## Root cause

`make_component_id()` previously included all optional fields (tolerance, voltage, current, wattage, type) for every category unconditionally. For LEDs, `V=5V` vs no `V` created a spurious split.

## Solution

Add a `component_id_fields` section to `generic.defaults.yaml` that defines per-category allowlists. Categories not listed fall back to the previous behavior (all non-empty fields included — backward-compatible).

### Built-in defaults
| Category | Included optional fields |
|----------|--------------------------|
| `led`  | `type` only (wavelength/color) |
| `res`  | `tolerance`, `voltage`, `wattage`, `type` |
| `cap`  | `tolerance`, `voltage`, `type` |
| `ind`  | `tolerance`, `current`, `type` |
| (others) | all optional fields (unchanged) |

### DRY authority
Added `OPTIONAL_ID_FIELD_DEFS` + `KNOWN_OPTIONAL_FIELD_NAMES` in `component_id.py` as the single mapping between YAML profile names, ComponentID keys, and `make_component_id` parameter names. Adding a new field requires exactly one entry there.

### Project-level overrides
`ProjectInventoryGenerator` accepts `cwd: Path | None = None`. The profile is loaded lazily from the project's `.jbom/` search path — no config injection needed. Tests use `tmp_path/.jbom/generic.defaults.yaml` overrides via the standard mechanism.

## Tests
12 new tests (9 in `test_defaults_config.py`, 3 in `test_project_inventory.py`). 769/769 pass.

## Migration note
Stored ComponentIDs for `led`, `cap`, `ind`, `res` components with partial property annotations will differ after regeneration. Re-run `jbom inventory` to update.

Co-Authored-By: Oz <oz-agent@warp.dev>