### PR TITLE
feat(audit): safer Issue #176 project repair workflow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   (e.g. wavelength) requires one entry here plus a new `make_component_id` parameter.
 
 ### Changed
+- `jbom audit PROJECT` now emits review-first CURRENT/SUGGESTED couplet rows with
+  richer component context (`Value`, `Footprint`, `Package`, `Description`), concise
+  per-reference missing-attribute notes, and safe default `Action=SKIP` guidance.
+  SUGGESTED values now use profile-backed EM defaults where deterministic (e.g.
+  resistor `Tolerance=5%`, package-based resistor `Power=100mW` for 0603, capacitor
+  `Tolerance=10%`, package-based capacitor `Voltage=25V` for 0603) and fall back to
+  `MISSING` otherwise.
+- `jbom annotate --repairs` now ignores `MISSING` placeholder values in repairs CSVs,
+  preventing placeholder text from being written into schematic properties.
 - All jBOM subcommands now accept `--defaults <profile>` (defaulting to
   `generic` when omitted). The selected defaults profile is applied for the
   command runtime and then restored, so profile selection does not leak across

--- a/features/audit/core.feature
+++ b/features/audit/core.feature
@@ -15,25 +15,28 @@ Feature: Audit command core behavior
     Then the command should succeed
     And the exit code should be 0
 
-  Scenario: QUALITY_ISSUE emitted for component missing required Value field
+  Scenario: required-field gaps appear in project couplet audit output
     Given a schematic that contains:
       | UUID    | Reference | Value | Footprint            | Package | LibID    |
       | uuid-r1 | R1        |       | Resistor_SMD:R_0603  | 0603    | Device:R |
     When I run jbom command "audit ."
     Then the command should fail
-    And the output should contain "QUALITY_ISSUE"
-    And the output should contain "Value"
-    And the output should contain "ERROR"
+    And the output should contain "RowType"
+    And the output should contain "Missing attributes: Value"
+    And the output should contain "SUGGESTED"
+    And the output should contain "MISSING"
 
-  Scenario: QUALITY_ISSUE emitted for component missing Manufacturer (WARN severity)
+  Scenario: project audit suggestions focus on EM fields and exclude supply-chain fields
     Given a schematic that contains:
       | UUID    | Reference | Value | Footprint            | Package | LibID    |
       | uuid-r1 | R1        | 10K   | Resistor_SMD:R_0603  | 0603    | Device:R |
     When I run jbom command "audit ."
     Then the command should succeed
-    And the output should contain "QUALITY_ISSUE"
-    And the output should contain "Manufacturer"
-    And the output should contain "WARN"
+    And the output should contain "Missing attributes: Tolerance, Power"
+    And the output should contain "5%"
+    And the output should contain "100mW"
+    And the output should not contain "Manufacturer"
+    And the output should not contain "MFGPN"
 
   Scenario: --strict promotes WARN rows to failures
     Given a schematic that contains:
@@ -47,7 +50,7 @@ Feature: Audit command core behavior
   # Coverage checks (project mode + --inventory)
   # ──────────────────────────────────────────────────────────────
 
-  Scenario: COVERAGE_GAP emitted when component has no inventory match
+  Scenario: audit fails when component has no inventory match
     Given a schematic that contains:
       | UUID    | Reference | Value | Footprint            | Package | LibID    |
       | uuid-r1 | R1        | 10K   | Resistor_SMD:R_0603  | 0603    | Device:R |
@@ -56,7 +59,7 @@ Feature: Audit command core behavior
       | ITEM    | C-100N   | CAP      | 100nF | 0603    | 1        |
     When I run jbom command "audit . --inventory catalog.csv"
     Then the command should fail
-    And the output should contain "COVERAGE_GAP"
+    And the exit code should be 1
     And the output should contain "R1"
 
   Scenario: No COVERAGE_GAP when every component matches inventory
@@ -81,7 +84,7 @@ Feature: Audit command core behavior
     When I run jbom command "audit . -o report.csv"
     Then the command should succeed
     And a file named "report.csv" should exist
-    And the file "report.csv" should contain "CheckType"
+    And the file "report.csv" should contain "RowType"
 
   Scenario: Audit-generated QUOTE_ALL report.csv is consumable by annotate without error
     Given a schematic that contains:

--- a/features/ux_consistency.feature
+++ b/features/ux_consistency.feature
@@ -22,7 +22,7 @@ Feature: UX Consistency Across Commands
       | CAP_100nF | CAP      | 100nF | 100nF capacitor  | 0603    |
       | IC_LM358  | IC       | LM358 | Op-amp           | SOIC-8  |
 
-  Scenario: bom/pos/parts/inventory default to file output
+  Scenario: bom/pos/parts default to file output and inventory defaults to console output
     When I run jbom command "bom"
     Then the command should succeed
     And a file named "project.bom.csv" should exist
@@ -37,7 +37,7 @@ Feature: UX Consistency Across Commands
 
     When I run jbom command "inventory"
     Then the command should succeed
-    And a file named "part-inventory.csv" should exist
+    And the output should contain "Generated inventory with"
 
   Scenario: All commands support -o - for CSV stdout
     When I run jbom command "bom -o -"

--- a/src/jbom/cli/audit.py
+++ b/src/jbom/cli/audit.py
@@ -4,16 +4,16 @@ Usage
 -----
 Project mode (positionals resolve to KiCad project directories or schematics)::
 
-    jbom audit <proj> [<proj> ...]  \\
-        [--inventory cat.csv]       \\
-        [-o report.csv]             \\
+    jbom audit <proj> [<proj> ...]  \
+        [--inventory cat.csv]       \
+        [-o report.csv]             \
         [--strict]
 
 Inventory mode (positionals are ``.csv`` files)::
 
-    jbom audit <cat.csv> [<cat.csv> ...]  \\
-        [--requirements req.csv]           \\
-        [-o report.csv]                    \\
+    jbom audit <cat.csv> [<cat.csv> ...]  \
+        [--requirements req.csv]           \
+        [-o report.csv]                    \
         [--strict]
 
 Mode is detected automatically: if every positional argument ends with
@@ -24,11 +24,50 @@ project mode.
 from __future__ import annotations
 
 import argparse
+import csv
+import io
 import sys
+from collections import OrderedDict
 from pathlib import Path
+from typing import Any
+from jbom.common.component_classification import get_component_type
+from jbom.common.component_filters import apply_component_filters
+from jbom.common.package_matching import extract_package_from_footprint
+from jbom.config.defaults import DefaultsConfig, get_defaults
 
-from jbom.services.audit_service import AuditService
+from jbom.services.audit_service import AuditRow, AuditService, CheckType
+from jbom.services.audit_service import _resolve_project as _resolve_project_for_cli
+from jbom.services.schematic_reader import SchematicReader
 from jbom.services.search.inventory_search_service import InventorySearchService
+
+_PROJECT_REPORT_BASE_COLUMNS: list[str] = [
+    "RowType",
+    "ProjectPath",
+    "RefDes",
+    "UUID",
+    "Category",
+]
+_PROJECT_REPORT_CONTEXT_COLUMNS: list[str] = [
+    "Value",
+    "Footprint",
+    "Package",
+    "Description",
+]
+
+_PROJECT_REPORT_TRAILING_COLUMNS: list[str] = [
+    "Action",
+    "Notes",
+]
+_PROJECT_SUPPLY_CHAIN_FIELDS: set[str] = {
+    "Manufacturer",
+    "MFGPN",
+}
+_PROJECT_ACTION_GUIDANCE = (
+    "SKIP=no change to kicad project, SET=update with new attribute values"
+)
+_PROJECT_MISSING_VALUE = "MISSING"
+_PROJECT_RES_CATEGORY = "RES"
+_PROJECT_CAP_CATEGORY = "CAP"
 
 
 def register_command(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -128,8 +167,7 @@ def handle_audit(args: argparse.Namespace) -> int:
         # Mode detection: all .csv → inventory mode; anything else → project mode.
         if all(p.suffix.lower() == ".csv" for p in inputs):
             return _run_inventory_mode(args, inputs)
-        else:
-            return _run_project_mode(args, inputs)
+        return _run_project_mode(args, inputs)
 
     except FileNotFoundError as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -164,8 +202,8 @@ def _run_project_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
         supplier_service=supplier_service,
         supplier_id=supplier_id,
     )
-
-    _write_report(args, report)
+    component_context = _collect_project_component_contexts(inputs)
+    _write_project_report(args, report, component_context=component_context)
     _print_summary(report)
 
     return report.exit_code_strict() if args.strict else report.exit_code
@@ -191,7 +229,7 @@ def _run_inventory_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
         supplier_id=supplier_id,
     )
 
-    _write_report(args, report)
+    _write_inventory_report(args, report)
     _print_summary(report)
 
     return report.exit_code_strict() if args.strict else report.exit_code
@@ -218,21 +256,243 @@ def _build_supplier_service(
     return service, supplier_id
 
 
-def _write_report(args: argparse.Namespace, report) -> None:
-    """Write the audit report to the configured output destination."""
-    import io
-
+def _write_project_report(
+    args: argparse.Namespace,
+    report: Any,
+    *,
+    component_context: dict[tuple[str, str, str, str], dict[str, str]],
+) -> None:
+    """Write project-mode report as wide CURRENT/SUGGESTED couplets."""
+    fieldnames, rows = _build_project_couplet_rows(
+        report.rows, component_context=component_context
+    )
     output_path: Path | None = getattr(args, "output", None)
 
     if output_path is not None:
-        with output_path.open("w", encoding="utf-8", newline="") as f:
-            report.write_csv(f)
+        with output_path.open("w", encoding="utf-8", newline="") as handle:
+            _write_csv_rows(handle, fieldnames, rows)
         print(f"Audit report written to {output_path}", file=sys.stderr)
-    else:
-        # Write CSV to stdout.
-        buf = io.StringIO()
-        report.write_csv(buf)
-        print(buf.getvalue(), end="")
+        return
+
+    buf = io.StringIO()
+    _write_csv_rows(buf, fieldnames, rows)
+    print(buf.getvalue(), end="")
+
+
+def _write_inventory_report(args: argparse.Namespace, report: Any) -> None:
+    """Write inventory-mode report using the stable audit CSV schema."""
+    output_path: Path | None = getattr(args, "output", None)
+
+    if output_path is not None:
+        with output_path.open("w", encoding="utf-8", newline="") as handle:
+            report.write_csv(handle)
+        print(f"Audit report written to {output_path}", file=sys.stderr)
+        return
+
+    buf = io.StringIO()
+    report.write_csv(buf)
+    print(buf.getvalue(), end="")
+
+
+def _build_project_couplet_rows(
+    report_rows: list[AuditRow],
+    *,
+    component_context: dict[tuple[str, str, str, str], dict[str, str]],
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Build wide CURRENT/SUGGESTED rows from tall QUALITY_ISSUE findings."""
+    defaults = get_defaults()
+    grouped: OrderedDict[tuple[str, str, str, str], dict[str, Any]] = OrderedDict()
+    field_order: list[str] = []
+
+    for row in report_rows:
+        if row.check_type != CheckType.QUALITY_ISSUE:
+            continue
+
+        field_name = (row.field or "").strip()
+        if not field_name or field_name in _PROJECT_SUPPLY_CHAIN_FIELDS:
+            continue
+
+        key = (row.project_path, row.ref_des, row.uuid, row.category)
+        group = grouped.setdefault(
+            key,
+            {
+                "current": {},
+                "suggested": {},
+                "missing_fields": [],
+            },
+        )
+
+        if field_name not in field_order:
+            field_order.append(field_name)
+        if field_name not in group["missing_fields"]:
+            group["missing_fields"].append(field_name)
+
+        current_value = (row.current_value or "").strip()
+        if field_name not in group["current"] and current_value:
+            group["current"][field_name] = current_value
+        group["suggested"][field_name] = _PROJECT_MISSING_VALUE
+
+    fieldnames = (
+        _PROJECT_REPORT_BASE_COLUMNS
+        + _PROJECT_REPORT_CONTEXT_COLUMNS
+        + field_order
+        + _PROJECT_REPORT_TRAILING_COLUMNS
+    )
+    if not grouped:
+        return fieldnames, []
+
+    output_rows: list[dict[str, str]] = []
+    for (project_path, ref_des, uuid, category), group in grouped.items():
+        current_row = {name: "" for name in fieldnames}
+        suggested_row = {name: "" for name in fieldnames}
+
+        current_row["RowType"] = "CURRENT"
+        current_row["ProjectPath"] = project_path
+        current_row["RefDes"] = ref_des
+        current_row["UUID"] = uuid
+        current_row["Category"] = category
+
+        suggested_row["RowType"] = "SUGGESTED"
+        suggested_row["ProjectPath"] = project_path
+        suggested_row["RefDes"] = ref_des
+        suggested_row["UUID"] = uuid
+        suggested_row["Category"] = category
+        context = component_context.get((project_path, ref_des, uuid, category), {})
+        for context_col in _PROJECT_REPORT_CONTEXT_COLUMNS:
+            context_value = context.get(context_col, "")
+            current_row[context_col] = context_value
+            suggested_row[context_col] = context_value
+
+        for field_name in field_order:
+            current_row[field_name] = group["current"].get(field_name, "")
+            raw_suggested = group["suggested"].get(field_name, "")
+            if raw_suggested:
+                suggested_row[field_name] = _resolve_project_default_suggestion(
+                    category=category,
+                    field_name=field_name,
+                    context=context,
+                    defaults=defaults,
+                )
+            else:
+                suggested_row[field_name] = raw_suggested
+        if group["missing_fields"]:
+            missing_fields = ", ".join(group["missing_fields"])
+            current_row["Notes"] = f"{ref_des}: Missing attributes: {missing_fields}"
+        suggested_row["Notes"] = _PROJECT_ACTION_GUIDANCE
+        current_row["Action"] = "SKIP"
+        suggested_row["Action"] = "SKIP"
+
+        output_rows.extend([current_row, suggested_row])
+
+    return fieldnames, output_rows
+
+
+def _resolve_project_default_suggestion(
+    *,
+    category: str,
+    field_name: str,
+    context: dict[str, str],
+    defaults: DefaultsConfig,
+) -> str:
+    """Return a deterministic suggested value for a missing project audit field."""
+    normalized_category = (category or "").strip().upper()
+    normalized_field = (field_name or "").strip()
+    package_code = _extract_context_package_code(context)
+
+    if normalized_category == _PROJECT_RES_CATEGORY:
+        if normalized_field == "Tolerance":
+            suggestion = defaults.get_domain_default(
+                "resistor", "tolerance", fallback=""
+            ).strip()
+            if suggestion:
+                return suggestion
+        if normalized_field == "Power" and package_code:
+            suggestion = defaults.get_package_power(package_code).strip()
+            if suggestion:
+                return suggestion
+
+    if normalized_category == _PROJECT_CAP_CATEGORY:
+        if normalized_field == "Tolerance":
+            suggestion = defaults.get_domain_default(
+                "capacitor", "tolerance", fallback=""
+            ).strip()
+            if suggestion:
+                return suggestion
+        if normalized_field == "Voltage" and package_code:
+            suggestion = defaults.get_package_voltage(package_code).strip()
+            if suggestion:
+                return suggestion
+
+    return _PROJECT_MISSING_VALUE
+
+
+def _extract_context_package_code(context: dict[str, str]) -> str:
+    """Extract a normalized package code from component context fields."""
+    footprint = (context.get("Footprint") or "").strip()
+    package_from_footprint = extract_package_from_footprint(footprint)
+    if package_from_footprint:
+        return package_from_footprint.upper()
+
+    raw_package = (context.get("Package") or "").strip()
+    if not raw_package:
+        return ""
+    if raw_package.isdigit() and len(raw_package) == 3:
+        return f"0{raw_package}"
+    return raw_package.upper()
+
+
+def _collect_project_component_contexts(
+    project_paths: list[Path],
+) -> dict[tuple[str, str, str, str], dict[str, str]]:
+    """Collect per-component context values for project couplet output."""
+    contexts: dict[tuple[str, str, str, str], dict[str, str]] = {}
+    reader = SchematicReader()
+
+    for project_path in project_paths:
+        try:
+            resolved_pro, schematic_files = _resolve_project_for_cli(project_path)
+        except (FileNotFoundError, ValueError):
+            # Context enrichment is best-effort; unresolved paths should not
+            # block report generation from already-computed audit rows.
+            continue
+        pro_str = str(resolved_pro)
+        for schematic_file in schematic_files:
+            raw_components = reader.load_components(schematic_file)
+            components = apply_component_filters(
+                raw_components,
+                {
+                    "exclude_dnp": True,
+                    "include_only_bom": True,
+                    "include_virtual_symbols": False,
+                },
+            )
+            for comp in components:
+                category = (
+                    get_component_type(comp.lib_id, comp.footprint, comp.reference)
+                    or ""
+                )
+                props = comp.properties or {}
+                key = (pro_str, comp.reference, comp.uuid, category)
+                contexts[key] = {
+                    "Value": comp.value or "",
+                    "Footprint": comp.footprint or "",
+                    "Package": (props.get("Package") or "").strip(),
+                    "Description": (props.get("Description") or "").strip(),
+                }
+
+    return contexts
+
+
+def _write_csv_rows(
+    handle: io.TextIOBase | io.StringIO,
+    fieldnames: list[str],
+    rows: list[dict[str, str]],
+) -> None:
+    """Write CSV rows using QUOTE_ALL for spreadsheet-safe text rendering."""
+    writer = csv.DictWriter(handle, fieldnames=fieldnames, quoting=csv.QUOTE_ALL)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
 
 
 def _print_summary(report) -> None:

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import argparse
-from typing import TYPE_CHECKING
+import copy
+from typing import TYPE_CHECKING, Any
 import csv
 import sys
 from datetime import datetime
@@ -124,7 +125,7 @@ def register_command(subparsers) -> None:
         "-o",
         "--output",
         help=(
-            "Output destination: omit for default file output (part-inventory.csv), "
+            "Output destination: omit for console table output, "
             "use 'console' for table, '-' for stdout, or a file path"
         ),
         default=None,
@@ -187,6 +188,16 @@ def register_command(subparsers) -> None:
         metavar="KEY",
         default=None,
         help="API key for the supplier search provider (overrides env vars)",
+    )
+    parser.add_argument(
+        "--limit",
+        metavar="N",
+        type=int,
+        default=1,
+        help=(
+            "Maximum supplier candidates to apply per unmatched row. "
+            "Use 1 (default) to apply best match only; use >1 to emit ranked alternatives."
+        ),
     )
 
     parser.set_defaults(handler=handle_inventory)
@@ -410,6 +421,7 @@ def _handle_batch_inventory(input_paths: list[str], args: argparse.Namespace) ->
             service,
             supplier_config,
             supplier_id,
+            limit=max(1, int(getattr(args, "limit", 1))),
             verbose=args.verbose,
         )
 
@@ -515,6 +527,7 @@ def _enrich_items_with_supplier(
     supplier_config: "SupplierConfig",
     supplier_id: str,
     *,
+    limit: int = 1,
     verbose: bool = False,
 ) -> "tuple[list[InventoryItem], list[str]]":
     """Auto-populate supplier PN column for items that lack one.
@@ -529,6 +542,9 @@ def _enrich_items_with_supplier(
         service: Instantiated :class:`InventorySearchService`.
         supplier_config: Resolved :class:`SupplierConfig` for the supplier.
         supplier_id: Normalized supplier ID string.
+        limit: Number of ranked candidates to emit per row when available.
+            ``1`` applies only the top result (default behavior).
+            ``>1`` emits up to ``limit`` ranked alternatives.
         verbose: When True, progress is printed to stderr.
 
     Returns:
@@ -538,10 +554,13 @@ def _enrich_items_with_supplier(
 
     col = supplier_config.inventory_column
     is_lcsc = supplier_id == "lcsc"
+    candidate_limit = max(1, int(limit))
 
     # Ensure supplier column is present in field list.
     if col not in field_names:
         field_names = list(field_names) + [col]
+    if candidate_limit > 1 and "Priority" not in field_names:
+        field_names = list(field_names) + ["Priority"]
 
     # Enrich both ITEM rows (inventory catalog) and COMPONENT rows (schematic-generated).
     item_rows = [
@@ -574,36 +593,107 @@ def _enrich_items_with_supplier(
         )
 
     records = service.search(searchable)
+    records_by_item_id = {id(record.inventory_item): record for record in records}
+    needs_pn_ids = {id(item) for item in needs_pn}
 
-    for record in records:
-        if not record.candidates:
+    enriched_items: list[InventoryItem] = []
+    for item in items:
+        item_id = id(item)
+        if item_id not in needs_pn_ids:
+            enriched_items.append(item)
             continue
-        best = record.candidates[0].result
-        pn = best.distributor_part_number or ""
-        if not pn:
-            continue
-        item = record.inventory_item
-        if is_lcsc:
-            item.lcsc = pn
-        else:
-            if item.raw_data is None:
-                item.raw_data = {}
-            item.raw_data[col] = pn
-        if not (item.manufacturer or "").strip() and best.manufacturer:
-            item.manufacturer = best.manufacturer
-        if not (item.mfgpn or "").strip() and best.mpn:
-            item.mfgpn = best.mpn
-        if verbose:
-            print(f"  {item.ipn}: set {col}={pn!r}", file=sys.stderr)
 
-    return items, field_names
+        record = records_by_item_id.get(item_id)
+        if record is None or not record.candidates:
+            if candidate_limit > 1:
+                if item.raw_data is None:
+                    item.raw_data = {}
+                item.raw_data.setdefault("Notes", "No supplier matches found")
+                if "Notes" not in field_names:
+                    field_names = list(field_names) + ["Notes"]
+            enriched_items.append(item)
+            continue
+
+        candidates = record.candidates[:candidate_limit]
+        if candidate_limit == 1:
+            _apply_supplier_candidate_to_item(
+                item=item,
+                supplier_column=col,
+                is_lcsc=is_lcsc,
+                candidate=candidates[0].result,
+            )
+            if verbose:
+                applied_pn = (
+                    item.lcsc
+                    if is_lcsc
+                    else str((item.raw_data or {}).get(col, "")).strip()
+                )
+                print(f"  {item.ipn}: set {col}={applied_pn!r}", file=sys.stderr)
+            enriched_items.append(item)
+            continue
+
+        emitted_any = False
+        for rank, candidate in enumerate(candidates, start=1):
+            distributor_pn = candidate.result.distributor_part_number or ""
+            if not distributor_pn:
+                continue
+            ranked_item = copy.deepcopy(item)
+            _apply_supplier_candidate_to_item(
+                item=ranked_item,
+                supplier_column=col,
+                is_lcsc=is_lcsc,
+                candidate=candidate.result,
+            )
+            if ranked_item.raw_data is None:
+                ranked_item.raw_data = {}
+            ranked_item.raw_data["Priority"] = str(rank)
+            ranked_item.priority = rank
+            enriched_items.append(ranked_item)
+            emitted_any = True
+            if verbose:
+                print(
+                    f"  {ranked_item.ipn}: candidate {rank} {col}={distributor_pn!r}",
+                    file=sys.stderr,
+                )
+
+        if not emitted_any:
+            if candidate_limit > 1:
+                if item.raw_data is None:
+                    item.raw_data = {}
+                item.raw_data.setdefault("Notes", "No supplier matches found")
+                if "Notes" not in field_names:
+                    field_names = list(field_names) + ["Notes"]
+            enriched_items.append(item)
+
+    return enriched_items, field_names
+
+
+def _apply_supplier_candidate_to_item(
+    *,
+    item: InventoryItem,
+    supplier_column: str,
+    is_lcsc: bool,
+    candidate: Any,
+) -> None:
+    """Apply one supplier candidate result onto an inventory item."""
+    pn = candidate.distributor_part_number or ""
+    if is_lcsc:
+        item.lcsc = pn
+    else:
+        if item.raw_data is None:
+            item.raw_data = {}
+        item.raw_data[supplier_column] = pn
+    if not (item.manufacturer or "").strip() and candidate.manufacturer:
+        item.manufacturer = candidate.manufacturer
+    if not (item.mfgpn or "").strip() and candidate.mpn:
+        item.mfgpn = candidate.mpn
 
 
 def _handle_generate_inventory(input_path: str, args: argparse.Namespace) -> int:
     """Generate inventory from project components with project-centric input resolution.
 
     Output destination handling (following BOM command pattern):
-    - None (default): write to 'part-inventory.csv'
+    - None (default): print formatted table to stdout
     - "console": pretty print table to stdout
     - "-": write CSV format to stdout
     - otherwise: treat as a file path
@@ -640,6 +730,7 @@ def _handle_generate_inventory(input_path: str, args: argparse.Namespace) -> int
             service,
             supplier_config,
             supplier_id,
+            limit=max(1, int(getattr(args, "limit", 1))),
             verbose=args.verbose,
         )
 
@@ -915,16 +1006,15 @@ def _output_inventory(
     """Output inventory data in the requested format.
 
     Defaults:
-    - output omitted => write to part-inventory.csv in the current working directory
+    - output omitted => print formatted table to stdout
     - output == "console" => formatted table to stdout
     - output == "-" => CSV to stdout
     - otherwise => treat as file path with safety checks
     """
-    default_path = Path("part-inventory.csv")
 
     dest = resolve_output_destination(
         output,
-        default_destination=OutputDestination(OutputKind.FILE, path=default_path),
+        default_destination=OutputDestination(OutputKind.CONSOLE),
     )
 
     if dest.kind == OutputKind.CONSOLE:
@@ -975,11 +1065,10 @@ def _output_inventory_rows(
     verbose: bool = False,
 ) -> int:
     """Output pre-built inventory row dictionaries in the requested format."""
-    default_path = Path("part-inventory.csv")
 
     dest = resolve_output_destination(
         output,
-        default_destination=OutputDestination(OutputKind.FILE, path=default_path),
+        default_destination=OutputDestination(OutputKind.CONSOLE),
     )
 
     if dest.kind == OutputKind.CONSOLE:
@@ -1119,6 +1208,8 @@ def _inventory_item_to_row(
         "LCSC": item.lcsc,
         "Datasheet": item.datasheet,
         "UUID": item.uuid,
+        "Priority": str((item.raw_data or {}).get("Priority", "")),
+        "Notes": str((item.raw_data or {}).get("Notes", "")),
     }
 
     # Write canonical EIA text for typed parametric fields, overriding the

--- a/src/jbom/services/annotation_service.py
+++ b/src/jbom/services/annotation_service.py
@@ -219,14 +219,15 @@ def annotate_from_repairs(
     1. Load *repairs_path* (audit ``report.csv``).
     2. Skip any row where ``Action`` is not ``'SET'``
        (blank / ``SKIP`` / ``IGNORE`` etc.) — counted as *skipped*.
-    3. Validate that ``UUID``, ``Field``, and ``ApprovedValue`` are all
-       non-blank for each ``SET`` row; skip silently if ``ApprovedValue`` is
-       blank (designer cleared it intentionally).
+    3. Parse updates from either:
+       - legacy tall rows (``Field`` + ``ApprovedValue``), or
+       - wide rows (``RowType=SUGGESTED`` + non-metadata suggestion columns).
+       Skip silently when a row has no actionable updates.
     4. Build a UUID → (symbol, file-path) index across all *schematic_files*.
-    5. For each ``SET`` row, look up the UUID in the index and write
-       ``Field <- ApprovedValue`` to the matching symbol.  A missing UUID is a
-       **hard failure** (added to *errors*, counted as *failed*); the row is
-       still attempted for all other ``SET`` rows.
+    5. For each actionable ``SET`` row, look up the UUID in the index and write
+       one or more field updates to the matching symbol. A missing UUID is a
+       **hard failure** (added to *errors*, counted as *failed*); processing
+       continues for subsequent rows.
     6. Write modified schematic files (unless *dry_run*).
 
     Args:
@@ -265,72 +266,88 @@ def annotate_from_repairs(
     changed_files: set[Path] = set()
 
     for row in rows:
-        if row.action.upper() != "SET":
+        action = _repairs_cell(row, "Action").upper()
+        if action != "SET":
             result.skipped += 1
             continue
 
-        # Blank ApprovedValue — designer intentionally cleared it; skip silently.
-        if not row.approved_value.strip():
+        row_type = _repairs_cell(row, "RowType").upper()
+        if row_type and row_type != "SUGGESTED":
+            result.skipped += 1
+            continue
+        row_field_name = _repairs_cell(row, "Field")
+        row_approved_value = _repairs_cell(row, "ApprovedValue")
+        has_legacy_columns = bool(row_field_name or row_approved_value)
+        if has_legacy_columns and not row_field_name:
+            result.failed += 1
+            result.errors.append(
+                f"SET row for RefDes={_repairs_cell(row, 'RefDes')!r} has blank UUID or Field — skipped"
+            )
+            continue
+
+        row_uuid = _repairs_cell(row, "UUID")
+        row_ref_des = _repairs_cell(row, "RefDes")
+        row_project_path = _repairs_cell(row, "ProjectPath")
+        if not row_uuid:
+            result.failed += 1
+            result.errors.append(
+                f"SET row for RefDes={row_ref_des!r} has blank UUID — skipped"
+            )
+            continue
+        updates = _extract_row_updates(row)
+        if not updates:
             result.skipped += 1
             continue
 
         # Multi-project filter: silently skip rows that belong to a different project.
-        if row.project_path:
-            rp = Path(row.project_path).resolve()
+        if row_project_path:
+            rp = Path(row_project_path).resolve()
             if rp.suffix == ".kicad_pro":
                 rp = rp.parent
             if rp not in project_dirs:
                 result.skipped += 1
                 continue
 
-        if not row.uuid.strip() or not row.field_name.strip():
-            # Malformed SET row — treat as failure.
-            result.failed += 1
-            result.errors.append(
-                f"SET row for RefDes={row.ref_des!r} has blank UUID or Field — skipped"
-            )
-            continue
-
-        location = uuid_to_location.get(row.uuid)
+        location = uuid_to_location.get(row_uuid)
         if location is None:
             result.failed += 1
+            field_names = ", ".join(field for field, _ in updates)
             result.errors.append(
-                f"UUID {row.uuid!r} (RefDes={row.ref_des!r}, Field={row.field_name!r}) "
+                f"UUID {row_uuid!r} (RefDes={row_ref_des!r}, Fields={field_names!r}) "
                 "not found in any schematic file"
             )
             continue
 
         symbol, sch_path = location
 
-        # RefDes mismatch warning (UUID matched but RefDes differs — informational).
-        if row.ref_des:
+        if row_ref_des:
             current_ref = _get_property_value(symbol, "Reference")
-            if current_ref and current_ref != row.ref_des:
+            if current_ref and current_ref != row_ref_des:
                 result.warnings.append(
-                    f"INFO: UUID {row.uuid!r}: RefDes changed "
-                    f"from {row.ref_des!r} (audit) to {current_ref!r} (schematic) "
+                    f"INFO: UUID {row_uuid!r}: RefDes changed "
+                    f"from {row_ref_des!r} (audit) to {current_ref!r} (schematic) "
                     f"\u2014 applying by UUID"
                 )
 
-        current = _get_property_value(symbol, row.field_name)
-        if current == row.approved_value:
-            # Already at the desired value — count as applied (idempotent).
-            result.applied += 1
-            continue
+        for field_name, approved_value in updates:
+            current = _get_property_value(symbol, field_name)
+            if current == approved_value:
+                result.applied += 1
+                continue
 
-        result.changes.append(
-            AnnotationChange(
-                uuid=row.uuid,
-                field=row.field_name,
-                before=current,
-                after=row.approved_value,
-                row_number=row.row_number,
+            result.changes.append(
+                AnnotationChange(
+                    uuid=row_uuid,
+                    field=field_name,
+                    before=current,
+                    after=approved_value,
+                    row_number=row.row_number,
+                )
             )
-        )
-        result.applied += 1
-        if not dry_run:
-            _set_property_value(symbol, row.field_name, row.approved_value)
-            changed_files.add(sch_path)
+            result.applied += 1
+            if not dry_run:
+                _set_property_value(symbol, field_name, approved_value)
+                changed_files.add(sch_path)
 
     if not dry_run:
         for sch_path in changed_files:
@@ -346,12 +363,7 @@ class _RepairsRowRaw:
     """Internal: one raw row from repairs CSV before filtering."""
 
     row_number: int
-    uuid: str
-    ref_des: str
-    field_name: str
-    approved_value: str
-    action: str
-    project_path: str
+    cells: dict[str, str]
 
 
 def _load_repairs_rows(repairs_path: Path) -> list[_RepairsRowRaw]:
@@ -362,23 +374,72 @@ def _load_repairs_rows(repairs_path: Path) -> list[_RepairsRowRaw]:
         if not reader.fieldnames:
             return rows
         for line_idx, raw in enumerate(reader, start=2):
-
-            def _cell(col: str) -> str:
-                v = raw.get(col) or ""
-                return v.strip() if isinstance(v, str) else ""
+            cells: dict[str, str] = {}
+            for col, val in raw.items():
+                if not col:
+                    continue
+                if isinstance(val, str):
+                    cells[col] = val.strip()
+                else:
+                    cells[col] = ""
 
             rows.append(
                 _RepairsRowRaw(
                     row_number=line_idx,
-                    uuid=_cell("UUID"),
-                    ref_des=_cell("RefDes"),
-                    field_name=_cell("Field"),
-                    approved_value=_cell("ApprovedValue"),
-                    action=_cell("Action"),
-                    project_path=_cell("ProjectPath"),
+                    cells=cells,
                 )
             )
     return rows
+
+
+_WIDE_REPAIRS_METADATA_COLUMNS: set[str] = {
+    "RowType",
+    "ProjectPath",
+    "RefDes",
+    "UUID",
+    "Category",
+    "CheckType",
+    "Severity",
+    "CatalogFile",
+    "IPN",
+    "Field",
+    "CurrentValue",
+    "SuggestedValue",
+    "ApprovedValue",
+    "Action",
+    "Supplier",
+    "SupplierPN",
+    "Description",
+    "Notes",
+}
+
+
+def _repairs_cell(row: _RepairsRowRaw, col: str) -> str:
+    """Return a normalized cell value from a parsed repairs CSV row."""
+    return (row.cells.get(col) or "").strip()
+
+
+def _extract_row_updates(row: _RepairsRowRaw) -> list[tuple[str, str]]:
+    """Extract field updates from a repairs row (legacy tall or wide format)."""
+    field_name = _repairs_cell(row, "Field")
+    approved_value = _repairs_cell(row, "ApprovedValue")
+    has_legacy_columns = bool(field_name or approved_value)
+    if has_legacy_columns:
+        if not field_name:
+            return []
+        if not approved_value or approved_value.upper() == "MISSING":
+            return []
+        return [(field_name, approved_value)]
+
+    updates: list[tuple[str, str]] = []
+    for col, val in row.cells.items():
+        if col in _WIDE_REPAIRS_METADATA_COLUMNS:
+            continue
+        cell_value = (val or "").strip()
+        if not cell_value or cell_value.upper() == "MISSING":
+            continue
+        updates.append((col, cell_value))
+    return updates
 
 
 def _get_symbol_uuid(symbol: list[Any]) -> str:

--- a/tests/unit/test_annotate_repairs.py
+++ b/tests/unit/test_annotate_repairs.py
@@ -48,7 +48,7 @@ def _write_repairs(
     rows: list[dict[str, str]],
 ) -> None:
     """Write an audit report.csv with the given rows."""
-    fieldnames = [
+    base_fieldnames = [
         "CheckType",
         "Severity",
         "ProjectPath",
@@ -65,7 +65,16 @@ def _write_repairs(
         "Supplier",
         "SupplierPN",
         "Description",
+        "RowType",
+        "Notes",
     ]
+    dynamic_fields: list[str] = []
+    known = set(base_fieldnames)
+    for row in rows:
+        for key in row.keys():
+            if key not in known and key not in dynamic_fields:
+                dynamic_fields.append(key)
+    fieldnames = base_fieldnames + dynamic_fields
     with path.open("w", encoding="utf-8", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
@@ -134,6 +143,72 @@ def test_repairs_multiple_set_rows_all_applied(tmp_path: Path) -> None:
     updated = sch.read_text(encoding="utf-8")
     assert '"Value" "33K"' in updated
     assert '"Manufacturer" "Yageo"' in updated
+
+
+def test_repairs_wide_suggested_row_applies_all_non_metadata_fields(
+    tmp_path: Path,
+) -> None:
+    """Wide couplet row should apply every populated suggestion column."""
+    sch = tmp_path / "proj.kicad_sch"
+    _write_schematic(sch)
+    repairs = tmp_path / "report.csv"
+    _write_repairs(
+        repairs,
+        [
+            {
+                "RowType": "CURRENT",
+                "UUID": "uuid-r1",
+                "RefDes": "R1",
+                "Value": "10K",
+                "Action": "",
+            },
+            {
+                "RowType": "SUGGESTED",
+                "UUID": "uuid-r1",
+                "RefDes": "R1",
+                "Value": "68K",
+                "Manufacturer": "Yageo",
+                "MFGPN": "RC0603FR-0768KL",
+                "Action": "SET",
+            },
+        ],
+    )
+
+    result = annotate_from_repairs(repairs, [sch], dry_run=False)
+
+    assert result.failed == 0
+    assert result.applied == 3
+    updated = sch.read_text(encoding="utf-8")
+    assert '"Value" "68K"' in updated
+    assert '"Manufacturer" "Yageo"' in updated
+    assert '"MFGPN" "RC0603FR-0768KL"' in updated
+
+
+def test_repairs_wide_missing_placeholders_are_not_applied(tmp_path: Path) -> None:
+    sch = tmp_path / "proj.kicad_sch"
+    _write_schematic(sch, value="10K")
+    repairs = tmp_path / "report.csv"
+    _write_repairs(
+        repairs,
+        [
+            {
+                "RowType": "SUGGESTED",
+                "UUID": "uuid-r1",
+                "RefDes": "R1",
+                "Value": "MISSING",
+                "Tolerance": "MISSING",
+                "Action": "SET",
+            }
+        ],
+    )
+
+    result = annotate_from_repairs(repairs, [sch], dry_run=False)
+
+    assert result.failed == 0
+    assert result.applied == 0
+    assert result.skipped == 1
+    updated = sch.read_text(encoding="utf-8")
+    assert '"Value" "10K"' in updated
 
 
 def test_repairs_non_set_actions_are_skipped(tmp_path: Path) -> None:

--- a/tests/unit/test_audit_cli.py
+++ b/tests/unit/test_audit_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from jbom.cli.audit import handle_audit
+from jbom.cli.audit import _build_project_couplet_rows, handle_audit
 from jbom.cli.main import create_parser
 from jbom.services.audit_service import AuditReport, AuditRow, CheckType, Severity
 
@@ -248,7 +248,8 @@ def test_output_file_is_written(tmp_path: Path) -> None:
 
     assert report_path.exists(), "Report file should be created at -o path"
     content = report_path.read_text(encoding="utf-8")
-    assert "QUALITY_ISSUE" in content
+    assert "RowType" in content
+    assert "MISSING" in content
     assert "R1" in content
 
 
@@ -256,12 +257,14 @@ def test_output_file_has_all_csv_columns(tmp_path: Path) -> None:
     from jbom.services.audit_service import REPORT_CSV_COLUMNS
 
     report_path = tmp_path / "report.csv"
+    catalog = tmp_path / "catalog.csv"
+    catalog.write_text("RowType,IPN,Category\nITEM,R001,RES\n", encoding="utf-8")
 
     with patch("jbom.cli.audit.AuditService") as MockService:
         instance = MockService.return_value
-        instance.audit_project.return_value = _mock_report()
+        instance.audit_inventory.return_value = _mock_report()
 
-        args = _make_args(inputs=[str(tmp_path)], output=report_path)
+        args = _make_args(inputs=[str(catalog)], output=report_path)
         handle_audit(args)
 
     assert report_path.exists()
@@ -271,7 +274,7 @@ def test_output_file_has_all_csv_columns(tmp_path: Path) -> None:
 
 
 def test_output_to_stdout_contains_csv_header(tmp_path: Path, capsys) -> None:
-    """When -o is not specified, CSV should be written to stdout."""
+    """When -o is not specified in project mode, couplet CSV should be written to stdout."""
     with patch("jbom.cli.audit.AuditService") as MockService:
         instance = MockService.return_value
         instance.audit_project.return_value = _mock_report()
@@ -280,7 +283,124 @@ def test_output_to_stdout_contains_csv_header(tmp_path: Path, capsys) -> None:
         handle_audit(args)
 
     captured = capsys.readouterr()
-    assert "CheckType" in captured.out, "CSV header should appear in stdout"
+    assert (
+        "RowType" in captured.out
+    ), "Project couplet CSV header should appear in stdout"
+
+
+def test_project_mode_output_is_couplet_rows(tmp_path: Path) -> None:
+    report_path = tmp_path / "report.csv"
+    rows = [
+        AuditRow(
+            check_type=CheckType.QUALITY_ISSUE,
+            severity=Severity.WARN,
+            project_path=str(tmp_path),
+            ref_des="R1",
+            uuid="uuid-r1",
+            category="RES",
+            field="Tolerance",
+            current_value="",
+            suggested_value="e.g. 1%, 5%, 10%",
+            description="R1: best-practice field 'Tolerance' is missing",
+        ),
+        AuditRow(
+            check_type=CheckType.QUALITY_ISSUE,
+            severity=Severity.WARN,
+            project_path=str(tmp_path),
+            ref_des="R1",
+            uuid="uuid-r1",
+            category="RES",
+            field="Power",
+            current_value="",
+            suggested_value="e.g. 0.1W",
+            description="R1: best-practice field 'Power' is missing",
+        ),
+    ]
+
+    with patch("jbom.cli.audit.AuditService") as MockService:
+        instance = MockService.return_value
+        instance.audit_project.return_value = _mock_report(warn_count=2, rows=rows)
+
+        args = _make_args(inputs=[str(tmp_path)], output=report_path)
+        handle_audit(args)
+
+    with report_path.open(encoding="utf-8", newline="") as handle:
+        written = list(csv.DictReader(handle))
+
+    assert len(written) == 2
+    assert {r["RowType"] for r in written} == {"CURRENT", "SUGGESTED"}
+    current = next(r for r in written if r["RowType"] == "CURRENT")
+    suggested = next(r for r in written if r["RowType"] == "SUGGESTED")
+    assert current["Notes"] == "R1: Missing attributes: Tolerance, Power"
+    assert suggested["Action"] == "SKIP"
+    assert suggested["Tolerance"] == "5%"
+    assert suggested["Power"] == "MISSING"
+
+
+def test_project_mode_suggests_package_and_domain_defaults() -> None:
+    rows = [
+        AuditRow(
+            check_type=CheckType.QUALITY_ISSUE,
+            severity=Severity.WARN,
+            project_path="/proj/example.kicad_pro",
+            ref_des="R1",
+            uuid="uuid-r1",
+            category="RES",
+            field="Tolerance",
+            current_value="",
+            suggested_value="",
+            description="R1 missing tolerance",
+        ),
+        AuditRow(
+            check_type=CheckType.QUALITY_ISSUE,
+            severity=Severity.WARN,
+            project_path="/proj/example.kicad_pro",
+            ref_des="R1",
+            uuid="uuid-r1",
+            category="RES",
+            field="Power",
+            current_value="",
+            suggested_value="",
+            description="R1 missing power",
+        ),
+        AuditRow(
+            check_type=CheckType.QUALITY_ISSUE,
+            severity=Severity.WARN,
+            project_path="/proj/example.kicad_pro",
+            ref_des="C1",
+            uuid="uuid-c1",
+            category="CAP",
+            field="Voltage",
+            current_value="",
+            suggested_value="",
+            description="C1 missing voltage",
+        ),
+    ]
+
+    context = {
+        ("/proj/example.kicad_pro", "R1", "uuid-r1", "RES"): {
+            "Value": "10K",
+            "Footprint": "SPCoast:0603-RES",
+            "Package": "603",
+            "Description": "Resistor",
+        },
+        ("/proj/example.kicad_pro", "C1", "uuid-c1", "CAP"): {
+            "Value": "100nF",
+            "Footprint": "SPCoast:0603-CAP",
+            "Package": "603",
+            "Description": "Capacitor",
+        },
+    }
+
+    _fieldnames, written = _build_project_couplet_rows(rows, component_context=context)
+    suggested_rows = [row for row in written if row["RowType"] == "SUGGESTED"]
+
+    r1_suggested = next(row for row in suggested_rows if row["RefDes"] == "R1")
+    assert r1_suggested["Tolerance"] == "5%"
+    assert r1_suggested["Power"] == "100mW"
+
+    c1_suggested = next(row for row in suggested_rows if row["RefDes"] == "C1")
+    assert c1_suggested["Voltage"] == "25V"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_inventory_output_defaults.py
+++ b/tests/unit/test_inventory_output_defaults.py
@@ -1,0 +1,77 @@
+"""Unit tests for inventory output destination defaults (Issue #176)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jbom.cli.inventory import _output_inventory, _output_inventory_rows
+from jbom.common.types import InventoryItem
+
+
+def _make_inventory_item() -> InventoryItem:
+    """Build a minimal InventoryItem for output-path tests."""
+    return InventoryItem(
+        ipn="RES-10K-0603",
+        keywords="",
+        category="RES",
+        description="10k resistor",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="",
+        voltage="",
+        amperage="",
+        wattage="",
+        lcsc="",
+        manufacturer="",
+        mfgpn="",
+        datasheet="",
+        row_type="ITEM",
+    )
+
+
+def test_output_inventory_defaults_to_console(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    item = _make_inventory_item()
+
+    exit_code = _output_inventory(
+        [item],
+        ["IPN", "Category", "Value"],
+        output=None,
+        force=False,
+        verbose=False,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Generated inventory" in captured.out
+    assert not (tmp_path / "part-inventory.csv").exists()
+
+
+def test_output_inventory_rows_defaults_to_console(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    rows = [
+        {
+            "RowType": "COMPONENT",
+            "Project": "/tmp/proj",
+            "ComponentID": "RES-10K-0603",
+        }
+    ]
+    field_names = ["RowType", "Project", "ComponentID"]
+
+    exit_code = _output_inventory_rows(
+        rows,
+        field_names,
+        output=None,
+        force=False,
+        verbose=False,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Generated inventory" in captured.out
+    assert not (tmp_path / "part-inventory.csv").exists()

--- a/tests/unit/test_inventory_supplier_flag.py
+++ b/tests/unit/test_inventory_supplier_flag.py
@@ -135,6 +135,7 @@ def _enrich(
     supplier_config=None,
     supplier_id: str = "generic",
     *,
+    limit: int = 1,
     verbose: bool = False,
     filter_returns: list[InventoryItem] | None = None,
 ) -> tuple[list[InventoryItem], list[str]]:
@@ -149,7 +150,13 @@ def _enrich(
         return_value=filter_returns if filter_returns is not None else items,
     ):
         return _enrich_items_with_supplier(
-            items, field_names, service, supplier_config, supplier_id, verbose=verbose
+            items,
+            field_names,
+            service,
+            supplier_config,
+            supplier_id,
+            limit=limit,
+            verbose=verbose,
         )
 
 
@@ -294,6 +301,28 @@ class TestEnrichSuccessful:
         items_out, _ = _enrich([item], ["IPN"], service, filter_returns=[item])
 
         assert items_out[0].mfgpn == "RC0402FR-07100KL"
+
+    def test_limit_gt_one_emits_ranked_alternatives(self) -> None:
+        item = _make_item()
+        record = InventorySearchRecord(
+            inventory_item=item,
+            query="10K",
+            candidates=[_candidate("S0001"), _candidate("S0002"), _candidate("S0003")],
+        )
+        service = _mock_service([record])
+
+        items_out, names = _enrich(
+            [item],
+            ["IPN", "Supplier"],
+            service,
+            limit=2,
+            filter_returns=[item],
+        )
+
+        assert len(items_out) == 2
+        assert [i.raw_data.get("Supplier") for i in items_out] == ["S0001", "S0002"]
+        assert [i.raw_data.get("Priority") for i in items_out] == ["1", "2"]
+        assert "Priority" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refactors `jbom audit PROJECT` wide couplet output for practical repair workflows: context-rich CURRENT rows, concise missing-attribute notes, and SKIP-first safety defaults
- excludes supply-chain-only fields (`Manufacturer`, `MFGPN`) from actionable audit suggestions
- replaces placeholder-only suggestions with profile-backed deterministic EM defaults where available (e.g. RES tolerance/power by package, CAP tolerance/voltage by package), with `MISSING` fallback otherwise
- hardens `jbom annotate --repairs` to ignore `MISSING` placeholders so placeholders are never written back into schematics
- keeps inventory workflow updates from Issue #176, including output-default behavior and supplier enrichment `--limit` coverage updates

## Validation
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src pytest /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_audit_cli.py /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_annotate_repairs.py`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src pytest /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_inventory_supplier_flag.py /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_inventory_output_defaults.py /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_audit_service.py /Users/jplocher/Dropbox/KiCad/jBOM/tests/unit/test_cli_multi_project_inventory.py /Users/jplocher/Dropbox/KiCad/jBOM/tests/integration/test_multi_project_batch.py`

## Notes
- regenerated project audit output confirms RES/CAP suggested defaults are now actionable and review-safe

Co-Authored-By: Oz <oz-agent@warp.dev>