### PR TITLE
feat(search): align inventory supplier enrichment with query-aware context

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   only enforces strict core-attribute matching when that core attribute is
   present in the provider results, preserving strict package matching for sparse
   Mouser payloads.
+- `jbom inventory --supplier` enrichment now applies query-aware filtering and
+  ranking context (query + category) in its keyword search path, aligning
+  inventory supplier-assignment behavior with `jbom search` relevance logic for
+  issue #182 workflows.
 
 ### Migration note
 - **Stored ComponentIDs may change** for `led`, `cap`, `ind`, and `res` components

--- a/src/jbom/services/search/inventory_search_service.py
+++ b/src/jbom/services/search/inventory_search_service.py
@@ -24,7 +24,11 @@ from jbom.config.defaults import DefaultsConfig, get_defaults
 from jbom.config.fabricators import FabricatorConfig
 from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import normalize_query
-from jbom.services.search.filtering import SearchSorter, apply_default_filters
+from jbom.services.search.filtering import (
+    SearchFilter,
+    SearchSorter,
+    apply_default_filters,
+)
 from jbom.services.search.models import SearchResult
 from jbom.services.search.provider import SearchProvider
 from jbom.services.sophisticated_inventory_matcher import (
@@ -443,7 +447,16 @@ class InventorySearchService:
                     limit=provider_limit,
                 )
                 filtered = apply_default_filters(raw_results)
-                ranked_by_query[key] = SearchSorter.rank(filtered)
+                filtered = SearchFilter.filter_by_query(
+                    filtered,
+                    provider_query,
+                    category=(representative_item.category or ""),
+                )
+                ranked_by_query[key] = SearchSorter.rank(
+                    filtered,
+                    category=(representative_item.category or ""),
+                    query=provider_query,
+                )
             except Exception as exc:
                 error_by_query[key] = str(exc)
 

--- a/tests/services/search/test_inventory_search_dedup.py
+++ b/tests/services/search/test_inventory_search_dedup.py
@@ -445,3 +445,58 @@ def test_inventory_search_service_uses_item_aware_lcsc_dispatch(monkeypatch) -> 
     assert [r.inventory_item.ipn for r in records] == ["R10K-1", "R10K-2"]
     assert all(r.candidates for r in records)
     assert search_for_inventory_item.call_count == 1
+
+
+def test_inventory_search_service_passes_query_and_category_to_filter_and_rank(
+    monkeypatch,
+) -> None:
+    calls: dict[str, tuple[str, str, int]] = {}
+
+    def _filter_by_query(
+        results: list[SearchResult], query: str, *, category: str = ""
+    ) -> list[SearchResult]:
+        calls["filter"] = (query, category, len(results))
+        return list(results)
+
+    def _rank(
+        results: list[SearchResult], *, category: str = "", query: str = ""
+    ) -> list[SearchResult]:
+        calls["rank"] = (query, category, len(results))
+        return list(results)
+
+    monkeypatch.setattr(
+        "jbom.services.search.inventory_search_service.SearchFilter.filter_by_query",
+        staticmethod(_filter_by_query),
+    )
+    monkeypatch.setattr(
+        "jbom.services.search.inventory_search_service.SearchSorter.rank",
+        staticmethod(_rank),
+    )
+
+    provider = Mock(spec=SearchProvider)
+    provider.search_for_item = Mock(
+        return_value=[
+            _sr(
+                description="10K 0603 resistor",
+                category="Thick Film Resistors - SMD",
+                attributes={"Package": "0603"},
+            )
+        ]
+    )
+
+    svc = InventorySearchService(provider, candidate_limit=1, request_delay_seconds=0.0)
+    item = _inv_item(
+        ipn="R10K-CTX",
+        category="RES",
+        value="10K",
+        package="0603",
+        tolerance="1%",
+    )
+
+    records = svc.search([item])
+    assert provider.search_for_item.call_count == 1
+    assert records and records[0].candidates
+
+    expected_query = svc.build_query(item)
+    assert calls["filter"] == (expected_query, "RES", 1)
+    assert calls["rank"] == (expected_query, "RES", 1)


### PR DESCRIPTION
## Summary
Implements #182 Step B in the current architecture by aligning `jbom inventory --supplier` keyword search behavior with query-aware filtering/ranking context used in `jbom search`.

### Changes
- In `InventorySearchService._search_by_keyword`:
  - apply `SearchFilter.filter_by_query(..., category=<item category>)`
  - apply `SearchSorter.rank(..., category=<item category>, query=<provider query>)`
- Added regression test to assert query/category context propagation in inventory enrichment path.
- Updated `docs/CHANGELOG.md` with Step B behavior note.

## Validation
- `python -m pytest tests/unit/test_inventory_supplier_flag.py tests/services/search/test_inventory_search_dedup.py tests/services/search/test_inventory_search_verbose.py tests/services/search/test_search_cli.py tests/services/search/test_filtering.py tests/services/search/test_mouser_provider.py`
- Result: 81 passed

## Notes
- This PR is intentionally scoped to #182 parity in the current inventory enrichment workflow.
- Broader cross-supplier/DRY follow-ons remain tracked in #195.

Closes #182

Co-Authored-By: Oz <oz-agent@warp.dev>
