### PR TITLE
feat: remove canonical c namespace and use source-only mismatch diagnostics

### DIFF
--- a/features/parts/core.feature
+++ b/features/parts/core.feature
@@ -52,7 +52,7 @@ Feature: Parts List Generation (Core Functionality)
       | R1   | 10K   | R_0805_2012 | 0603    |
       | R2   | 10K   | R_0805_2012 | 0805    |
 
-  Scenario: Explicit namespace fields are available in parts output
+  Scenario: Explicit source and annotation namespace fields are available in parts output
     Given a PCB that contains:
       | Reference | X | Y | Footprint   |
       | R1        | 5 | 3 | R_0805_2012 |
@@ -61,13 +61,13 @@ Feature: Parts List Generation (Core Functionality)
       | C1        | 8 | 3 | C_0603_1608 |
       | C20       | 9 | 3 | C_0603_1608 |
       | U1        | 1 | 1 | SOIC-8_3.9x4.9mm |
-    When I run jbom command "parts -f refs,s:footprint,c:footprint"
+    When I run jbom command "parts -f refs,s:footprint,a:footprint"
     Then the command should succeed
     And the output should contain these fields:
-      | Refs | S:Footprint | C:Footprint |
+      | Refs | S:Footprint | A:Footprint |
     And the CSV output has rows where:
-      | Refs      | S:Footprint | C:Footprint |
-      | R1,R2,R10 | R_0805_2012 | R_0805_2012 |
+      | Refs      | S:Footprint | A:Footprint |
+      | R1,R2,R10 | R_0805_2012 |             |
 
   Scenario: Parts list-fields includes merge namespace fields
     When I run jbom command "parts --list-fields"
@@ -75,5 +75,5 @@ Feature: Parts List Generation (Core Functionality)
     And the output should contain "Known parts fields"
     And the output should contain "s:value"
     And the output should not contain "p:footprint"
-    And the output should contain "c:value"
+    And the output should not contain "c:value"
     And the output should contain "a:value"

--- a/src/jbom/cli/audit.py
+++ b/src/jbom/cli/audit.py
@@ -623,14 +623,9 @@ def _format_merge_mismatch_note(row: AuditRow) -> str:
 
     field_name = (row.field or "").strip() or "field"
     source_summary = (row.current_value or "").strip()
-    canonical_value = (row.suggested_value or "").strip()
 
-    if source_summary and canonical_value:
-        return f"{field_name} ({source_summary}) -> c:{canonical_value}"
     if source_summary:
         return f"{field_name} ({source_summary})"
-    if canonical_value:
-        return f"{field_name} -> c:{canonical_value}"
     return field_name
 
 

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -107,7 +107,7 @@ def _enrich_bom_with_merge_namespaces(
     bom_data: BOMData,
     merge_result: ComponentMergeResult | None,
 ) -> BOMData:
-    """Attach stable merge-model namespaces (`s:/p:/c:/a:`) onto BOM entries."""
+    """Attach stable merge-model namespaces (`s:/p:/a:`) onto BOM entries."""
 
     if merge_result is None or not merge_result.records:
         return bom_data
@@ -161,9 +161,6 @@ def _enrich_bom_with_merge_namespaces(
             "merge_model_enabled": True,
             "merge_model_reference_count": merge_result.reference_count,
             "merge_model_mismatch_count": len(merge_result.mismatches),
-            "merge_precedence_profile": merge_result.metadata.get(
-                "precedence_profile", ""
-            ),
         }
     )
     return BOMData(
@@ -511,7 +508,6 @@ def _list_available_fields(
         Column(header="s:", key="s:", preferred_width=16, wrap=False),
         Column(header="p:", key="p:", preferred_width=16, wrap=False),
         Column(header="i:", key="i:", preferred_width=16, wrap=False),
-        Column(header="c:", key="c:", preferred_width=16, wrap=False),
         Column(header="a:", key="a:", preferred_width=16, wrap=False),
     ]
     print_table(
@@ -561,8 +557,6 @@ def _get_available_bom_fields(components) -> dict[str, str]:
         "s:value": "Schematic source value",
         "s:footprint": "Schematic source footprint",
         "p:footprint": "PCB source footprint",
-        "c:value": "Canonical merged value",
-        "c:footprint": "Canonical merged footprint",
         "a:value": "Merge annotation value",
         "a:footprint": "Merge annotation footprint",
         # Add inventory fields with I: prefix
@@ -928,21 +922,9 @@ def _get_attribute_value(entry: BOMEntry, key: str) -> str:
 
 
 def _resolve_inventory_field_value(entry: BOMEntry, inventory_field: str) -> str:
-    """Resolve an inventory-prefixed field with schema-aware fallbacks."""
-    raw_value = entry.attributes.get(f"i:{inventory_field}", "")
-    if isinstance(raw_value, str):
-        if raw_value.strip():
-            return raw_value
-    elif raw_value:
-        return str(raw_value)
-    legacy_value = entry.attributes.get(inventory_field, "")
-    if isinstance(legacy_value, str):
-        if legacy_value.strip():
-            return legacy_value
-    elif legacy_value:
-        return str(legacy_value)
+    """Resolve an inventory-prefixed field from the inventory namespace only."""
 
-    return ""
+    return _get_attribute_value(entry, f"i:{inventory_field}")
 
 
 def _resolve_standard_field_value(
@@ -988,24 +970,15 @@ def _resolve_namespaced_field_value(
     fabricator_id: str,
     fabricator_config: Optional[FabricatorConfig],
 ) -> str:
-    """Resolve a namespace-qualified field with deterministic fallbacks."""
-
-    explicit = _get_attribute_value(entry, f"{namespace}:{namespaced_field}")
-    if explicit:
-        return explicit
+    """Resolve a namespace-qualified field under strict source semantics."""
 
     if namespace == "i":
         return _resolve_inventory_field_value(entry, namespaced_field)
 
-    if namespace in {"s", "c"}:
-        return _resolve_standard_field_value(
-            entry,
-            namespaced_field,
-            fabricator_id=fabricator_id,
-            fabricator_config=fabricator_config,
-        )
+    if namespace in {"s", "p"}:
+        return _get_attribute_value(entry, f"{namespace}:{namespaced_field}")
 
-    return ""
+    return _get_attribute_value(entry, f"{namespace}:{namespaced_field}")
 
 
 def _resolve_annotation_field_value(
@@ -1044,21 +1017,18 @@ def _resolve_annotation_field_value(
     if inventory_value:
         lines.append(("i", inventory_value))
 
-    canonical_value = _resolve_namespaced_field_value(
-        entry,
-        "c",
-        annotation_field,
-        fabricator_id=fabricator_id,
-        fabricator_config=fabricator_config,
-    )
-    if canonical_value:
-        if not lines or any(value != canonical_value for _, value in lines):
-            lines.append(("c", canonical_value))
-
     if not lines:
         return ""
 
-    return "\n".join(f"{namespace}:{value}" for namespace, value in lines)
+    unique_lines: list[tuple[str, str]] = []
+    seen_pairs: set[tuple[str, str]] = set()
+    for namespace_value in lines:
+        if namespace_value in seen_pairs:
+            continue
+        seen_pairs.add(namespace_value)
+        unique_lines.append(namespace_value)
+
+    return "\n".join(f"{namespace}:{value}" for namespace, value in unique_lines)
 
 
 def _get_field_value(
@@ -1100,15 +1070,6 @@ def _get_field_value(
         return _resolve_namespaced_field_value(
             entry,
             "p",
-            field[2:],
-            fabricator_id=fabricator_id,
-            fabricator_config=fabricator_config,
-        )
-
-    if field.startswith("c:"):
-        return _resolve_namespaced_field_value(
-            entry,
-            "c",
             field[2:],
             fabricator_id=fabricator_id,
             fabricator_config=fabricator_config,

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -104,7 +104,7 @@ def _enrich_parts_with_merge_namespaces(
     parts_data: PartsListData,
     merge_result: ComponentMergeResult | None,
 ) -> PartsListData:
-    """Attach merge namespace attributes (`s:/p:/c:/a:`) to parts entries."""
+    """Attach merge namespace attributes (`s:/p:/a:`) to parts entries."""
 
     if merge_result is None or not merge_result.records:
         return parts_data
@@ -161,9 +161,6 @@ def _enrich_parts_with_merge_namespaces(
             "merge_model_enabled": True,
             "merge_model_reference_count": merge_result.reference_count,
             "merge_model_mismatch_count": len(merge_result.mismatches),
-            "merge_precedence_profile": merge_result.metadata.get(
-                "precedence_profile", ""
-            ),
         }
     )
     return PartsListData(
@@ -187,7 +184,6 @@ def _get_available_parts_fields() -> dict[str, str]:
         "dielectric": "Dielectric type",
         "s:value": "Schematic source value",
         "p:footprint": "PCB source footprint",
-        "c:value": "Canonical merged value",
         "a:value": "Merge annotation value",
     }
 
@@ -208,7 +204,6 @@ def _list_available_parts_fields() -> None:
         Column(header="s:", key="s:", preferred_width=16, wrap=False),
         Column(header="p:", key="p:", preferred_width=16, wrap=False),
         Column(header="i:", key="i:", preferred_width=16, wrap=False),
-        Column(header="c:", key="c:", preferred_width=16, wrap=False),
         Column(header="a:", key="a:", preferred_width=16, wrap=False),
     ]
     print_table(
@@ -540,7 +535,7 @@ def _get_parts_field_value(entry: PartsListEntry, field: str) -> str:
         return str(getattr(entry, mapped_attr, "") or "")
 
     namespace_prefix, separator, _ = field.partition(":")
-    if separator and namespace_prefix in {"s", "p", "i", "c", "a"}:
+    if separator and namespace_prefix in {"s", "p", "i", "a"}:
         if not is_namespace_applicable(
             namespace_prefix,
             requirements=_PARTS_SOURCE_REQUIREMENTS,

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -95,7 +95,7 @@ def _enrich_pos_with_merge_namespaces(
     pos_data: list[dict[str, Any]],
     merge_result: ComponentMergeResult | None,
 ) -> list[dict[str, Any]]:
-    """Attach merge namespace fields (`s:/p:/c:/a:`) onto POS row dictionaries."""
+    """Attach merge namespace fields (`s:/p:/a:`) onto POS row dictionaries."""
 
     if merge_result is None or not merge_result.records:
         return pos_data
@@ -111,7 +111,6 @@ def _enrich_pos_with_merge_namespaces(
 
         merged_fields: dict[str, str] = {}
         merged_fields.update(merge_record.source_fields)
-        merged_fields.update(merge_record.canonical_fields)
         merged_fields.update(merge_record.annotated_fields)
         if not merged_fields:
             enriched_rows.append(row)
@@ -421,8 +420,6 @@ def _get_available_pos_fields() -> dict:
         "s:value": "Schematic source value",
         "s:footprint": "Schematic source footprint",
         "p:footprint": "PCB source footprint",
-        "c:value": "Canonical merged value",
-        "c:footprint": "Canonical merged footprint",
         "a:value": "Merge annotation value",
         "a:footprint": "Merge annotation footprint",
     }
@@ -452,7 +449,6 @@ def _list_available_pos_fields(fabricator: str) -> None:
         Column(header="s:", key="s:", preferred_width=16, wrap=False),
         Column(header="p:", key="p:", preferred_width=16, wrap=False),
         Column(header="i:", key="i:", preferred_width=16, wrap=False),
-        Column(header="c:", key="c:", preferred_width=16, wrap=False),
         Column(header="a:", key="a:", preferred_width=16, wrap=False),
     ]
     print_table(
@@ -695,7 +691,7 @@ def _get_pos_field_value(
         String value for the field
     """
     namespace_prefix, separator, _ = field.partition(":")
-    if separator and namespace_prefix in {"s", "p", "i", "c", "a"}:
+    if separator and namespace_prefix in {"s", "p", "i", "a"}:
         if not is_namespace_applicable(
             namespace_prefix,
             requirements=_POS_SOURCE_REQUIREMENTS,

--- a/src/jbom/common/fields.py
+++ b/src/jbom/common/fields.py
@@ -60,13 +60,10 @@ def normalize_field_name(field: str) -> str:
     if not field:
         return ""
 
-    # Handle prefixes (I:, C:, S:, P:, and A:) separately
+    # Handle prefixes (I:, S:, P:, and A:) separately
     prefix = ""
     if field.lower().startswith("i:"):
         prefix = "i:"
-        field = field[2:]
-    elif field.lower().startswith("c:"):
-        prefix = "c:"
         field = field[2:]
     elif field.lower().startswith("s:"):
         prefix = "s:"
@@ -120,9 +117,6 @@ def field_to_header(field: str) -> str:
     prefix = ""
     if field.lower().startswith("i:"):
         prefix = "I:"
-        field = field[2:]
-    elif field.lower().startswith("c:"):
-        prefix = "C:"
         field = field[2:]
     elif field.lower().startswith("s:"):
         prefix = "S:"

--- a/src/jbom/services/audit_service.py
+++ b/src/jbom/services/audit_service.py
@@ -415,13 +415,10 @@ class AuditService:
                 if str(value or "").strip()
             ]
             source_summary = ", ".join(source_segments)
-            canonical_value = mismatch.canonical_value
             severity = Severity.ERROR if mismatch.severity == "error" else Severity.WARN
             description = (
                 f"{mismatch.reference}: merge mismatch for {mismatch.field_key}"
                 f" ({source_summary})"
-                f" -> c:{canonical_value or '(empty)'}"
-                f" [{mismatch.decision_reason}]"
             )
             rows.append(
                 AuditRow(
@@ -433,7 +430,7 @@ class AuditService:
                     category=category,
                     field=mismatch.field_key,
                     current_value=source_summary,
-                    suggested_value=canonical_value,
+                    suggested_value="",
                     description=description,
                 )
             )

--- a/src/jbom/services/component_merge_service.py
+++ b/src/jbom/services/component_merge_service.py
@@ -1,18 +1,15 @@
-"""Component merge service for canonical namespace-aware workflows.
+"""Component merge service for source namespace-aware workflows.
 
 Current scope:
-- load field precedence policy metadata from defaults configuration
-- build deterministic source/canonical/annotation fields (`s:*`, `p:*`, `c:*`, `a:*`)
-- emit structured mismatch metadata with canonical decision reasons
+- build deterministic source and annotation fields (`s:*`, `p:*`, `a:*`)
+- emit structured mismatch metadata for source disagreements
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Literal
 
-from jbom.config.defaults import get_defaults
 from jbom.services.project_component_collector import (
     ProjectComponentGraph,
     ProjectReferenceRecord,
@@ -20,50 +17,15 @@ from jbom.services.project_component_collector import (
 
 MismatchSeverity = Literal["warning", "error"]
 
-_DEFAULT_SCHEMATIC_BIASED_FIELDS: tuple[str, ...] = (
-    "value",
-    "tolerance",
-    "voltage",
-    "current",
-    "wavelength",
-)
-_DEFAULT_PCB_BIASED_FIELDS: tuple[str, ...] = (
-    "footprint",
-    "package",
-    "mount_type",
-    "side",
-    "x",
-    "y",
-    "rotation",
-)
-_DEFAULT_INVENTORY_BIASED_FIELDS: tuple[str, ...] = (
-    "manufacturer",
-    "manufacturer_part",
-    "fabricator_part_number",
-    "lcsc",
-)
-
-
-@dataclass(frozen=True)
-class MergePrecedencePolicy:
-    """Field precedence policy loaded from defaults configuration."""
-
-    profile_name: str
-    schematic_biased_fields: tuple[str, ...] = tuple()
-    pcb_biased_fields: tuple[str, ...] = tuple()
-    inventory_biased_fields: tuple[str, ...] = tuple()
-
 
 @dataclass(frozen=True)
 class MergeMismatchRecord:
-    """Structured mismatch metadata for one merged field decision."""
+    """Structured mismatch metadata for one merged field disagreement."""
 
     reference: str
     field_key: str
     severity: MismatchSeverity
-    decision_reason: str
     source_values: dict[str, str] = field(default_factory=dict)
-    canonical_value: str = ""
 
 
 @dataclass(frozen=True)
@@ -72,7 +34,6 @@ class MergedReferenceRecord:
 
     reference: str
     source_fields: dict[str, str] = field(default_factory=dict)
-    canonical_fields: dict[str, str] = field(default_factory=dict)
     annotated_fields: dict[str, str] = field(default_factory=dict)
     mismatches: tuple[MergeMismatchRecord, ...] = tuple()
 
@@ -97,13 +58,13 @@ def resolve_grouped_merge_namespace_values(
 ) -> dict[str, str]:
     """Resolve grouped namespace values for one aggregated output entry.
 
-    `s:*` and `c:*` fields are emitted only when grouped references agree.
+    `s:*` and `p:*` fields are emitted only when grouped references agree.
     `a:*` fields are always human-oriented: when grouped references disagree on
     annotation text, render a deterministic reference-indexed summary.
     """
 
     resolved_fields: dict[str, str] = {}
-    for namespace_field in ("source_fields", "canonical_fields", "annotated_fields"):
+    for namespace_field in ("source_fields", "annotated_fields"):
         field_keys = sorted(
             {
                 field_key
@@ -162,8 +123,8 @@ def _resolve_grouped_annotation_field_value(
     - If grouped references resolve to multiple summaries, render deterministic
       reference-indexed segments joined by ` || `.
     - Mismatch summaries prefer concise diagnostic wording:
-      `S: and P: differ\\np:<value> chosen\\ns:<value>`.
-    - Non-mismatch summaries collapse to the canonical value when available.
+      `S: and P: differ\\ns:<value>\\np:<value>`.
+    - Non-mismatch summaries collapse to one source value when available.
     """
 
     field_name = _annotation_field_name(field_key)
@@ -218,18 +179,10 @@ def _build_grouped_annotation_summary(
 
     source_s = str(record.source_fields.get(f"s:{field_name}", "")).strip()
     source_p = str(record.source_fields.get(f"p:{field_name}", "")).strip()
-    canonical_value = str(record.canonical_fields.get(f"c:{field_name}", "")).strip()
     explicit_annotation = str(record.annotated_fields.get(field_key, "")).strip()
 
     if source_s and source_p and source_s != source_p:
-        return _format_mismatch_annotation_summary(
-            source_s=source_s,
-            source_p=source_p,
-            canonical_value=canonical_value,
-        )
-
-    if canonical_value:
-        return canonical_value
+        return _format_mismatch_annotation_summary(source_s=source_s, source_p=source_p)
     if source_s and source_p and source_s == source_p:
         return source_s
     if source_s:
@@ -245,59 +198,13 @@ def _format_mismatch_annotation_summary(
     *,
     source_s: str,
     source_p: str,
-    canonical_value: str,
 ) -> str:
     """Render concise mismatch annotation text for grouped `a:*` output."""
-
-    chosen_prefix, chosen_value = _resolve_annotation_choice(
-        source_s=source_s,
-        source_p=source_p,
-        canonical_value=canonical_value,
-    )
     lines: list[str] = ["S: and P: differ"]
-    if chosen_prefix and chosen_value:
-        lines.append(f"{chosen_prefix}:{chosen_value} chosen")
-
-    candidate_lines: list[tuple[str, str]] = [
-        ("s", source_s),
-        ("p", source_p),
-        ("c", canonical_value),
-    ]
-    seen_values: set[tuple[str, str]] = set()
-    for prefix, value in candidate_lines:
-        normalized_value = str(value or "").strip()
-        if not normalized_value:
-            continue
-        if chosen_value and normalized_value == chosen_value:
-            continue
-        pair = (prefix, normalized_value)
-        if pair in seen_values:
-            continue
-        seen_values.add(pair)
-        lines.append(f"{prefix}:{normalized_value}")
+    lines.append(f"s:{source_s}")
+    lines.append(f"p:{source_p}")
 
     return "\n".join(lines)
-
-
-def _resolve_annotation_choice(
-    *,
-    source_s: str,
-    source_p: str,
-    canonical_value: str,
-) -> tuple[str, str]:
-    """Resolve which source/canonical value should be marked as chosen."""
-
-    if canonical_value and source_p and canonical_value == source_p:
-        return "p", source_p
-    if canonical_value and source_s and canonical_value == source_s:
-        return "s", source_s
-    if canonical_value:
-        return "c", canonical_value
-    if source_p:
-        return "p", source_p
-    if source_s:
-        return "s", source_s
-    return "", ""
 
 
 def _group_reference_sort_key(references: list[str]) -> list[object]:
@@ -330,24 +237,13 @@ def _natural_reference_sort_key(reference: str) -> list[object]:
 
 
 class ComponentMergeService:
-    """Merge project component graphs into canonical namespace-aware records."""
+    """Merge project component graphs into source namespace-aware records."""
 
-    def __init__(
-        self, *, defaults_profile: str = "generic", cwd: Path | None = None
-    ) -> None:
-        """Initialize merge service and load defaults-backed policy metadata."""
-
-        self._defaults = get_defaults(defaults_profile, cwd=cwd)
-        self._policy = self._load_precedence_policy()
-
-    @property
-    def precedence_policy(self) -> MergePrecedencePolicy:
-        """Return the loaded merge precedence policy."""
-
-        return self._policy
+    def __init__(self) -> None:
+        """Initialize the merge service."""
 
     def merge(self, project_graph: ProjectComponentGraph) -> ComponentMergeResult:
-        """Merge collected project graph into canonical namespace-rich records."""
+        """Merge collected project graph into source namespace-rich records."""
 
         merged_records: dict[str, MergedReferenceRecord] = {}
         mismatch_records: list[MergeMismatchRecord] = []
@@ -358,58 +254,25 @@ class ComponentMergeService:
             merged_records[reference] = merged_record
             mismatch_records.extend(merged_record.mismatches)
 
-        metadata: dict[str, object] = {
-            "precedence_profile": self._policy.profile_name,
-            "schematic_biased_fields": self._policy.schematic_biased_fields,
-            "pcb_biased_fields": self._policy.pcb_biased_fields,
-            "inventory_biased_fields": self._policy.inventory_biased_fields,
-            "mismatch_count": len(mismatch_records),
-        }
+        metadata: dict[str, object] = {"mismatch_count": len(mismatch_records)}
         return ComponentMergeResult(
             records=merged_records,
             mismatches=tuple(mismatch_records),
             metadata=metadata,
         )
 
-    def _load_precedence_policy(self) -> MergePrecedencePolicy:
-        """Load precedence policy from defaults config with deterministic fallback."""
-
-        configured_policy = self._defaults.get_field_precedence_policy()
-        schematic_fields = configured_policy.get("schematic_biased")
-        pcb_fields = configured_policy.get("pcb_biased")
-        inventory_fields = configured_policy.get("inventory_biased")
-
-        return MergePrecedencePolicy(
-            profile_name=self._defaults.name,
-            schematic_biased_fields=self._dedupe_fields(
-                schematic_fields or _DEFAULT_SCHEMATIC_BIASED_FIELDS
-            ),
-            pcb_biased_fields=self._dedupe_fields(
-                pcb_fields or _DEFAULT_PCB_BIASED_FIELDS
-            ),
-            inventory_biased_fields=self._dedupe_fields(
-                inventory_fields or _DEFAULT_INVENTORY_BIASED_FIELDS
-            ),
-        )
-
     def _merge_reference_record(
         self, project_record: ProjectReferenceRecord
     ) -> MergedReferenceRecord:
-        """Merge one reference record into source/canonical/annotated namespaces."""
+        """Merge one reference record into source/annotated namespaces."""
 
         source_fields = self._build_source_fields(project_record)
-        canonical_fields = self._build_canonical_fields(source_fields)
-        mismatches = self._build_mismatches(
-            project_record.reference,
-            source_fields,
-            canonical_fields,
-        )
+        mismatches = self._build_mismatches(project_record.reference, source_fields)
         annotated_fields = self._build_annotated_fields(mismatches)
 
         return MergedReferenceRecord(
             reference=project_record.reference,
             source_fields=source_fields,
-            canonical_fields=canonical_fields,
             annotated_fields=annotated_fields,
             mismatches=tuple(mismatches),
         )
@@ -428,29 +291,12 @@ class ComponentMergeService:
             source_fields[f"p:{field_name}"] = field_value
         return source_fields
 
-    def _build_canonical_fields(self, source_fields: dict[str, str]) -> dict[str, str]:
-        """Build canonical `c:*` fields using precedence policy resolution."""
-
-        canonical_fields: dict[str, str] = {}
-        for field_name in self._iter_source_field_names(source_fields):
-            schematic_value = source_fields.get(f"s:{field_name}", "")
-            pcb_value = source_fields.get(f"p:{field_name}", "")
-            canonical_value, _ = self._resolve_canonical_value(
-                field_name,
-                schematic_value=schematic_value,
-                pcb_value=pcb_value,
-            )
-            if canonical_value:
-                canonical_fields[f"c:{field_name}"] = canonical_value
-        return canonical_fields
-
     def _build_mismatches(
         self,
         reference: str,
         source_fields: dict[str, str],
-        canonical_fields: dict[str, str],
     ) -> list[MergeMismatchRecord]:
-        """Build structured mismatch records for source namespace disagreements."""
+        """Build mismatch records for source namespace disagreements."""
 
         mismatches: list[MergeMismatchRecord] = []
         for field_name in self._iter_source_field_names(source_fields):
@@ -458,20 +304,12 @@ class ComponentMergeService:
             pcb_value = source_fields.get(f"p:{field_name}", "")
             if not schematic_value or not pcb_value or schematic_value == pcb_value:
                 continue
-
-            _, decision_reason = self._resolve_canonical_value(
-                field_name,
-                schematic_value=schematic_value,
-                pcb_value=pcb_value,
-            )
             mismatches.append(
                 MergeMismatchRecord(
                     reference=reference,
                     field_key=field_name,
                     severity="warning",
-                    decision_reason=decision_reason,
                     source_values={"s": schematic_value, "p": pcb_value},
-                    canonical_value=canonical_fields.get(f"c:{field_name}", ""),
                 )
             )
         return mismatches
@@ -488,8 +326,6 @@ class ComponentMergeService:
                 source_lines.append(f"s:{mismatch.source_values['s']}")
             if mismatch.source_values.get("p"):
                 source_lines.append(f"p:{mismatch.source_values['p']}")
-            if mismatch.canonical_value:
-                source_lines.append(f"c:{mismatch.canonical_value}")
             if source_lines:
                 annotated[f"a:{mismatch.field_key}"] = "\n".join(source_lines)
         return annotated
@@ -610,35 +446,7 @@ class ComponentMergeService:
         for prefixed_name in source_fields:
             if prefixed_name.startswith("s:") or prefixed_name.startswith("p:"):
                 field_names.add(prefixed_name[2:])
-
-        field_names.update(self._policy.schematic_biased_fields)
-        field_names.update(self._policy.pcb_biased_fields)
-        field_names.update(self._policy.inventory_biased_fields)
         return tuple(sorted(field_names))
-
-    def _resolve_canonical_value(
-        self,
-        field_name: str,
-        *,
-        schematic_value: str,
-        pcb_value: str,
-    ) -> tuple[str, str]:
-        """Resolve canonical value and decision reason for one field."""
-
-        if schematic_value and pcb_value:
-            if schematic_value == pcb_value:
-                return schematic_value, "sources_agree"
-            if field_name in self._policy.pcb_biased_fields:
-                return pcb_value, "pcb_biased_precedence"
-            if field_name in self._policy.schematic_biased_fields:
-                return schematic_value, "schematic_biased_precedence"
-            return schematic_value, "schematic_default_precedence"
-
-        if schematic_value:
-            return schematic_value, "schematic_only"
-        if pcb_value:
-            return pcb_value, "pcb_only"
-        return "", "no_source_value"
 
     def _get_component_property(
         self,
@@ -677,16 +485,3 @@ class ComponentMergeService:
         """Normalize scalar values to stripped string form."""
 
         return str(raw_value or "").strip()
-
-    def _dedupe_fields(self, fields: tuple[str, ...] | list[str]) -> tuple[str, ...]:
-        """Normalize and deduplicate field tokens while preserving order."""
-
-        seen: set[str] = set()
-        deduped: list[str] = []
-        for field_name in fields:
-            normalized = str(field_name or "").strip().lower()
-            if not normalized or normalized in seen:
-                continue
-            seen.add(normalized)
-            deduped.append(normalized)
-        return tuple(deduped)

--- a/src/jbom/services/field_listing_service.py
+++ b/src/jbom/services/field_listing_service.py
@@ -12,7 +12,7 @@ from typing import Iterable
 from jbom.common.fields import normalize_field_name
 
 
-_NAMESPACE_PREFIXES: tuple[str, ...] = ("s", "p", "i", "c", "a")
+_NAMESPACE_PREFIXES: tuple[str, ...] = ("s", "p", "i", "a")
 
 
 @dataclass(frozen=True)
@@ -23,7 +23,6 @@ class FieldNamespaceMatrixRow:
     s_token: str = ""
     p_token: str = ""
     i_token: str = ""
-    c_token: str = ""
     a_token: str = ""
 
     def to_console_row(self) -> dict[str, str]:
@@ -34,7 +33,6 @@ class FieldNamespaceMatrixRow:
             "s:": self.s_token,
             "p:": self.p_token,
             "i:": self.i_token,
-            "c:": self.c_token,
             "a:": self.a_token,
         }
 
@@ -61,7 +59,7 @@ def is_namespace_applicable(
         return requirements.require_pcb
     if namespace_prefix == "i":
         return requirements.require_inv
-    if namespace_prefix in {"c", "a"}:
+    if namespace_prefix == "a":
         return True
     return True
 
@@ -105,7 +103,6 @@ class FieldListingService:
                     "s": "",
                     "p": "",
                     "i": "",
-                    "c": "",
                     "a": "",
                 },
             )
@@ -121,7 +118,6 @@ class FieldListingService:
                     s_token=row["s"],
                     p_token=row["p"],
                     i_token=row["i"],
-                    c_token=row["c"],
                     a_token=row["a"],
                 )
             )

--- a/tests/unit/test_audit_cli.py
+++ b/tests/unit/test_audit_cli.py
@@ -562,7 +562,7 @@ def test_project_mode_includes_merge_mismatch_diagnostics_in_notes() -> None:
     _fieldnames, written = _build_project_couplet_rows(rows, component_context=context)
     current = next(row for row in written if row["RowType"] == "CURRENT")
     assert "Merge mismatch diagnostics:" in current["Notes"]
-    assert "footprint (s:SCH:0603, p:PCB:0402) -> c:PCB:0402" in current["Notes"]
+    assert "footprint (s:SCH:0603, p:PCB:0402)" in current["Notes"]
 
 
 def test_project_mode_matchability_exact_for_supplier_identifier_and_led_color() -> (

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -343,7 +343,8 @@ def test_audit_project_emits_merge_mismatch_rows_for_pcb_disagreement(
     assert mismatch_row.severity == Severity.WARN
     assert mismatch_row.ref_des == "R1"
     assert mismatch_row.field == "footprint"
-    assert "pcb_biased_precedence" in mismatch_row.description
+    assert "s:Resistor_SMD:R_0603_1608Metric" in mismatch_row.description
+    assert "p:Resistor_SMD:R_0402_1005Metric" in mismatch_row.description
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bom_cli_field_resolution.py
+++ b/tests/unit/test_bom_cli_field_resolution.py
@@ -89,9 +89,9 @@ def test_inventory_package_field_uses_namespaced_value_when_present() -> None:
     assert _get_field_value(entry, "i:package", fabricator_id="jlc") == "0603-LED"
 
 
-def test_inventory_package_field_prefers_explicit_package_attribute() -> None:
+def test_inventory_package_field_is_strict_namespace_only() -> None:
     entry = _make_entry({"package": "0603-LED"})
-    assert _get_field_value(entry, "i:package", fabricator_id="jlc") == "0603-LED"
+    assert _get_field_value(entry, "i:package", fabricator_id="jlc") == ""
 
 
 def test_inventory_package_field_is_blank_without_overlay_projection() -> None:
@@ -99,21 +99,10 @@ def test_inventory_package_field_is_blank_without_overlay_projection() -> None:
     assert _get_field_value(entry, "i:package", fabricator_id="jlc") == ""
 
 
-def test_s_namespace_field_falls_back_to_standard_field_resolution() -> None:
-    entry = _make_entry({"description": "Pull-up resistor"})
-    assert _get_field_value(entry, "s:value", fabricator_id="jlc") == "10k"
-    assert (
-        _get_field_value(entry, "s:description", fabricator_id="jlc")
-        == "Pull-up resistor"
-    )
-
-
-def test_c_namespace_field_prefers_explicit_value_and_falls_back_to_standard() -> None:
-    explicit_entry = _make_entry({"c:value": "9k99"})
-    assert _get_field_value(explicit_entry, "c:value", fabricator_id="jlc") == "9k99"
-
-    fallback_entry = _make_entry({})
-    assert _get_field_value(fallback_entry, "c:value", fabricator_id="jlc") == "10k"
+def test_s_namespace_field_is_strict_source_namespace() -> None:
+    entry = _make_entry({"description": "Pull-up resistor", "s:value": "9k99"})
+    assert _get_field_value(entry, "s:value", fabricator_id="jlc") == "9k99"
+    assert _get_field_value(entry, "s:description", fabricator_id="jlc") == ""
 
 
 def test_p_namespace_field_returns_explicit_value_only() -> None:
@@ -127,16 +116,14 @@ def test_p_namespace_field_returns_explicit_value_only() -> None:
     assert _get_field_value(fallback_entry, "p:footprint", fabricator_id="jlc") == ""
 
 
-def test_a_namespace_field_renders_annotation_lines_with_canonical_on_mismatch() -> (
-    None
-):
+def test_a_namespace_field_renders_source_annotation_lines_on_mismatch() -> None:
     entry = _make_entry(
         {"s:footprint": "SCH:0603", "p:footprint": "PCB:0402"},
         footprint="SCH:0603",
     )
     assert (
         _get_field_value(entry, "a:footprint", fabricator_id="jlc")
-        == "s:SCH:0603\np:PCB:0402\nc:SCH:0603"
+        == "s:SCH:0603\np:PCB:0402"
     )
 
 
@@ -167,8 +154,7 @@ def test_merge_namespace_enrichment_adds_uniform_values_to_grouped_entry() -> No
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0603",
                 },
-                canonical_fields={"c:footprint": "PCB:0603"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603\nc:PCB:0603"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
@@ -176,24 +162,22 @@ def test_merge_namespace_enrichment_adds_uniform_values_to_grouped_entry() -> No
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0603",
                 },
-                canonical_fields={"c:footprint": "PCB:0603"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603\nc:PCB:0603"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603"},
             ),
         },
         mismatches=tuple(),
-        metadata={"precedence_profile": "generic"},
+        metadata={},
     )
 
     enriched = _enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
     attrs = enriched.entries[0].attributes
     assert attrs["s:footprint"] == "SCH:0603"
-    assert attrs["c:footprint"] == "PCB:0603"
-    assert attrs["a:footprint"] == "S: and P: differ\np:PCB:0603 chosen\ns:SCH:0603"
+    assert attrs["p:footprint"] == "PCB:0603"
+    assert attrs["a:footprint"] == "S: and P: differ\ns:SCH:0603\np:PCB:0603"
     assert enriched.metadata["merge_model_enabled"] is True
     assert enriched.metadata["merge_model_reference_count"] == 2
     assert enriched.metadata["merge_model_mismatch_count"] == 0
-    assert enriched.metadata["merge_precedence_profile"] == "generic"
 
 
 def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -> None:
@@ -218,8 +202,7 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0402",
                 },
-                canonical_fields={"c:footprint": "PCB:0402"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402\nc:PCB:0402"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
@@ -227,7 +210,6 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
                     "s:footprint": "PCB:0603",
                     "p:footprint": "PCB:0603",
                 },
-                canonical_fields={"c:footprint": "PCB:0603"},
             ),
             "R10": MergedReferenceRecord(
                 reference="R10",
@@ -235,8 +217,7 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0402",
                 },
-                canonical_fields={"c:footprint": "PCB:0402"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402\nc:PCB:0402"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
             ),
         },
         mismatches=tuple(),
@@ -247,7 +228,7 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
 
     assert (
         enriched.entries[0].attributes["a:footprint"]
-        == "R1,R10 -> S: and P: differ\np:PCB:0402 chosen\ns:SCH:0603 || "
+        == "R1,R10 -> S: and P: differ\ns:SCH:0603\np:PCB:0402 || "
         "R2 -> PCB:0603"
     )
 
@@ -270,11 +251,11 @@ def test_merge_namespace_enrichment_skips_conflicting_grouped_values() -> None:
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                canonical_fields={"c:value": "10k", "c:rotation": "0"},
+                source_fields={"s:value": "10k", "p:rotation": "0"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
-                canonical_fields={"c:value": "10k", "c:rotation": "90"},
+                source_fields={"s:value": "10k", "p:rotation": "90"},
             ),
         },
         mismatches=tuple(),
@@ -284,5 +265,5 @@ def test_merge_namespace_enrichment_skips_conflicting_grouped_values() -> None:
     enriched = _enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
     attrs = enriched.entries[0].attributes
-    assert attrs["c:value"] == "10k"
-    assert "c:rotation" not in attrs
+    assert attrs["s:value"] == "10k"
+    assert "p:rotation" not in attrs

--- a/tests/unit/test_component_merge_service.py
+++ b/tests/unit/test_component_merge_service.py
@@ -54,14 +54,12 @@ def _make_graph_with_footprint_mismatch() -> ProjectComponentGraph:
     )
 
 
-def test_merge_service_loads_precedence_policy_from_defaults() -> None:
+def test_merge_service_reports_mismatch_count_metadata() -> None:
     service = ComponentMergeService()
-    policy = service.precedence_policy
+    graph = _make_graph_with_footprint_mismatch()
 
-    assert policy.profile_name == "generic"
-    assert "value" in policy.schematic_biased_fields
-    assert "footprint" in policy.pcb_biased_fields
-    assert "lcsc" in policy.inventory_biased_fields
+    result = service.merge(graph)
+    assert result.metadata["mismatch_count"] == 1
 
 
 def test_merge_creates_namespaced_records_and_mismatch_annotations() -> None:
@@ -74,19 +72,14 @@ def test_merge_creates_namespaced_records_and_mismatch_annotations() -> None:
     assert len(result.mismatches) == 1
     mismatch = result.mismatches[0]
     assert mismatch.field_key == "footprint"
-    assert mismatch.decision_reason == "pcb_biased_precedence"
     assert mismatch.source_values == {"s": "SCH:0603", "p": "PCB:0402"}
     merged = result.records["R1"]
     assert merged.source_fields["s:footprint"] == "SCH:0603"
     assert merged.source_fields["p:footprint"] == "PCB:0402"
-    assert merged.canonical_fields["c:footprint"] == "PCB:0402"
-    assert merged.canonical_fields["c:package"] == "0402"
-    assert (
-        merged.annotated_fields["a:footprint"] == "s:SCH:0603\np:PCB:0402\nc:PCB:0402"
-    )
+    assert merged.annotated_fields["a:footprint"] == "s:SCH:0603\np:PCB:0402"
 
 
-def test_merge_without_pcb_record_still_produces_canonical_schematic_fields() -> None:
+def test_merge_without_pcb_record_has_no_source_disagreement() -> None:
     collector = ProjectComponentCollector()
     graph = collector.collect(
         schematic_components=[_make_component("R2", value="1k", footprint="SCH:0805")],
@@ -97,6 +90,6 @@ def test_merge_without_pcb_record_still_produces_canonical_schematic_fields() ->
     result = service.merge(graph)
 
     merged = result.records["R2"]
-    assert merged.canonical_fields["c:value"] == "1k"
-    assert merged.canonical_fields["c:footprint"] == "SCH:0805"
+    assert merged.source_fields["s:value"] == "1k"
+    assert merged.source_fields["s:footprint"] == "SCH:0805"
     assert merged.mismatches == tuple()

--- a/tests/unit/test_field_listing_service.py
+++ b/tests/unit/test_field_listing_service.py
@@ -15,7 +15,6 @@ def test_build_namespace_matrix_groups_tokens_by_canonical_name() -> None:
             "value",
             "s:value",
             "p:value",
-            "c:value",
             "reference",
             "i:voltage",
         ]
@@ -25,7 +24,6 @@ def test_build_namespace_matrix_groups_tokens_by_canonical_name() -> None:
     assert as_dict["value"].name == "value"
     assert as_dict["value"].s_token == "s:value"
     assert as_dict["value"].p_token == "p:value"
-    assert as_dict["value"].c_token == "c:value"
     assert as_dict["value"].i_token == ""
     assert as_dict["reference"].name == "reference"
     assert as_dict["voltage"].i_token == "i:voltage"
@@ -53,7 +51,7 @@ def test_matrix_row_to_console_row_exposes_fixed_columns() -> None:
     row = FieldListingService().build_namespace_matrix(["value", "s:value"])[0]
     console = row.to_console_row()
 
-    assert set(console.keys()) == {"Name", "s:", "p:", "i:", "c:", "a:"}
+    assert set(console.keys()) == {"Name", "s:", "p:", "i:", "a:"}
     assert console["Name"] == "value"
     assert console["s:"] == "s:value"
 
@@ -61,7 +59,7 @@ def test_matrix_row_to_console_row_exposes_fixed_columns() -> None:
 def test_build_namespace_matrix_respects_source_requirements() -> None:
     service = FieldListingService()
     rows = service.build_namespace_matrix(
-        ["s:value", "p:value", "i:value", "c:value", "a:value"],
+        ["s:value", "p:value", "i:value", "a:value"],
         requirements=FieldSourceRequirements(
             require_sch=True,
             require_pcb=False,
@@ -73,7 +71,6 @@ def test_build_namespace_matrix_respects_source_requirements() -> None:
     assert value_row.s_token == "s:value"
     assert value_row.p_token == ""
     assert value_row.i_token == ""
-    assert value_row.c_token == "c:value"
     assert value_row.a_token == "a:value"
 
 
@@ -87,5 +84,4 @@ def test_is_namespace_applicable_matches_requirements_contract() -> None:
     assert is_namespace_applicable("s", requirements=requirements) is False
     assert is_namespace_applicable("p", requirements=requirements) is True
     assert is_namespace_applicable("i", requirements=requirements) is False
-    assert is_namespace_applicable("c", requirements=requirements) is True
     assert is_namespace_applicable("a", requirements=requirements) is True

--- a/tests/unit/test_field_namespace_prefixes.py
+++ b/tests/unit/test_field_namespace_prefixes.py
@@ -8,7 +8,6 @@ def test_normalize_field_name_preserves_supported_namespace_prefixes() -> None:
     assert normalize_field_name("s:Footprint") == "s:footprint"
     assert normalize_field_name("p:Mount Type") == "p:mount_type"
     assert normalize_field_name("a:Value") == "a:value"
-    assert normalize_field_name("c:Value") == "c:value"
     assert normalize_field_name("i:Package") == "i:package"
 
 
@@ -16,7 +15,7 @@ def test_field_to_header_formats_supported_namespace_prefixes() -> None:
     assert field_to_header("s:footprint") == "S:Footprint"
     assert field_to_header("p:mount_type") == "P:Mount Type"
     assert field_to_header("a:value") == "A:Value"
-    assert field_to_header("c:value") == "C:Value"
+    assert field_to_header("c:value") == "C:value"
     assert field_to_header("i:package") == "I:Package"
 
 
@@ -28,7 +27,7 @@ def test_parse_fields_argument_accepts_namespace_prefixed_tokens() -> None:
     }
 
     selected = parse_fields_argument(
-        "reference,s:footprint,p:mount_type,a:value,c:value,i:package",
+        "reference,s:footprint,p:mount_type,a:value,i:package",
         available,
         fabricator_id="generic",
         context="bom",
@@ -39,6 +38,5 @@ def test_parse_fields_argument_accepts_namespace_prefixed_tokens() -> None:
         "s:footprint",
         "p:mount_type",
         "a:value",
-        "c:value",
         "i:package",
     ]

--- a/tests/unit/test_parts_cli_field_resolution.py
+++ b/tests/unit/test_parts_cli_field_resolution.py
@@ -64,11 +64,11 @@ def test_get_parts_field_value_reads_namespaced_attributes() -> None:
         refs=["R1"],
         value="10k",
         footprint="R_0603",
-        attributes={"c:value": "9k99"},
+        attributes={"s:value": "9k99"},
     )
 
     assert _get_parts_field_value(entry, "refs") == "R1"
-    assert _get_parts_field_value(entry, "c:value") == "9k99"
+    assert _get_parts_field_value(entry, "s:value") == "9k99"
 
 
 def test_get_parts_field_value_respects_source_requirements() -> None:
@@ -80,14 +80,12 @@ def test_get_parts_field_value_respects_source_requirements() -> None:
             "s:footprint": "R_0603",
             "p:footprint": "R_0603",
             "i:voltage": "25V",
-            "c:footprint": "R_0603",
         },
     )
 
     assert _get_parts_field_value(entry, "s:footprint") == "R_0603"
     assert _get_parts_field_value(entry, "p:footprint") == ""
     assert _get_parts_field_value(entry, "i:voltage") == ""
-    assert _get_parts_field_value(entry, "c:footprint") == "R_0603"
 
 
 def test_enrich_parts_with_merge_namespaces_adds_uniform_fields() -> None:
@@ -108,26 +106,24 @@ def test_enrich_parts_with_merge_namespaces_adds_uniform_fields() -> None:
             "R1": MergedReferenceRecord(
                 reference="R1",
                 source_fields={"s:value": "10k", "p:value": "9k99"},
-                canonical_fields={"c:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99\nc:9k99"},
+                annotated_fields={"a:value": "s:10k\np:9k99"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
                 source_fields={"s:value": "10k", "p:value": "9k99"},
-                canonical_fields={"c:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99\nc:9k99"},
+                annotated_fields={"a:value": "s:10k\np:9k99"},
             ),
         },
         mismatches=tuple(),
-        metadata={"precedence_profile": "generic"},
+        metadata={},
     )
 
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
 
     attrs = enriched.entries[0].attributes
     assert attrs["s:value"] == "10k"
-    assert attrs["c:value"] == "9k99"
-    assert attrs["a:value"] == "S: and P: differ\np:9k99 chosen\ns:10k"
+    assert attrs["p:value"] == "9k99"
+    assert attrs["a:value"] == "S: and P: differ\ns:10k\np:9k99"
     assert enriched.metadata["merge_model_enabled"] is True
     assert enriched.metadata["merge_model_reference_count"] == 2
     assert enriched.metadata["merge_model_mismatch_count"] == 0
@@ -154,8 +150,7 @@ def test_enrich_parts_with_merge_namespaces_summarizes_divergent_annotations() -
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0402",
                 },
-                canonical_fields={"c:footprint": "PCB:0402"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402\nc:PCB:0402"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
@@ -163,7 +158,6 @@ def test_enrich_parts_with_merge_namespaces_summarizes_divergent_annotations() -
                     "s:footprint": "PCB:0603",
                     "p:footprint": "PCB:0603",
                 },
-                canonical_fields={"c:footprint": "PCB:0603"},
             ),
             "R10": MergedReferenceRecord(
                 reference="R10",
@@ -171,18 +165,17 @@ def test_enrich_parts_with_merge_namespaces_summarizes_divergent_annotations() -
                     "s:footprint": "SCH:0603",
                     "p:footprint": "PCB:0402",
                 },
-                canonical_fields={"c:footprint": "PCB:0402"},
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402\nc:PCB:0402"},
+                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
             ),
         },
         mismatches=tuple(),
-        metadata={"precedence_profile": "generic"},
+        metadata={},
     )
 
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
     assert (
         enriched.entries[0].attributes["a:footprint"]
-        == "R1,R10 -> S: and P: differ\np:PCB:0402 chosen\ns:SCH:0603 || "
+        == "R1,R10 -> S: and P: differ\ns:SCH:0603\np:PCB:0402 || "
         "R2 -> PCB:0603"
     )
 
@@ -204,11 +197,11 @@ def test_enrich_parts_with_merge_namespaces_skips_conflicting_grouped_values() -
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                canonical_fields={"c:value": "9k99", "c:rotation": "0"},
+                source_fields={"s:value": "9k99", "p:rotation": "0"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
-                canonical_fields={"c:value": "9k99", "c:rotation": "90"},
+                source_fields={"s:value": "9k99", "p:rotation": "90"},
             ),
         },
         mismatches=tuple(),
@@ -217,5 +210,5 @@ def test_enrich_parts_with_merge_namespaces_skips_conflicting_grouped_values() -
 
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
     attrs = enriched.entries[0].attributes
-    assert attrs["c:value"] == "9k99"
-    assert "c:rotation" not in attrs
+    assert attrs["s:value"] == "9k99"
+    assert "p:rotation" not in attrs

--- a/tests/unit/test_pos_cli_field_resolution.py
+++ b/tests/unit/test_pos_cli_field_resolution.py
@@ -68,9 +68,8 @@ def test_enrich_pos_with_merge_namespaces_adds_namespaced_fields() -> None:
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                source_fields={"s:value": "10k"},
-                canonical_fields={"c:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99\nc:9k99"},
+                source_fields={"s:value": "10k", "p:value": "9k99"},
+                annotated_fields={"a:value": "s:10k\np:9k99"},
             )
         },
         mismatches=tuple(),
@@ -80,8 +79,8 @@ def test_enrich_pos_with_merge_namespaces_adds_namespaced_fields() -> None:
     enriched = _enrich_pos_with_merge_namespaces(pos_rows, merge_result)
 
     assert enriched[0]["s:value"] == "10k"
-    assert enriched[0]["c:value"] == "9k99"
-    assert enriched[0]["a:value"] == "s:10k\np:9k99\nc:9k99"
+    assert enriched[0]["p:value"] == "9k99"
+    assert enriched[0]["a:value"] == "s:10k\np:9k99"
 
 
 def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -> None:
@@ -90,7 +89,7 @@ def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -
         records={
             "R2": MergedReferenceRecord(
                 reference="R2",
-                canonical_fields={"c:value": "1k"},
+                source_fields={"s:value": "1k"},
             )
         },
         mismatches=tuple(),
@@ -99,16 +98,14 @@ def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -
 
     enriched = _enrich_pos_with_merge_namespaces(pos_rows, merge_result)
 
-    assert "c:value" not in enriched[0]
+    assert "s:value" not in enriched[0]
 
 
 def test_get_pos_field_value_respects_source_requirements() -> None:
     entry = {
         "s:value": "10k",
         "p:footprint": "R_0603",
-        "c:value": "9k99",
     }
 
     assert _get_pos_field_value(entry, "s:value") == ""
     assert _get_pos_field_value(entry, "p:footprint") == "R_0603"
-    assert _get_pos_field_value(entry, "c:value") == "9k99"


### PR DESCRIPTION
## Summary
- remove `c:` namespace from merge model, field listing matrix, and CLI field resolution paths
- keep source namespaces (`s:`, `p:`, `i:`) and source-oriented `a:` diagnostics
- keep audit merge mismatch reporting as linter output without canonical chosen-value suggestions
- update unit + behave tests to match the no-`c:` contract

## Validation
- `pytest`
- `behave`

Co-Authored-By: Oz <oz-agent@warp.dev>
