### PR TITLE
fix(search): stabilize defaults profiles and improve LCSC search quality

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   (e.g. wavelength) requires one entry here plus a new `make_component_id` parameter.
 
 ### Changed
+- All jBOM subcommands now accept `--defaults <profile>` (defaulting to
+  `generic` when omitted). The selected defaults profile is applied for the
+  command runtime and then restored, so profile selection does not leak across
+  commands.
+- `jbom search` now defaults to `--supplier generic` when no supplier is
+  specified (instead of implicitly selecting Mouser behavior).
+- `jbom search --fields` now accepts common aliases (e.g. `stock` →
+  `stock_quantity`, `supplier_pn` → `supplier_part_number`) while preserving
+  canonical field keys.
+- `jbom search` default output fields are now profile-driven via
+  `defaults.search.output_fields.default` (with supplier `search.fields`
+  override). Missing/invalid profile field configuration now fails loudly
+  instead of silently falling back to hardcoded fields.
+- Search ranking now includes query-aware relevance signals (token overlap,
+  requested package boosts, and explicit non-requested package penalties), and
+  demotes obvious category mismatches such as thermistors for resistor queries.
+- When provider metadata includes library tier (`componentLibraryType`), search
+  ranking now gives a small preference to basic/base parts, and `Description`
+  output includes `[basic]`/`[extended]` notation for visibility.
+- For passive-intent searches (currently resistor/capacitor), low-stock
+  candidates are now treated as a coarse eligibility gate (below 2000 is
+  filtered when better-stocked alternatives exist), and in-rank ordering now
+  prioritizes lower price instead of raw stock-count differences.
+- `jbom search` now adaptively expands the raw provider fetch window
+  progressively (50 → 100 → 200 → … up to 1024) when post-filter results are
+  below the requested display limit, improving recall for valid parts that rank
+  beyond the first page-sized slice.
 - `ProjectInventoryGenerator` accepts an optional `cwd: Path | None = None` kwarg;
   the generic defaults profile is loaded lazily from the project directory's
   `.jbom/` search path (no config injection required).

--- a/src/jbom/cli/main.py
+++ b/src/jbom/cli/main.py
@@ -14,6 +14,10 @@ from jbom.cli import (
     parts,
     search,
 )
+from jbom.config.defaults import (
+    get_active_defaults_profile,
+    set_active_defaults_profile,
+)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -51,8 +55,25 @@ def create_parser() -> argparse.ArgumentParser:
     pos.register_command(subparsers)
     parts.register_command(subparsers)
     search.register_command(subparsers)
+    _add_defaults_argument_to_subcommands(subparsers)
 
     return parser
+
+
+def _add_defaults_argument_to_subcommands(
+    subparsers: argparse._SubParsersAction,  # type: ignore[type-arg]
+) -> None:
+    """Add a shared defaults-profile selector to every subcommand parser."""
+
+    for command_parser in subparsers.choices.values():
+        command_parser.add_argument(
+            "--defaults",
+            metavar="PROFILE",
+            default="generic",
+            help=(
+                "Defaults profile name for configurable behavior " "(default: generic)"
+            ),
+        )
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -80,7 +101,13 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # Execute command handler (already set by register_command)
     if hasattr(args, "handler"):
-        return args.handler(args)
+        selected_profile = getattr(args, "defaults", "generic")
+        previous_profile = get_active_defaults_profile()
+        set_active_defaults_profile(selected_profile)
+        try:
+            return args.handler(args)
+        finally:
+            set_active_defaults_profile(previous_profile)
 
     # This shouldn't happen with proper command registration
     print(f"Error: No handler for command '{args.command}'", file=sys.stderr)

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 import sys
 from dataclasses import dataclass
 from typing import Callable, Optional, TextIO
@@ -17,6 +18,7 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.config.defaults import get_defaults
 from jbom.config.providers import get_provider, list_searchable_suppliers
 from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
@@ -27,6 +29,8 @@ from jbom.services.search.filtering import (
 )
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
+
+_MAX_ADAPTIVE_FETCH_LIMIT = 1024
 
 
 @dataclass(frozen=True)
@@ -41,6 +45,73 @@ class _FieldDef:
 def _s(r: SearchResult, value: object) -> str:
     # Ensure everything is a safe string for console/CSV output.
     return str(value if value is not None else "")
+
+
+_PACKAGE_PATTERN = re.compile(
+    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
+)
+
+
+def _package_value(r: SearchResult) -> str:
+    """Resolve package from normalized attrs or provider raw fields."""
+
+    if r.attributes and r.attributes.get("Package"):
+        return _s(r, r.attributes.get("Package", ""))
+
+    if r.raw_data:
+        for key in ("componentSpecificationEn", "Package", "package"):
+            raw = str(r.raw_data.get(key, "")).strip()
+            if raw:
+                return raw
+
+    match = _PACKAGE_PATTERN.search((r.description or "").upper())
+    if match:
+        return match.group(1).upper()
+
+    return ""
+
+
+def _component_library_tier_label(r: SearchResult) -> str:
+    """Return display label for provider library tier metadata."""
+
+    if not r.raw_data:
+        return ""
+
+    raw = str(r.raw_data.get("componentLibraryType", "")).strip().lower()
+    if raw in {"base", "basic"}:
+        return "basic"
+    if raw in {"expand", "extended"}:
+        return "extended"
+    return ""
+
+
+def _description_value(r: SearchResult) -> str:
+    """Render description with optional basic/extended tier notation."""
+
+    desc = str(r.description or "").strip()
+    tier = _component_library_tier_label(r)
+    if not tier:
+        return desc
+    if not desc:
+        return f"[{tier}]"
+    return f"[{tier}] {desc}"
+
+
+def _category_value(r: SearchResult) -> str:
+    """Resolve category from normalized field or provider raw payload."""
+
+    if r.category:
+        return r.category
+    if r.raw_data:
+        primary = str(r.raw_data.get("firstSortName", "")).strip()
+        secondary = str(r.raw_data.get("secondSortName", "")).strip()
+        if primary and secondary:
+            return f"{secondary}: {primary}"
+        if primary:
+            return primary
+        if secondary:
+            return secondary
+    return ""
 
 
 _FIELD_REGISTRY: dict[str, _FieldDef] = {
@@ -67,6 +138,16 @@ _FIELD_REGISTRY: dict[str, _FieldDef] = {
             header="Manufacturer", key="manufacturer", preferred_width=16, wrap=True
         ),
         extractor=lambda r: _s(r, r.manufacturer),
+    ),
+    "package": _FieldDef(
+        key="package",
+        column=Column(header="Package", key="package", preferred_width=10, wrap=True),
+        extractor=lambda r: _s(r, _package_value(r)),
+    ),
+    "category": _FieldDef(
+        key="category",
+        column=Column(header="Category", key="category", preferred_width=18, wrap=True),
+        extractor=lambda r: _s(r, _category_value(r)),
     ),
     "price": _FieldDef(
         key="price",
@@ -105,7 +186,7 @@ _FIELD_REGISTRY: dict[str, _FieldDef] = {
         column=Column(
             header="Description", key="description", preferred_width=60, wrap=True
         ),
-        extractor=lambda r: _s(r, r.description),
+        extractor=lambda r: _s(r, _description_value(r)),
     ),
     "availability": _FieldDef(
         key="availability",
@@ -123,6 +204,20 @@ _FIELD_REGISTRY: dict[str, _FieldDef] = {
     ),
 }
 
+_FIELD_ALIASES: dict[str, str] = {
+    "stock": "stock_quantity",
+    "supplier_pn": "supplier_part_number",
+    "supplierpn": "supplier_part_number",
+    "supplier_part": "supplier_part_number",
+}
+
+
+def _normalize_field_key(field_token: str) -> str:
+    """Normalize a user-supplied field token to a registry key."""
+
+    normalized = field_token.strip().lower().replace("-", "_").replace(" ", "_")
+    return _FIELD_ALIASES.get(normalized, normalized)
+
 
 def register_command(subparsers) -> None:
     """Register search command with argument parser."""
@@ -139,7 +234,7 @@ def register_command(subparsers) -> None:
 
     # Search backend is selected by supplier ID discovered from supplier YAML profiles.
     supplier_choices = list_searchable_suppliers()
-    default_supplier = "mouser" if "mouser" in supplier_choices else None
+    default_supplier = "generic" if "generic" in supplier_choices else None
     if default_supplier is None and supplier_choices:
         default_supplier = supplier_choices[0]
 
@@ -227,22 +322,16 @@ def handle_search(
 
     # Pull extra results to allow client-side filtering.
     display_limit = max(1, int(args.limit))
-    fetch_limit = min(100, max(50, display_limit * 3))
+    initial_fetch_limit = min(100, max(50, display_limit * 3))
 
-    try:
-        results = provider.search(args.query, limit=fetch_limit)
-    except Exception as exc:
-        print(f"Error: search failed: {exc}", file=sys.stderr)
+    results = _run_adaptive_search_pipeline(
+        provider=provider,
+        args=args,
+        display_limit=display_limit,
+        initial_fetch_limit=initial_fetch_limit,
+    )
+    if results is None:
         return 1
-
-    if not args.all:
-        results = apply_default_filters(results)
-
-    # Parametric filtering is optional.
-    if not args.no_parametric:
-        results = SearchFilter.filter_by_query(results, args.query)
-
-    results = SearchSorter.rank(results)
     results = results[:display_limit]
 
     force = bool(getattr(args, "force", False))
@@ -252,6 +341,68 @@ def handle_search(
         force=force,
         fields=resolved_fields,
     )
+
+
+def _run_adaptive_search_pipeline(
+    *,
+    provider: SearchProvider,
+    args: argparse.Namespace,
+    display_limit: int,
+    initial_fetch_limit: int,
+    max_fetch_limit: int = _MAX_ADAPTIVE_FETCH_LIMIT,
+) -> list[SearchResult] | None:
+    """Fetch, filter, and rank with progressive window expansion when needed."""
+
+    fetch_limit = max(1, int(initial_fetch_limit))
+    max_limit = max(fetch_limit, int(max_fetch_limit))
+    best_results: list[SearchResult] = []
+    last_raw_count = -1
+
+    while True:
+        try:
+            raw_results = provider.search(args.query, limit=fetch_limit)
+        except Exception as exc:
+            if not best_results:
+                print(f"Error: search failed: {exc}", file=sys.stderr)
+                return None
+            break
+
+        candidate_results = _apply_result_pipeline(raw_results, args)
+        if len(candidate_results) > len(best_results):
+            best_results = candidate_results
+
+        if len(best_results) >= display_limit:
+            break
+        if fetch_limit >= max_limit:
+            break
+
+        raw_count = len(raw_results)
+        if last_raw_count >= 0 and raw_count <= last_raw_count:
+            # Provider appears saturated for this query; larger limits are unlikely to help.
+            break
+        last_raw_count = raw_count
+
+        next_fetch_limit = min(max_limit, max(fetch_limit * 2, fetch_limit + 1))
+        if next_fetch_limit == fetch_limit:
+            break
+        fetch_limit = next_fetch_limit
+
+    return best_results
+
+
+def _apply_result_pipeline(
+    results: list[SearchResult], args: argparse.Namespace
+) -> list[SearchResult]:
+    """Apply default filters, parametric filtering, and ranking."""
+
+    filtered = list(results)
+    if not args.all:
+        filtered = apply_default_filters(filtered)
+
+    if not args.no_parametric:
+        filtered = SearchFilter.filter_by_query(filtered, args.query)
+
+    return SearchSorter.rank(filtered, query=args.query)
 
 
 def _print_list_fields() -> None:
@@ -276,7 +427,7 @@ def _parse_fields_argument(fields: str) -> list[str] | None:
         return None
 
     # Registry keys only.
-    normalized = [t.strip().lower() for t in tokens]
+    normalized = [_normalize_field_key(t) for t in tokens]
 
     unknown = [f for f in normalized if f not in _FIELD_REGISTRY]
     if unknown:
@@ -299,29 +450,57 @@ def _resolve_fields_from_args(args: argparse.Namespace) -> list[str] | None:
     # 1) CLI override
     if getattr(args, "fields", None) is not None:
         return _parse_fields_argument(args.fields)
-
     # 2) Supplier profile fields
     supplier_id = (getattr(args, "supplier", "") or "").strip().lower()
     supplier = resolve_supplier_by_id(supplier_id)
     if supplier is not None and supplier.search_fields:
-        return list(supplier.search_fields)
+        validated_supplier_fields = _validate_profile_field_list(
+            supplier.search_fields, source=f"supplier profile '{supplier_id}'"
+        )
+        if validated_supplier_fields is None:
+            return None
+        return validated_supplier_fields
 
-    # 3) Generic profile fields
-    try:
-        generic = load_supplier("generic")
-        if generic.search_fields:
-            return list(generic.search_fields)
-    except ValueError:
-        pass
+    # 3) Defaults profile fields (selected by --defaults, default: generic).
+    defaults_cfg = get_defaults()
+    defaults_fields = defaults_cfg.get_search_output_fields_default()
+    if defaults_fields:
+        validated_defaults_fields = _validate_profile_field_list(
+            defaults_fields, source=f"defaults profile '{defaults_cfg.name}'"
+        )
+        if validated_defaults_fields is None:
+            return None
+        return validated_defaults_fields
 
-    # 4) Emergency fallback (keep it simple and always include description)
-    return [
-        "supplier_part_number",
-        "price",
-        "stock_quantity",
-        "lifecycle_status",
-        "description",
-    ]
+    print(
+        "Error: No default search fields configured. Set supplier.search.fields "
+        "or defaults.search.output_fields.default.",
+        file=sys.stderr,
+    )
+    return None
+
+
+def _validate_profile_field_list(fields: list[str], *, source: str) -> list[str] | None:
+    """Validate and normalize profile-provided field lists."""
+
+    normalized = [str(field).strip().lower() for field in fields if str(field).strip()]
+    unknown = [field for field in normalized if field not in _FIELD_REGISTRY]
+    if unknown:
+        print(
+            f"Error: {source} defines unknown search field(s): {', '.join(unknown)}",
+            file=sys.stderr,
+        )
+        print("Use --list-fields to see valid field keys.", file=sys.stderr)
+        return None
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for field in normalized:
+        if field in seen:
+            continue
+        seen.add(field)
+        deduped.append(field)
+    return deduped
 
 
 def _row_for_result(r: SearchResult) -> dict[str, str]:

--- a/src/jbom/config/defaults.py
+++ b/src/jbom/config/defaults.py
@@ -29,12 +29,20 @@ from jbom.config.profile_search import find_profile
 log = logging.getLogger(__name__)
 
 _BUILTIN_DIR = Path(__file__).parent / "defaults"
+_ACTIVE_DEFAULTS_PROFILE = "generic"
 
 
 def _normalize_field_synonym_canonical_key(canonical: str) -> str:
     """Normalize field-synonym canonical keys."""
 
     return str(canonical).strip().lower()
+
+
+def _normalize_defaults_profile_name(name: str) -> str:
+    """Normalize a defaults profile name, falling back to 'generic'."""
+
+    normalized = str(name or "").strip()
+    return normalized or "generic"
 
 
 @dataclass(frozen=True)
@@ -71,6 +79,7 @@ class DefaultsConfig:
         default_factory=dict
     )
     field_synonyms: dict[str, FieldSynonymConfig] = field(default_factory=dict)
+    search_output_fields_default: tuple[str, ...] = field(default_factory=tuple)
     search_excluded_categories: frozenset[str] = field(default_factory=frozenset)
     component_id_fields: dict[str, frozenset[str]] = field(default_factory=dict)
 
@@ -153,6 +162,37 @@ class DefaultsConfig:
                     synonyms=synonyms,
                 )
 
+        search_cfg = data.get("search") or {}
+        search_output_fields_default: tuple[str, ...] = tuple()
+        if isinstance(search_cfg, dict):
+            output_fields_cfg = search_cfg.get("output_fields") or {}
+            if isinstance(output_fields_cfg, dict):
+                default_output_fields = output_fields_cfg.get("default") or []
+                if isinstance(default_output_fields, list):
+                    normalized_fields: list[str] = []
+                    for field_name in default_output_fields:
+                        normalized = str(field_name).strip().lower()
+                        if normalized:
+                            normalized_fields.append(normalized)
+                    search_output_fields_default = tuple(
+                        dict.fromkeys(normalized_fields).keys()
+                    )
+                else:
+                    log.warning(
+                        "search.output_fields.default must be a list; found %r",
+                        type(default_output_fields).__name__,
+                    )
+            else:
+                log.warning(
+                    "search.output_fields must be a mapping; found %r",
+                    type(output_fields_cfg).__name__,
+                )
+        else:
+            log.warning(
+                "search must be a mapping; found %r",
+                type(search_cfg).__name__,
+            )
+
         raw_excluded = data.get("search_excluded_categories") or []
         search_excluded_categories: frozenset[str] = frozenset(
             str(c).upper().strip() for c in raw_excluded if str(c).strip()
@@ -186,6 +226,7 @@ class DefaultsConfig:
             category_route_rules=category_route_rules,
             enrichment_attributes=enrichment_attributes,
             field_synonyms=field_synonyms,
+            search_output_fields_default=search_output_fields_default,
             search_excluded_categories=search_excluded_categories,
             component_id_fields=component_id_fields,
         )
@@ -230,6 +271,11 @@ class DefaultsConfig:
 
         return self.search_excluded_categories
 
+    def get_search_output_fields_default(self) -> list[str]:
+        """Return default search output fields from the active defaults profile."""
+
+        return list(self.search_output_fields_default)
+
     def get_component_id_fields(self, category: str) -> frozenset[str] | None:
         """Return the optional-field allowlist for *category*, or ``None``.
 
@@ -265,20 +311,38 @@ def load_defaults(name: str, *, cwd: Path | None = None) -> DefaultsConfig:
     return DefaultsConfig.from_yaml_dict(data, name=name)
 
 
-def get_defaults(name: str = "generic", *, cwd: Path | None = None) -> DefaultsConfig:
+def get_defaults(name: str | None = None, *, cwd: Path | None = None) -> DefaultsConfig:
     """Load a defaults profile, returning built-in generic on any error.
 
     Safe wrapper for callers that must not fail (e.g. query building).
 
     Args:
-        name: Profile name to load.
+        name: Profile name to load. When omitted, uses the active profile.
         cwd: Working directory for project-local search.
     """
+    resolved_name = _normalize_defaults_profile_name(
+        name if name is not None else _ACTIVE_DEFAULTS_PROFILE
+    )
     try:
-        return load_defaults(name, cwd=cwd)
+        return load_defaults(resolved_name, cwd=cwd)
     except Exception:
-        log.warning("Could not load defaults profile %r; using built-in generic", name)
+        log.warning(
+            "Could not load defaults profile %r; using built-in generic", resolved_name
+        )
         return _load_builtin_generic()
+
+
+def get_active_defaults_profile() -> str:
+    """Return the active defaults profile name used by get_defaults()."""
+
+    return _ACTIVE_DEFAULTS_PROFILE
+
+
+def set_active_defaults_profile(name: str) -> None:
+    """Set the active defaults profile name used by get_defaults()."""
+
+    global _ACTIVE_DEFAULTS_PROFILE
+    _ACTIVE_DEFAULTS_PROFILE = _normalize_defaults_profile_name(name)
 
 
 def _load_yaml_resolved(name: str, *, cwd: Path | None = None) -> dict[str, Any]:
@@ -336,6 +400,8 @@ __all__ = [
     "DefaultsConfig",
     "EnrichmentCategoryConfig",
     "FieldSynonymConfig",
+    "get_active_defaults_profile",
     "get_defaults",
     "load_defaults",
+    "set_active_defaults_profile",
 ]

--- a/src/jbom/config/defaults/generic.defaults.yaml
+++ b/src/jbom/config/defaults/generic.defaults.yaml
@@ -162,6 +162,20 @@ field_synonyms:
     display_name: "Power"
 
 # ---------------------------------------------------------------------------
+# Default CLI search output fields (used when supplier profile has no override).
+# ---------------------------------------------------------------------------
+search:
+  output_fields:
+    default:
+      - supplier_part_number
+      - manufacturer
+      - mpn
+      - package
+      - category
+      - price
+      - description
+
+# ---------------------------------------------------------------------------
 # Component categories excluded from supplier catalog search.
 # Items whose normalized category matches any entry here are silently skipped
 # before any query is built.  All other categories are searchable (denylist model).

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -23,11 +23,10 @@ from jbom.common.value_parsing import (
     decode_typed_parametric,
 )
 from jbom.common.synonym_normalization import first_non_empty_alias_value
-from jbom.config.defaults import get_defaults
+from jbom.config.defaults import DefaultsConfig, get_defaults
 from jbom.services.jlc_loader import JLCPrivateInventoryLoader
 
 log = logging.getLogger(__name__)
-_DEFAULTS_PROFILE = get_defaults("generic")
 
 _ROW_TYPE_ITEM = "ITEM"
 _ROW_TYPE_COMPONENT = "COMPONENT"
@@ -100,6 +99,14 @@ class InventoryReader:
 
         self.inventory: List[InventoryItem] = []
         self.inventory_fields: List[str] = []
+        self._defaults_profile: DefaultsConfig | None = None
+
+    def _get_defaults_profile(self) -> DefaultsConfig:
+        """Return the active defaults profile for this reader instance."""
+
+        if self._defaults_profile is None:
+            self._defaults_profile = get_defaults()
+        return self._defaults_profile
 
     def load(self) -> tuple[List[InventoryItem], List[str]]:
         """Load inventory from all provided files.
@@ -507,7 +514,7 @@ class InventoryReader:
         """Resolve a canonical value via defaults-profile synonym mappings."""
 
         keys: List[str] = []
-        config = _DEFAULTS_PROFILE.get_field_synonym_config(canonical)
+        config = self._get_defaults_profile().get_field_synonym_config(canonical)
         if config is not None:
             keys.extend([config.display_name, *config.synonyms])
         keys.extend(fallback_keys or [])

--- a/src/jbom/services/project_inventory.py
+++ b/src/jbom/services/project_inventory.py
@@ -50,7 +50,7 @@ class ProjectInventoryGenerator:
     def _get_defaults(self) -> DefaultsConfig:
         """Return the loaded defaults profile, loading lazily on first call."""
         if self._defaults is None:
-            self._defaults = get_defaults("generic", cwd=self._cwd)
+            self._defaults = get_defaults(cwd=self._cwd)
         return self._defaults
 
     def _classify_all_components(self) -> Dict[int, Optional[str]]:

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -29,6 +29,31 @@ _CATEGORY_ATTR_NAME: dict[str, str] = {
     "REG": "Output Voltage",
 }
 
+_KNOWN_PACKAGE_TOKENS: tuple[str, ...] = (
+    "0201",
+    "0402",
+    "0603",
+    "0805",
+    "1206",
+    "1210",
+    "1812",
+    "2010",
+    "2512",
+)
+
+_QUERY_CATEGORY_HINTS: dict[str, tuple[str, ...]] = {
+    "RES": ("RESISTOR", "RESISTORS"),
+    "CAP": ("CAPACITOR", "CAPACITORS"),
+    "IND": ("INDUCTOR", "INDUCTORS"),
+}
+_PASSIVE_STOCK_MIN_QTY = 2000
+_PASSIVE_STOCK_INTENTS = frozenset({"RES", "CAP"})
+_BASIC_PART_RELEVANCE_BOOST = 2
+
+_PACKAGE_PATTERN = re.compile(
+    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
+)
+
 
 def _close_enough(a: float, b: float, *, rel_tol: float = 0.001) -> bool:
     if a == b:
@@ -36,6 +61,29 @@ def _close_enough(a: float, b: float, *, rel_tol: float = 0.001) -> bool:
     if b == 0:
         return abs(a) < rel_tol
     return abs(a - b) <= abs(b) * rel_tol
+
+
+def _extract_package_token(result: SearchResult) -> str:
+    """Extract normalized package token from attributes/raw data/description."""
+
+    candidates: list[str] = []
+    if result.attributes:
+        candidates.append(str(result.attributes.get("Package", "")))
+    if result.raw_data:
+        for key in ("componentSpecificationEn", "package", "Package"):
+            candidates.append(str(result.raw_data.get(key, "")))
+
+    candidates.append(result.description or "")
+    candidates.append(result.mpn or "")
+
+    for text in candidates:
+        if not text:
+            continue
+        match = _PACKAGE_PATTERN.search(text.upper())
+        if match:
+            return match.group(1).upper()
+
+    return ""
 
 
 class SearchFilter:
@@ -98,23 +146,31 @@ class SearchFilter:
                 target_tol = float(tol_match.group(1))
             except ValueError:
                 target_tol = None
+
+        # Package token target (e.g. 0603, 0805).
+        target_package = ""
+        for token in re.split(r"[\s,/_-]+", query or ""):
+            package_token = token.strip().upper()
+            if package_token in _KNOWN_PACKAGE_TOKENS:
+                target_package = package_token
+                break
+
         attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
         strict_core_attr = target_value is not None and bool(attr_name)
+        strict_package = bool(
+            target_package and any(_extract_package_token(r) for r in results)
+        )
 
-        def _filter_pass(*, require_core_attr: bool) -> list[SearchResult]:
+        def _filter_pass(
+            *, require_core_attr: bool, require_package_match: bool
+        ) -> list[SearchResult]:
             filtered: list[SearchResult] = []
 
             for r in results:
-                if not r.attributes:
-                    if require_core_attr and strict_core_attr:
-                        continue
-                    filtered.append(r)
-                    continue
-
                 keep = True
 
                 if target_value is not None and attr_name:
-                    raw_attr = r.attributes.get(attr_name, "")
+                    raw_attr = (r.attributes or {}).get(attr_name, "")
                     if not raw_attr:
                         if require_core_attr:
                             keep = False
@@ -126,7 +182,7 @@ class SearchFilter:
                             keep = False
 
                 if keep and cat == "CAP" and target_volts is not None:
-                    vr_attr = r.attributes.get("Voltage Rating", "")
+                    vr_attr = (r.attributes or {}).get("Voltage Rating", "")
                     if vr_attr:
                         attr_volts = parse_voltage_to_volts(vr_attr)
                         # Interpret voltage rating as a minimum requirement.
@@ -134,7 +190,7 @@ class SearchFilter:
                             keep = False
 
                 if keep and target_tol is not None:
-                    tol_attr = r.attributes.get("Tolerance", "")
+                    tol_attr = (r.attributes or {}).get("Tolerance", "")
                     if tol_attr:
                         clean_tol = tol_attr.replace("%", "").replace("+/-", "").strip()
                         try:
@@ -145,17 +201,28 @@ class SearchFilter:
                             # If the result tolerance is unparsable, fail open.
                             pass
 
+                if keep and target_package:
+                    observed_package = _extract_package_token(r)
+                    if observed_package:
+                        if observed_package != target_package and require_package_match:
+                            keep = False
+                    elif require_package_match:
+                        keep = False
+
                 if keep:
                     filtered.append(r)
 
             return filtered
 
-        if strict_core_attr:
-            strict_filtered = _filter_pass(require_core_attr=True)
+        if strict_core_attr or strict_package:
+            strict_filtered = _filter_pass(
+                require_core_attr=strict_core_attr,
+                require_package_match=strict_package,
+            )
             if strict_filtered:
                 return strict_filtered
 
-        return _filter_pass(require_core_attr=False)
+        return _filter_pass(require_core_attr=False, require_package_match=False)
 
 
 def apply_default_filters(results: Iterable[SearchResult]) -> list[SearchResult]:
@@ -188,14 +255,20 @@ class SearchSorter:
     """Sorting utilities."""
 
     @staticmethod
-    def rank(results: list[SearchResult], *, category: str = "") -> list[SearchResult]:
-        """Rank by stock (desc), price (asc), then category value (asc)."""
+    def rank(
+        results: list[SearchResult], *, category: str = "", query: str = ""
+    ) -> list[SearchResult]:
+        """Rank by relevance/price with passive stock used as a coarse eligibility gate."""
 
         cat = normalize_component_type(category or "")
         attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
+        relevance_context = _build_relevance_context(query)
+        category_intent = relevance_context.get("category_intent", "") or cat
+        ranked_pool = _apply_passive_stock_gate(
+            results, category_intent=category_intent
+        )
 
-        def sort_key(r: SearchResult) -> tuple[int, float, float]:
-            stock = r.stock_quantity
+        def sort_key(r: SearchResult) -> tuple[int, float, float, str, str, str]:
             try:
                 price_clean = (
                     (r.price or "")
@@ -215,10 +288,134 @@ class SearchSorter:
                     v = parse_value_to_normal(cat, raw)
                     if v is not None:
                         canonical = v
+            relevance = _query_relevance_score(r, context=relevance_context)
+            manufacturer = (r.manufacturer or "").upper()
+            mpn = (r.mpn or "").upper()
+            supplier_pn = (r.distributor_part_number or "").upper()
+            return (-relevance, price_value, canonical, manufacturer, mpn, supplier_pn)
 
-            return (-stock, price_value, canonical)
+        return sorted(ranked_pool, key=sort_key)
 
-        return sorted(results, key=sort_key)
+
+def _apply_passive_stock_gate(
+    results: list[SearchResult], *, category_intent: str
+) -> list[SearchResult]:
+    """Filter low-stock passive candidates when better-stocked options exist."""
+
+    if category_intent not in _PASSIVE_STOCK_INTENTS:
+        return results
+
+    sufficiently_stocked = [
+        r for r in results if r.stock_quantity >= _PASSIVE_STOCK_MIN_QTY
+    ]
+    if sufficiently_stocked:
+        return sufficiently_stocked
+
+    # Fail-open: preserve context when all candidates are low stock.
+    return results
+
+
+def _build_relevance_context(query: str) -> dict[str, str]:
+    """Parse query once for ranking relevance calculations."""
+
+    query_tokens = [
+        tok.strip().upper()
+        for tok in re.split(r"[\s,/_-]+", query or "")
+        if tok.strip()
+    ]
+
+    requested_package = ""
+    for tok in query_tokens:
+        if tok in _KNOWN_PACKAGE_TOKENS:
+            requested_package = tok
+            break
+
+    category_intent = ""
+    for category_key, hints in _QUERY_CATEGORY_HINTS.items():
+        if any(hint in query_tokens for hint in hints):
+            category_intent = category_key
+            break
+
+    return {
+        "requested_package": requested_package,
+        "category_intent": category_intent,
+        "query_tokens": " ".join(query_tokens),
+    }
+
+
+def _query_relevance_score(result: SearchResult, *, context: dict[str, str]) -> int:
+    """Score a result against query terms, package intent, and category intent."""
+
+    query_tokens = [tok for tok in context.get("query_tokens", "").split(" ") if tok]
+    if not query_tokens:
+        return 0
+
+    haystack = " ".join(
+        [
+            result.description or "",
+            result.category or "",
+            result.manufacturer or "",
+            result.mpn or "",
+            " ".join(f"{k} {v}" for k, v in (result.attributes or {}).items()),
+        ]
+    ).upper()
+
+    score = 0
+    for tok in query_tokens:
+        if len(tok) < 2:
+            continue
+        if tok in haystack:
+            score += 1
+
+    requested_package = context.get("requested_package", "")
+    if requested_package:
+        if requested_package in haystack:
+            score += 8
+        else:
+            mismatched_package = any(
+                pkg in haystack
+                for pkg in _KNOWN_PACKAGE_TOKENS
+                if pkg != requested_package
+            )
+            if mismatched_package:
+                score -= 8
+
+    category_intent = context.get("category_intent", "")
+    if category_intent == "RES":
+        if "RESISTOR" in haystack:
+            score += 6
+        elif "THERMISTOR" in haystack:
+            score -= 10
+        else:
+            score -= 4
+    elif category_intent == "CAP":
+        if "CAPACITOR" in haystack:
+            score += 6
+        else:
+            score -= 4
+    elif category_intent == "IND":
+        if "INDUCTOR" in haystack:
+            score += 6
+        else:
+            score -= 4
+    if _component_library_tier(result) == "basic":
+        score += _BASIC_PART_RELEVANCE_BOOST
+
+    return score
+
+
+def _component_library_tier(result: SearchResult) -> str:
+    """Normalize provider library tier labels to basic/extended where possible."""
+
+    if not result.raw_data:
+        return ""
+
+    raw = str(result.raw_data.get("componentLibraryType", "")).strip().lower()
+    if raw in {"base", "basic"}:
+        return "basic"
+    if raw in {"expand", "extended"}:
+        return "extended"
+    return ""
 
 
 __all__ = ["SearchFilter", "SearchSorter", "apply_default_filters"]

--- a/tests/services/search/test_filtering.py
+++ b/tests/services/search/test_filtering.py
@@ -124,7 +124,53 @@ def test_filter_by_query_falls_back_to_fail_open_when_strict_pass_is_empty():
     assert "D" in mpns
 
 
-def test_sorter_prefers_higher_stock_then_lower_price():
+def test_filter_by_query_strict_package_match_when_query_includes_package():
+    results = [
+        _sr(
+            attributes={"Resistance": "10 kOhms"},
+            description="10k 0603 resistor",
+            raw_data={"componentSpecificationEn": "0603"},
+            mpn="A",
+        ),
+        _sr(
+            attributes={"Resistance": "10 kOhms"},
+            description="10k 0805 resistor",
+            raw_data={"componentSpecificationEn": "0805"},
+            mpn="B",
+        ),
+        _sr(
+            attributes={"Resistance": "10 kOhms"},
+            description="10k 0402 resistor",
+            raw_data={"componentSpecificationEn": "0402"},
+            mpn="C",
+        ),
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10k 0603 resistor")
+    assert [r.mpn for r in filtered] == ["A"]
+
+
+def test_filter_by_query_package_filter_falls_open_when_no_package_matches():
+    results = [
+        _sr(
+            attributes={"Resistance": "10 kOhms"},
+            description="10k 0805 resistor",
+            raw_data={"componentSpecificationEn": "0805"},
+            mpn="A",
+        ),
+        _sr(
+            attributes={"Resistance": "10 kOhms"},
+            description="10k 0402 resistor",
+            raw_data={"componentSpecificationEn": "0402"},
+            mpn="B",
+        ),
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10k 0603 resistor")
+    assert {r.mpn for r in filtered} == {"A", "B"}
+
+
+def test_sorter_prefers_lower_price_over_stock_when_relevance_equal():
     results = [
         _sr(stock_quantity=10, price="$0.20", mpn="A"),
         _sr(stock_quantity=10, price="$0.10", mpn="B"),
@@ -132,7 +178,7 @@ def test_sorter_prefers_higher_stock_then_lower_price():
     ]
 
     ranked = SearchSorter.rank(results)
-    assert [r.mpn for r in ranked] == ["C", "B", "A"]
+    assert [r.mpn for r in ranked] == ["B", "A", "C"]
 
 
 def test_sorter_uses_numeric_value_as_tertiary_key_when_category_provided():
@@ -159,3 +205,144 @@ def test_sorter_uses_numeric_value_as_tertiary_key_when_category_provided():
 
     ranked = SearchSorter.rank(results, category="CAP")
     assert [r.mpn for r in ranked] == ["B", "A", "C"]
+
+
+def test_sorter_prefers_requested_package_match_from_query():
+    results = [
+        _sr(
+            mpn="A",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=2500,
+            price="$0.20",
+        ),
+        _sr(
+            mpn="B",
+            category="Thick Film Resistors - SMD",
+            description="10K 0805 Chip Resistor",
+            stock_quantity=10000,
+            price="$0.10",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10k 0603 resistor")
+    assert [r.mpn for r in ranked] == ["A", "B"]
+
+
+def test_sorter_filters_low_stock_passive_results_when_alternatives_exist():
+    results = [
+        _sr(
+            mpn="LOW",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=1500,
+            price="$0.01",
+        ),
+        _sr(
+            mpn="OK",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=2500,
+            price="$0.03",
+        ),
+        _sr(
+            mpn="HIGH",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=500000,
+            price="$0.02",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10k 0603 resistor")
+    assert [r.mpn for r in ranked] == ["HIGH", "OK"]
+
+
+def test_sorter_passive_low_stock_gate_fails_open_when_no_alternatives():
+    results = [
+        _sr(
+            mpn="A",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=1000,
+            price="$0.03",
+        ),
+        _sr(
+            mpn="B",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=1500,
+            price="$0.02",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10k 0603 resistor")
+    assert [r.mpn for r in ranked] == ["B", "A"]
+
+
+def test_sorter_does_not_apply_passive_stock_gate_for_inductors():
+    results = [
+        _sr(
+            mpn="LOW",
+            category="Power Inductors",
+            description="10uH 0603 Inductor",
+            stock_quantity=1500,
+            price="$0.01",
+        ),
+        _sr(
+            mpn="HIGH",
+            category="Power Inductors",
+            description="10uH 0603 Inductor",
+            stock_quantity=3000,
+            price="$0.02",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10uH 0603 inductor")
+    assert [r.mpn for r in ranked] == ["LOW", "HIGH"]
+
+
+def test_sorter_demotes_thermistors_for_resistor_query():
+    results = [
+        _sr(
+            mpn="RES",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            stock_quantity=2500,
+            price="$0.20",
+        ),
+        _sr(
+            mpn="NTC",
+            category="NTC Thermistors",
+            description="10Kohms 1% NTC Thermistor 0603",
+            stock_quantity=100000,
+            price="$0.10",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10k 0603 resistor")
+    assert [r.mpn for r in ranked] == ["RES", "NTC"]
+
+
+def test_sorter_prefers_basic_part_tier_when_relevance_is_otherwise_equal():
+    results = [
+        _sr(
+            mpn="BASE",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            raw_data={"componentLibraryType": "base"},
+            stock_quantity=5000,
+            price="$0.20",
+        ),
+        _sr(
+            mpn="EXPAND",
+            category="Thick Film Resistors - SMD",
+            description="10K 0603 Chip Resistor",
+            raw_data={"componentLibraryType": "expand"},
+            stock_quantity=5000,
+            price="$0.01",
+        ),
+    ]
+
+    ranked = SearchSorter.rank(results, query="10k 0603 resistor")
+    assert [r.mpn for r in ranked] == ["BASE", "EXPAND"]

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from jbom.cli.main import create_parser
 
 from jbom.cli.search import _build_cache as _build_search_cache
 from jbom.cli.search import handle_search
@@ -50,6 +51,12 @@ def test_build_cache_clear_cache_flag_calls_clear_provider(monkeypatch) -> None:
     cache = _build_search_cache(args)
     assert isinstance(cache, InMemorySearchCache)
     assert calls["provider_id"] == "mouser"
+
+
+def test_search_default_supplier_is_generic() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["search", "10k resistor"])
+    assert args.supplier == "generic"
 
 
 def test_search_console_output(monkeypatch, capsys):
@@ -113,9 +120,106 @@ def test_search_csv_stdout(monkeypatch, capsys):
     out_text = capsys.readouterr().out
     reader = csv_mod.reader(io.StringIO(out_text))
     header = next(reader)
-    assert header[:3] == ["Supplier PN", "Price", "Stock"]
+    assert header[:4] == ["Supplier PN", "Manufacturer", "MPN", "Package"]
+    assert "Category" in header
+    assert "Price" in header
     data_rows = list(reader)
     assert any("123-ABC" in cell for row in data_rows for cell in row)
+
+
+def test_search_adaptive_fetch_expands_when_results_are_sparse(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    calls: list[int] = []
+
+    def _search(self, query, *, limit=10):
+        calls.append(int(limit))
+        if limit < 100:
+            return [
+                _sr(mpn="A", distributor_part_number="PN-A", stock_quantity=3),
+                _sr(mpn="B", distributor_part_number="PN-B", stock_quantity=2),
+                _sr(mpn="C", distributor_part_number="PN-C", stock_quantity=1),
+            ]
+        return [
+            _sr(
+                mpn=f"P{i}",
+                distributor_part_number=f"PN-{i}",
+                stock_quantity=200 - i,
+            )
+            for i in range(1, 15)
+        ]
+
+    monkeypatch.setattr(mouser_provider.MouserProvider, "search", _search)
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=10,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+        fields="supplier_part_number",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+    assert calls == [50, 100]
+
+    out_text = capsys.readouterr().out
+    assert "PN-10" in out_text
+
+
+def test_search_adaptive_fetch_can_expand_multiple_windows(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    calls: list[int] = []
+
+    def _search(self, query, *, limit=10):
+        calls.append(int(limit))
+        return [
+            _sr(
+                mpn=f"P{i}",
+                distributor_part_number=f"PN-{i}",
+                stock_quantity=5000 - i,
+            )
+            for i in range(1, int(limit) + 1)
+        ]
+
+    def _sparse_filter(results, _query):
+        # Keep every 50th item to emulate strict filtering that needs deeper windows.
+        return results[::50]
+
+    monkeypatch.setattr(mouser_provider.MouserProvider, "search", _search)
+    monkeypatch.setattr(
+        "jbom.cli.search.SearchFilter.filter_by_query", staticmethod(_sparse_filter)
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=7,
+        api_key="dummy",
+        all=True,
+        no_parametric=False,
+        output="-",
+        fields="supplier_part_number",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+    assert calls == [50, 100, 200, 400]
+    import csv as csv_mod
+    import io
+
+    out_text = capsys.readouterr().out
+    reader = csv_mod.reader(io.StringIO(out_text))
+    next(reader)  # header
+    rows = list(reader)
+    assert len(rows) == 7
+    assert "PN-301" in out_text
 
 
 def test_search_csv_file(monkeypatch, tmp_path):
@@ -149,7 +253,9 @@ def test_search_csv_file(monkeypatch, tmp_path):
     text = outpath.read_text(encoding="utf-8")
     reader = csv_mod.reader(text.splitlines())
     header = next(reader)
-    assert header[:3] == ["Supplier PN", "Price", "Stock"]
+    assert header[:4] == ["Supplier PN", "Manufacturer", "MPN", "Package"]
+    assert "Category" in header
+    assert "Price" in header
     assert "123-ABC" in text
 
 
@@ -218,6 +324,139 @@ def test_search_fields_override_affects_csv_schema(monkeypatch, capsys):
     assert any("Yageo" in cell for row in data_rows for cell in row)
 
 
+def test_search_fields_aliases_are_accepted(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [_sr()],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+        fields="Category,Description,Manufacturer,MPN,Package,Price,Stock,Supplier_PN",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+
+    import csv as csv_mod
+    import io
+
+    out_text = capsys.readouterr().out
+    reader = csv_mod.reader(io.StringIO(out_text))
+    header = next(reader)
+    assert header == [
+        "Category",
+        "Description",
+        "Manufacturer",
+        "MPN",
+        "Package",
+        "Price",
+        "Stock",
+        "Supplier PN",
+    ]
+
+
+def test_search_package_and_category_use_raw_payload_fallback(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    fallback_result = _sr(
+        category="",
+        raw_data={
+            "componentSpecificationEn": "0603",
+            "firstSortName": "Chip Resistor - Surface Mount",
+            "secondSortName": "Resistors",
+        },
+    )
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [fallback_result],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+        fields="category,package",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+
+    import csv as csv_mod
+    import io
+
+    out_text = capsys.readouterr().out
+    reader = csv_mod.reader(io.StringIO(out_text))
+    header = next(reader)
+    row = next(reader)
+    assert header == ["Category", "Package"]
+    assert row == ["Resistors: Chip Resistor - Surface Mount", "0603"]
+
+
+def test_search_description_shows_library_tier_notation(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    basic = _sr(
+        distributor_part_number="PN-BASIC",
+        description="10K 0603 resistor",
+        raw_data={"componentLibraryType": "base"},
+    )
+    extended = _sr(
+        distributor_part_number="PN-EXT",
+        description="10K 0603 resistor",
+        raw_data={"componentLibraryType": "expand"},
+    )
+
+    monkeypatch.setattr(
+        mouser_provider.MouserProvider,
+        "search",
+        lambda self, query, *, limit=10: [basic, extended],
+    )
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=2,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="-",
+        fields="supplier_part_number,description",
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 0
+
+    import csv as csv_mod
+    import io
+
+    out_text = capsys.readouterr().out
+    reader = csv_mod.reader(io.StringIO(out_text))
+    header = next(reader)
+    rows = list(reader)
+    assert header == ["Supplier PN", "Description"]
+    assert ["PN-BASIC", "[basic] 10K 0603 resistor"] in rows
+    assert ["PN-EXT", "[extended] 10K 0603 resistor"] in rows
+
+
 def test_search_unknown_field_rejected(monkeypatch, capsys):
     import jbom.suppliers.mouser.provider as mouser_provider
 
@@ -269,3 +508,37 @@ def test_search_lcsc_provider_exits_cleanly_when_unavailable(monkeypatch, capsys
 
     captured = capsys.readouterr()
     assert "requires the 'requests' package" in captured.err
+
+
+def test_search_errors_when_no_profile_default_fields(monkeypatch, capsys):
+    import jbom.suppliers.mouser.provider as mouser_provider
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("Provider.search should not be called with no defaults")
+
+    class _NoFieldsDefaults:
+        name = "empty"
+
+        def get_search_output_fields_default(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(mouser_provider.MouserProvider, "search", _boom)
+    monkeypatch.setattr("jbom.cli.search.get_defaults", lambda: _NoFieldsDefaults())
+
+    args = argparse.Namespace(
+        query="10K resistor 0603",
+        supplier="mouser",
+        limit=1,
+        api_key="dummy",
+        all=True,
+        no_parametric=True,
+        output="console",
+        fields=None,
+        list_fields=False,
+    )
+
+    rc = handle_search(args, _cache=InMemorySearchCache())
+    assert rc == 1
+
+    captured = capsys.readouterr()
+    assert "No default search fields configured" in captured.err

--- a/tests/unit/test_cli_defaults_profile.py
+++ b/tests/unit/test_cli_defaults_profile.py
@@ -1,0 +1,67 @@
+"""Unit tests for global CLI --defaults profile selection."""
+
+from __future__ import annotations
+
+from jbom.cli.main import create_parser, main
+from jbom.config.defaults import (
+    get_active_defaults_profile,
+    set_active_defaults_profile,
+)
+
+
+def test_all_subcommands_accept_defaults_argument() -> None:
+    parser = create_parser()
+    custom = "custom-profile"
+
+    cases = [
+        ["annotate", ".", "--defaults", custom],
+        ["audit", ".", "--defaults", custom],
+        ["bom", ".", "--defaults", custom],
+        ["inventory", ".", "--defaults", custom],
+        ["parts", ".", "--defaults", custom],
+        ["pos", ".", "--defaults", custom],
+        ["search", "10k resistor", "--defaults", custom],
+    ]
+
+    for argv in cases:
+        args = parser.parse_args(argv)
+        assert args.defaults == custom
+
+
+def test_all_subcommands_default_defaults_profile_to_generic() -> None:
+    parser = create_parser()
+
+    cases = [
+        ["annotate", "."],
+        ["audit", "."],
+        ["bom", "."],
+        ["inventory", "."],
+        ["parts", "."],
+        ["pos", "."],
+        ["search", "10k resistor"],
+    ]
+
+    for argv in cases:
+        args = parser.parse_args(argv)
+        assert args.defaults == "generic"
+
+
+def test_main_sets_active_defaults_profile_for_handler(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+    custom = "custom-profile"
+
+    def _fake_handle_search(_args) -> int:
+        captured["active_profile"] = get_active_defaults_profile()
+        return 0
+
+    monkeypatch.setattr("jbom.cli.search.handle_search", _fake_handle_search)
+
+    previous = get_active_defaults_profile()
+    set_active_defaults_profile("generic")
+    try:
+        rc = main(["search", "10k resistor", "--defaults", custom])
+        assert rc == 0
+        assert captured["active_profile"] == custom
+        assert get_active_defaults_profile() == "generic"
+    finally:
+        set_active_defaults_profile(previous)

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -90,6 +90,12 @@ def test_root_help_does_not_include_retired_inventory_search():
     assert "inventory-search" not in out
 
 
+def test_all_subcommands_show_defaults_option_in_help():
+    for command in ["annotate", "audit", "bom", "inventory", "parts", "pos", "search"]:
+        out = run_help([command]).lower()
+        assert "--defaults" in out
+
+
 def test_search_help_lists_only_configured_supplier_providers():
     out = run_help(["search"]).lower()
     assert "--supplier" in out

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -22,8 +22,10 @@ from jbom.config.defaults import (
     DefaultsConfig,
     EnrichmentCategoryConfig,
     _deep_merge,
+    get_active_defaults_profile,
     get_defaults,
     load_defaults,
+    set_active_defaults_profile,
 )
 
 
@@ -112,6 +114,19 @@ def test_generic_profile_has_field_synonyms() -> None:
     assert "Manufacturer Part Number" in mpn.synonyms
 
 
+def test_generic_profile_has_default_search_output_fields() -> None:
+    cfg = load_defaults("generic")
+    assert cfg.get_search_output_fields_default() == [
+        "supplier_part_number",
+        "manufacturer",
+        "mpn",
+        "package",
+        "category",
+        "price",
+        "description",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
@@ -126,6 +141,26 @@ def test_get_defaults_returns_generic_on_unknown_name() -> None:
     cfg = get_defaults("nonexistent_xyz_profile_abc")
     assert cfg.name == "generic"
     assert cfg.get_domain_default("resistor", "tolerance") == "5%"
+
+
+def test_get_defaults_uses_active_profile_when_name_omitted(tmp_path: Path) -> None:
+    jbom_dir = tmp_path / ".jbom"
+    jbom_dir.mkdir()
+    (jbom_dir / "tight.defaults.yaml").write_text(
+        "extends: generic\n"
+        "domain_defaults:\n"
+        "  resistor:\n"
+        "    tolerance: '1%'\n"
+    )
+
+    previous = get_active_defaults_profile()
+    set_active_defaults_profile("tight")
+    try:
+        cfg = get_defaults(cwd=tmp_path)
+        assert cfg.name == "tight"
+        assert cfg.get_domain_default("resistor", "tolerance") == "1%"
+    finally:
+        set_active_defaults_profile(previous)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add global `--defaults <profile>` support across CLI subcommands with runtime profile activation/restoration
- make `jbom search` defaults profile-driven (`defaults.search.output_fields.default`) with supplier override and loud failure on invalid config
- switch default search supplier to `generic` and accept common `--fields` aliases (e.g. `stock`, `supplier_pn`)
- improve search filtering/ranking with strict-first package handling, progressive adaptive fetch expansion (50 → 100 → 200 → … up to 1024), passive stock gating for RES/CAP, and price-first in-rank ordering
- add provider metadata handling for JLC library tiers: small basic-part preference boost plus `[basic]`/`[extended]` notation in Description output
- add/update coverage across CLI/defaults/search filtering and adaptive fetch behavior

## Validation
- `pytest` (full suite): 793 passed
- `behave` (functional suite): 42 features passed, 219 scenarios passed
- focused regressions: `pytest tests/services/search/test_filtering.py tests/services/search/test_search_cli.py`

Co-Authored-By: Oz <oz-agent@warp.dev>