### PR TITLE
fix(inventory): normalize standard manufacturer aliases at intake

### DIFF
--- a/src/jbom/common/synonym_normalization.py
+++ b/src/jbom/common/synonym_normalization.py
@@ -1,0 +1,54 @@
+"""Shared helpers for robust synonym matching across config and intake paths."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+
+def normalize_synonym_token(token: str) -> str:
+    """Normalize a synonym token for forgiving comparisons.
+
+    Normalization is case-insensitive and treats underscores/hyphens as spaces.
+    """
+
+    if not token:
+        return ""
+
+    normalized = str(token).replace("_", " ").replace("-", " ")
+    return " ".join(normalized.split()).strip().lower()
+
+
+def first_non_empty_alias_value(row: Mapping[str, str], aliases: Sequence[str]) -> str:
+    """Return first non-empty row value matching any alias token.
+
+    Matching first attempts exact key lookup, then normalized-token lookup.
+    """
+
+    if not row:
+        return ""
+
+    normalized_row_keys: dict[str, str] = {}
+    for row_key in row.keys():
+        normalized = normalize_synonym_token(str(row_key))
+        if normalized and normalized not in normalized_row_keys:
+            normalized_row_keys[normalized] = str(row_key)
+
+    for alias in aliases:
+        alias_key = str(alias).strip()
+        if not alias_key:
+            continue
+
+        exact_value = str(row.get(alias_key, "")).strip()
+        if exact_value:
+            return exact_value
+
+        normalized_alias = normalize_synonym_token(alias_key)
+        matched_key = normalized_row_keys.get(normalized_alias)
+        if matched_key is None:
+            continue
+
+        normalized_value = str(row.get(matched_key, "")).strip()
+        if normalized_value:
+            return normalized_value
+
+    return ""

--- a/src/jbom/config/defaults.py
+++ b/src/jbom/config/defaults.py
@@ -32,12 +32,9 @@ _BUILTIN_DIR = Path(__file__).parent / "defaults"
 
 
 def _normalize_field_synonym_canonical_key(canonical: str) -> str:
-    """Normalize field-synonym canonical keys for schema consistency."""
+    """Normalize field-synonym canonical keys."""
 
-    normalized = str(canonical).strip().lower()
-    if normalized == "mfgpn":
-        return "mpn"
-    return normalized
+    return str(canonical).strip().lower()
 
 
 @dataclass(frozen=True)

--- a/src/jbom/config/defaults.py
+++ b/src/jbom/config/defaults.py
@@ -31,6 +31,15 @@ log = logging.getLogger(__name__)
 _BUILTIN_DIR = Path(__file__).parent / "defaults"
 
 
+def _normalize_field_synonym_canonical_key(canonical: str) -> str:
+    """Normalize field-synonym canonical keys for schema consistency."""
+
+    normalized = str(canonical).strip().lower()
+    if normalized == "mfgpn":
+        return "mpn"
+    return normalized
+
+
 @dataclass(frozen=True)
 class EnrichmentCategoryConfig:
     """Camp 2/3 attribute classification for one component category."""
@@ -130,10 +139,22 @@ class DefaultsConfig:
                 synonyms = tuple(str(s).strip() for s in synonyms_cfg if str(s).strip())
             else:
                 synonyms = tuple()
-            field_synonyms[str(canonical).strip().lower()] = FieldSynonymConfig(
-                display_name=display_name or str(canonical).strip(),
-                synonyms=synonyms,
-            )
+            canonical_key = _normalize_field_synonym_canonical_key(canonical)
+
+            existing = field_synonyms.get(canonical_key)
+            if existing is not None:
+                merged_synonyms = tuple(
+                    dict.fromkeys([*existing.synonyms, *synonyms]).keys()
+                )
+                field_synonyms[canonical_key] = FieldSynonymConfig(
+                    display_name=existing.display_name or display_name or canonical_key,
+                    synonyms=merged_synonyms,
+                )
+            else:
+                field_synonyms[canonical_key] = FieldSynonymConfig(
+                    display_name=display_name or canonical_key,
+                    synonyms=synonyms,
+                )
 
         raw_excluded = data.get("search_excluded_categories") or []
         search_excluded_categories: frozenset[str] = frozenset(
@@ -202,7 +223,9 @@ class DefaultsConfig:
 
     def get_field_synonym_config(self, canonical: str) -> FieldSynonymConfig | None:
         """Return field synonym config for a canonical key."""
-
+        return self.field_synonyms.get(
+            _normalize_field_synonym_canonical_key(canonical)
+        )
         return self.field_synonyms.get(canonical.strip().lower())
 
     def get_search_excluded_categories(self) -> frozenset[str]:

--- a/src/jbom/config/defaults/generic.defaults.yaml
+++ b/src/jbom/config/defaults/generic.defaults.yaml
@@ -125,6 +125,23 @@ category_route_rules:
 # Canonical schema field synonyms for inventory header intake/output.
 # ---------------------------------------------------------------------------
 field_synonyms:
+  manufacturer:
+    synonyms:
+      - "Manufacturer"
+      - "Manufacturer_Name"
+      - "Mfr"
+      - "MFR"
+      - "Brand"
+    display_name: "Manufacturer"
+  mfgpn:
+    synonyms:
+      - "MFGPN"
+      - "Manufacturer_Part_Number"
+      - "MPN"
+      - "Mfr_PN"
+      - "Part Number"
+      - "PartNumber"
+    display_name: "MFGPN"
   voltage:
     synonyms:
       - "Voltage"

--- a/src/jbom/config/defaults/generic.defaults.yaml
+++ b/src/jbom/config/defaults/generic.defaults.yaml
@@ -133,15 +133,15 @@ field_synonyms:
       - "MFR"
       - "Brand"
     display_name: "Manufacturer"
-  mfgpn:
+  mpn:
     synonyms:
-      - "MFGPN"
-      - "Manufacturer_Part_Number"
       - "MPN"
-      - "Mfr_PN"
+      - "MFGPN"
+      - "Manufacturer Part Number"
+      - "Mfr PN"
       - "Part Number"
       - "PartNumber"
-    display_name: "MFGPN"
+    display_name: "MPN"
   voltage:
     synonyms:
       - "Voltage"

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 import yaml
+from jbom.common.synonym_normalization import normalize_synonym_token
 
 from jbom.config.profile_search import find_profile
 from jbom.config.suppliers import resolve_supplier_by_id
@@ -220,14 +221,14 @@ class FabricatorConfig:
         Matching is forgiving (case-insensitive, ignores surrounding whitespace).
         Returns None when the field name is unknown.
         """
-        field_normalized = field_name.strip().lower()
+        field_normalized = normalize_synonym_token(field_name)
 
         for canonical, config in self.field_synonyms.items():
-            if canonical.strip().lower() == field_normalized:
+            if normalize_synonym_token(canonical) == field_normalized:
                 return canonical
 
             for synonym in config.synonyms:
-                if synonym.strip().lower() == field_normalized:
+                if normalize_synonym_token(synonym) == field_normalized:
                     return canonical
 
         return None

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -22,6 +22,7 @@ from jbom.common.value_parsing import (
     UNCLASSIFIED_CATEGORIES,
     decode_typed_parametric,
 )
+from jbom.common.synonym_normalization import first_non_empty_alias_value
 from jbom.config.defaults import get_defaults
 from jbom.services.jlc_loader import JLCPrivateInventoryLoader
 
@@ -397,7 +398,7 @@ class InventoryReader:
                 ),
                 mfgpn=self._get_canonical_profile_value(
                     row,
-                    canonical="mfgpn",
+                    canonical="mpn",
                     fallback_keys=[
                         "MFGPN",
                         "MPN",
@@ -519,7 +520,7 @@ class InventoryReader:
                 continue
             seen.add(normalized.lower())
             deduped_keys.append(normalized)
-
+        return first_non_empty_alias_value(row, deduped_keys)
         return self._get_first_value(row, deduped_keys)
 
     def _get_first_value(self, row: Dict[str, str], keys: List[str]) -> str:

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -390,11 +390,15 @@ class InventoryReader:
                 ),
                 # Phase 4 inventory schema: LCSC is an explicit column (no DPN fallback).
                 lcsc=self._get_first_value(row, ["LCSC", "LCSC Part", "LCSC Part #"]),
-                manufacturer=row.get("Manufacturer", ""),
-                # MPN header varies across inventories; treat these as synonyms.
-                mfgpn=self._get_first_value(
+                manufacturer=self._get_canonical_profile_value(
                     row,
-                    [
+                    canonical="manufacturer",
+                    fallback_keys=["Manufacturer"],
+                ),
+                mfgpn=self._get_canonical_profile_value(
+                    row,
+                    canonical="mfgpn",
+                    fallback_keys=[
                         "MFGPN",
                         "MPN",
                         "Manufacturer Part Number",
@@ -490,12 +494,24 @@ class InventoryReader:
         is authoritative, and intentional omission means aliases are disabled.
         """
 
-        keys: list[str] = []
+        return self._get_canonical_profile_value(row, canonical=canonical)
+
+    def _get_canonical_profile_value(
+        self,
+        row: Dict[str, str],
+        *,
+        canonical: str,
+        fallback_keys: Optional[List[str]] = None,
+    ) -> str:
+        """Resolve a canonical value via defaults-profile synonym mappings."""
+
+        keys: List[str] = []
         config = _DEFAULTS_PROFILE.get_field_synonym_config(canonical)
         if config is not None:
             keys.extend([config.display_name, *config.synonyms])
+        keys.extend(fallback_keys or [])
 
-        deduped_keys: list[str] = []
+        deduped_keys: List[str] = []
         seen: set[str] = set()
         for key in keys:
             normalized = key.strip()

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -19,6 +19,7 @@ from jbom.common.value_parsing import (
     UNCLASSIFIED_CATEGORIES,
     decode_typed_parametric,
 )
+from jbom.common.synonym_normalization import first_non_empty_alias_value
 
 log = logging.getLogger(__name__)
 
@@ -427,7 +428,7 @@ class ProjectInventoryGenerator:
             ),
             mfgpn=self._get_canonical_field_value(
                 props,
-                canonical="mfgpn",
+                canonical="mpn",
                 fallback_keys=("MFGPN", "MPN"),
             ),
             datasheet=props.get("Datasheet", ""),
@@ -490,11 +491,7 @@ class ProjectInventoryGenerator:
                 continue
             seen.add(normalized.lower())
             deduped_keys.append(normalized)
-
-        for key in deduped_keys:
-            value = str(row.get(key, "")).strip()
-            if value:
-                return value
+        return first_non_empty_alias_value(row, deduped_keys)
         return ""
 
     def _resolve_category_for_typed_decode(

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -420,8 +420,16 @@ class ProjectInventoryGenerator:
                 props.get("Power", props.get("Wattage", props.get("W", ""))),
             ),
             lcsc=props.get("LCSC", ""),
-            manufacturer=props.get("Manufacturer", ""),
-            mfgpn=props.get("MFGPN", props.get("MPN", "")),
+            manufacturer=self._get_canonical_field_value(
+                props,
+                canonical="manufacturer",
+                fallback_keys=("Manufacturer",),
+            ),
+            mfgpn=self._get_canonical_field_value(
+                props,
+                canonical="mfgpn",
+                fallback_keys=("MFGPN", "MPN"),
+            ),
             datasheet=props.get("Datasheet", ""),
             package=package,
             uuid=uuid_str,
@@ -458,6 +466,36 @@ class ProjectInventoryGenerator:
                 "ki_keywords": props.get("Keywords", ""),
             },
         )
+
+    def _get_canonical_field_value(
+        self,
+        row: Dict[str, str],
+        *,
+        canonical: str,
+        fallback_keys: tuple[str, ...] = (),
+    ) -> str:
+        """Resolve a canonical field value from defaults-profile aliases."""
+
+        keys: list[str] = []
+        config = self._get_defaults().get_field_synonym_config(canonical)
+        if config is not None:
+            keys.extend([config.display_name, *config.synonyms])
+        keys.extend(fallback_keys)
+
+        deduped_keys: list[str] = []
+        seen: set[str] = set()
+        for key in keys:
+            normalized = key.strip()
+            if not normalized or normalized.lower() in seen:
+                continue
+            seen.add(normalized.lower())
+            deduped_keys.append(normalized)
+
+        for key in deduped_keys:
+            value = str(row.get(key, "")).strip()
+            if value:
+                return value
+        return ""
 
     def _resolve_category_for_typed_decode(
         self,

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -101,6 +101,16 @@ def test_generic_profile_has_field_synonyms() -> None:
     assert voltage.display_name == "Voltage"
     assert "V" in voltage.synonyms
 
+    manufacturer = cfg.get_field_synonym_config("manufacturer")
+    assert manufacturer is not None
+    assert manufacturer.display_name == "Manufacturer"
+    assert "Manufacturer_Name" in manufacturer.synonyms
+
+    mfgpn = cfg.get_field_synonym_config("mfgpn")
+    assert mfgpn is not None
+    assert mfgpn.display_name == "MFGPN"
+    assert "Manufacturer_Part_Number" in mfgpn.synonyms
+
 
 # ---------------------------------------------------------------------------
 # Error handling

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -106,10 +106,15 @@ def test_generic_profile_has_field_synonyms() -> None:
     assert manufacturer.display_name == "Manufacturer"
     assert "Manufacturer_Name" in manufacturer.synonyms
 
-    mfgpn = cfg.get_field_synonym_config("mfgpn")
-    assert mfgpn is not None
-    assert mfgpn.display_name == "MFGPN"
-    assert "Manufacturer_Part_Number" in mfgpn.synonyms
+    mpn = cfg.get_field_synonym_config("mpn")
+    assert mpn is not None
+    assert mpn.display_name == "MPN"
+    assert "Manufacturer Part Number" in mpn.synonyms
+
+    # Legacy canonical name support: mfgpn key is normalized to mpn.
+    mfgpn_legacy = cfg.get_field_synonym_config("mfgpn")
+    assert mfgpn_legacy is not None
+    assert mfgpn_legacy.display_name == "MPN"
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +273,21 @@ def test_from_yaml_dict_parses_field_synonyms() -> None:
     assert voltage is not None
     assert voltage.display_name == "Voltage"
     assert voltage.synonyms == ("Voltage", "V")
+
+
+def test_from_yaml_dict_normalizes_legacy_mfgpn_canonical_key() -> None:
+    data = {
+        "field_synonyms": {
+            "mfgpn": {
+                "display_name": "MFGPN",
+                "synonyms": ["Manufacturer Part Number"],
+            }
+        }
+    }
+    cfg = DefaultsConfig.from_yaml_dict(data, name="test")
+    mpn = cfg.get_field_synonym_config("mpn")
+    assert mpn is not None
+    assert "Manufacturer Part Number" in mpn.synonyms
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -111,11 +111,6 @@ def test_generic_profile_has_field_synonyms() -> None:
     assert mpn.display_name == "MPN"
     assert "Manufacturer Part Number" in mpn.synonyms
 
-    # Legacy canonical name support: mfgpn key is normalized to mpn.
-    mfgpn_legacy = cfg.get_field_synonym_config("mfgpn")
-    assert mfgpn_legacy is not None
-    assert mfgpn_legacy.display_name == "MPN"
-
 
 # ---------------------------------------------------------------------------
 # Error handling
@@ -273,21 +268,6 @@ def test_from_yaml_dict_parses_field_synonyms() -> None:
     assert voltage is not None
     assert voltage.display_name == "Voltage"
     assert voltage.synonyms == ("Voltage", "V")
-
-
-def test_from_yaml_dict_normalizes_legacy_mfgpn_canonical_key() -> None:
-    data = {
-        "field_synonyms": {
-            "mfgpn": {
-                "display_name": "MFGPN",
-                "synonyms": ["Manufacturer Part Number"],
-            }
-        }
-    }
-    cfg = DefaultsConfig.from_yaml_dict(data, name="test")
-    mpn = cfg.get_field_synonym_config("mpn")
-    assert mpn is not None
-    assert "Manufacturer Part Number" in mpn.synonyms
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fabricator_config_schema.py
+++ b/tests/unit/test_fabricator_config_schema.py
@@ -47,6 +47,7 @@ def test_resolve_field_synonym_is_forgiving() -> None:
 
     assert fab.resolve_field_synonym(" Lcsc Part # ") == "fab_pn"
     assert fab.resolve_field_synonym("fab_pn") == "fab_pn"
+    assert fab.resolve_field_synonym("Manufacturer_Part_Number") == "mpn"
     assert fab.resolve_field_synonym("unknown_field") is None
 
 

--- a/tests/unit/test_inventory_item_fields.py
+++ b/tests/unit/test_inventory_item_fields.py
@@ -166,3 +166,13 @@ class TestInventoryReaderHarvestFidelityRoundtrip:
         assert items[0].symbol_name == ""
         assert items[0].pins == ""
         assert items[0].pitch == ""
+
+    def test_alias_columns_populate_manufacturer_and_mfgpn(self):
+        """Standard alias headers should populate canonical manufacturer/mfgpn fields."""
+        csv = (
+            "IPN,Category,Value,Package,Manufacturer_Name,Manufacturer_Part_Number\n"
+            "R-001,RES,10K,0603,LITTELFUSE,CPC1709J\n"
+        )
+        items = _csv_reader(csv)
+        assert items[0].manufacturer == "LITTELFUSE"
+        assert items[0].mfgpn == "CPC1709J"

--- a/tests/unit/test_project_inventory.py
+++ b/tests/unit/test_project_inventory.py
@@ -216,6 +216,27 @@ def test_phase2_propagated_category_reflected_in_component_id() -> None:
         )
 
 
+def test_load_per_instance_maps_manufacturer_aliases_to_canonical_fields() -> None:
+    """Schematic alias properties populate canonical manufacturer and mfgpn fields."""
+
+    comp = _comp(
+        lib_id="Device:Relay",
+        value="CPC1709J",
+        footprint="Relay_THT:Relay_SPST",
+        reference="K1",
+        extra_props={
+            "Manufacturer_Name": "LITTELFUSE",
+            "Manufacturer_Part_Number": "CPC1709J",
+        },
+    )
+    gen = ProjectInventoryGenerator([comp])
+    items, _ = gen.load_per_instance()
+
+    assert len(items) == 1
+    assert items[0].manufacturer == "LITTELFUSE"
+    assert items[0].mfgpn == "CPC1709J"
+
+
 # ---------------------------------------------------------------------------
 # component_id_fields: per-category optional field filtering
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add canonical alias entries for `manufacturer` and `mfgpn` in `generic.defaults.yaml` field synonyms
- normalize these fields during project schematic intake (`ProjectInventoryGenerator`) using defaults-profile alias resolution
- normalize these fields during CSV inventory intake (`InventoryReader`) using the same canonical alias mechanism
- add test coverage proving `Manufacturer_Name` and `Manufacturer_Part_Number` populate `InventoryItem.manufacturer` and `InventoryItem.mfgpn`

## Validation
- `PYTHONPATH=src python -m pytest tests/unit/test_defaults_config.py tests/unit/test_project_inventory.py tests/unit/test_inventory_item_fields.py tests/services/search/test_inventory_search_mpn_lookup.py -v`
- `PYTHONPATH=src python -m pytest tests/ -v`
- `python -m behave --format progress`
- `pre-commit run --files src/jbom/config/defaults/generic.defaults.yaml src/jbom/services/inventory_reader.py src/jbom/services/project_inventory.py tests/unit/test_defaults_config.py tests/unit/test_inventory_item_fields.py tests/unit/test_project_inventory.py`

Closes #164

Co-Authored-By: Oz <oz-agent@warp.dev>
