### PR TITLE
fix(search): strict-first core attribute filtering for query matches (issue #175)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `ProjectInventoryGenerator` accepts an optional `cwd: Path | None = None` kwarg;
   the generic defaults profile is loaded lazily from the project directory's
   `.jbom/` search path (no config injection required).
+- `jbom search` query filtering now uses a strict-first pass for category core
+  attributes (`Resistance`, `Capacitance`, `Inductance`): when strict matches
+  exist, candidates missing the core attribute are excluded (fixes resistor
+  queries returning capacitor false positives). If strict pass yields no matches,
+  filtering falls back to legacy fail-open behavior to preserve clueful results
+  (issue #175).
 
 ### Migration note
 - **Stored ComponentIDs may change** for `led`, `cap`, `ind`, and `res` components

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -46,17 +46,18 @@ class SearchFilter:
         results: list[SearchResult], query: str, *, category: str = ""
     ) -> list[SearchResult]:
         """Filter results based on query terms matching parametric attributes.
-
+        Category-aware behavior:
         Current behavior mirrors legacy jBOM's implementation for resistors:
         - If the query contains a parseable resistance, keep only results whose
           "Resistance" attribute matches.
         - If the query contains a tolerance percentage, keep only exact matches
           when the result includes "Tolerance".
-
-        Filtering is "fail open" when a result lacks parametric attributes.
+        - When a strict core-attribute pass (Resistance/Capacitance/Inductance)
+          yields at least one match, candidates missing that core attribute are
+          excluded.
+        - If strict pass yields zero results, automatically fall back to
+          fail-open behavior so users still get clueful context.
         """
-
-        filtered: list[SearchResult] = []
 
         cat = normalize_component_type(category or "")
 
@@ -97,49 +98,64 @@ class SearchFilter:
                 target_tol = float(tol_match.group(1))
             except ValueError:
                 target_tol = None
+        attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
+        strict_core_attr = target_value is not None and bool(attr_name)
 
-        for r in results:
-            if not r.attributes:
-                filtered.append(r)
-                continue
+        def _filter_pass(*, require_core_attr: bool) -> list[SearchResult]:
+            filtered: list[SearchResult] = []
 
-            keep = True
+            for r in results:
+                if not r.attributes:
+                    if require_core_attr and strict_core_attr:
+                        continue
+                    filtered.append(r)
+                    continue
 
-            if target_value is not None:
-                attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
-                if attr_name:
+                keep = True
+
+                if target_value is not None and attr_name:
                     raw_attr = r.attributes.get(attr_name, "")
-                    if raw_attr:
+                    if not raw_attr:
+                        if require_core_attr:
+                            keep = False
+                    else:
                         attr_value = parse_value_to_normal(cat, raw_attr)
                         if attr_value is None or not _close_enough(
                             attr_value, target_value
                         ):
                             keep = False
 
-            if keep and cat == "CAP" and target_volts is not None:
-                vr_attr = r.attributes.get("Voltage Rating", "")
-                if vr_attr:
-                    attr_volts = parse_voltage_to_volts(vr_attr)
-                    # Interpret voltage rating as a minimum requirement.
-                    if attr_volts is None or attr_volts + 1e-12 < target_volts:
-                        keep = False
-
-            if keep and target_tol is not None:
-                tol_attr = r.attributes.get("Tolerance", "")
-                if tol_attr:
-                    clean_tol = tol_attr.replace("%", "").replace("+/-", "").strip()
-                    try:
-                        attr_tol = float(clean_tol)
-                        if attr_tol != target_tol:
+                if keep and cat == "CAP" and target_volts is not None:
+                    vr_attr = r.attributes.get("Voltage Rating", "")
+                    if vr_attr:
+                        attr_volts = parse_voltage_to_volts(vr_attr)
+                        # Interpret voltage rating as a minimum requirement.
+                        if attr_volts is None or attr_volts + 1e-12 < target_volts:
                             keep = False
-                    except ValueError:
-                        # If the result tolerance is unparsable, fail open.
-                        pass
 
-            if keep:
-                filtered.append(r)
+                if keep and target_tol is not None:
+                    tol_attr = r.attributes.get("Tolerance", "")
+                    if tol_attr:
+                        clean_tol = tol_attr.replace("%", "").replace("+/-", "").strip()
+                        try:
+                            attr_tol = float(clean_tol)
+                            if attr_tol != target_tol:
+                                keep = False
+                        except ValueError:
+                            # If the result tolerance is unparsable, fail open.
+                            pass
 
-        return filtered
+                if keep:
+                    filtered.append(r)
+
+            return filtered
+
+        if strict_core_attr:
+            strict_filtered = _filter_pass(require_core_attr=True)
+            if strict_filtered:
+                return strict_filtered
+
+        return _filter_pass(require_core_attr=False)
 
 
 def apply_default_filters(results: Iterable[SearchResult]) -> list[SearchResult]:

--- a/tests/services/search/test_filtering.py
+++ b/tests/services/search/test_filtering.py
@@ -44,42 +44,42 @@ def test_filter_by_query_resistance_strict_matches_when_attribute_present():
     results = [
         _sr(attributes={"Resistance": "10 kOhms"}, mpn="A"),
         _sr(attributes={"Resistance": "22 kOhms"}, mpn="B"),
-        _sr(attributes={}, mpn="C"),  # fail-open
+        _sr(attributes={}, mpn="C"),  # excluded when strict pass has matches
     ]
 
     filtered = SearchFilter.filter_by_query(results, "10K 0603")
     mpns = {r.mpn for r in filtered}
     assert "A" in mpns
     assert "B" not in mpns
-    assert "C" in mpns
+    assert "C" not in mpns
 
 
 def test_filter_by_query_backward_compat_empty_category_filters_resistance():
     results = [
         _sr(attributes={"Resistance": "10 kOhms"}, mpn="A"),
         _sr(attributes={"Resistance": "22 kOhms"}, mpn="B"),
-        _sr(attributes={}, mpn="C"),  # fail-open
+        _sr(attributes={}, mpn="C"),  # excluded when strict pass has matches
     ]
 
     filtered = SearchFilter.filter_by_query(results, "10K 0603", category="")
     mpns = {r.mpn for r in filtered}
     assert "A" in mpns
     assert "B" not in mpns
-    assert "C" in mpns
+    assert "C" not in mpns
 
 
 def test_filter_by_query_capacitance_when_category_provided():
     results = [
         _sr(attributes={"Capacitance": "100nF"}, mpn="A"),
         _sr(attributes={"Capacitance": "1uF"}, mpn="B"),
-        _sr(attributes={}, mpn="C"),  # fail-open
+        _sr(attributes={}, mpn="C"),  # excluded when strict pass has matches
     ]
 
     filtered = SearchFilter.filter_by_query(results, "100nF 0805", category="CAP")
     mpns = {r.mpn for r in filtered}
     assert "A" in mpns
     assert "B" not in mpns
-    assert "C" in mpns
+    assert "C" not in mpns
 
 
 def test_filter_by_query_capacitor_voltage_rating_when_present_in_query():
@@ -100,14 +100,28 @@ def test_filter_by_query_inductance_when_category_provided():
     results = [
         _sr(attributes={"Inductance": "100uH"}, mpn="A"),
         _sr(attributes={"Inductance": "10uH"}, mpn="B"),
-        _sr(attributes={}, mpn="C"),  # fail-open
+        _sr(attributes={}, mpn="C"),  # excluded when strict pass has matches
     ]
 
     filtered = SearchFilter.filter_by_query(results, "100uH 0603", category="IND")
     mpns = {r.mpn for r in filtered}
     assert "A" in mpns
     assert "B" not in mpns
+    assert "C" not in mpns
+
+
+def test_filter_by_query_falls_back_to_fail_open_when_strict_pass_is_empty():
+    results = [
+        _sr(attributes={"Resistance": "22 kOhms"}, mpn="A"),
+        _sr(attributes={"Capacitance": "100nF"}, mpn="C"),
+        _sr(attributes={}, mpn="D"),
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10K 0603")
+    mpns = {r.mpn for r in filtered}
+    assert "A" not in mpns
     assert "C" in mpns
+    assert "D" in mpns
 
 
 def test_sorter_prefers_higher_stock_then_lower_price():


### PR DESCRIPTION
## Summary
- Fixes issue #175 by changing `SearchFilter.filter_by_query` to run a strict-first core-attribute pass for category-specific value matching (`Resistance`, `Capacitance`, `Inductance`).
- When strict matches exist, candidates missing the query-relevant core attribute are excluded (prevents capacitor false positives in resistor queries).
- If strict pass yields no candidates, filtering automatically falls back to legacy fail-open behavior to preserve clueful results.
- Updates search filtering tests to assert strict behavior and adds a regression test for fallback behavior.
- Updates `docs/CHANGELOG.md` with the high-level change note.

## Validation
- `pytest tests/services/search/test_filtering.py tests/services/search/test_search_cli.py`
- 18 passed

Closes #175

Co-Authored-By: Oz <oz-agent@warp.dev>