### PR TITLE
fix(bom): align explicit --fields with fabricator mapping and PCB SMD metadata

### DIFF
--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -15,8 +15,9 @@ from jbom.cli.output import (
     resolve_output_destination,
 )
 from jbom.services.schematic_reader import SchematicReader
-from jbom.services.bom_generator import BOMGenerator, BOMData
+from jbom.services.bom_generator import BOMGenerator, BOMData, BOMEntry
 from jbom.services.inventory_matcher import InventoryMatcher
+from jbom.services.pcb_reader import DefaultKiCadReaderService
 from jbom.services.project_file_resolver import ProjectFileResolver
 from jbom.common.options import GeneratorOptions
 from jbom.config.fabricators import (
@@ -36,6 +37,7 @@ from jbom.common.component_filters import (
     create_filter_config,
 )
 from jbom.common.component_utils import derive_package_from_footprint
+from jbom.common.package_matching import PackageType
 from jbom.cli.formatting import Column, print_table, get_terminal_width
 
 
@@ -305,6 +307,12 @@ def handle_bom(args: argparse.Namespace) -> int:
                 project_name=project_name,
             )
 
+        bom_data = _enrich_bom_smd_from_project_pcb(
+            bom_data,
+            project_context.pcb_file if project_context else None,
+            verbose=args.verbose,
+        )
+
         # Handle output
         return _output_bom(
             bom_data,
@@ -413,6 +421,106 @@ def _get_available_bom_fields(components) -> dict[str, str]:
                         fields[normalized_key] = f"Component property: {attr_key}"
 
     return fields
+
+
+def _load_pcb_smd_lookup(
+    pcb_file: Optional[Path], *, verbose: bool = False
+) -> dict[str, bool]:
+    """Return reference -> is_smd lookup from a KiCad PCB file."""
+
+    if pcb_file is None or not pcb_file.exists():
+        return {}
+
+    try:
+        board = DefaultKiCadReaderService().read_pcb_file(pcb_file)
+    except Exception as exc:
+        if verbose:
+            print(
+                f"Warning: Could not read PCB mount metadata from {pcb_file}: {exc}",
+                file=sys.stderr,
+            )
+        return {}
+
+    smd_by_reference: dict[str, bool] = {}
+    for footprint in board.footprints:
+        reference = (footprint.reference or "").strip()
+        if not reference:
+            continue
+
+        mount_type = str(footprint.attributes.get("mount_type", "")).strip().lower()
+        if mount_type == "smd":
+            smd_by_reference[reference] = True
+        elif mount_type in {"through_hole", "through-hole", "tht"}:
+            smd_by_reference[reference] = False
+
+    return smd_by_reference
+
+
+def _entry_smd_from_reference_lookup(
+    entry: BOMEntry, smd_by_reference: dict[str, bool]
+) -> Optional[bool]:
+    """Resolve an entry-level SMD boolean from per-reference PCB mount metadata."""
+
+    known_values = [
+        smd_by_reference[ref] for ref in entry.references if ref in smd_by_reference
+    ]
+    if not known_values:
+        return None
+
+    # Aggregated BOM groups should be homogeneous by footprint.
+    return all(known_values)
+
+
+def _enrich_bom_smd_from_project_pcb(
+    bom_data: BOMData,
+    pcb_file: Optional[Path],
+    *,
+    verbose: bool = False,
+) -> BOMData:
+    """Populate missing BOM `smd` attributes from PCB mount metadata."""
+
+    smd_by_reference = _load_pcb_smd_lookup(pcb_file, verbose=verbose)
+    if not smd_by_reference:
+        return bom_data
+
+    updated = False
+    enriched_entries: list[BOMEntry] = []
+
+    for entry in bom_data.entries:
+        current_smd = str(entry.attributes.get("smd", "")).strip()
+        if current_smd:
+            enriched_entries.append(entry)
+            continue
+
+        resolved = _entry_smd_from_reference_lookup(entry, smd_by_reference)
+        if resolved is None:
+            enriched_entries.append(entry)
+            continue
+
+        attrs = dict(entry.attributes)
+        attrs["smd"] = resolved
+        enriched_entries.append(
+            BOMEntry(
+                references=entry.references,
+                value=entry.value,
+                footprint=entry.footprint,
+                quantity=entry.quantity,
+                lib_id=entry.lib_id,
+                attributes=attrs,
+            )
+        )
+        updated = True
+
+    if not updated:
+        return bom_data
+
+    metadata = dict(bom_data.metadata)
+    metadata["pcb_mount_metadata_used"] = True
+    return BOMData(
+        project_name=bom_data.project_name,
+        entries=enriched_entries,
+        metadata=metadata,
+    )
 
 
 def _output_bom(
@@ -644,6 +752,46 @@ def _resolve_fabricator_part_number(
     return ""
 
 
+def _is_smd_token(value: str) -> bool:
+    """Return True when a token contains known SMD package patterns."""
+
+    token = (value or "").strip().lower()
+    if not token:
+        return False
+
+    for pattern in sorted(PackageType.SMD_PACKAGES, key=len, reverse=True):
+        if pattern in token:
+            return True
+    return False
+
+
+def _resolve_smd_indicator(entry: BOMEntry) -> str:
+    """Resolve BOM SMD value as `Yes`/`No` from explicit and inferred signals."""
+
+    raw = entry.attributes.get("smd", "")
+    if isinstance(raw, bool):
+        return "Yes" if raw else "No"
+
+    raw_text = str(raw).strip().lower()
+    if raw_text in {"yes", "y", "true", "1", "smd"}:
+        return "Yes"
+    if raw_text in {"no", "n", "false", "0", "tht", "through_hole", "through-hole"}:
+        return "No"
+
+    package = str(entry.attributes.get("package", "")).strip()
+    if _is_smd_token(package):
+        return "Yes"
+
+    derived_package = derive_package_from_footprint(entry.footprint)
+    if _is_smd_token(derived_package):
+        return "Yes"
+
+    if _is_smd_token(entry.footprint):
+        return "Yes"
+
+    return "No"
+
+
 def _get_field_value(
     entry,
     field: str,
@@ -679,7 +827,7 @@ def _get_field_value(
             fabricator_id=fabricator_id,
             fabricator_config=fabricator_config,
         ),
-        "smd": lambda e: "Yes" if e.attributes.get("smd", False) else "No",
+        "smd": lambda e: _resolve_smd_indicator(e),
         "lcsc": lambda e: e.attributes.get("lcsc", "") or e.attributes.get("LCSC", ""),
         "package": lambda e: e.attributes.get("package", "")
         or derive_package_from_footprint(e.footprint),

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -4,7 +4,7 @@ import argparse
 import csv
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from jbom.cli.output import (
     OutputDestination,
@@ -20,6 +20,8 @@ from jbom.services.inventory_matcher import InventoryMatcher
 from jbom.services.project_file_resolver import ProjectFileResolver
 from jbom.common.options import GeneratorOptions
 from jbom.config.fabricators import (
+    FabricatorConfig,
+    load_fabricator,
     get_available_fabricators,
     get_fabricator_presets,
     apply_fabricator_column_mapping,
@@ -425,6 +427,7 @@ def _output_bom(
     """Output BOM data in the requested format with field customization."""
 
     headers = apply_fabricator_column_mapping(fabricator, "bom", selected_fields)
+    fabricator_config = _load_fabricator_config(fabricator)
 
     dest = resolve_output_destination(
         output,
@@ -434,11 +437,23 @@ def _output_bom(
     )
 
     if dest.kind == OutputKind.CONSOLE:
-        _print_console_table(bom_data, selected_fields, headers)
+        _print_console_table(
+            bom_data,
+            selected_fields,
+            headers,
+            fabricator_id=fabricator,
+            fabricator_config=fabricator_config,
+        )
         return 0
 
     if dest.kind == OutputKind.STDOUT:
-        _print_csv(bom_data, selected_fields, headers)
+        _print_csv(
+            bom_data,
+            selected_fields,
+            headers,
+            fabricator_id=fabricator,
+            fabricator_config=fabricator_config,
+        )
         return 0
 
     if not dest.path:
@@ -453,7 +468,14 @@ def _output_bom(
             force=force,
             refused_message=refused,
         ) as f:
-            _write_csv_handle(bom_data, f, selected_fields, headers)
+            _write_csv_handle(
+                bom_data,
+                f,
+                selected_fields,
+                headers,
+                fabricator_id=fabricator,
+                fabricator_config=fabricator_config,
+            )
     except OutputRefusedError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -463,7 +485,12 @@ def _output_bom(
 
 
 def _print_console_table(
-    bom_data: BOMData, selected_fields: list[str], headers: list[str]
+    bom_data: BOMData,
+    selected_fields: list[str],
+    headers: list[str],
+    *,
+    fabricator_id: str,
+    fabricator_config: Optional[FabricatorConfig],
 ) -> None:
     """Print BOM as formatted console table with dynamic fields."""
     print(f"\n{bom_data.project_name} - Bill of Materials")
@@ -474,7 +501,15 @@ def _print_console_table(
         return
 
     rows = [
-        {h: _get_field_value(entry, f) for f, h in zip(selected_fields, headers)}
+        {
+            h: _get_field_value(
+                entry,
+                f,
+                fabricator_id=fabricator_id,
+                fabricator_config=fabricator_config,
+            )
+            for f, h in zip(selected_fields, headers)
+        }
         for entry in bom_data.entries
     ]
     columns = [
@@ -496,11 +531,22 @@ def _print_console_table(
 
 
 def _print_csv(
-    bom_data: BOMData, selected_fields: list[str], headers: list[str]
+    bom_data: BOMData,
+    selected_fields: list[str],
+    headers: list[str],
+    *,
+    fabricator_id: str,
+    fabricator_config: Optional[FabricatorConfig],
 ) -> None:
     """Print BOM as CSV to stdout with dynamic fields."""
-
-    _write_csv_handle(bom_data, sys.stdout, selected_fields, headers)
+    _write_csv_handle(
+        bom_data,
+        sys.stdout,
+        selected_fields,
+        headers,
+        fabricator_id=fabricator_id,
+        fabricator_config=fabricator_config,
+    )
 
 
 def _write_csv_handle(
@@ -508,6 +554,9 @@ def _write_csv_handle(
     f,
     selected_fields: list[str],
     headers: list[str],
+    *,
+    fabricator_id: str,
+    fabricator_config: Optional[FabricatorConfig],
 ) -> None:
     """Write BOM as CSV to a file-like object."""
 
@@ -516,11 +565,92 @@ def _write_csv_handle(
     writer = csv.writer(f, quoting=csv.QUOTE_ALL)
     writer.writerow(headers)
     for entry in bom_data.entries:
-        row = [_get_field_value(entry, field) for field in selected_fields]
+        row = [
+            _get_field_value(
+                entry,
+                field,
+                fabricator_id=fabricator_id,
+                fabricator_config=fabricator_config,
+            )
+            for field in selected_fields
+        ]
         writer.writerow(row)
 
 
-def _get_field_value(entry, field: str) -> str:
+def _load_fabricator_config(fabricator_id: str) -> Optional[FabricatorConfig]:
+    """Best-effort load of a fabricator configuration."""
+
+    try:
+        return load_fabricator(fabricator_id)
+    except ValueError:
+        return None
+
+
+def _normalize_fabricator_attributes(
+    raw_attributes: Mapping[str, Any], fabricator_config: FabricatorConfig
+) -> dict[str, str]:
+    """Add canonical synonym keys to a raw attributes mapping."""
+
+    normalized: dict[str, str] = {
+        str(key): str(value) for key, value in raw_attributes.items()
+    }
+
+    for header, value in list(normalized.items()):
+        canonical = fabricator_config.resolve_field_synonym(header)
+        if canonical is None:
+            continue
+
+        existing_value = normalized.get(canonical, "").strip()
+        if existing_value:
+            continue
+
+        normalized[canonical] = value
+
+    return normalized
+
+
+def _part_number_precedence_for_fabricator(fabricator_id: str) -> list[str]:
+    """Return canonical part-number precedence for the given fabricator."""
+
+    if (fabricator_id or "").strip().lower() == "pcbway":
+        return ["mpn", "supplier_pn", "fab_pn"]
+    return ["fab_pn", "supplier_pn", "mpn"]
+
+
+def _resolve_fabricator_part_number(
+    entry,
+    *,
+    fabricator_id: str,
+    fabricator_config: Optional[FabricatorConfig],
+) -> str:
+    """Resolve fabricator part number via explicit and synonym-driven attributes."""
+
+    explicit = str(entry.attributes.get("fabricator_part_number", "")).strip()
+    if explicit:
+        return explicit
+
+    effective_config = fabricator_config or _load_fabricator_config(fabricator_id)
+    if effective_config is None:
+        return ""
+
+    normalized_attributes = _normalize_fabricator_attributes(
+        entry.attributes, effective_config
+    )
+    for canonical in _part_number_precedence_for_fabricator(fabricator_id):
+        candidate = normalized_attributes.get(canonical, "").strip()
+        if candidate:
+            return candidate
+
+    return ""
+
+
+def _get_field_value(
+    entry,
+    field: str,
+    *,
+    fabricator_id: str = "generic",
+    fabricator_config: Optional[FabricatorConfig] = None,
+) -> str:
     """Extract field value from BOM entry.
 
     Args:
@@ -544,8 +674,10 @@ def _get_field_value(entry, field: str) -> str:
         "footprint": lambda e: e.footprint,
         "manufacturer": lambda e: e.attributes.get("manufacturer", ""),
         "mfgpn": lambda e: e.attributes.get("manufacturer_part", ""),
-        "fabricator_part_number": lambda e: e.attributes.get(
-            "fabricator_part_number", ""
+        "fabricator_part_number": lambda e: _resolve_fabricator_part_number(
+            e,
+            fabricator_id=fabricator_id,
+            fabricator_config=fabricator_config,
         ),
         "smd": lambda e: "Yes" if e.attributes.get("smd", False) else "No",
         "lcsc": lambda e: e.attributes.get("lcsc", "") or e.attributes.get("LCSC", ""),

--- a/src/jbom/common/field_parser.py
+++ b/src/jbom/common/field_parser.py
@@ -7,6 +7,38 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Any
 
 from .fields import normalize_field_name, FIELD_PRESETS
+from .synonym_normalization import normalize_synonym_token
+
+
+def _resolve_field_token(
+    token: str,
+    *,
+    fabricator_id: str,
+    context: str,
+) -> str:
+    """Resolve a user field token to an internal field ID.
+
+    This accepts either internal field IDs (e.g. ``reference``) or fabricator
+    output column headers (e.g. ``Designator`` / ``Surface Mount``).
+    """
+
+    normalized_token = normalize_field_name(token)
+
+    from jbom.config.fabricators import get_fabricator_column_mapping
+
+    column_mapping = get_fabricator_column_mapping(fabricator_id, context)
+    if not column_mapping:
+        return normalized_token
+
+    if normalized_token in column_mapping.values():
+        return normalized_token
+
+    token_key = normalize_synonym_token(token)
+    for header, internal_field in column_mapping.items():
+        if normalize_synonym_token(header) == token_key:
+            return internal_field
+
+    return normalized_token
 
 
 def parse_fields_argument(
@@ -104,7 +136,11 @@ def parse_fields_argument(
             else:
                 # Not a preset — treat as a field addition request.
                 # Permissive: accept any field name. Unknown fields produce blank cells.
-                field_name = normalize_field_name(tok[1:])
+                field_name = _resolve_field_token(
+                    tok[1:],
+                    fabricator_id=fabricator_id,
+                    context=context,
+                )
                 # Add appropriate context defaults first if result is empty
                 if not result:
                     if fabricator_id != "generic":
@@ -155,7 +191,11 @@ def parse_fields_argument(
         else:
             # Custom field name — permissive: normalize and accept regardless of whether
             # the field exists in available_fields. Unknown fields produce blank cells.
-            normalized = normalize_field_name(tok)
+            normalized = _resolve_field_token(
+                tok,
+                fabricator_id=fabricator_id,
+                context=context,
+            )
             result.append(normalized)
 
     # Deduplicate while preserving order

--- a/tests/unit/test_bom_cli_field_resolution.py
+++ b/tests/unit/test_bom_cli_field_resolution.py
@@ -1,6 +1,6 @@
 """Unit tests for BOM CLI field resolution helpers."""
 
-from jbom.cli.bom import _get_field_value
+from jbom.cli.bom import _entry_smd_from_reference_lookup, _get_field_value
 from jbom.services.bom_generator import BOMEntry
 
 
@@ -43,3 +43,30 @@ def test_fabricator_part_number_prefers_explicit_value() -> None:
         _get_field_value(entry, "fabricator_part_number", fabricator_id="jlc")
         == "JLC-OVERRIDE-123"
     )
+
+
+def test_smd_field_uses_footprint_inference_when_attribute_missing() -> None:
+    entry = _make_entry({})
+    assert _get_field_value(entry, "smd", fabricator_id="jlc") == "Yes"
+
+
+def test_smd_field_honors_explicit_false_attribute() -> None:
+    entry = _make_entry({"smd": False})
+    assert _get_field_value(entry, "smd", fabricator_id="jlc") == "No"
+
+
+def test_entry_smd_lookup_returns_none_without_known_references() -> None:
+    entry = _make_entry({})
+    assert _entry_smd_from_reference_lookup(entry, {}) is None
+
+
+def test_entry_smd_lookup_requires_all_known_references_smd() -> None:
+    entry = BOMEntry(
+        references=["R1", "R2"],
+        value="10k",
+        footprint="Resistor_SMD:R_0603_1608Metric",
+        quantity=2,
+        attributes={},
+    )
+    assert _entry_smd_from_reference_lookup(entry, {"R1": True, "R2": True}) is True
+    assert _entry_smd_from_reference_lookup(entry, {"R1": True, "R2": False}) is False

--- a/tests/unit/test_bom_cli_field_resolution.py
+++ b/tests/unit/test_bom_cli_field_resolution.py
@@ -1,0 +1,45 @@
+"""Unit tests for BOM CLI field resolution helpers."""
+
+from jbom.cli.bom import _get_field_value
+from jbom.services.bom_generator import BOMEntry
+
+
+def _make_entry(attributes: dict[str, object]) -> BOMEntry:
+    """Create a minimal BOM entry for field resolution tests."""
+    return BOMEntry(
+        references=["R1"],
+        value="10k",
+        footprint="Resistor_SMD:R_0603_1608Metric",
+        quantity=1,
+        attributes=attributes,
+    )
+
+
+def test_fabricator_part_number_resolves_from_jlc_lcsc_attribute() -> None:
+    entry = _make_entry({"lcsc": "C25585"})
+    assert (
+        _get_field_value(entry, "fabricator_part_number", fabricator_id="jlc")
+        == "C25585"
+    )
+
+
+def test_fabricator_part_number_resolves_from_jlc_synonym_alias() -> None:
+    entry = _make_entry({"jlcpcb_part_#": "C965799"})
+    assert (
+        _get_field_value(entry, "fabricator_part_number", fabricator_id="jlc")
+        == "C965799"
+    )
+
+
+def test_fabricator_part_number_prefers_explicit_value() -> None:
+    entry = _make_entry(
+        {
+            "fabricator_part_number": "JLC-OVERRIDE-123",
+            "lcsc": "C25585",
+            "jlcpcb_part_#": "C965799",
+        }
+    )
+    assert (
+        _get_field_value(entry, "fabricator_part_number", fabricator_id="jlc")
+        == "JLC-OVERRIDE-123"
+    )

--- a/tests/unit/test_issue_133_data_quality.py
+++ b/tests/unit/test_issue_133_data_quality.py
@@ -16,9 +16,13 @@ from pathlib import Path
 import pytest
 
 from jbom.common.component_utils import derive_package_from_footprint
-from jbom.common.field_parser import parse_fields_argument
+from jbom.common.field_parser import (
+    parse_fields_argument,
+    check_fabricator_field_completeness,
+)
 from jbom.common.component_filters import apply_component_filters
 from jbom.common.types import Component
+from jbom.config.fabricators import get_fabricator_presets
 from jbom.services.bom_generator import BOMGenerator
 from jbom.services.project_inventory import ProjectInventoryGenerator
 
@@ -265,3 +269,34 @@ class TestBug5PermissiveFields:
     def test_empty_fields_still_raises(self) -> None:
         with pytest.raises(ValueError, match="cannot be empty"):
             parse_fields_argument("", self._available)
+
+    def test_jlc_header_tokens_map_to_internal_fields_without_warning(self) -> None:
+        available = {
+            "reference": "Reference",
+            "quantity": "Quantity",
+            "value": "Value",
+            "description": "Description",
+            "footprint": "Footprint",
+            "i:package": "Inventory package",
+            "fabricator_part_number": "Fabricator part number",
+            "smd": "Surface mount indicator",
+        }
+        presets = get_fabricator_presets("jlc")
+        selected = parse_fields_argument(
+            "Designator,Quantity,Value,Comment,Footprint,LCSC,Surface_Mount",
+            available,
+            fabricator_id="jlc",
+            fabricator_presets=presets,
+            context="bom",
+        )
+        assert selected == [
+            "reference",
+            "quantity",
+            "value",
+            "description",
+            "i:package",
+            "fabricator_part_number",
+            "smd",
+        ]
+        warning = check_fabricator_field_completeness(selected, "jlc", presets)
+        assert warning is None


### PR DESCRIPTION
## Summary
- map explicit BOM `--fields` tokens through fabricator column mappings so header-style selections resolve to canonical internal fields
- remove output divergence between default `--jlc` fields and equivalent explicit header lists
- populate BOM `Surface Mount` values from project PCB mount metadata by reference, with package/footprint fallback
- add focused regression tests for JLC header token parity, warning suppression, and SMD resolution behavior

## Verification
- `pytest tests/unit/test_bom_cli_field_resolution.py tests/unit/test_issue_133_data_quality.py tests/unit/test_cli_help.py`
- manual repro: `jbom bom ... --jlc` and `jbom bom ... --jlc --fields "Designator,Quantity,Value,Comment,Footprint,LCSC,Surface_Mount"` now produce matching rows and `Surface Mount` values

Co-Authored-By: Oz <oz-agent@warp.dev>