### PR TITLE
fix(search): standardize on --supplier flag for search

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -354,8 +354,8 @@ Searches distributor catalogs for parts matching a keyword or part number.
 **QUERY**
 : Search query (keyword, part number, description). Required.
 
-**--provider {mouser}**
-: Search provider to use (default: mouser). Set `MOUSER_API_KEY` environment variable or use `--api-key`.
+**--supplier {mouser}**
+: Supplier ID to search (default: mouser). Set `MOUSER_API_KEY` environment variable or use `--api-key`.
 
 **--limit N**
 : Maximum results to display (default: 10).
@@ -388,7 +388,7 @@ Searches distributor catalogs for parts matching a keyword or part number.
 
 The `inventory-search` subcommand has been retired as of this release. Its catalog-search functionality has been consolidated into `jbom audit --supplier`.
 
-**Migration**: replace `jbom inventory-search inventory.csv --provider mouser` with:
+**Migration**: replace old `jbom inventory-search ...` usage with:
 
 ```sh
 jbom audit ./my_project --supplier mouser --api-key YOUR_KEY -o report.csv

--- a/docs/tutorial/README.integration.md
+++ b/docs/tutorial/README.integration.md
@@ -31,9 +31,9 @@ YAGEO         RC0603FR-0710KL  10 kOhms ±1% 0603 Thick..  847200  0.004
 
 By default jBOM applies smart parametric filtering: it parses `"10k 0603 resistor"` and adds attribute filters for resistance, package, and tolerance. Disable this with `--no-parametric` if you want raw keyword results.
 
-**Filter to a specific provider:**
+**Filter to a specific supplier:**
 ```bash
-jbom search "100nF 0603 X7R" --provider lcsc --limit 10
+jbom search "100nF 0603 X7R" --supplier lcsc --limit 10
 ```
 
 **See all available fields:**

--- a/features/search/supplier_flag.feature
+++ b/features/search/supplier_flag.feature
@@ -1,0 +1,16 @@
+Feature: Search supplier flag
+  As a jBOM user
+  I want search to use the same supplier flag as audit and inventory
+  So that the CLI is consistent across commands
+
+  Scenario: Search accepts --supplier
+    Given a generic supplier
+    When I run "jbom search 10k --supplier generic --limit 1"
+    Then the command should succeed
+    And the output should contain "No results found."
+
+  Scenario: Search rejects retired --provider flag
+    Given a generic supplier
+    When I run "jbom search 10k --provider generic --limit 1"
+    Then the command should fail
+    And the output should contain "--provider"

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -137,17 +137,17 @@ def register_command(subparsers) -> None:
         "query", help="Search query (keyword, part number, description)"
     )
 
-    # Provider is selected by supplier ID, discovered from supplier YAML profiles.
-    provider_choices = list_searchable_suppliers()
-    default_provider = "mouser" if "mouser" in provider_choices else None
-    if default_provider is None and provider_choices:
-        default_provider = provider_choices[0]
+    # Search backend is selected by supplier ID discovered from supplier YAML profiles.
+    supplier_choices = list_searchable_suppliers()
+    default_supplier = "mouser" if "mouser" in supplier_choices else None
+    if default_supplier is None and supplier_choices:
+        default_supplier = supplier_choices[0]
 
     parser.add_argument(
-        "--provider",
-        choices=provider_choices,
-        default=default_provider,
-        help="Search provider to use (default: derived from supplier profiles)",
+        "--supplier",
+        choices=supplier_choices,
+        default=default_supplier,
+        help="Supplier ID to use for search (default: derived from supplier profiles)",
     )
 
     parser.add_argument(
@@ -168,7 +168,7 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "--clear-cache",
         action="store_true",
-        help="Clear persistent cache entries for this provider before running",
+        help="Clear persistent cache entries for this supplier before running",
     )
 
     parser.add_argument(
@@ -220,7 +220,7 @@ def handle_search(
     cache = _cache if _cache is not None else _build_cache(args)
 
     try:
-        provider = _create_provider(args.provider, api_key=args.api_key, cache=cache)
+        provider = _create_provider(args.supplier, api_key=args.api_key, cache=cache)
     except (ValueError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -300,8 +300,8 @@ def _resolve_fields_from_args(args: argparse.Namespace) -> list[str] | None:
     if getattr(args, "fields", None) is not None:
         return _parse_fields_argument(args.fields)
 
-    # 2) Supplier profile fields (provider id is the closest proxy for supplier id)
-    supplier_id = (getattr(args, "provider", "") or "").strip().lower()
+    # 2) Supplier profile fields
+    supplier_id = (getattr(args, "supplier", "") or "").strip().lower()
     supplier = resolve_supplier_by_id(supplier_id)
     if supplier is not None and supplier.search_fields:
         return list(supplier.search_fields)
@@ -332,12 +332,12 @@ def _row_for_result(r: SearchResult) -> dict[str, str]:
 
 def _build_cache(args: argparse.Namespace) -> SearchCache:
     if getattr(args, "clear_cache", False):
-        DiskSearchCache.clear_provider(args.provider)
+        DiskSearchCache.clear_provider(args.supplier)
 
     if getattr(args, "no_cache", False):
         return InMemorySearchCache()
 
-    return DiskSearchCache(args.provider)
+    return DiskSearchCache(args.supplier)
 
 
 def _create_provider(

--- a/src/jbom/config/providers.py
+++ b/src/jbom/config/providers.py
@@ -88,8 +88,7 @@ def get_provider(
 
 def list_searchable_suppliers() -> list[str]:
     """Return supplier IDs that declare at least one search provider, sorted.
-
-    Used to populate --provider choices in CLI commands.
+    Used to populate --supplier choices in CLI commands.
     """
 
     from jbom.config.suppliers import list_suppliers, load_supplier

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -31,7 +31,7 @@ def _sr(**kw) -> SearchResult:
 
 
 def test_build_cache_no_cache_flag_returns_inmemory(monkeypatch) -> None:
-    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=False)
+    args = argparse.Namespace(supplier="mouser", no_cache=True, clear_cache=False)
     cache = _build_search_cache(args)
     assert isinstance(cache, InMemorySearchCache)
 
@@ -46,7 +46,7 @@ def test_build_cache_clear_cache_flag_calls_clear_provider(monkeypatch) -> None:
         DiskSearchCache, "clear_provider", staticmethod(_clear_provider)
     )
 
-    args = argparse.Namespace(provider="mouser", no_cache=True, clear_cache=True)
+    args = argparse.Namespace(supplier="mouser", no_cache=True, clear_cache=True)
     cache = _build_search_cache(args)
     assert isinstance(cache, InMemorySearchCache)
     assert calls["provider_id"] == "mouser"
@@ -64,7 +64,7 @@ def test_search_console_output(monkeypatch, capsys):
 
     args = argparse.Namespace(
         query="10K resistor 0603",
-        provider="mouser",
+        supplier="mouser",
         limit=1,
         api_key="dummy",
         all=True,
@@ -94,7 +94,7 @@ def test_search_csv_stdout(monkeypatch, capsys):
 
     args = argparse.Namespace(
         query="10K resistor 0603",
-        provider="mouser",
+        supplier="mouser",
         limit=1,
         api_key="dummy",
         all=True,
@@ -131,7 +131,7 @@ def test_search_csv_file(monkeypatch, tmp_path):
 
     args = argparse.Namespace(
         query="10K resistor 0603",
-        provider="mouser",
+        supplier="mouser",
         limit=1,
         api_key="dummy",
         all=True,
@@ -164,7 +164,7 @@ def test_search_list_fields_exits_without_api_key(monkeypatch, capsys):
 
     args = argparse.Namespace(
         query="ignored",
-        provider="mouser",
+        supplier="mouser",
         limit=1,
         api_key=None,
         all=True,
@@ -193,7 +193,7 @@ def test_search_fields_override_affects_csv_schema(monkeypatch, capsys):
 
     args = argparse.Namespace(
         query="10K resistor 0603",
-        provider="mouser",
+        supplier="mouser",
         limit=1,
         api_key="dummy",
         all=True,
@@ -254,7 +254,7 @@ def test_search_lcsc_provider_exits_cleanly_when_unavailable(monkeypatch, capsys
 
     args = argparse.Namespace(
         query="10K resistor 0603",
-        provider="lcsc",
+        supplier="lcsc",
         limit=1,
         api_key=None,
         all=True,

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -92,6 +92,8 @@ def test_root_help_does_not_include_retired_inventory_search():
 
 def test_search_help_lists_only_configured_supplier_providers():
     out = run_help(["search"]).lower()
+    assert "--supplier" in out
+    assert "--provider" not in out
 
     # Only suppliers with search.providers in YAML should appear as choices.
     assert "mouser" in out


### PR DESCRIPTION
## Summary
- remove --provider from jbom search and standardize on --supplier
- migrate search CLI internals and cache/field resolution to use args.supplier
- update unit tests and add Gherkin coverage for accepted/rejected flag behavior
- refresh search command docs/tutorial references to --supplier

## Validation
- PYTHONPATH=src python -m pytest tests/ -v
- python -m behave --format progress
- pre-commit run --files src/jbom/cli/search.py src/jbom/config/providers.py tests/services/search/test_search_cli.py tests/unit/test_cli_help.py docs/README.man1.md docs/tutorial/README.integration.md features/search/supplier_flag.feature

Closes #174

Co-Authored-By: Oz <oz-agent@warp.dev>
