### PR TITLE
feat(inventory): add one-run multi-supplier enrichment workflow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   only enforces strict core-attribute matching when that core attribute is
   present in the provider results, preserving strict package matching for sparse
   Mouser payloads.
+- `jbom inventory` now accepts repeatable `--supplier` flags for one-pass
+  multi-supplier enrichment (e.g. `--supplier lcsc --supplier mouser`). In this
+  mode, enrichment is additive: original rows are preserved, supplier-specific
+  matched rows are appended, and added rows receive global per-IPN priority
+  assignment while `--limit` remains supplier-local (issue #197).
 
 ### Migration note
 - **Stored ComponentIDs may change** for `led`, `cap`, `ind`, and `res` components

--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -316,6 +316,14 @@ Generates an initial inventory template from schematic components. The output is
 
 **--filter-matches**
 : When used with `--inventory`, exclude components that already match items in the existing inventory (show only new/unmatched components).
+**--supplier SUPPLIER_ID**
+: Auto-populate supplier part numbers during inventory generation. Repeat the flag to enrich from multiple suppliers in one run (for example: `--supplier lcsc --supplier mouser`).
+
+**--api-key KEY**
+: API key override for supplier catalog providers.
+
+**--limit N**
+: Maximum candidates applied per supplier per unmatched seed row (default: `1`). In multi-supplier mode, the limit is evaluated independently for each supplier pass.
 
 
 **-v, --verbose**
@@ -503,6 +511,11 @@ jbom pos MyBoard.kicad_pcb -o placement.csv -f "Reference,X,Y,Footprint,Side"
 Generate inventory template:
 ```
 jbom inventory MyProject/ -o my_inventory.csv
+```
+
+Generate inventory with one-pass multi-supplier enrichment:
+```
+jbom inventory MyProject/ --supplier lcsc --supplier mouser --limit 2 -o inventory.csv
 ```
 
 Show only components not yet in an existing inventory:

--- a/docs/dev/requirements/0-User-Scenarios.md
+++ b/docs/dev/requirements/0-User-Scenarios.md
@@ -1,9 +1,9 @@
 ## Features and Scenarios
 ### Meet Alex, an Electronic Product Development Engineer
 
-Alex runs a small electronics consulting company. One day, Alex is designing analog circuits in KiCad. tbe next afternoon, Alex is researching component suppliers and updating inventory spreadsheets. Later, Alex is generating manufacturing files for projects going out to three different fabricators. Once he catches his breath, Alex is updating his inventory stock, adding new components and replacing obsolete and expensive ones.
+Alex runs a small electronics consulting company. One day might be spent designing analog circuits in KiCad, while the next, researching component suppliers and updating inventory spreadsheets. Once those tasks are complete, manufacturing files need to be generated for projects going out to three different fabricators. In the midst of all this, choices about suppliers, invoices, inventory management need to be made, all of which impact product production.
 
-Some might have the luxury of separate engineering and procurement teams, but Alex needs to wear multiple hats efficiently without getting bogged down in the complexity of each role.  The following scenarios demonstrate how Alex integrates jBOM into his workflow.
+Some might have the luxury of separate engineering and procurement teams, but Alex needs to wear multiple hats efficiently without getting bogged down in the complexity of each role.  The following scenarios demonstrate how Alex integrates jBOM into their electronic project workflow.
 
 ### @Scenario: `[Generate.Inventory]`
 Alex creates an initial inventory from the components used in an existing KiCad project
@@ -13,10 +13,19 @@ Alex creates an initial inventory from the components used in an existing KiCad 
    - `[Create.Inventory]`   Create an inventory that includes these new components
 
 @Documentation:
+Alex starts with a KiCad project.  Or two.  Or more...  As the number of projects grow, so does the complexity of managing eCAD designs, production needs and product distribution. When old projects becomes popular and orders flood in, the effort needed to update the old KiCad design files and BOMs to reflect current availability and component costs becomes overwhelming.
+
+Alex does not want to modify KiCad project files every time supply chain details change, but would prefer to extract the supply chain details and deal with them seperately.  Once extracted, Alex wants to select parts in supplier catalogs that match the design requirements, and use them to generate the Bill of Materials artifacts used by their fabrication vendor:
+  - Specify the KiCad projects of interest
+  - Select candidate parts from the supplier catalogs
+  - Create an inventory artifact that can be used to create BOMs
+
 The items in an inventory created from a KiCad project will reflect the components and attributes from the KiCad project.
 By default, KiCad's component libraries do not include supply chain details, though KiCad users can add supply chain details (e.g., Manufacturer part numbers) to their KiCad projects, either piecemeal, by curating their own libraries with this information added to each component, or by leveraging KiCad's support for Web/Database libraries.
 
-jBOM's inventories add another, less invasive way to manage KiCad supply chain details. Inventory csv/spreadsheets associate Manufacturer and supplier part information with the electronic and mechanical details so that jBOM can match inventory items to KiCad components when constucting the Bill of Materials files for a fabricator.  In this scenario, Alex will create a new spreadsheet that is missing these supply chain details; he will add them in the `[Search.Inventory]` scenario.
+jBOM's inventories add another, less invasive way to manage KiCad supply chain details. Inventory csv/spreadsheets associate Manufacturer and supplier part information with the electronic and mechanical details. jBOM can then match inventory items to KiCad components when constucting the Bill of Materials files for a fabricator.
+
+In this scenario, Alex will create a new spreadsheet from KiCad projects that are missing these supply chain details.
 
 #### Required Inventory columns
 
@@ -24,33 +33,34 @@ jBOM's inventories add another, less invasive way to manage KiCad supply chain d
 : Unique identifier for this inventory item. jBOM uses IPN to group components in the BOM.
 
 **Category**
-: Component classification (RES, CAP, IND, LED, DIO, IC, MCU, CON, etc.). Must match the schematic component type detected from lib_id or footprint. Used as first-stage filter.
+: Component classification (RES, CAP, IND, LED, DIO, IC, MCU, CON, etc.). jBOM intuits the component type from the schematic component's attribute information. Used as first-stage filter.
 
 **Value**
 : Component value in appropriate units. Format depends on category:
   - RES: ohms (330, 330R, 3R3, 10k, 10K0, 2M2, 0R22, etc.)
   - CAP: farads (100nF, 0.1u, 1u0, 220pF, etc.)
   - IND: henrys (10uH, 2m2, 100nH, etc.)
-  - LED/DIO: part number or color code
+  - DIO: part number or code,
+  - LED: Color
   - IC/MCU: part number
 
 **Package**
-: Physical package code (0603, 0805, 1206, SOT-23, SOIC-8, QFN-32, etc.). Extracted from schematic footprint and matched exactly.
+: Physical package code (0603, 0805, 1206, SOT-23, SOIC-8, QFN-32, etc.). Extracted from schematic and/or pcb footprint.
 
 **Priority**
-: Integer ranking (1 = most preferred, higher = less preferred). When multiple parts match equally, the lowest Priority is selected. Allows you to prefer stocked parts (Priority=1) over others (Priority=2+).
+: Integer ranking (1 = most preferred, higher = less preferred). When multiple parts share the same IPN, those that remain after supplier filtering are chosen based on priority.  This allows you to prefer stocked parts (Priority=1) over others (Priority=2+).
 
 **Manufacturer**
 : Component manufacturer name (UNI-ROYAL, YAGEO, WIMA, etc.).
 
 **MFGPN**
-: Manufacturer part number.  Used as the part number in the BOM if no supplier part number is provided and a supplier profile is used.
+: Manufacturer part number.
 
 **Supplier**
-: Supplier name. Used for identifying the preferred items when using a supplier profile.
+: Supplier name. Used to filter items when using a supplier profile.
 
 **SPN**
-: Supplier part number. Used as the part number identifier in the BOM output.
+: Supplier part number.
 
 #### Optional Inventory columns
 
@@ -64,7 +74,7 @@ jBOM's inventories add another, less invasive way to manage KiCad supply chain d
 : Surface mount indicator (SMD, Y, YES, TRUE, 1 for SMD; PTH, THT, TH, N, NO, FALSE, 0 for through-hole). If omitted or unclear, jBOM infers from footprint.
 
 **Tolerance**
-: Tolerance rating (5%, 1%, ±10%, etc.). Used in scoring heuristics when available.
+: Tolerance rating (5%, 1%, ±10%, etc.). Used in conjunction with Value in scoring heuristics when available.
 
 **V (Voltage)**
 : Working voltage rating (25V, 50V, 75V, 400V, etc.).
@@ -120,10 +130,10 @@ jBOM's inventories add another, less invasive way to manage KiCad supply chain d
 Alex resolves supplier options for inventory items that lack supply chain details
 
 Use cases:
-    * Find prospective items in a distributor or fabricator's product list and associate them with items in the inventory
-    * Add a new distributor to their inventory and associate existing inventory items with that distributor's offerings
+    * Find prospective items in a supplier's product catalog and associate them with items in the inventory
+    * Add a new distributor to an inventory and associate existing inventory items with that distributor's offerings
+    * Run one command that enriches and consolidates an inventory with data from multiple suppliers
     * Audit / update the inventory against current distributor and fabricator parts lists
-    * Interactively search, evaluate and select supplier sourcing website data to add to their inventory
 
 @Steps:
    - `[Discover.Profiles]`  Discover available supply chain profiles
@@ -135,16 +145,20 @@ Use cases:
    - `[Create.Inventory]`   Create an inventory with supply chain details
 
 @Documentation:
-Once Alex has an (incomplete) inventory, he needs to search supplier databases for parts that meet his needs.  The basic flow is:
+Once Alex has an (incomplete) inventory, Alex would like to search supplier databases for parts that meet project needs:
   * find components that match the items in the online catalog (type, values, tolerances, etc, similar to the component matching BOM algorithm)
   * filter them to remove unsuitable results (non-stocked/long lead time etc)
-  * filter them by quantity (is quantity needed (plus margin) more than available stock?)
+  * filter them by quantity (is quantity needed (plus margin) more than available stock?  High stock levels can be a proxy for popularity and cost)
   * Heuristically sort the resulting list to find the "best" candidates
       - manufacturer, manufacturer part number, alternate manufacturing sources, alternate-but-equivalent part numbering schemes
-      - preferred manufacturers?  Consistency with other inventory items, product families, ...?
-      - quantity on hand is a good indication of popularity/suitability
+      - Consistency with other inventory items, product families, ...
       - minimum quantity for ordering may filter out some candidates, depending on the quantity discount rates
       - price matters - all things equivalent, pick the lowest price
+
+High-level workflow expectations for multi-supplier enrichment:
+  * Alex can enrich from multiple suppliers in one run while keeping a single inventory artifact
+  * each supplier pass contributes additively to the same IPN requirement pool
+  * ranking/priority remains meaningful across all same-IPN items, even when items were discovered from different suppliers
 @End
 
 ### @Scenario: `[Validate]`
@@ -164,7 +178,7 @@ Alex validates a KiCad project's component usage against inventory items
 @Description:
 Generating a BOM with jBOM will identify components that
   * matched an inventory item exactly
-  * matched an alternate item
+  * matched an alternate item using heuristics and derived data
   * didn't match any items.
 
 A BOM with every component matched is ready for fabrication.

--- a/docs/dev/requirements/1-Functional-Scenarios.md
+++ b/docs/dev/requirements/1-Functional-Scenarios.md
@@ -16,9 +16,9 @@ Profiles capture supply chain context to enable fabricator switching without des
 ### Scenario: `[Discover.Profiles]`
 System finds and loads supply chain configuration files
 
-Alex needs jBOM to work with his supply chain preferences without hardcoded assumptions. Maybe Alex prefers Mouser over Digikey, or his company mandates specific manufacturers. Maybe Alex's fabricator expects "LCSC Part#" column while another expects "Supplier PN".
+Alex needs jBOM to work with Alex's supply chain preferences without hardcoded assumptions. Maybe Alex prefers Mouser over Digikey, or Alex's company mandates specific manufacturers. Maybe Alex's fabricator expects "LCSC Part#" column while another expects "Supplier PN".
 
-jBOM should find configuration files that define these preferences - from the project folder, user settings, or system defaults. This lets Alex (or his team) customize supplier APIs, BOM formatting, component matching rules without code changes.
+jBOM should find configuration files that define these preferences - from the project folder, user settings, or system defaults. This lets Alex (or Alex's team) customize supplier APIs, BOM formatting, component matching rules without code changes.
 
 The system searches multiple locations in priority order: project directory, git repository root, user home directory, system installation. Higher priority profiles can extend or override lower priority ones.
 
@@ -27,7 +27,7 @@ Select which supply chain configuration to use for this operation
 
 Alex operates in different supply chain contexts - hobby projects use LCSC/JLCPCB, client work uses Mouser/PCBWay, company projects have approved vendor lists. Each context needs different supplier preferences, BOM formats, and component matching rules.
 
-The system should let Alex choose his supply chain context explicitly or automatically detect it based on project location. Company projects in shared repositories might automatically use organization-wide profiles. Personal projects use Alex's preferred suppliers.
+The system should let Alex choose Alex's supply chain context explicitly or automatically detect it based on project location. Company projects in shared repositories might automatically use organization-wide profiles. Personal projects use Alex's preferred suppliers.
 
 Profiles define everything from "prefer YAGEO resistors" to "BOM needs LCSC column for JLCPCB" to "search Mouser first, Digikey as backup." Alex shouldn't need to reconfigure these preferences for each project.
 
@@ -43,18 +43,18 @@ jBOM should automatically discover project files, resolve file dependencies (sch
 ### Scenario: `[Specify.Inventory]`
 Determine which inventory sources to use for component matching
 
-Alex maintains component inventory in spreadsheets - maybe one master CSV file, maybe separate files per supplier, maybe Excel files shared with teammates. His inventory maps design requirements ("1kΩ resistor, 0603") to real parts he can actually order ("YAGEO RC0603JR-071KL from Mouser").
+Alex maintains component inventory in spreadsheets - maybe one master CSV file, maybe separate files per supplier, maybe Excel files shared with teammates. Alex's inventory maps design requirements ("1kΩ resistor, 0603") to real parts Alex can actually order ("YAGEO RC0603JR-071KL from Mouser").
 
-The system should find Alex's inventory files automatically or let him specify them explicitly. Alex might have multiple inventory sources - his personal parts collection, company-approved parts list, supplier-specific catalogs. The system should combine these intelligently and handle missing or corrupted files gracefully.
+The system should find Alex's inventory files automatically or let Alex specify them explicitly. Alex might have multiple inventory sources - Alex's personal parts collection, company-approved parts list, supplier-specific catalogs. The system should combine these intelligently and handle missing or corrupted files gracefully.
 
-When Alex adds new components to projects, the system should help him update his inventory with suitable supplier options rather than requiring manual research every time.
+When Alex adds new components to projects, the system should help Alex update Alex's inventory with suitable supplier options rather than requiring manual research every time.
 
 ## read and extract data from sources
 
 ### Scenario: `[Extract.Components]`
 Get component specifications from KiCad project files
 
-Alex's KiCad project contains components with design requirements: "R1: 1kΩ resistor, 0603 package, 5% tolerance" or "U1: ESP32-WROOM-32 microcontroller." The system needs to extract these components and their attributes from schematic files to understand what Alex actually needs to build his board.
+Alex's KiCad project contains components with design requirements: "R1: 1kΩ resistor, 0603 package, 5% tolerance" or "U1: ESP32-WROOM-32 microcontroller." The system needs to extract these components and their attributes from schematic files to understand what Alex actually needs to build Alex's board.
 
 The system should handle hierarchical schematics, multiple sheets, and all the different ways KiCad stores component information. It should capture reference designators (R1, C5, U3), values (1kΩ, 100nF), footprints (0603, SOIC-8), and any custom fields Alex added.
 
@@ -63,7 +63,7 @@ This gives jBOM the complete component requirements list that can be matched aga
 ### Scenario: `[Extract.Items]`
 Load inventory data from Alex's spreadsheets and databases
 
-Alex maintains his component inventory in various formats - maybe a master CSV file, maybe separate Excel sheets per supplier, maybe Apple Numbers files shared with teammates. Each inventory item maps design requirements to real, orderable parts with supplier details.
+Alex maintains Alex's component inventory in various formats - maybe a master CSV file, maybe separate Excel sheets per supplier, maybe Apple Numbers files shared with teammates. Each inventory item maps design requirements to real, orderable parts with supplier details.
 
 The system should read Alex's inventory files regardless of format (CSV, Excel, Numbers, KiCad databases) and extract the component specifications, supplier part numbers, manufacturer details, and any custom attributes Alex tracks like "preferred for new designs" or "bulk pricing available."
 
@@ -73,20 +73,20 @@ This gives jBOM the pool of available parts that can satisfy the component requi
 ### Scenario: `[Search.Suppliers]`
 Find parts using configured supplier catalogs
 
-Alex has inventory items missing supplier details or encounters new components not in his inventory. Rather than manually browsing Mouser, Digikey, or LCSC websites, Alex needs the system to search supplier catalogs automatically using component specifications.
+Alex has inventory items missing supplier details or encounters new components not in Alex's inventory. Rather than manually browsing Mouser, Digikey, or LCSC websites, Alex needs the system to search supplier catalogs automatically using component specifications.
 
 The system should use Alex's configured supplier APIs (Mouser REST, Digikey OAuth, LCSC databases) to find parts matching electrical and mechanical requirements. For a "1kΩ, 0603, 5%" resistor, it should return candidate parts with full supplier details, stock levels, and pricing.
 
-This lets Alex quickly expand his inventory with real, orderable parts rather than doing repetitive manual research for every new component.
+This lets Alex quickly expand Alex's inventory with real, orderable parts rather than doing repetitive manual research for every new component.
 
 ### Scenario: `[Select.Items]`
 Narrow supplier search results to reasonable candidate parts
 
-Supplier catalogs return thousands of parts for "1kΩ resistor" - different manufacturers, packages, tolerances, power ratings, prices. Alex doesn't want to manually review hundreds of options; he needs the system to identify a manageable set of good candidates.
+Supplier catalogs return thousands of parts for "1kΩ resistor" - different manufacturers, packages, tolerances, power ratings, prices. Alex doesn't want to manually review hundreds of options; Alex needs the system to identify a manageable set of good candidates.
 
 The system should apply heuristics to rank and filter results: prefer active parts over obsolete, higher stock quantities suggest popular/reliable parts, reasonable pricing, minimum order quantities that make sense for Alex's typical volumes.
 
-Alex gets a short, ranked list of suitable candidates with clear explanations of why each was selected. He can quickly approve good options or reject unsuitable ones, building his inventory efficiently without endless catalog browsing.
+Alex gets a short, ranked list of suitable candidates with clear explanations of why each was selected. Alex can quickly approve good options or reject unsuitable ones, building Alex's inventory efficiently without endless catalog browsing.
 
 
 ## Data processing - Heuristics and filtering
@@ -97,12 +97,12 @@ Alex generates BOMs for different fabricators with different supplier ecosystems
 
 The system should apply supply chain context to prioritize suitable inventory items. For JLCPCB BOMs, rank LCSC parts higher than Mouser parts. For company projects, prioritize approved manufacturers over random alternatives.
 
-This isn't hard filtering (eliminating options) but intelligent ranking so Alex gets the most suitable parts for his chosen fabricator while keeping fallback options available when preferred parts aren't available.
+This isn't hard filtering (eliminating options) but intelligent ranking so Alex gets the most suitable parts for Alex's chosen fabricator while keeping fallback options available when preferred parts aren't available.
 
 ### Scenario: `[Match.Components]`
 Find inventory items that can satisfy each KiCad component requirement
 
-Alex's KiCad design specifies "R1: 1kΩ, 0603, 5%" but his inventory contains specific supplier parts with full specifications. The system needs to intelligently match loose design requirements with precise inventory capabilities.
+Alex's KiCad design specifies "R1: 1kΩ, 0603, 5%" but Alex's inventory contains specific supplier parts with full specifications. The system needs to intelligently match loose design requirements with precise inventory capabilities.
 
 A KiCad "1kΩ, 5%" requirement could be satisfied by inventory items with 1% tolerance (better than required) but not 10% tolerance (worse than required). "1K" in KiCad should match "1000Ω" or "1k0" in inventory through value normalization.
 
@@ -112,7 +112,7 @@ The system orchestrates multiple sub-processes: normalize values for comparison,
 ### Scenario: `[Resolve.Conflicts]`
 Handle uncertain component matches and missing inventory items
 
-Matching doesn't always produce clear winners. Sometimes Alex gets multiple equally-good candidates, sometimes low-confidence matches that might not be suitable, sometimes no matches at all for components not in his inventory.
+Matching doesn't always produce clear winners. Sometimes Alex gets multiple equally-good candidates, sometimes low-confidence matches that might not be suitable, sometimes no matches at all for components not in Alex's inventory.
 
 The system should present these situations clearly to Alex with actionable options. For ambiguous matches, show the candidates with explanations of differences. For low-confidence matches, explain what requirements aren't well-satisfied. For missing matches, suggest supplier catalog searches to find suitable parts.
 
@@ -123,18 +123,18 @@ This gives Alex the information needed to make informed decisions: update KiCad 
 ### Scenario: `[Grade.Items]`
 Quantify how well inventory items satisfy component requirements
 
-Alex needs to understand match quality when the system suggests inventory items for his components. A "perfect match" means the inventory item meets or exceeds all requirements. Lower grades indicate potential issues that Alex should review.
+Alex needs to understand match quality when the system suggests inventory items for Alex's components. A "perfect match" means the inventory item meets or exceeds all requirements. Lower grades indicate potential issues that Alex should review.
 
 The system should provide confidence scores with clear explanations. A 1% resistor matching a 5% requirement gets high confidence ("tolerance upgrade"). A 10% resistor matching 5% requirement gets low confidence ("tolerance downgrade - verify if acceptable"). Value mismatches, package incompatibilities, or missing specifications reduce confidence.
 
-This helps Alex make informed decisions about whether suggested matches are suitable for his design or if he needs to search for better alternatives.
+This helps Alex make informed decisions about whether suggested matches are suitable for Alex's design or if Alex needs to search for better alternatives.
 
 ### Scenario: `[Rank.Items]`
 Manage inventory priorities to optimize cost and avoid waste
 
 Alex has real inventory management challenges: expensive parts already purchased that need to be used up before ordering cheaper alternatives, partial reels that shouldn't be wasted, preferred suppliers for consistency, and evolving cost optimization as market conditions change.
 
-For example, Alex bought an expensive reel of resistors from LCSC for JLC assembly, then found cheaper equivalents. He wants to rank the expensive reel as Priority 1 (use first) and the basic part as Priority 2 (use after expensive stock is consumed). Later, when the expensive parts are used up, he can flip the priorities.
+For example, Alex bought an expensive reel of resistors from LCSC for JLC assembly, then found cheaper equivalents. Alex wants to rank the expensive reel as Priority 1 (use first) and the basic part as Priority 2 (use after expensive stock is consumed). Later, when the expensive parts are used up, Alex can flip the priorities.
 
 The system should respect Alex's explicit inventory priorities while providing flexibility to adjust rankings as business needs evolve. This prevents waste of already-purchased parts while enabling long-term cost optimization.
 
@@ -142,11 +142,11 @@ The system should respect Alex's explicit inventory priorities while providing f
 ### Scenario: `[Identify.Ambiguous]`
 Flag components with unclear or multiple inventory matches
 
-Alex needs to know when component matching produces uncertain results that require his attention. Sometimes multiple inventory items match equally well, sometimes the single match has low confidence, sometimes the component specification is too vague or too restrictive.
+Alex needs to know when component matching produces uncertain results that require Alex's attention. Sometimes multiple inventory items match equally well, sometimes the single match has low confidence, sometimes the component specification is too vague or too restrictive.
 
 The system should clearly identify ambiguous situations: "R5 matched 3 equally-suitable 1kΩ resistors - choose preferred supplier" or "C12 has only one low-confidence match - verify 25V rating is sufficient for 12V design" or "U3 found no matches - specifications may be incomplete."
 
-This validation feedback helps Alex decide whether his BOM is fabrication-ready or needs component specification improvements, inventory updates, or supplier searches.
+This validation feedback helps Alex decide whether Alex's BOM is fabrication-ready or needs component specification improvements, inventory updates, or supplier searches.
 
 
 ### Scenario: `[Identify.Gaps]`
@@ -156,7 +156,7 @@ Alex's inventory may have components that lack critical supply chain details nee
 
 The system should identify inventory gaps that could block fabrication: "10 components missing supplier part numbers - cannot generate fabricator BOM" or "5 items lack power ratings - verify specifications before high-power applications."
 
-This inventory audit helps Alex prioritize which components need supplier research (`[Search.Suppliers]`) to find complete part specifications and update his inventory for fabrication readiness.
+This inventory audit helps Alex prioritize which components need supplier research (`[Search.Suppliers]`) to find complete part specifications and update Alex's inventory for fabrication readiness.
 
 
 ### Scenario: `[Identify.Obsolete]`
@@ -166,13 +166,13 @@ Alex's inventory may contain parts that are no longer suitable - supplier catalo
 
 The system should identify lifecycle issues: "R12, C5 using discontinued LCSC parts - find alternatives before production" or "U7 marked 'not recommended for new designs' - consider upgrade" or "Q3 price increased 300% - evaluate cheaper alternatives."
 
-This proactive warning helps Alex update his designs and inventory before supply chain problems block fabrication or inflate costs.
+This proactive warning helps Alex update Alex's designs and inventory before supply chain problems block fabrication or inflate costs.
 
 
 ### Scenario: `[Identify.Orphans]`
 Highlight project components with no inventory matches
 
-Alex needs to know which components in his project have no corresponding inventory items. These orphaned components block BOM generation and fabrication until Alex finds suitable supplier options.
+Alex needs to know which components in Alex's project have no corresponding inventory items. These orphaned components block BOM generation and fabrication until Alex finds suitable supplier options.
 
 The system should clearly list unmatched components: "5 components need inventory: U4 (STM32F103), C15 (22pF, NP0), D3 (Schottky, SOD-123)" with enough detail for Alex to search supplier catalogs effectively.
 
@@ -237,7 +237,7 @@ Alex needs to bootstrap inventory from scratch or merge multiple sources into ne
 
 The system should extract unique components from KiCad projects, set up proper inventory file structures, and merge multiple inventory sources intelligently. Uses `[Manage.Inventory]` for all file operations and data handling.
 
-This gives Alex the ability to create inventory foundations from his existing KiCad projects and consolidate inventory sources as his operations grow.
+This gives Alex the ability to create inventory foundations from Alex's existing KiCad projects and consolidate inventory sources as Alex's operations grow.
 
 ### Scenario: `[Update.Inventory]`
 Add supplier details and components to existing inventory
@@ -246,4 +246,18 @@ Alex needs to enhance existing inventory with new supplier information, add comp
 
 The system should match new components against existing inventory items, add supplier details from search results (`[Search.Suppliers]` → `[Select.Items]`), and incrementally expand inventory without data loss. Uses `[Manage.Inventory]` for all file operations.
 
-This enables Alex to continuously improve his inventory as he encounters new components and finds better supplier options.
+This enables Alex to continuously improve Alex's inventory as Alex encounters new components and finds better supplier options.
+
+### Scenario: `[Update.Inventory.MultiSupplier]`
+Enrich one inventory run against multiple suppliers with additive semantics
+
+Alex often needs alternates from more than one supplier for the same project requirements. Running separate commands per supplier is repetitive and makes reconciliation harder. Alex needs one enrichment run that gathers supplier candidates across multiple catalogs.
+
+The system should accept repeatable supplier inputs in one command, execute supplier searches in deterministic order, and merge results into one consolidated inventory output.
+
+Functional expectations:
+- supplier passes are additive; existing rows are preserved and new candidate rows are appended
+- candidate limit is evaluated independently for each supplier pass
+- added rows participate in global same-IPN priority ordering so downstream matching remains deterministic
+- no automatic deletion/rotation of rows in this phase; lifecycle cleanup is a separate explicit workflow
+- automatic safe-refresh mutation of existing rows is deferred pending edge-condition validation against examples/fixtures

--- a/docs/dev/requirements/README.md
+++ b/docs/dev/requirements/README.md
@@ -75,15 +75,15 @@ While this process obviously works, it has a couple of downsides:
 
 ### Meet Alex, an Electronic Product Development Engineer
 
-Alex runs a small electronics consulting company. One day, Alex is designing analog circuits in KiCad. tbe next afternoon, Alex is researching component suppliers and updating inventory spreadsheets. Later, Alex is generating manufacturing files for projects going out to three different fabricators. Once he catches his breath, Alex is updating his inventory stock, adding new components and replacing obsolete and expensive ones.
+Alex runs a small electronics consulting company. One day, Alex is designing analog circuits in KiCad. tbe next afternoon, Alex is researching component suppliers and updating inventory spreadsheets. Later, Alex is generating manufacturing files for projects going out to three different fabricators. Once Alex catches Alex's breath, Alex is updating Alex's inventory stock, adding new components and replacing obsolete and expensive ones.
 
 Some might have the luxury of separate engineering and procurement teams, but Alex needs to wear multiple hats efficiently without getting bogged down in the complexity of each role.
 
 ### The Challenge: Context Switching
 
-When Alex is in "circuit design mode," thinking about op-amp slew rates and filter responses, the last thing he wants to worry about is whether JLCPCB stocks a particular resistor value or what the Mouser stock number is for a specific capacitor.
+When Alex is in "circuit design mode," thinking about op-amp slew rates and filter responses, the last thing Alex wants to worry about is whether JLCPCB stocks a particular resistor value or what the Mouser stock number is for a specific capacitor.
 
-But when Alex switches to "procurement mode," he needs detailed supplier information, current pricing, and availability data to make smart business decisions about which fabricator to use and which components to stock.
+But when Alex switches to "procurement mode," Alex needs detailed supplier information, current pricing, and availability data to make smart business decisions about which fabricator to use and which components to stock.
 
 ### How jBOM Enables Efficient Context Switching
 
@@ -130,7 +130,7 @@ jBOM lets Alex work in the appropriate context for each task without losing the 
 #### The Problem Without jBOM:
 Alex could
 1. produce a minimal design using the standard KiCad libraries that do not provide supply chain details, or
-2. manually fully specify supply chain attributes in the symbols he uses, or use custom-curated component libraries that have this information, or he could use KiCad's database/Web library integration with `git-plm`'s inventory management system, each of which embeds supply chain choices as component attributes directly into the project's KiCad design files.
+2. manually fully specify supply chain attributes in the symbols Alex uses, or use custom-curated component libraries that have this information, or Alex could use KiCad's database/Web library integration with `git-plm`'s inventory management system, each of which embeds supply chain choices as component attributes directly into the project's KiCad design files.
 
 After the KiCad project is complete, Alex would use KiCad to generate the artifacts needed for fabrication, including a BOM.
 With the first option above, the BOM would **not** contain the manufacturer and supplier information needed for fabrication, so someone would need to manually research and add that information for every component.
@@ -182,8 +182,8 @@ Use the jBOM app to identify the new components, search for candidates using sup
 #### The Problem Without jBOM:
 
 1. Alex would manually generate Gerbers in KiCad, export CPL and BOM files BOM, and manually add the required supply chain information to the BOM file.
-2. Alex would choose to add LCSC part numbers to his KiCad projects and use the JLC Fabrication Plugin to automatically create all the Gerber, CPL and BOM files required by JLCPCB.
-3. Alex would choose to add Manufacture Part Numbers to his KiCad projects and use the PCBWay Fabrication Plugin to automatically create all the Gerber, CPL and BOM files required by PCBWay.
+2. Alex would choose to add LCSC part numbers to Alex's KiCad projects and use the JLC Fabrication Plugin to automatically create all the Gerber, CPL and BOM files required by JLCPCB.
+3. Alex would choose to add Manufacture Part Numbers to Alex's KiCad projects and use the PCBWay Fabrication Plugin to automatically create all the Gerber, CPL and BOM files required by PCBWay.
 
 #### The Solution With jBOM:
 

--- a/docs/dev/requirements/README.md
+++ b/docs/dev/requirements/README.md
@@ -75,9 +75,9 @@ While this process obviously works, it has a couple of downsides:
 
 ### Meet Alex, an Electronic Product Development Engineer
 
-Alex runs a small electronics consulting company. One day, Alex is designing analog circuits in KiCad. tbe next afternoon, Alex is researching component suppliers and updating inventory spreadsheets. Later, Alex is generating manufacturing files for projects going out to three different fabricators. Once Alex catches Alex's breath, Alex is updating Alex's inventory stock, adding new components and replacing obsolete and expensive ones.
+Alex runs a small electronics consulting company. One day might be spent designing analog circuits in KiCad, while the next, researching component suppliers and updating inventory spreadsheets. Once those tasks are complete, manufacturing files need to be generated for projects going out to three different fabricators. In the midst of all this, choices about suppliers, invoices, inventory management need to be made, all of which impact product production.
 
-Some might have the luxury of separate engineering and procurement teams, but Alex needs to wear multiple hats efficiently without getting bogged down in the complexity of each role.
+Some might have the luxury of separate engineering and procurement teams, but Alex needs to wear multiple hats efficiently without getting bogged down in the complexity of each role.  The following scenarios demonstrate how Alex integrates jBOM into their electronic project workflow.
 
 ### The Challenge: Context Switching
 

--- a/features/inventory/supplier_populate.feature
+++ b/features/inventory/supplier_populate.feature
@@ -45,3 +45,39 @@ Feature: Inventory supplier PN auto-populate
     When I run jbom command "inventory --supplier generic -o result.csv"
     Then the command should succeed
     And the file "result.csv" should contain "Supplier"
+
+  Scenario: Repeatable suppliers add supplier-specific rows in one run
+    Given a supplier profile "generic" with catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | G25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a supplier profile "mouser" with catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | M25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic --supplier mouser -o result.csv"
+    Then the command should succeed
+    And the file "result.csv" contains exactly 3 data rows
+    And the file "result.csv" should contain "Supplier"
+    And the file "result.csv" should contain "Mouser Part Number"
+    And the file "result.csv" should contain "G25804"
+    And the file "result.csv" should contain "M25804"
+
+  Scenario: --limit applies independently to each supplier pass
+    Given a supplier profile "generic" with catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | G10001         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+      | G10002         | Yageo        | RC0603FR-0710KL | 400            | 0.02  |
+    And a supplier profile "mouser" with catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | M20001         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+      | M20002         | Yageo        | RC0603FR-0710KL | 400            | 0.02  |
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic --supplier mouser --limit 1 -o result.csv"
+    Then the command should succeed
+    And the file "result.csv" contains exactly 3 data rows
+    And the file "result.csv" should contain "G10001"
+    And the file "result.csv" should contain "M20001"

--- a/features/inventory/supplier_populate.feature
+++ b/features/inventory/supplier_populate.feature
@@ -60,7 +60,7 @@ Feature: Inventory supplier PN auto-populate
     Then the command should succeed
     And the file "result.csv" contains exactly 3 data rows
     And the file "result.csv" should contain "Supplier"
-    And the file "result.csv" should contain "Mouser Part Number"
+    And the file "result.csv" should contain "Mouser"
     And the file "result.csv" should contain "G25804"
     And the file "result.csv" should contain "M25804"
 

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from behave import given, then
+import yaml
 
 
 def _write_schematic_local(
@@ -596,15 +597,22 @@ def then_inventory_file_contains_value(context, value: str) -> None:
 # -------------------------
 
 
-def _supplier_display_name(supplier_id: str) -> str:
+def _load_builtin_supplier_profile(supplier_id: str) -> dict[str, Any]:
+    """Load the built-in supplier profile YAML for a supplier id."""
     sid = (supplier_id or "").strip().lower()
-    if sid == "lcsc":
-        return "LCSC"
-    if sid == "mouser":
-        return "Mouser Part Number"
-    if sid == "generic":
-        return "Supplier"
-    return sid.upper() if sid else "Supplier"
+    repo_root = Path(__file__).resolve().parents[2]
+    profile_path = (
+        repo_root / "src" / "jbom" / "config" / "suppliers" / (f"{sid}.supplier.yaml")
+    )
+    if not profile_path.exists():
+        raise AssertionError(f"Unknown supplier profile fixture source: {sid}")
+
+    data = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise AssertionError(
+            f"Built-in supplier profile is not a YAML mapping: {profile_path}"
+        )
+    return data
 
 
 def _write_supplier_profile(
@@ -613,41 +621,45 @@ def _write_supplier_profile(
     supplier_id: str,
     results: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Write a null_api supplier profile (with optional fixture results)."""
+    """Write a supplier profile using built-in metadata + null_api fixtures."""
     import json as _json
 
     sid = (supplier_id or "").strip().lower()
-    display_name = _supplier_display_name(sid)
+    profile_data = _load_builtin_supplier_profile(sid)
     jbom_dir = Path(context.sandbox_root) / ".jbom"
     jbom_dir.mkdir(exist_ok=True)
-
-    fixtures_block = ""
+    provider_cfg: dict[str, Any] = {"type": "null_api"}
     if results is not None:
         fixture_file = jbom_dir / f"{sid}_results.json"
         fixture_file.write_text(_json.dumps(results), encoding="utf-8")
-        fixtures_block = f"      fixtures: {fixture_file}\n"
+        provider_cfg["fixtures"] = str(fixture_file)
+
+    search_cfg = profile_data.get("search")
+    if not isinstance(search_cfg, dict):
+        search_cfg = {}
+    search_cfg = dict(search_cfg)
+    search_cfg["providers"] = [provider_cfg]
+    profile_data["search"] = search_cfg
 
     (jbom_dir / f"{sid}.supplier.yaml").write_text(
-        f'id: {sid}\nname: "{sid.capitalize()}"\n'
-        "field_synonyms:\n"
-        "  supplier_pn:\n"
-        f'    display_name: "{display_name}"\n'
-        "    synonyms: []\n"
-        "search:\n"
-        "  providers:\n"
-        "    - type: null_api\n"
-        f"{fixtures_block}",
+        yaml.safe_dump(profile_data, sort_keys=False),
         encoding="utf-8",
     )
 
 
 def _table_to_supplier_results(context) -> list[dict[str, Any]]:
     """Convert a Gherkin table into null_api SearchResult fixtures."""
+    supplier_id = (
+        str(
+            getattr(context, "_active_supplier_profile_id_for_catalog", "generic")
+        ).strip()
+        or "generic"
+    )
     return [
         {
             "manufacturer": r.get("manufacturer", ""),
             "mpn": r.get("mpn", ""),
-            "distributor": "generic",
+            "distributor": supplier_id,
             "distributor_part_number": r.get("distributor_pn", ""),
             "description": r.get("description", ""),
             "datasheet": "",
@@ -683,6 +695,7 @@ def given_a_supplier_catalog(context) -> None:
     Table columns: distributor_pn, manufacturer, mpn, stock_quantity, price,
     description (all optional except distributor_pn).
     """
+    context._active_supplier_profile_id_for_catalog = "generic"
     _write_supplier_profile(
         context,
         supplier_id="generic",
@@ -693,6 +706,7 @@ def given_a_supplier_catalog(context) -> None:
 @given('a supplier profile "{supplier_id}" with catalog that contains:')
 def given_supplier_profile_with_catalog(context, supplier_id: str) -> None:
     """Create a named supplier profile backed by table-driven null_api fixtures."""
+    context._active_supplier_profile_id_for_catalog = supplier_id
     _write_supplier_profile(
         context,
         supplier_id=supplier_id,

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -596,40 +596,54 @@ def then_inventory_file_contains_value(context, value: str) -> None:
 # -------------------------
 
 
-@given("a generic supplier")
-def given_a_generic_supplier(context) -> None:
-    """Set up an empty generic supplier config (null_api, returns no results).
+def _supplier_display_name(supplier_id: str) -> str:
+    sid = (supplier_id or "").strip().lower()
+    if sid == "lcsc":
+        return "LCSC"
+    if sid == "mouser":
+        return "Mouser Part Number"
+    if sid == "generic":
+        return "Supplier"
+    return sid.upper() if sid else "Supplier"
 
-    Writes .jbom/generic.supplier.yaml with null_api and no fixtures key.
-    The null_api provider always returns [] when no fixtures are configured.
-    Use 'And a supplier catalog that contains:' to add specific results.
-    """
+
+def _write_supplier_profile(
+    context,
+    *,
+    supplier_id: str,
+    results: list[dict[str, Any]] | None = None,
+) -> None:
+    """Write a null_api supplier profile (with optional fixture results)."""
+    import json as _json
+
+    sid = (supplier_id or "").strip().lower()
+    display_name = _supplier_display_name(sid)
     jbom_dir = Path(context.sandbox_root) / ".jbom"
     jbom_dir.mkdir(exist_ok=True)
-    (jbom_dir / "generic.supplier.yaml").write_text(
-        "id: generic\nname: Generic\n"
-        "field_synonyms:\n  supplier_pn:\n    display_name: Supplier\n    synonyms: []\n"
-        "search:\n  providers:\n    - type: null_api\n",
+
+    fixtures_block = ""
+    if results is not None:
+        fixture_file = jbom_dir / f"{sid}_results.json"
+        fixture_file.write_text(_json.dumps(results), encoding="utf-8")
+        fixtures_block = f"      fixtures: {fixture_file}\n"
+
+    (jbom_dir / f"{sid}.supplier.yaml").write_text(
+        f'id: {sid}\nname: "{sid.capitalize()}"\n'
+        "field_synonyms:\n"
+        "  supplier_pn:\n"
+        f'    display_name: "{display_name}"\n'
+        "    synonyms: []\n"
+        "search:\n"
+        "  providers:\n"
+        "    - type: null_api\n"
+        f"{fixtures_block}",
         encoding="utf-8",
     )
 
 
-@given("a supplier catalog that contains:")
-def given_a_supplier_catalog(context) -> None:
-    """Populate the generic supplier with table-driven fixture results.
-
-    Writes .jbom/generic_results.json from the Gherkin table and updates
-    .jbom/generic.supplier.yaml to point the null_api provider at it.
-    Expects 'Given a generic supplier' to have run first (or runs standalone).
-
-    Table columns: distributor_pn, manufacturer, mpn, stock_quantity, price,
-    description (all optional except distributor_pn).
-    """
-    import json as _json
-
-    jbom_dir = Path(context.sandbox_root) / ".jbom"
-    jbom_dir.mkdir(exist_ok=True)
-    results = [
+def _table_to_supplier_results(context) -> list[dict[str, Any]]:
+    """Convert a Gherkin table into null_api SearchResult fixtures."""
+    return [
         {
             "manufacturer": r.get("manufacturer", ""),
             "mpn": r.get("mpn", ""),
@@ -645,13 +659,42 @@ def given_a_supplier_catalog(context) -> None:
         }
         for r in [row.as_dict() for row in context.table]
     ]
-    fixture_file = jbom_dir / "generic_results.json"
-    fixture_file.write_text(_json.dumps(results), encoding="utf-8")
-    # Write (or overwrite) the supplier yaml with absolute fixtures path.
-    (jbom_dir / "generic.supplier.yaml").write_text(
-        "id: generic\nname: Generic\n"
-        "field_synonyms:\n  supplier_pn:\n    display_name: Supplier\n    synonyms: []\n"
-        "search:\n  providers:\n    - type: null_api\n"
-        f"      fixtures: {fixture_file}\n",
-        encoding="utf-8",
+
+
+@given("a generic supplier")
+def given_a_generic_supplier(context) -> None:
+    """Set up an empty generic supplier config (null_api, returns no results).
+
+    Writes .jbom/generic.supplier.yaml with null_api and no fixtures key.
+    The null_api provider always returns [] when no fixtures are configured.
+    Use 'And a supplier catalog that contains:' to add specific results.
+    """
+    _write_supplier_profile(context, supplier_id="generic", results=None)
+
+
+@given("a supplier catalog that contains:")
+def given_a_supplier_catalog(context) -> None:
+    """Populate the generic supplier with table-driven fixture results.
+
+    Writes .jbom/generic_results.json from the Gherkin table and updates
+    .jbom/generic.supplier.yaml to point the null_api provider at it.
+    Expects 'Given a generic supplier' to have run first (or runs standalone).
+
+    Table columns: distributor_pn, manufacturer, mpn, stock_quantity, price,
+    description (all optional except distributor_pn).
+    """
+    _write_supplier_profile(
+        context,
+        supplier_id="generic",
+        results=_table_to_supplier_results(context),
+    )
+
+
+@given('a supplier profile "{supplier_id}" with catalog that contains:')
+def given_supplier_profile_with_catalog(context, supplier_id: str) -> None:
+    """Create a named supplier profile backed by table-driven null_api fixtures."""
+    _write_supplier_profile(
+        context,
+        supplier_id=supplier_id,
+        results=_table_to_supplier_results(context),
     )

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -177,10 +177,12 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "--supplier",
         metavar="SUPPLIER_ID",
+        action="append",
         default=None,
         help=(
-            "Supplier ID for auto-populating the supplier PN column "
-            "(e.g. 'lcsc', 'mouser', 'generic'). Items already having a PN are skipped."
+            "Supplier ID for auto-populating supplier PN columns. "
+            "Repeat to enrich from multiple suppliers in one run "
+            "(e.g. --supplier lcsc --supplier mouser)."
         ),
     )
     parser.add_argument(
@@ -413,14 +415,12 @@ def _handle_batch_inventory(input_paths: list[str], args: argparse.Namespace) ->
     ordered_fields = _merge_field_names(all_field_names)
 
     # Supplier enrichment (batch path)
-    service, supplier_config, supplier_id = _build_inventory_supplier_service(args)
-    if service is not None and supplier_config is not None:
-        accumulated_items, ordered_fields = _enrich_items_with_supplier(
+    supplier_services = _build_inventory_supplier_services(args)
+    if supplier_services:
+        accumulated_items, ordered_fields = _enrich_items_with_suppliers(
             accumulated_items,
             ordered_fields,
-            service,
-            supplier_config,
-            supplier_id,
+            supplier_services,
             limit=max(1, int(getattr(args, "limit", 1))),
             verbose=args.verbose,
         )
@@ -477,47 +477,272 @@ def _merge_field_names(all_field_names: set[str]) -> list[str]:
     return ordered
 
 
-def _build_inventory_supplier_service(
+def _normalize_supplier_ids(raw_suppliers: Any) -> list[str]:
+    """Normalize and de-duplicate supplier IDs while preserving input order."""
+
+    if raw_suppliers is None:
+        return []
+
+    if isinstance(raw_suppliers, str):
+        candidates = [raw_suppliers]
+    elif isinstance(raw_suppliers, list):
+        candidates = [str(value) for value in raw_suppliers]
+    else:
+        candidates = [str(raw_suppliers)]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        supplier_id = candidate.strip().lower()
+        if not supplier_id or supplier_id in seen:
+            continue
+        seen.add(supplier_id)
+        normalized.append(supplier_id)
+
+    return normalized
+
+
+def _build_inventory_supplier_services(
     args: argparse.Namespace,
-) -> "tuple[InventorySearchService | None, SupplierConfig | None, str]":
-    """Build a supplier search service from CLI args, or return (None, None, '').
+) -> "list[tuple[InventorySearchService, SupplierConfig, str]]":
+    """Build ordered supplier search services from CLI args.
 
-    Mirrors ``cli/audit.py``'s ``_build_supplier_service()`` but also returns
-    the resolved :class:`SupplierConfig` so callers can find the inventory column.
-
-    Returns:
-        Tuple of (service, supplier_config, supplier_id).  All three are falsy
-        when ``--supplier`` is not given or the supplier has no search providers.
+    Returns a list of (service, supplier_config, supplier_id) tuples preserving
+    ``--supplier`` order.
     """
-    supplier_id = (getattr(args, "supplier", None) or "").strip().lower()
-    if not supplier_id:
-        return None, None, ""
+    supplier_ids = _normalize_supplier_ids(getattr(args, "supplier", None))
+    if not supplier_ids:
+        return []
 
     api_key = getattr(args, "api_key", None)
+    resolved_services: list[tuple[InventorySearchService, SupplierConfig, str]] = []
 
     try:
         from jbom.config.suppliers import resolve_supplier_by_id
         from jbom.services.search.provider_factory import create_search_provider
         from jbom.services.search.inventory_search_service import InventorySearchService
 
-        supplier_config = resolve_supplier_by_id(supplier_id)
-        if supplier_config is None:
-            print(f"Error: Unknown supplier '{supplier_id}'", file=sys.stderr)
-            return None, None, ""
+        for supplier_id in supplier_ids:
+            supplier_config = resolve_supplier_by_id(supplier_id)
+            if supplier_config is None:
+                print(f"Error: Unknown supplier '{supplier_id}'", file=sys.stderr)
+                continue
 
-        provider = create_search_provider(
-            supplier_id,
-            api_key=api_key,
-            cache=None,  # default DiskSearchCache
-        )
-        verbose = getattr(args, "verbose", False)
-        service = InventorySearchService(
-            provider, request_delay_seconds=0.2, verbose=verbose
-        )
-        return service, supplier_config, supplier_id
+            provider = create_search_provider(
+                supplier_id,
+                api_key=api_key,
+                cache=None,  # default DiskSearchCache
+            )
+            verbose = getattr(args, "verbose", False)
+            service = InventorySearchService(
+                provider, request_delay_seconds=0.2, verbose=verbose
+            )
+            resolved_services.append((service, supplier_config, supplier_id))
+
+        return resolved_services
     except (ValueError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
-        return None, None, ""
+        return []
+
+
+def _supplier_part_number(
+    item: "InventoryItem", *, supplier_column: str, is_lcsc: bool
+) -> str:
+    """Return the normalized PN value for this supplier from one inventory row."""
+
+    if is_lcsc:
+        return (item.lcsc or "").strip()
+    return str((item.raw_data or {}).get(supplier_column, "")).strip()
+
+
+def _has_any_target_supplier_pn(
+    item: "InventoryItem",
+    supplier_services: "list[tuple[InventorySearchService, SupplierConfig, str]]",
+) -> bool:
+    """Return True if row already has a PN for any target supplier."""
+
+    for _service, supplier_config, supplier_id in supplier_services:
+        if _supplier_part_number(
+            item,
+            supplier_column=supplier_config.inventory_column,
+            is_lcsc=(supplier_id == "lcsc"),
+        ):
+            return True
+    return False
+
+
+def _supplier_item_key(
+    item: "InventoryItem", *, supplier_column: str, is_lcsc: bool
+) -> tuple[str, str, str]:
+    """Return a stable de-duplication key for one supplier-assigned row."""
+
+    pn = _supplier_part_number(item, supplier_column=supplier_column, is_lcsc=is_lcsc)
+    identity = (
+        (item.ipn or "").strip()
+        or (item.component_id or "").strip()
+        or f"{(item.category or '').strip()}|{(item.value or '').strip()}|{(item.package or '').strip()}"
+    )
+    return identity, supplier_column, pn
+
+
+def _extract_explicit_priority(item: "InventoryItem") -> int | None:
+    """Return explicit row priority from raw inventory data, when present."""
+
+    raw_priority = str((item.raw_data or {}).get("Priority", "")).strip()
+    if not raw_priority:
+        return None
+    try:
+        value = int(raw_priority)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _build_next_priority_by_ipn(items: "list[InventoryItem]") -> dict[str, int]:
+    """Return per-IPN next priority counters based on explicit inventory values."""
+
+    max_priority_by_ipn: dict[str, int] = {}
+    for item in items:
+        ipn = (item.ipn or "").strip()
+        if not ipn:
+            continue
+        explicit_priority = _extract_explicit_priority(item)
+        if explicit_priority is None:
+            continue
+        max_priority_by_ipn[ipn] = max(
+            explicit_priority, max_priority_by_ipn.get(ipn, 0)
+        )
+
+    return {
+        ipn: (max_priority + 1) for ipn, max_priority in max_priority_by_ipn.items()
+    }
+
+
+def _assign_next_priority(
+    item: "InventoryItem", *, next_priority_by_ipn: dict[str, int]
+) -> bool:
+    """Assign the next global per-IPN priority to an added row.
+
+    Returns True when a priority value was assigned.
+    """
+
+    ipn = (item.ipn or "").strip()
+    if not ipn:
+        return False
+
+    next_priority = next_priority_by_ipn.get(ipn, 1)
+    if item.raw_data is None:
+        item.raw_data = {}
+    item.raw_data["Priority"] = str(next_priority)
+    item.priority = next_priority
+    next_priority_by_ipn[ipn] = next_priority + 1
+    return True
+
+
+def _enrich_items_with_suppliers(
+    items: "list[InventoryItem]",
+    field_names: list[str],
+    supplier_services: "list[tuple[InventorySearchService, SupplierConfig, str]]",
+    *,
+    limit: int = 1,
+    verbose: bool = False,
+) -> "tuple[list[InventoryItem], list[str]]":
+    """Apply supplier enrichment for one or more suppliers.
+
+    Multi-supplier mode is additive: original rows are preserved and supplier-
+    specific rows are appended for discovered candidates.
+    """
+
+    if not supplier_services:
+        return items, field_names
+
+    if len(supplier_services) == 1:
+        service, supplier_config, supplier_id = supplier_services[0]
+        return _enrich_items_with_supplier(
+            items,
+            field_names,
+            service,
+            supplier_config,
+            supplier_id,
+            limit=limit,
+            verbose=verbose,
+        )
+
+    candidate_limit = max(1, int(limit))
+    base_items = list(items)
+    working_field_names = list(field_names)
+    added_items: list[InventoryItem] = []
+
+    seed_items = [
+        item
+        for item in base_items
+        if (item.row_type or "ITEM").strip().upper() in {"ITEM", "COMPONENT"}
+        and not _has_any_target_supplier_pn(item, supplier_services)
+    ]
+
+    if not seed_items:
+        return base_items, working_field_names
+
+    next_priority_by_ipn = _build_next_priority_by_ipn(base_items)
+    seen_keys: set[tuple[str, str, str]] = set()
+
+    for base_item in base_items:
+        for _service, supplier_config, supplier_id in supplier_services:
+            key = _supplier_item_key(
+                base_item,
+                supplier_column=supplier_config.inventory_column,
+                is_lcsc=(supplier_id == "lcsc"),
+            )
+            if key[-1]:
+                seen_keys.add(key)
+
+    priority_assigned = False
+    for service, supplier_config, supplier_id in supplier_services:
+        supplier_seed = copy.deepcopy(seed_items)
+        enriched_items, working_field_names = _enrich_items_with_supplier(
+            supplier_seed,
+            working_field_names,
+            service,
+            supplier_config,
+            supplier_id,
+            limit=candidate_limit,
+            verbose=verbose,
+        )
+        supplier_column = supplier_config.inventory_column
+        is_lcsc = supplier_id == "lcsc"
+
+        for enriched_item in enriched_items:
+            supplier_pn = _supplier_part_number(
+                enriched_item,
+                supplier_column=supplier_column,
+                is_lcsc=is_lcsc,
+            )
+            if not supplier_pn:
+                continue
+
+            key = _supplier_item_key(
+                enriched_item,
+                supplier_column=supplier_column,
+                is_lcsc=is_lcsc,
+            )
+            if key in seen_keys:
+                continue
+
+            priority_assigned = (
+                _assign_next_priority(
+                    enriched_item, next_priority_by_ipn=next_priority_by_ipn
+                )
+                or priority_assigned
+            )
+            added_items.append(enriched_item)
+            seen_keys.add(key)
+
+    if priority_assigned and "Priority" not in working_field_names:
+        working_field_names = list(working_field_names) + ["Priority"]
+
+    if not added_items:
+        return base_items, working_field_names
+    return base_items + added_items, working_field_names
 
 
 def _enrich_items_with_supplier(
@@ -722,14 +947,12 @@ def _handle_generate_inventory(input_path: str, args: argparse.Namespace) -> int
     inventory_items, field_names = generator.load()
 
     # Supplier enrichment (single-project path)
-    service, supplier_config, supplier_id = _build_inventory_supplier_service(args)
-    if service is not None and supplier_config is not None:
-        inventory_items, field_names = _enrich_items_with_supplier(
+    supplier_services = _build_inventory_supplier_services(args)
+    if supplier_services:
+        inventory_items, field_names = _enrich_items_with_suppliers(
             inventory_items,
             list(field_names),
-            service,
-            supplier_config,
-            supplier_id,
+            supplier_services,
             limit=max(1, int(getattr(args, "limit", 1))),
             verbose=args.verbose,
         )

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -62,6 +62,8 @@ def test_inventory_help_shows_inventory_interface_tokens():
         "--inventory",
         "--filter-matches",
         "--per-instance",
+        "--supplier",
+        "--limit",
         "-o",
         "--output",
     ]

--- a/tests/unit/test_inventory_supplier_flag.py
+++ b/tests/unit/test_inventory_supplier_flag.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from jbom.cli.inventory import _enrich_items_with_supplier
+from jbom.cli.inventory import (
+    _enrich_items_with_supplier,
+    _enrich_items_with_suppliers,
+    _normalize_supplier_ids,
+)
 from jbom.common.types import InventoryItem
 from jbom.services.search.inventory_search_service import (
     InventorySearchCandidate,
@@ -110,10 +114,12 @@ def _record_no_candidates(item: InventoryItem) -> InventorySearchRecord:
     )
 
 
-def _supplier_config(inventory_column: str = "Supplier") -> MagicMock:
+def _supplier_config(
+    inventory_column: str = "Supplier", supplier_id: str = "generic"
+) -> MagicMock:
     cfg = MagicMock()
     cfg.inventory_column = inventory_column
-    cfg.id = "generic"
+    cfg.id = supplier_id
     return cfg
 
 
@@ -437,3 +443,125 @@ class TestEnrichNoOp:
 
         assert items_out == []
         assert "Supplier" in names  # column is still added to field list
+
+
+class TestNormalizeSupplierIds:
+    def test_normalizes_and_deduplicates_preserving_order(self) -> None:
+        assert _normalize_supplier_ids([" Mouser ", "LCSC", "mouser", ""]) == [
+            "mouser",
+            "lcsc",
+        ]
+
+    def test_accepts_single_string(self) -> None:
+        assert _normalize_supplier_ids(" Mouser ") == ["mouser"]
+
+
+def _dynamic_service_with_candidates(
+    supplier_pns: list[str], *, manufacturer: str = "Yageo", mpn: str = "RC0603"
+) -> MagicMock:
+    service = MagicMock(spec=InventorySearchService)
+
+    def _search(items: list[InventoryItem]) -> list[InventorySearchRecord]:
+        return [
+            InventorySearchRecord(
+                inventory_item=item,
+                query="10K resistor",
+                candidates=[
+                    InventorySearchCandidate(
+                        result=_make_result(pn=pn, mfr=manufacturer, mpn=mpn),
+                        match_score=80,
+                    )
+                    for pn in supplier_pns
+                ],
+            )
+            for item in items
+        ]
+
+    service.search.side_effect = _search
+    return service
+
+
+class TestEnrichMultipleSuppliers:
+    def test_multi_supplier_adds_rows_without_replacing_base_item(self) -> None:
+        seed = _make_item(ipn="RES_10K_0603")
+        mouser_service = _dynamic_service_with_candidates(["M-1001"])
+        lcsc_service = _dynamic_service_with_candidates(["C-2001"])
+        supplier_services = [
+            (
+                mouser_service,
+                _supplier_config("Mouser Part Number", "mouser"),
+                "mouser",
+            ),
+            (lcsc_service, _supplier_config("LCSC", "lcsc"), "lcsc"),
+        ]
+
+        items_out, names = _enrich_items_with_suppliers(
+            [seed],
+            ["IPN"],
+            supplier_services,
+            limit=1,
+            verbose=False,
+        )
+
+        assert len(items_out) == 3
+        # Base requirement row preserved (add-only semantics).
+        assert items_out[0].raw_data.get("Mouser Part Number", "") == ""
+        assert items_out[0].lcsc == ""
+
+        assert items_out[1].raw_data.get("Mouser Part Number") == "M-1001"
+        assert items_out[1].lcsc == ""
+        assert items_out[2].lcsc == "C-2001"
+        assert items_out[2].raw_data.get("Mouser Part Number", "") == ""
+
+        assert items_out[1].raw_data.get("Priority") == "1"
+        assert items_out[2].raw_data.get("Priority") == "2"
+        assert "Mouser Part Number" in names
+        assert "LCSC" in names
+        assert "Priority" in names
+
+    def test_limit_applies_per_supplier_and_global_priority_is_monotonic(self) -> None:
+        seed = _make_item(ipn="RES_10K_0603")
+        mouser_service = _dynamic_service_with_candidates(["M-1", "M-2"])
+        lcsc_service = _dynamic_service_with_candidates(["C-1", "C-2"])
+        supplier_services = [
+            (
+                mouser_service,
+                _supplier_config("Mouser Part Number", "mouser"),
+                "mouser",
+            ),
+            (lcsc_service, _supplier_config("LCSC", "lcsc"), "lcsc"),
+        ]
+
+        items_out, names = _enrich_items_with_suppliers(
+            [seed],
+            ["IPN"],
+            supplier_services,
+            limit=2,
+            verbose=False,
+        )
+
+        assert len(items_out) == 5  # base + 2 mouser + 2 lcsc
+        priorities = [
+            row.raw_data.get("Priority", "") for row in items_out[1:]  # skip base
+        ]
+        assert priorities == ["1", "2", "3", "4"]
+        assert "Priority" in names
+
+    def test_single_supplier_path_remains_backward_compatible(self) -> None:
+        seed = _make_item(ipn="RES_10K_0603")
+        service = _dynamic_service_with_candidates(["M-1001"])
+        supplier_services = [
+            (service, _supplier_config("Supplier", "generic"), "generic"),
+        ]
+
+        items_out, _ = _enrich_items_with_suppliers(
+            [seed],
+            ["IPN"],
+            supplier_services,
+            limit=1,
+            verbose=False,
+        )
+
+        # Single supplier path keeps existing behavior (mutate in-place, no append).
+        assert len(items_out) == 1
+        assert items_out[0].raw_data.get("Supplier") == "M-1001"


### PR DESCRIPTION
Closes #197

## Summary
- enable repeatable `--supplier` for `jbom inventory` and resolve ordered supplier services
- add additive multi-supplier enrichment orchestration (preserve base rows, append supplier-qualified rows)
- keep `--limit` supplier-local per pass, with global same-IPN priority assignment for added rows
- extend unit coverage for multi-supplier behavior and preserve single-supplier compatibility
- add Behave scenarios for repeatable suppliers and per-supplier `--limit` behavior
- update CLI docs/changelog and requirements user stories (including inclusive pronoun wording updates)

## Validation
- `pytest tests/unit/test_inventory_supplier_flag.py tests/unit/test_cli_help.py tests/unit/test_cli_multi_project_inventory.py`
- `pytest tests/services/search/test_inventory_search_dedup.py tests/services/search/test_search_cli.py`
- `behave features/inventory/supplier_populate.feature`

Co-Authored-By: Oz <oz-agent@warp.dev>
