### PR TITLE
feat(search): improve Mouser result relevance parity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   queries returning capacitor false positives). If strict pass yields no matches,
   filtering falls back to legacy fail-open behavior to preserve clueful results
   (issue #175).
+- Mouser provider parsing now normalizes common parametric attribute names and
+  derives missing package/value/tolerance clues from description text when
+  structured attributes are sparse, improving ranking/filtering quality for
+  passive queries such as `10k 0603 resistor` (issue #182). Query filtering now
+  only enforces strict core-attribute matching when that core attribute is
+  present in the provider results, preserving strict package matching for sparse
+  Mouser payloads.
 
 ### Migration note
 - **Stored ComponentIDs may change** for `led`, `cap`, `ind`, and `res` components

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -156,7 +156,15 @@ class SearchFilter:
                 break
 
         attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
-        strict_core_attr = target_value is not None and bool(attr_name)
+        has_core_attr_observations = bool(
+            attr_name
+            and any(
+                str((r.attributes or {}).get(attr_name, "")).strip() for r in results
+            )
+        )
+        strict_core_attr = (
+            target_value is not None and bool(attr_name) and has_core_attr_observations
+        )
         strict_package = bool(
             target_package and any(_extract_package_token(r) for r in results)
         )

--- a/src/jbom/suppliers/mouser/provider.py
+++ b/src/jbom/suppliers/mouser/provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -16,6 +17,38 @@ if TYPE_CHECKING:
     from jbom.config.providers import SearchProviderConfig
 
 logger = logging.getLogger(__name__)
+
+_PACKAGE_TOKEN_PATTERN = re.compile(
+    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
+)
+_RESISTANCE_TOKEN_PATTERN = re.compile(
+    r"\b(?:\d+(?:\.\d+)?(?:R|K|M)\d*|\d+(?:\.\d+)?\s*(?:OHM|OHMS|KOHM|KOHMS|MOHM|MOHMS|Ω))\b",
+    re.IGNORECASE,
+)
+_CAPACITANCE_TOKEN_PATTERN = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:PF|NF|UF|µF|μF|MF)\b", re.IGNORECASE
+)
+_INDUCTANCE_TOKEN_PATTERN = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:NH|UH|µH|μH|MH|H)\b", re.IGNORECASE
+)
+_TOLERANCE_TOKEN_PATTERN = re.compile(r"(?:\+/-\s*)?(\d+(?:\.\d+)?)\s*%", re.IGNORECASE)
+
+_ATTRIBUTE_NORMALIZATION_MAP: dict[str, str] = {
+    "resistance": "Resistance",
+    "resistance value": "Resistance",
+    "resistor value": "Resistance",
+    "capacitance": "Capacitance",
+    "capacitance value": "Capacitance",
+    "inductance": "Inductance",
+    "tolerance": "Tolerance",
+    "voltage rating": "Voltage Rating",
+    "rated voltage": "Voltage Rating",
+    "package": "Package",
+    "package / case": "Package",
+    "package case": "Package",
+    "case code - in": "Package",
+    "case code - mm": "Package",
+}
 
 try:
     import requests  # type: ignore
@@ -277,6 +310,79 @@ class MouserProvider(SearchProvider):
         except ValueError:
             return 0
 
+    @staticmethod
+    def _normalize_attribute_name(name: str) -> str:
+        key = " ".join((name or "").strip().lower().split())
+        return _ATTRIBUTE_NORMALIZATION_MAP.get(key, (name or "").strip())
+
+    @staticmethod
+    def _extract_package_token(*texts: str) -> str:
+        for text in texts:
+            if not text:
+                continue
+            match = _PACKAGE_TOKEN_PATTERN.search(text.upper())
+            if match:
+                return match.group(1).upper()
+        return ""
+
+    @staticmethod
+    def _extract_first(pattern: re.Pattern[str], text: str) -> str:
+        if not text:
+            return ""
+        match = pattern.search(text)
+        if not match:
+            return ""
+        return match.group(0).strip()
+
+    @staticmethod
+    def _infer_passive_intent(category: str, description: str) -> str:
+        haystack = f"{category} {description}".upper()
+        if "RESISTOR" in haystack:
+            return "RES"
+        if "CAPACITOR" in haystack:
+            return "CAP"
+        if "INDUCTOR" in haystack:
+            return "IND"
+        return ""
+
+    def _enrich_attributes_from_description(
+        self,
+        *,
+        attributes: dict[str, str],
+        description: str,
+        category: str,
+        mpn: str,
+    ) -> dict[str, str]:
+        out = dict(attributes)
+
+        if not out.get("Package"):
+            package = self._extract_package_token(description, mpn)
+            if package:
+                out["Package"] = package
+
+        if not out.get("Tolerance"):
+            tolerance_num = self._extract_first(_TOLERANCE_TOKEN_PATTERN, description)
+            if tolerance_num:
+                norm = tolerance_num.replace("+/-", "").replace(" ", "")
+                if norm.endswith("%"):
+                    out["Tolerance"] = norm
+
+        intent = self._infer_passive_intent(category, description)
+        if intent == "RES" and not out.get("Resistance"):
+            resistance = self._extract_first(_RESISTANCE_TOKEN_PATTERN, description)
+            if resistance:
+                out["Resistance"] = resistance
+        if intent == "CAP" and not out.get("Capacitance"):
+            capacitance = self._extract_first(_CAPACITANCE_TOKEN_PATTERN, description)
+            if capacitance:
+                out["Capacitance"] = capacitance
+        if intent == "IND" and not out.get("Inductance"):
+            inductance = self._extract_first(_INDUCTANCE_TOKEN_PATTERN, description)
+            if inductance:
+                out["Inductance"] = inductance
+
+        return out
+
     def _parse_results(self, data: dict[str, Any]) -> list[SearchResult]:
         search_results = data.get("SearchResults", {})
         parts = search_results.get("Parts", [])
@@ -306,7 +412,19 @@ class MouserProvider(SearchProvider):
                 name = str(attr.get("AttributeName", "") or "").strip()
                 value = str(attr.get("AttributeValue", "") or "").strip()
                 if name and value:
-                    attributes[name] = value
+                    canonical_name = self._normalize_attribute_name(name)
+                    if canonical_name and canonical_name not in attributes:
+                        attributes[canonical_name] = value
+
+            description = str(part.get("Description", ""))
+            category = str(part.get("Category", ""))
+            mpn = str(part.get("ManufacturerPartNumber", ""))
+            attributes = self._enrich_attributes_from_description(
+                attributes=attributes,
+                description=description,
+                category=category,
+                mpn=mpn,
+            )
 
             lifecycle = str(part.get("LifecycleStatus", "Unknown"))
             min_order_raw = str(part.get("Min", "1"))
@@ -318,8 +436,8 @@ class MouserProvider(SearchProvider):
             results.append(
                 SearchResult(
                     manufacturer=str(part.get("Manufacturer", "")),
-                    mpn=str(part.get("ManufacturerPartNumber", "")),
-                    description=str(part.get("Description", "")),
+                    mpn=mpn,
+                    description=description,
                     datasheet=str(part.get("DataSheetUrl", "")),
                     distributor=self.provider_id,
                     distributor_part_number=str(part.get("MouserPartNumber", "")),
@@ -329,7 +447,7 @@ class MouserProvider(SearchProvider):
                     raw_data=part,
                     lifecycle_status=lifecycle,
                     min_order_qty=min_order,
-                    category=str(part.get("Category", "")),
+                    category=category,
                     attributes=attributes,
                     stock_quantity=stock_qty,
                 )

--- a/tests/services/search/test_filtering.py
+++ b/tests/services/search/test_filtering.py
@@ -150,6 +150,26 @@ def test_filter_by_query_strict_package_match_when_query_includes_package():
     assert [r.mpn for r in filtered] == ["A"]
 
 
+def test_filter_by_query_package_strictness_survives_missing_core_attributes():
+    results = [
+        _sr(
+            attributes={},
+            description="10k 0603 resistor",
+            category="Thick Film Resistors - SMD",
+            mpn="A",
+        ),
+        _sr(
+            attributes={},
+            description="10k 0805 resistor",
+            category="Thick Film Resistors - SMD",
+            mpn="B",
+        ),
+    ]
+
+    filtered = SearchFilter.filter_by_query(results, "10k 0603 resistor")
+    assert [r.mpn for r in filtered] == ["A"]
+
+
 def test_filter_by_query_package_filter_falls_open_when_no_package_matches():
     results = [
         _sr(

--- a/tests/services/search/test_mouser_provider.py
+++ b/tests/services/search/test_mouser_provider.py
@@ -80,6 +80,103 @@ def test_mouser_provider_parses_basic_result(monkeypatch):
     assert r.attributes.get("Resistance") == "10 kOhms"
 
 
+def test_mouser_provider_normalizes_common_attribute_names(monkeypatch):
+    cache = InMemorySearchCache()
+
+    import jbom.suppliers.mouser.provider as mp
+
+    post = Mock(
+        return_value=_mock_response(
+            {
+                "SearchResults": {
+                    "Parts": [
+                        {
+                            "Manufacturer": "Yageo",
+                            "ManufacturerPartNumber": "RC0603FR-0710KL",
+                            "Description": "Thick Film Resistors - SMD 10k 1% 0603",
+                            "DataSheetUrl": "http://example",
+                            "MouserPartNumber": "123-ABC",
+                            "Availability": "6,609 In Stock",
+                            "PriceBreaks": [{"Price": "$0.10"}],
+                            "ProductDetailUrl": "http://detail",
+                            "LifecycleStatus": "Active",
+                            "Min": "1",
+                            "Category": "Resistors",
+                            "ProductAttributes": [
+                                {
+                                    "AttributeName": "Resistance Value",
+                                    "AttributeValue": "10 kOhms",
+                                },
+                                {
+                                    "AttributeName": "Package / Case",
+                                    "AttributeValue": "0603 (1608 Metric)",
+                                },
+                                {
+                                    "AttributeName": "Rated Voltage",
+                                    "AttributeValue": "50 V",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(mp, "requests", Mock(post=post))
+
+    cfg = SearchProviderConfig(type="mouser_api", extra={"api_key": "dummy"})
+    provider = MouserProvider.from_config(cfg, cache=cache)
+    results = provider.search("10K resistor", limit=5)
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.attributes.get("Resistance") == "10 kOhms"
+    assert r.attributes.get("Package") == "0603 (1608 Metric)"
+    assert r.attributes.get("Voltage Rating") == "50 V"
+
+
+def test_mouser_provider_extracts_fallback_attributes_from_description(monkeypatch):
+    cache = InMemorySearchCache()
+
+    import jbom.suppliers.mouser.provider as mp
+
+    post = Mock(
+        return_value=_mock_response(
+            {
+                "SearchResults": {
+                    "Parts": [
+                        {
+                            "Manufacturer": "Yageo",
+                            "ManufacturerPartNumber": "RC0603FR-0710KL",
+                            "Description": "Thick Film Resistors - SMD 10k 1% 0603",
+                            "DataSheetUrl": "http://example",
+                            "MouserPartNumber": "123-ABC",
+                            "Availability": "6,609 In Stock",
+                            "PriceBreaks": [{"Price": "$0.10"}],
+                            "ProductDetailUrl": "http://detail",
+                            "LifecycleStatus": "Active",
+                            "Min": "1",
+                            "Category": "Thick Film Resistors - SMD",
+                            "ProductAttributes": [],
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(mp, "requests", Mock(post=post))
+
+    cfg = SearchProviderConfig(type="mouser_api", extra={"api_key": "dummy"})
+    provider = MouserProvider.from_config(cfg, cache=cache)
+    results = provider.search("10K resistor", limit=5)
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.attributes.get("Resistance") == "10k"
+    assert r.attributes.get("Tolerance") == "1%"
+    assert r.attributes.get("Package") == "0603"
+
+
 def test_mouser_provider_uses_cache(monkeypatch):
     cache = InMemorySearchCache()
 


### PR DESCRIPTION
## Summary
Implements Step A for issue #182 by improving Mouser search relevance in the supplier search path (`jbom search`) while keeping changes narrowly scoped.

### What changed
- Mouser provider now normalizes common attribute-name variants (for example `Resistance Value` -> `Resistance`, `Package / Case` -> `Package`).
- Mouser parsing now derives fallback package/value/tolerance clues from description text when `ProductAttributes` are sparse.
- Query filtering strictness now requires observed core attributes before enforcing strict core-attribute matching, preserving strict package matching for sparse Mouser payloads.
- Added regression tests for:
  - strict package behavior when core attributes are missing
  - Mouser attribute normalization
  - Mouser description-derived fallback extraction

## Validation
- `python -m pytest tests/services/search/test_filtering.py tests/services/search/test_mouser_provider.py tests/services/search/test_search_cli.py`

Part of #182 (Step A)

Co-Authored-By: Oz <oz-agent@warp.dev>
