### PR TITLE
feat(search): add fixture-based parity matrix diagnostics evidence (issue #199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ To contribute:
 3. Run tests: `pytest && python -m behave --format progress`
 4. Submit a pull request
 
+Regenerate deterministic search parity artifacts (fixture-based):
+`python scripts/generate_search_parity_artifacts.py`
+
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
 
 **License**: AGPLv3 — See LICENSE file for full terms.

--- a/scripts/generate_search_parity_artifacts.py
+++ b/scripts/generate_search_parity_artifacts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate deterministic search parity matrix + diagnostics artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running from repository root without installation.
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "src"))
+
+from jbom.services.search.parity_artifacts import (  # noqa: E402
+    DEFAULT_DIAGNOSTICS_JSON_RELATIVE_PATH,
+    DEFAULT_MATRIX_CSV_RELATIVE_PATH,
+    write_search_parity_artifacts,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=_ROOT / "tests" / "fixtures",
+        help="Root fixture directory containing supplier fixture subdirectories.",
+    )
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        default=_ROOT / DEFAULT_MATRIX_CSV_RELATIVE_PATH,
+        help="Output CSV path for parity matrix artifact.",
+    )
+    parser.add_argument(
+        "--diagnostics",
+        type=Path,
+        default=_ROOT / DEFAULT_DIAGNOSTICS_JSON_RELATIVE_PATH,
+        help="Output JSON path for diagnostics evidence artifact.",
+    )
+    parser.add_argument(
+        "--max-results-per-supplier",
+        type=int,
+        default=80,
+        help="Cap parsed results per supplier fixture for deterministic artifact size.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    payload = write_search_parity_artifacts(
+        matrix_path=args.matrix,
+        diagnostics_path=args.diagnostics,
+        fixture_root=args.fixture_root,
+        max_results_per_supplier=args.max_results_per_supplier,
+    )
+
+    print(
+        f"Wrote parity matrix: {args.matrix}\n"
+        f"Wrote diagnostics: {args.diagnostics}\n"
+        f"Intents: {len(payload.get('intents', []))}, "
+        f"gaps: {len(payload.get('parity_gaps', []))}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jbom/services/search/diagnostics.py
+++ b/src/jbom/services/search/diagnostics.py
@@ -1,0 +1,121 @@
+"""Search pipeline diagnostics helpers.
+
+This module exposes a deterministic, test-friendly diagnostics contract for:
+- default result filtering decisions
+- query-derived parametric filtering decisions
+- ranking decisions (including passive-stock gate impact)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from jbom.services.search.filtering import (
+    SearchFilter,
+    SearchFilterDecision,
+    SearchRankDecision,
+    SearchSorter,
+    apply_default_filters,
+    describe_default_filter_decisions,
+    describe_query_filter_decisions,
+    describe_rank_decisions,
+    search_result_id,
+)
+from jbom.services.search.models import SearchResult
+
+SEARCH_DIAGNOSTICS_CONTRACT_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class SearchPipelineDiagnostics:
+    """Structured diagnostics for one query run through the search pipeline."""
+
+    contract_version: str
+    query: str
+    category: str
+    raw_count: int
+    default_filtered_count: int
+    query_filtered_count: int
+    ranked_count: int
+    final_result_ids: tuple[str, ...]
+    default_filter_decisions: tuple[SearchFilterDecision, ...]
+    query_filter_decisions: tuple[SearchFilterDecision, ...]
+    rank_decisions: tuple[SearchRankDecision, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable diagnostics payload."""
+
+        return {
+            "contract_version": self.contract_version,
+            "query": self.query,
+            "category": self.category,
+            "raw_count": self.raw_count,
+            "default_filtered_count": self.default_filtered_count,
+            "query_filtered_count": self.query_filtered_count,
+            "ranked_count": self.ranked_count,
+            "final_result_ids": list(self.final_result_ids),
+            "default_filter_decisions": [
+                decision.to_dict() for decision in self.default_filter_decisions
+            ],
+            "query_filter_decisions": [
+                decision.to_dict() for decision in self.query_filter_decisions
+            ],
+            "rank_decisions": [decision.to_dict() for decision in self.rank_decisions],
+        }
+
+
+def run_search_pipeline_with_diagnostics(
+    raw_results: Iterable[SearchResult], *, query: str, category: str = ""
+) -> tuple[list[SearchResult], SearchPipelineDiagnostics]:
+    """Run the search pipeline and return both ranked results and diagnostics."""
+
+    raw = list(raw_results)
+    default_decisions = describe_default_filter_decisions(raw)
+    default_filtered = apply_default_filters(raw)
+
+    query_decisions = describe_query_filter_decisions(
+        default_filtered, query, category=category
+    )
+    query_filtered = SearchFilter.filter_by_query(
+        default_filtered, query, category=category
+    )
+
+    ranked = SearchSorter.rank(query_filtered, category=category, query=query)
+    rank_decisions = describe_rank_decisions(
+        query_filtered, category=category, query=query
+    )
+
+    diagnostics = SearchPipelineDiagnostics(
+        contract_version=SEARCH_DIAGNOSTICS_CONTRACT_VERSION,
+        query=query,
+        category=category,
+        raw_count=len(raw),
+        default_filtered_count=len(default_filtered),
+        query_filtered_count=len(query_filtered),
+        ranked_count=len(ranked),
+        final_result_ids=tuple(search_result_id(result) for result in ranked),
+        default_filter_decisions=tuple(default_decisions),
+        query_filter_decisions=tuple(query_decisions),
+        rank_decisions=tuple(rank_decisions),
+    )
+    return ranked, diagnostics
+
+
+def build_search_pipeline_diagnostics(
+    raw_results: Iterable[SearchResult], *, query: str, category: str = ""
+) -> SearchPipelineDiagnostics:
+    """Build diagnostics only for one search query."""
+
+    _ranked, diagnostics = run_search_pipeline_with_diagnostics(
+        raw_results, query=query, category=category
+    )
+    return diagnostics
+
+
+__all__ = [
+    "SEARCH_DIAGNOSTICS_CONTRACT_VERSION",
+    "SearchPipelineDiagnostics",
+    "build_search_pipeline_diagnostics",
+    "run_search_pipeline_with_diagnostics",
+]

--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -9,6 +9,7 @@ All functions are side-effect free.
 """
 
 from __future__ import annotations
+from dataclasses import asdict, dataclass
 
 import re
 from typing import Iterable
@@ -53,6 +54,54 @@ _BASIC_PART_RELEVANCE_BOOST = 2
 _PACKAGE_PATTERN = re.compile(
     r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
 )
+
+
+@dataclass(frozen=True)
+class SearchFilterDecision:
+    """Diagnostic decision for one filtering stage and one search result."""
+
+    result_id: str
+    kept: bool
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable mapping."""
+
+        payload = asdict(self)
+        payload["reasons"] = list(self.reasons)
+        return payload
+
+
+@dataclass(frozen=True)
+class SearchRankDecision:
+    """Diagnostic ranking decision for one search result."""
+
+    result_id: str
+    included: bool
+    rank: int | None
+    passive_stock_gate_kept: bool
+    relevance_score: int
+    price_value: float
+    canonical_value: float
+    component_library_tier: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable mapping."""
+
+        return asdict(self)
+
+
+def search_result_id(result: SearchResult) -> str:
+    """Return a stable, human-readable identifier for one search result."""
+
+    distributor = (result.distributor or "").strip().lower() or "unknown"
+    distributor_pn = (result.distributor_part_number or "").strip()
+    mpn = (result.mpn or "").strip()
+    if distributor_pn:
+        return f"{distributor}:{distributor_pn}"
+    if mpn:
+        return f"{distributor}:mpn:{mpn}"
+    return f"{distributor}:result:{id(result)}"
 
 
 def _close_enough(a: float, b: float, *, rel_tol: float = 0.001) -> bool:
@@ -259,6 +308,63 @@ def apply_default_filters(results: Iterable[SearchResult]) -> list[SearchResult]
     return filtered
 
 
+def describe_default_filter_decisions(
+    results: Iterable[SearchResult],
+) -> list[SearchFilterDecision]:
+    """Return keep/drop diagnostics for default availability/lifecycle filtering."""
+
+    decisions: list[SearchFilterDecision] = []
+    for result in results:
+        reasons: list[str] = []
+        if result.stock_quantity <= 0:
+            reasons.append("stock_quantity<=0")
+
+        status = (result.lifecycle_status or "").lower()
+        if "obsolete" in status:
+            reasons.append("lifecycle=obsolete")
+        elif "not recommended" in status:
+            reasons.append("lifecycle=not_recommended")
+
+        if "factory order" in (result.availability or "").lower():
+            reasons.append("availability=factory_order")
+
+        decisions.append(
+            SearchFilterDecision(
+                result_id=search_result_id(result),
+                kept=not reasons,
+                reasons=tuple(reasons) if reasons else ("passed_default_filters",),
+            )
+        )
+
+    return decisions
+
+
+def describe_query_filter_decisions(
+    results: list[SearchResult], query: str, *, category: str = ""
+) -> list[SearchFilterDecision]:
+    """Return keep/drop diagnostics for query-derived parametric filtering."""
+
+    filtered = SearchFilter.filter_by_query(results, query, category=category)
+    kept_ids = {id(result) for result in filtered}
+
+    decisions: list[SearchFilterDecision] = []
+    for result in results:
+        kept = id(result) in kept_ids
+        decisions.append(
+            SearchFilterDecision(
+                result_id=search_result_id(result),
+                kept=kept,
+                reasons=(
+                    ("matched_query_constraints",)
+                    if kept
+                    else ("excluded_by_query_constraints",)
+                ),
+            )
+        )
+
+    return decisions
+
+
 class SearchSorter:
     """Sorting utilities."""
 
@@ -277,25 +383,10 @@ class SearchSorter:
         )
 
         def sort_key(r: SearchResult) -> tuple[int, float, float, str, str, str]:
-            try:
-                price_clean = (
-                    (r.price or "")
-                    .replace("$", "")
-                    .replace("€", "")
-                    .replace("£", "")
-                    .strip()
-                )
-                price_value = float(price_clean)
-            except ValueError:
-                price_value = float("inf")
-
-            canonical = float("inf")
-            if attr_name and r.attributes:
-                raw = r.attributes.get(attr_name, "")
-                if raw:
-                    v = parse_value_to_normal(cat, raw)
-                    if v is not None:
-                        canonical = v
+            price_value = _price_value_for_ranking(r)
+            canonical = _canonical_value_for_ranking(
+                r, category=cat, attribute_name=attr_name
+            )
             relevance = _query_relevance_score(r, context=relevance_context)
             manufacturer = (r.manufacturer or "").upper()
             mpn = (r.mpn or "").upper()
@@ -303,6 +394,48 @@ class SearchSorter:
             return (-relevance, price_value, canonical, manufacturer, mpn, supplier_pn)
 
         return sorted(ranked_pool, key=sort_key)
+
+
+def describe_rank_decisions(
+    results: list[SearchResult], *, category: str = "", query: str = ""
+) -> list[SearchRankDecision]:
+    """Return ranking diagnostics, including passive-stock-gate inclusion."""
+
+    cat = normalize_component_type(category or "")
+    attr_name = _CATEGORY_ATTR_NAME.get(cat, "")
+    relevance_context = _build_relevance_context(query)
+    category_intent = relevance_context.get("category_intent", "") or cat
+    gated_pool = _apply_passive_stock_gate(results, category_intent=category_intent)
+    ranked = SearchSorter.rank(results, category=category, query=query)
+
+    gated_ids = {id(result) for result in gated_pool}
+    rank_by_id: dict[int, int] = {
+        id(result): index for index, result in enumerate(ranked, 1)
+    }
+
+    out: list[SearchRankDecision] = []
+    for result in results:
+        result_object_id = id(result)
+        out.append(
+            SearchRankDecision(
+                result_id=search_result_id(result),
+                included=result_object_id in rank_by_id,
+                rank=rank_by_id.get(result_object_id),
+                passive_stock_gate_kept=result_object_id in gated_ids,
+                relevance_score=_query_relevance_score(
+                    result, context=relevance_context
+                ),
+                price_value=_price_value_for_ranking(result),
+                canonical_value=_canonical_value_for_ranking(
+                    result,
+                    category=cat,
+                    attribute_name=attr_name,
+                ),
+                component_library_tier=_component_library_tier(result),
+            )
+        )
+
+    return out
 
 
 def _apply_passive_stock_gate(
@@ -321,6 +454,37 @@ def _apply_passive_stock_gate(
 
     # Fail-open: preserve context when all candidates are low stock.
     return results
+
+
+def _price_value_for_ranking(result: SearchResult) -> float:
+    """Parse a numeric unit price for ranking sort order."""
+
+    try:
+        price_clean = (
+            (result.price or "")
+            .replace("$", "")
+            .replace("€", "")
+            .replace("£", "")
+            .strip()
+        )
+        return float(price_clean)
+    except ValueError:
+        return float("inf")
+
+
+def _canonical_value_for_ranking(
+    result: SearchResult, *, category: str, attribute_name: str
+) -> float:
+    """Parse category-specific canonical value used as ranking tertiary key."""
+
+    canonical = float("inf")
+    if attribute_name and result.attributes:
+        raw = result.attributes.get(attribute_name, "")
+        if raw:
+            value = parse_value_to_normal(category, raw)
+            if value is not None:
+                canonical = value
+    return canonical
 
 
 def _build_relevance_context(query: str) -> dict[str, str]:
@@ -426,4 +590,14 @@ def _component_library_tier(result: SearchResult) -> str:
     return ""
 
 
-__all__ = ["SearchFilter", "SearchSorter", "apply_default_filters"]
+__all__ = [
+    "SearchFilter",
+    "SearchFilterDecision",
+    "SearchRankDecision",
+    "SearchSorter",
+    "apply_default_filters",
+    "describe_default_filter_decisions",
+    "describe_query_filter_decisions",
+    "describe_rank_decisions",
+    "search_result_id",
+]

--- a/src/jbom/services/search/parity_artifacts.py
+++ b/src/jbom/services/search/parity_artifacts.py
@@ -1,0 +1,319 @@
+"""Deterministic cross-supplier parity artifact generation for search.
+
+This module intentionally uses committed fixtures (not live supplier APIs) so
+evidence generation is reproducible and test-friendly.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jbom.services.search.cache import InMemorySearchCache
+from jbom.services.search.diagnostics import (
+    SEARCH_DIAGNOSTICS_CONTRACT_VERSION,
+    SearchPipelineDiagnostics,
+    run_search_pipeline_with_diagnostics,
+)
+from jbom.services.search.filtering import search_result_id
+from jbom.services.search.models import SearchResult
+from jbom.suppliers.lcsc.provider import JlcpcbProvider
+from jbom.suppliers.mouser.provider import MouserProvider
+
+
+PARITY_SUPPLIERS: tuple[str, ...] = ("mouser", "lcsc")
+DEFAULT_MATRIX_CSV_RELATIVE_PATH = Path("tests/fixtures/search_parity/matrix.csv")
+DEFAULT_DIAGNOSTICS_JSON_RELATIVE_PATH = Path(
+    "tests/fixtures/search_parity/diagnostics.json"
+)
+
+
+@dataclass(frozen=True)
+class ParityIntentSpec:
+    """Fixture-backed query intent to include in parity evidence."""
+
+    intent_id: str
+    category: str
+    query: str
+    mouser_fixture: str
+    lcsc_fixture: str
+
+
+PARITY_INTENTS: tuple[ParityIntentSpec, ...] = (
+    ParityIntentSpec(
+        intent_id="RES_10K_0603",
+        category="RES",
+        query="10k resistor 0603",
+        mouser_fixture="keyword_resistor_10k_0603.json",
+        lcsc_fixture="keyword_resistor_10k_0603.json",
+    ),
+    ParityIntentSpec(
+        intent_id="CAP_1UF_0805",
+        category="CAP",
+        query="1uF capacitor 0805",
+        mouser_fixture="keyword_capacitor_1uf_0805.json",
+        lcsc_fixture="keyword_capacitor_1uf_0805.json",
+    ),
+    ParityIntentSpec(
+        intent_id="IND_100UH",
+        category="IND",
+        query="100uH inductor",
+        mouser_fixture="keyword_inductor_100uh.json",
+        lcsc_fixture="keyword_inductor_100uh.json",
+    ),
+    ParityIntentSpec(
+        intent_id="LED_GREEN_0603",
+        category="LED",
+        query="green LED 0603",
+        mouser_fixture="keyword_led_green_0603.json",
+        lcsc_fixture="keyword_led_green_0603.json",
+    ),
+)
+
+
+def generate_search_parity_artifacts(
+    *,
+    fixture_root: Path | None = None,
+    max_results_per_supplier: int = 80,
+) -> dict[str, Any]:
+    """Generate matrix rows + diagnostics payload from deterministic fixtures."""
+
+    root = fixture_root if fixture_root is not None else _default_fixture_root()
+    result_cap = max(1, int(max_results_per_supplier))
+
+    matrix_rows: list[dict[str, Any]] = []
+    intents_payload: list[dict[str, Any]] = []
+
+    for intent in PARITY_INTENTS:
+        supplier_payload: dict[str, Any] = {}
+        for supplier in PARITY_SUPPLIERS:
+            fixture_filename = _fixture_filename_for_supplier(intent, supplier=supplier)
+            fixture_path = root / supplier / fixture_filename
+            payload = _load_fixture_payload(fixture_path)
+            raw_results = _parse_fixture_results(supplier=supplier, payload=payload)[
+                :result_cap
+            ]
+
+            ranked, diagnostics = run_search_pipeline_with_diagnostics(
+                raw_results,
+                query=intent.query,
+                category=intent.category,
+            )
+            summary = _build_summary(ranked=ranked, diagnostics=diagnostics)
+
+            matrix_rows.append(
+                {
+                    "intent_id": intent.intent_id,
+                    "category": intent.category,
+                    "query": intent.query,
+                    "supplier": supplier,
+                    **summary,
+                }
+            )
+
+            supplier_payload[supplier] = {
+                "fixture": str(fixture_path.relative_to(root)),
+                "summary": summary,
+                "diagnostics": diagnostics.to_dict(),
+            }
+
+        intents_payload.append(
+            {
+                "intent_id": intent.intent_id,
+                "category": intent.category,
+                "query": intent.query,
+                "suppliers": supplier_payload,
+            }
+        )
+
+    parity_gaps = _summarize_parity_gaps(intents_payload)
+    return {
+        "contract_version": SEARCH_DIAGNOSTICS_CONTRACT_VERSION,
+        "suppliers": list(PARITY_SUPPLIERS),
+        "intents": intents_payload,
+        "matrix_rows": matrix_rows,
+        "parity_gaps": parity_gaps,
+    }
+
+
+def write_search_parity_artifacts(
+    *,
+    matrix_path: Path,
+    diagnostics_path: Path,
+    fixture_root: Path | None = None,
+    max_results_per_supplier: int = 80,
+) -> dict[str, Any]:
+    """Generate and write parity matrix CSV + diagnostics JSON artifacts."""
+
+    payload = generate_search_parity_artifacts(
+        fixture_root=fixture_root,
+        max_results_per_supplier=max_results_per_supplier,
+    )
+    matrix_rows = payload.get("matrix_rows", [])
+
+    matrix_path.parent.mkdir(parents=True, exist_ok=True)
+    diagnostics_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _write_matrix_csv(matrix_path, matrix_rows)
+    diagnostics_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def _default_fixture_root() -> Path:
+    return Path(__file__).resolve().parents[4] / "tests" / "fixtures"
+
+
+def _fixture_filename_for_supplier(intent: ParityIntentSpec, *, supplier: str) -> str:
+    if supplier == "mouser":
+        return intent.mouser_fixture
+    if supplier == "lcsc":
+        return intent.lcsc_fixture
+    raise ValueError(f"Unsupported supplier for parity artifacts: {supplier}")
+
+
+def _load_fixture_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Search parity fixture not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Fixture {path} must contain a JSON object, got {type(payload).__name__}"
+        )
+    return payload
+
+
+def _parse_fixture_results(
+    *, supplier: str, payload: dict[str, Any]
+) -> list[SearchResult]:
+    if supplier == "mouser":
+        provider = MouserProvider(api_key="fixture")
+        return provider._parse_results(payload)
+    if supplier == "lcsc":
+        provider = JlcpcbProvider(cache=InMemorySearchCache(), rate_limit_seconds=0.0)
+        return provider._parse_results(payload)
+    raise ValueError(f"Unsupported supplier parser for parity artifacts: {supplier}")
+
+
+def _build_summary(
+    *,
+    ranked: list[SearchResult],
+    diagnostics: SearchPipelineDiagnostics,
+) -> dict[str, Any]:
+    top = ranked[0] if ranked else None
+    return {
+        "raw_count": diagnostics.raw_count,
+        "default_filtered_count": diagnostics.default_filtered_count,
+        "query_filtered_count": diagnostics.query_filtered_count,
+        "ranked_count": diagnostics.ranked_count,
+        "success": bool(top),
+        "top_result_id": search_result_id(top) if top else "",
+        "top_distributor_part_number": (top.distributor_part_number if top else ""),
+        "top_mpn": (top.mpn if top else ""),
+        "top_manufacturer": (top.manufacturer if top else ""),
+        "top_price": (top.price if top else ""),
+        "top_stock_quantity": (top.stock_quantity if top else 0),
+    }
+
+
+def _summarize_parity_gaps(
+    intents_payload: list[dict[str, Any]]
+) -> list[dict[str, str]]:
+    gaps: list[dict[str, str]] = []
+    for intent in intents_payload:
+        suppliers = intent.get("suppliers", {})
+        mouser_summary = (
+            suppliers.get("mouser", {}).get("summary", {})
+            if isinstance(suppliers, dict)
+            else {}
+        )
+        lcsc_summary = (
+            suppliers.get("lcsc", {}).get("summary", {})
+            if isinstance(suppliers, dict)
+            else {}
+        )
+
+        mouser_success = bool(mouser_summary.get("success"))
+        lcsc_success = bool(lcsc_summary.get("success"))
+
+        if mouser_success != lcsc_success:
+            gaps.append(
+                {
+                    "intent_id": str(intent.get("intent_id", "")),
+                    "impact": "high",
+                    "reason": "supplier_success_mismatch",
+                }
+            )
+            continue
+
+        if not mouser_success and not lcsc_success:
+            gaps.append(
+                {
+                    "intent_id": str(intent.get("intent_id", "")),
+                    "impact": "high",
+                    "reason": "both_suppliers_no_ranked_result",
+                }
+            )
+            continue
+
+        mouser_mpn = str(mouser_summary.get("top_mpn", "")).strip().upper()
+        lcsc_mpn = str(lcsc_summary.get("top_mpn", "")).strip().upper()
+        if mouser_mpn and lcsc_mpn and mouser_mpn != lcsc_mpn:
+            gaps.append(
+                {
+                    "intent_id": str(intent.get("intent_id", "")),
+                    "impact": "medium",
+                    "reason": "top_result_mpn_mismatch",
+                }
+            )
+
+    impact_priority = {"high": 0, "medium": 1, "low": 2}
+    return sorted(
+        gaps,
+        key=lambda gap: (
+            impact_priority.get(gap.get("impact", "low"), 99),
+            gap.get("intent_id", ""),
+            gap.get("reason", ""),
+        ),
+    )
+
+
+def _write_matrix_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    fieldnames = [
+        "intent_id",
+        "category",
+        "query",
+        "supplier",
+        "raw_count",
+        "default_filtered_count",
+        "query_filtered_count",
+        "ranked_count",
+        "success",
+        "top_result_id",
+        "top_distributor_part_number",
+        "top_mpn",
+        "top_manufacturer",
+        "top_price",
+        "top_stock_quantity",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fieldnames})
+
+
+__all__ = [
+    "DEFAULT_DIAGNOSTICS_JSON_RELATIVE_PATH",
+    "DEFAULT_MATRIX_CSV_RELATIVE_PATH",
+    "PARITY_INTENTS",
+    "PARITY_SUPPLIERS",
+    "ParityIntentSpec",
+    "generate_search_parity_artifacts",
+    "write_search_parity_artifacts",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,20 @@ def load_mouser_fixture(name: str) -> dict[str, Any]:
         )
 
     return data
+
+
+def load_lcsc_fixture(name: str) -> dict[str, Any]:
+    """Load a named fixture from tests/fixtures/lcsc/."""
+
+    filename = name if name.endswith(".json") else f"{name}.json"
+    fixture_path = _FIXTURES_DIR / "lcsc" / filename
+    if not fixture_path.exists():
+        raise FileNotFoundError(f"Fixture not found: {fixture_path}")
+
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Fixture {fixture_path} must contain a JSON object, got {type(data).__name__}"
+        )
+
+    return data

--- a/tests/fixtures/lcsc/keyword_capacitor_1uf_0805.json
+++ b/tests/fixtures/lcsc/keyword_capacitor_1uf_0805.json
@@ -1,0 +1,69 @@
+{
+  "code": 200,
+  "data": {
+    "componentPageInfo": {
+      "list": [
+        {
+          "componentCode": "C15849",
+          "componentModelEn": "CL21A105KAFNNNE",
+          "componentBrandEn": "Samsung Electro-Mechanics",
+          "describe": "Multilayer Ceramic Capacitor 1uF 25V 0805 X7R",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C15849.html",
+          "dataManualUrl": "https://example.com/cl21a105kafnnne.pdf",
+          "stockCount": 112000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.009",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Capacitance",
+              "attribute_value_name": "1uF"
+            },
+            {
+              "attribute_name_en": "Voltage Rating",
+              "attribute_value_name": "25V"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0805"
+            }
+          ]
+        },
+        {
+          "componentCode": "C99990",
+          "componentModelEn": "CL21A475KAFNNNE",
+          "componentBrandEn": "Samsung Electro-Mechanics",
+          "describe": "Multilayer Ceramic Capacitor 4.7uF 16V 0805 X5R",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C99990.html",
+          "dataManualUrl": "",
+          "stockCount": 180000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.011",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Capacitance",
+              "attribute_value_name": "4.7uF"
+            },
+            {
+              "attribute_name_en": "Voltage Rating",
+              "attribute_value_name": "16V"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0805"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/lcsc/keyword_inductor_100uh.json
+++ b/tests/fixtures/lcsc/keyword_inductor_100uh.json
@@ -1,0 +1,61 @@
+{
+  "code": 200,
+  "data": {
+    "componentPageInfo": {
+      "list": [
+        {
+          "componentCode": "C40858",
+          "componentModelEn": "NR6028T101M",
+          "componentBrandEn": "Taiyo Yuden",
+          "describe": "Power Inductor 100uH 2.1A 6x6mm",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C40858.html",
+          "dataManualUrl": "https://example.com/nr6028t101m.pdf",
+          "stockCount": 56000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.061",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Inductance",
+              "attribute_value_name": "100uH"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "6x6"
+            }
+          ]
+        },
+        {
+          "componentCode": "C77654",
+          "componentModelEn": "LQH32CN101K53L",
+          "componentBrandEn": "Murata",
+          "describe": "Signal Inductor 100uH 1210",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C77654.html",
+          "dataManualUrl": "",
+          "stockCount": 24000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.044",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Inductance",
+              "attribute_value_name": "100uH"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "1210"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/lcsc/keyword_led_green_0603.json
+++ b/tests/fixtures/lcsc/keyword_led_green_0603.json
@@ -1,0 +1,53 @@
+{
+  "code": 200,
+  "data": {
+    "componentPageInfo": {
+      "list": [
+        {
+          "componentCode": "C2286",
+          "componentModelEn": "KT-0603G",
+          "componentBrandEn": "Everlight",
+          "describe": "Green LED 0603",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C2286.html",
+          "dataManualUrl": "https://example.com/kt-0603g.pdf",
+          "stockCount": 0,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.013",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0603"
+            }
+          ]
+        },
+        {
+          "componentCode": "C21999",
+          "componentModelEn": "KT-0805G",
+          "componentBrandEn": "Everlight",
+          "describe": "Green LED 0805",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C21999.html",
+          "dataManualUrl": "",
+          "stockCount": 0,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.011",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0805"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/lcsc/keyword_resistor_10k_0603.json
+++ b/tests/fixtures/lcsc/keyword_resistor_10k_0603.json
@@ -1,0 +1,65 @@
+{
+  "code": 200,
+  "data": {
+    "componentPageInfo": {
+      "list": [
+        {
+          "componentCode": "C25804",
+          "componentModelEn": "RC0603FR-0710KL",
+          "componentBrandEn": "Yageo",
+          "describe": "Thick Film Resistor 10k 1% 0603",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C25804.html",
+          "dataManualUrl": "https://example.com/rc0603fr0710kl.pdf",
+          "stockCount": 236000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.004",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Resistance",
+              "attribute_value_name": "10kΩ"
+            },
+            {
+              "attribute_name_en": "Tolerance",
+              "attribute_value_name": "1%"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0603"
+            }
+          ]
+        },
+        {
+          "componentCode": "C55555",
+          "componentModelEn": "NTC0603-10K",
+          "componentBrandEn": "Generic",
+          "describe": "NTC Thermistor 10k 0603",
+          "lcscGoodsUrl": "https://www.lcsc.com/product-detail/C55555.html",
+          "dataManualUrl": "",
+          "stockCount": 88000,
+          "minBuyNumber": 1,
+          "componentPrices": [
+            {
+              "productPrice": "0.0035",
+              "productNumber": 1
+            }
+          ],
+          "attributes": [
+            {
+              "attribute_name_en": "Resistance",
+              "attribute_value_name": "10kΩ"
+            },
+            {
+              "attribute_name_en": "Package",
+              "attribute_value_name": "0603"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/mouser/keyword_led_green_0603.json
+++ b/tests/fixtures/mouser/keyword_led_green_0603.json
@@ -1,0 +1,62 @@
+{
+  "Errors": [],
+  "SearchResults": {
+    "NumberOfResult": 2,
+    "Parts": [
+      {
+        "Manufacturer": "Kingbright",
+        "ManufacturerPartNumber": "KP-1608SGC",
+        "Description": "Standard LEDs - SMD Green LED 0603",
+        "DataSheetUrl": "https://example.com/kp-1608sgc.pdf",
+        "MouserPartNumber": "604-KP-1608SGC",
+        "Availability": "15432 In Stock",
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.08",
+            "Currency": "USD"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Kingbright/KP-1608SGC",
+        "LifecycleStatus": "Active",
+        "Min": "1",
+        "Category": "Standard LEDs - SMD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Wavelength/Color Temperature",
+            "AttributeValue": "Green"
+          },
+          {
+            "AttributeName": "Package / Case",
+            "AttributeValue": "0603"
+          }
+        ]
+      },
+      {
+        "Manufacturer": "Legacy LED Co",
+        "ManufacturerPartNumber": "LEG-0603-GREEN",
+        "Description": "Standard LEDs - SMD Green LED 0805",
+        "DataSheetUrl": "https://example.com/legacy-led.pdf",
+        "MouserPartNumber": "999-LEG-0603-GREEN",
+        "Availability": "12 In Stock",
+        "PriceBreaks": [
+          {
+            "Quantity": 1,
+            "Price": "$0.02",
+            "Currency": "USD"
+          }
+        ],
+        "ProductDetailUrl": "https://www.mouser.com/ProductDetail/Legacy-LED-Co/LEG-0603-GREEN",
+        "LifecycleStatus": "Not Recommended for New Designs",
+        "Min": "1",
+        "Category": "Standard LEDs - SMD",
+        "ProductAttributes": [
+          {
+            "AttributeName": "Package / Case",
+            "AttributeValue": "0805"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/search_parity/diagnostics.json
+++ b/tests/fixtures/search_parity/diagnostics.json
@@ -1,0 +1,3808 @@
+{
+  "contract_version": "1.0",
+  "intents": [
+    {
+      "category": "RES",
+      "intent_id": "RES_10K_0603",
+      "query": "10k resistor 0603",
+      "suppliers": {
+        "lcsc": {
+          "diagnostics": {
+            "category": "RES",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C25804"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C55555"
+              }
+            ],
+            "default_filtered_count": 2,
+            "final_result_ids": [
+              "lcsc:C25804",
+              "lcsc:C55555"
+            ],
+            "query": "10k resistor 0603",
+            "query_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "lcsc:C25804"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "lcsc:C55555"
+              }
+            ],
+            "query_filtered_count": 2,
+            "rank_decisions": [
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.004,
+                "rank": 1,
+                "relevance_score": 17,
+                "result_id": "lcsc:C25804"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.0035,
+                "rank": 2,
+                "relevance_score": 0,
+                "result_id": "lcsc:C55555"
+              }
+            ],
+            "ranked_count": 2,
+            "raw_count": 2
+          },
+          "fixture": "lcsc/keyword_resistor_10k_0603.json",
+          "summary": {
+            "default_filtered_count": 2,
+            "query_filtered_count": 2,
+            "ranked_count": 2,
+            "raw_count": 2,
+            "success": true,
+            "top_distributor_part_number": "C25804",
+            "top_manufacturer": "Yageo",
+            "top_mpn": "RC0603FR-0710KL",
+            "top_price": "0.004",
+            "top_result_id": "lcsc:C25804",
+            "top_stock_quantity": 236000
+          }
+        },
+        "mouser": {
+          "diagnostics": {
+            "category": "RES",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030C1022FP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603MD1052BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:279-CRG0603F1M0/10"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603HC1002FP1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030D1002BPW"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PTN0603E1002BST0"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-CHPHT0603K1002FGT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CHP0603AFX1003EL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PAT0603E1002BST1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603HC1002FP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030D1072BP1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PNM0603E1002BST1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:72-P0603E1002BNT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PTN0603E1002BBTF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:303-0603WAD1002T5E"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:303-0603WAJ0103TCE"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:303-0603SAF1002P5E"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:303-0603WGF1002T5E"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603MG1002BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030F1002BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603ADY-1002E"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-NTCS0603E3103FLT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030C1002FPW"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CR0603AFX1002EAS"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030C1002FP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:279-CRG0603F22K/10"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030E1002BP1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603FY1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PLT0603Z1002AST5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603FZ1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603BY1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CR0603FX-1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603FX1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-NTCS0603E3103FMT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CRT0603BY1002EAS"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PHP00603E1002BST1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CHP0603AFX1002EL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CMP0603-FX-1002L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-2381-615-36103"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-PATT0603E1002BGT1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030D1022BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT06030D1002BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CR0603FX-1072ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CR0603FX-1052ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603MD1002BP1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:871-B57321V2103H60"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603PD1002DP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:71-RCG06034K99FKEA"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:652-CMP0603AFX-1002L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:594-MCT0603MC1002FP5"
+              }
+            ],
+            "default_filtered_count": 50,
+            "final_result_ids": [
+              "mouser:652-CR0603AFX1002EAS",
+              "mouser:594-MCT06030C1002FP5",
+              "mouser:594-MCT06030C1002FPW",
+              "mouser:594-MCT0603MC1002FP5",
+              "mouser:652-CRT0603BY1002EAS",
+              "mouser:594-MCT0603PD1002DP5",
+              "mouser:594-MCT06030D1002BPW",
+              "mouser:594-MCT0603MD1002BP1",
+              "mouser:594-MCT06030E1002BP1",
+              "mouser:71-PAT0603E1002BST1",
+              "mouser:594-MCT06030F1002BP5",
+              "mouser:594-MCT0603MG1002BP5"
+            ],
+            "query": "10k resistor 0603",
+            "query_filter_decisions": [
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030C1022FP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603MD1052BP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:279-CRG0603F1M0/10"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603HC1002FP1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030D1002BPW"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-PTN0603E1002BST0"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-CHPHT0603K1002FGT"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CHP0603AFX1003EL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:71-PAT0603E1002BST1"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603HC1002FP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030D1072BP1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-PNM0603E1002BST1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:72-P0603E1002BNT"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-PTN0603E1002BBTF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:303-0603WAD1002T5E"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:303-0603WAJ0103TCE"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:303-0603SAF1002P5E"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:303-0603WGF1002T5E"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603MG1002BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030F1002BP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603ADY-1002E"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-NTCS0603E3103FLT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030C1002FPW"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:652-CR0603AFX1002EAS"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030C1002FP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:279-CRG0603F22K/10"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030E1002BP1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603FY1002ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:71-PLT0603Z1002AST5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603FZ1002ELF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603BY1002ELF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CR0603FX-1002ELF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603FX1002ELF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-NTCS0603E3103FMT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:652-CRT0603BY1002EAS"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-PHP00603E1002BST1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CHP0603AFX1002EL"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CMP0603-FX-1002L"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-2381-615-36103"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-PATT0603E1002BGT1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030D1022BP5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT06030D1002BP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CR0603FX-1072ELF"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CR0603FX-1052ELF"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603MD1002BP1"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:871-B57321V2103H60"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603PD1002DP5"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:71-RCG06034K99FKEA"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:652-CMP0603AFX-1002L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:594-MCT0603MC1002FP5"
+              }
+            ],
+            "query_filtered_count": 16,
+            "rank_decisions": [
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.81,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603HC1002FP1"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.39,
+                "rank": 7,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030D1002BPW"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.65,
+                "rank": 10,
+                "relevance_score": 17,
+                "result_id": "mouser:71-PAT0603E1002BST1"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.46,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603HC1002FP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.48,
+                "rank": 12,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603MG1002BP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.16,
+                "rank": 11,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030F1002BP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.1,
+                "rank": 3,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030C1002FPW"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.1,
+                "rank": 1,
+                "relevance_score": 17,
+                "result_id": "mouser:652-CR0603AFX1002EAS"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.1,
+                "rank": 2,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030C1002FP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.6,
+                "rank": 9,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030E1002BP1"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 3.79,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:71-PLT0603Z1002AST5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.16,
+                "rank": 5,
+                "relevance_score": 17,
+                "result_id": "mouser:652-CRT0603BY1002EAS"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.13,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT06030D1002BP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.47,
+                "rank": 8,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603MD1002BP1"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.16,
+                "rank": 6,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603PD1002DP5"
+              },
+              {
+                "canonical_value": 10000.0,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.1,
+                "rank": 4,
+                "relevance_score": 17,
+                "result_id": "mouser:594-MCT0603MC1002FP5"
+              }
+            ],
+            "ranked_count": 12,
+            "raw_count": 50
+          },
+          "fixture": "mouser/keyword_resistor_10k_0603.json",
+          "summary": {
+            "default_filtered_count": 50,
+            "query_filtered_count": 16,
+            "ranked_count": 12,
+            "raw_count": 50,
+            "success": true,
+            "top_distributor_part_number": "652-CR0603AFX1002EAS",
+            "top_manufacturer": "Bourns",
+            "top_mpn": "CR0603AFX-1002EAS",
+            "top_price": "$0.10",
+            "top_result_id": "mouser:652-CR0603AFX1002EAS",
+            "top_stock_quantity": 29024
+          }
+        }
+      }
+    },
+    {
+      "category": "CAP",
+      "intent_id": "CAP_1UF_0805",
+      "query": "1uF capacitor 0805",
+      "suppliers": {
+        "lcsc": {
+          "diagnostics": {
+            "category": "CAP",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C15849"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C99990"
+              }
+            ],
+            "default_filtered_count": 2,
+            "final_result_ids": [
+              "lcsc:C15849"
+            ],
+            "query": "1uF capacitor 0805",
+            "query_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "lcsc:C15849"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "lcsc:C99990"
+              }
+            ],
+            "query_filtered_count": 1,
+            "rank_decisions": [
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.009,
+                "rank": 1,
+                "relevance_score": 17,
+                "result_id": "lcsc:C15849"
+              }
+            ],
+            "ranked_count": 1,
+            "raw_count": 2
+          },
+          "fixture": "lcsc/keyword_capacitor_1uf_0805.json",
+          "summary": {
+            "default_filtered_count": 2,
+            "query_filtered_count": 1,
+            "ranked_count": 1,
+            "raw_count": 2,
+            "success": true,
+            "top_distributor_part_number": "C15849",
+            "top_manufacturer": "Samsung Electro-Mechanics",
+            "top_mpn": "CL21A105KAFNNNE",
+            "top_price": "0.009",
+            "top_result_id": "lcsc:C15849",
+            "top_stock_quantity": 112000
+          }
+        },
+        "mouser": {
+          "diagnostics": {
+            "category": "CAP",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08055C105JAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08056D105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-0805YC105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08053G105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:77-VJ0805Y105KXQTBC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08056C105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805T105K4RACTU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08056C105JAZ2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105J4RACLR"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105K3RACTM"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08053C105JAZ2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105K8NAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-0805ZC105K4Z2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08053C105J4T2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105M4RECLR"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08053D105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805X105K8NACTU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:791-0805B105J160CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:791-0805B105M500CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805X105J4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR51H105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105M4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR71E105JU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:791-0805X105M160CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:791-0805X105K250CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR51E105MU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105J3REAULR"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805X105K9R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:791-0805B105J250CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805X105K8R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08055C105K4Z4A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:767-0805B104K250NT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR71C105JU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR51E105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGF21KR71H105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805F105K4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KAM21KR71C105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805J105K4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KAM21KR71H105KL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KAF21KR71E105KL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AV51H105ZU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-KGM21AR51C105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-M325354E2X105KZMB"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:603-CC805KKX7R7BB105"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:603-CC805KKX7R9BB105"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08053C105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08055D105K"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-0805ZC105K"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:581-08055C105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:80-C0805C105K5R"
+              }
+            ],
+            "default_filtered_count": 50,
+            "final_result_ids": [
+              "mouser:603-CC805KKX7R7BB105",
+              "mouser:80-C0805C105K3RACTM",
+              "mouser:77-VJ0805Y105KXQTBC",
+              "mouser:581-08053G105MAT2A",
+              "mouser:581-KGM21AR51E105KU",
+              "mouser:80-C0805C105M4RAUTO",
+              "mouser:581-KGM21AR51C105KU",
+              "mouser:603-CC805KKX7R9BB105",
+              "mouser:581-08056D105KAT2A",
+              "mouser:80-C0805C105J4RACLR",
+              "mouser:80-C0805C105M4RECLR",
+              "mouser:581-KGM21AR71C105JU",
+              "mouser:80-C0805F105K4RAUTO",
+              "mouser:581-08056C105MAT2A",
+              "mouser:80-C0805X105K9R",
+              "mouser:80-C0805C105K5R",
+              "mouser:80-C0805J105K4RAUTO",
+              "mouser:581-KAF21KR71E105KL",
+              "mouser:80-C0805C105J3REAULR",
+              "mouser:581-KGM21AR71E105JU",
+              "mouser:581-KGM21AR51H105KU",
+              "mouser:581-KGM21AR51E105MU",
+              "mouser:80-C0805X105K8R",
+              "mouser:80-C0805T105K4RACTU",
+              "mouser:791-0805X105M160CT",
+              "mouser:791-0805B105J160CT",
+              "mouser:791-0805B105J250CT",
+              "mouser:791-0805B105M500CT"
+            ],
+            "query": "1uF capacitor 0805",
+            "query_filter_decisions": [
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08055C105JAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-08056D105KAT2A"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-0805YC105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-08053G105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:77-VJ0805Y105KXQTBC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-08056C105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805T105K4RACTU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-08056C105JAZ2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105J4RACLR"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105K3RACTM"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-08053C105JAZ2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105K8NAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-0805ZC105K4Z2A"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08053C105J4T2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105M4RECLR"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08053D105MAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805X105K8NACTU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:791-0805B105J160CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:791-0805B105M500CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805X105J4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR51H105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105M4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR71E105JU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:791-0805X105M160CT"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:791-0805X105K250CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR51E105MU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105J3REAULR"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805X105K9R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:791-0805B105J250CT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805X105K8R"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08055C105K4Z4A"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:767-0805B104K250NT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR71C105JU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR51E105KU"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-KGF21KR71H105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805F105K4RAUTO"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KAM21KR71C105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805J105K4RAUTO"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-KAM21KR71H105KL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KAF21KR71E105KL"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AV51H105ZU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:581-KGM21AR51C105KU"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-M325354E2X105KZMB"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:603-CC805KKX7R7BB105"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:603-CC805KKX7R9BB105"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08053C105KAT2A"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08055D105K"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-0805ZC105K"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:581-08055C105KAT2A"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:80-C0805C105K5R"
+              }
+            ],
+            "query_filtered_count": 37,
+            "rank_decisions": [
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.24,
+                "rank": 9,
+                "relevance_score": 17,
+                "result_id": "mouser:581-08056D105KAT2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.21,
+                "rank": 4,
+                "relevance_score": 17,
+                "result_id": "mouser:581-08053G105MAT2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.17,
+                "rank": 3,
+                "relevance_score": 17,
+                "result_id": "mouser:77-VJ0805Y105KXQTBC"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.34,
+                "rank": 14,
+                "relevance_score": 17,
+                "result_id": "mouser:581-08056C105MAT2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.98,
+                "rank": 24,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805T105K4RACTU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 1.73,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:581-08056C105JAZ2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.25,
+                "rank": 10,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105J4RACLR"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.16,
+                "rank": 2,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105K3RACTM"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 2.04,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:581-08053C105JAZ2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 1.03,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105K8NAUTO"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.98,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:581-0805ZC105K4Z2A"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.26,
+                "rank": 11,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105M4RECLR"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 1.13,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805X105K8NACTU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.11,
+                "rank": 26,
+                "relevance_score": 16,
+                "result_id": "mouser:791-0805B105J160CT"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.11,
+                "rank": 28,
+                "relevance_score": 16,
+                "result_id": "mouser:791-0805B105M500CT"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 1.24,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805X105J4RAUTO"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.56,
+                "rank": 21,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR51H105KU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.22,
+                "rank": 6,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105M4RAUTO"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.48,
+                "rank": 20,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR71E105JU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.1,
+                "rank": 25,
+                "relevance_score": 16,
+                "result_id": "mouser:791-0805X105M160CT"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.6,
+                "rank": 22,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR51E105MU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.39,
+                "rank": 19,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105J3REAULR"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.35,
+                "rank": 15,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805X105K9R"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.11,
+                "rank": 27,
+                "relevance_score": 16,
+                "result_id": "mouser:791-0805B105J250CT"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.71,
+                "rank": 23,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805X105K8R"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.26,
+                "rank": 12,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR71C105JU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.21,
+                "rank": 5,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR51E105KU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.31,
+                "rank": 13,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805F105K4RAUTO"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.77,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KAM21KR71C105KU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.38,
+                "rank": 17,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805J105K4RAUTO"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.38,
+                "rank": 18,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KAF21KR71E105KL"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 0.21,
+                "rank": null,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AV51H105ZU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.23,
+                "rank": 7,
+                "relevance_score": 17,
+                "result_id": "mouser:581-KGM21AR51C105KU"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": false,
+                "passive_stock_gate_kept": false,
+                "price_value": 13.89,
+                "rank": null,
+                "relevance_score": 16,
+                "result_id": "mouser:80-M325354E2X105KZMB"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.13,
+                "rank": 1,
+                "relevance_score": 17,
+                "result_id": "mouser:603-CC805KKX7R7BB105"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.23,
+                "rank": 8,
+                "relevance_score": 17,
+                "result_id": "mouser:603-CC805KKX7R9BB105"
+              },
+              {
+                "canonical_value": 1e-06,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.38,
+                "rank": 16,
+                "relevance_score": 17,
+                "result_id": "mouser:80-C0805C105K5R"
+              }
+            ],
+            "ranked_count": 28,
+            "raw_count": 50
+          },
+          "fixture": "mouser/keyword_capacitor_1uf_0805.json",
+          "summary": {
+            "default_filtered_count": 50,
+            "query_filtered_count": 37,
+            "ranked_count": 28,
+            "raw_count": 50,
+            "success": true,
+            "top_distributor_part_number": "603-CC805KKX7R7BB105",
+            "top_manufacturer": "YAGEO",
+            "top_mpn": "CC0805KKX7R7BB105",
+            "top_price": "$0.13",
+            "top_result_id": "mouser:603-CC805KKX7R7BB105",
+            "top_stock_quantity": 133254
+          }
+        }
+      }
+    },
+    {
+      "category": "IND",
+      "intent_id": "IND_100UH",
+      "query": "100uH inductor",
+      "suppliers": {
+        "lcsc": {
+          "diagnostics": {
+            "category": "IND",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C40858"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "lcsc:C77654"
+              }
+            ],
+            "default_filtered_count": 2,
+            "final_result_ids": [
+              "lcsc:C77654",
+              "lcsc:C40858"
+            ],
+            "query": "100uH inductor",
+            "query_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "lcsc:C40858"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "lcsc:C77654"
+              }
+            ],
+            "query_filtered_count": 2,
+            "rank_decisions": [
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.061,
+                "rank": 2,
+                "relevance_score": 8,
+                "result_id": "lcsc:C40858"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.044,
+                "rank": 1,
+                "relevance_score": 8,
+                "result_id": "lcsc:C77654"
+              }
+            ],
+            "ranked_count": 2,
+            "raw_count": 2
+          },
+          "fixture": "lcsc/keyword_inductor_100uh.json",
+          "summary": {
+            "default_filtered_count": 2,
+            "query_filtered_count": 2,
+            "ranked_count": 2,
+            "raw_count": 2,
+            "success": true,
+            "top_distributor_part_number": "C77654",
+            "top_manufacturer": "Murata",
+            "top_mpn": "LQH32CN101K53L",
+            "top_price": "0.044",
+            "top_result_id": "lcsc:C77654",
+            "top_stock_quantity": 24000
+          }
+        },
+        "mouser": {
+          "diagnostics": {
+            "category": "IND",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:504-HPAL1V1260-101-R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:504-HPAL1V1265-101-R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-PCV-2-104-10L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSS6132T-104MLC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:815-ACMS-Q3222F-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSS1583-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:871-B82442T1104K050"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-LPS4018-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-DO1608C-104MLC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:815-ACMS-Q3225-101-T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-DO3316P-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:710-7447706101"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:70-IHSM7832ER101L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:70-ISC1210ER101K"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:81-LQH2HNH101J03L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:710-74477420"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:815-ACMS-Q4526C-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:810-NLFV32T-101K-EFT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-PCV-2-104-03L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:710-744877101"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:710-74477820"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSD1514-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:70-IHLE5050FHR101M51"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:871-B82472G4104M"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSD1048-104MED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-XFL2010-104MEC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-RFC0807B-104KE"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-DO3308P-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:851-CDRH127LDNP101MC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:70-IHTH1125KZEB101M5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-LPS4012-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-LPS4414-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-LPS3314-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:851-CDR6D23MNNP101NC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-DR0608-104L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-LPS8045B-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-PCV-0-104-05L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-RFB0807-101L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSD1583-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-XFL2006-104MEC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MOS6020-104MLC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:542-PM5022-101M-RC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:70-IMC1210ER101J"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSD1278-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:815-ACMS-Q3225C-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-MSD1260-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:994-RFS1113-104ME"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:580-24101C"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:710-74477720"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:815-ATCA-01-101M-V"
+              }
+            ],
+            "default_filtered_count": 50,
+            "final_result_ids": [
+              "mouser:810-NLFV32T-101K-EFT",
+              "mouser:504-HPAL1V1260-101-R",
+              "mouser:504-HPAL1V1265-101-R",
+              "mouser:580-24101C",
+              "mouser:542-PM5022-101M-RC",
+              "mouser:70-ISC1210ER101K",
+              "mouser:871-B82472G4104M",
+              "mouser:851-CDR6D23MNNP101NC",
+              "mouser:871-B82442T1104K050",
+              "mouser:994-DR0608-104L",
+              "mouser:994-RFC0807B-104KE",
+              "mouser:851-CDRH127LDNP101MC",
+              "mouser:710-7447706101",
+              "mouser:994-RFB0807-101L",
+              "mouser:994-LPS4414-104MRC",
+              "mouser:70-IMC1210ER101J",
+              "mouser:994-LPS4012-104MRC",
+              "mouser:994-LPS4018-104MRC",
+              "mouser:994-LPS3314-104MRC",
+              "mouser:994-DO1608C-104MLC",
+              "mouser:710-74477420",
+              "mouser:994-RFS1113-104ME",
+              "mouser:994-DO3308P-104MLD",
+              "mouser:994-MOS6020-104MLC",
+              "mouser:994-MSS6132T-104MLC",
+              "mouser:994-DO3316P-104MLD",
+              "mouser:994-XFL2006-104MEC",
+              "mouser:710-74477720",
+              "mouser:994-MSD1048-104MED",
+              "mouser:994-MSD1260-104MLD",
+              "mouser:710-74477820",
+              "mouser:710-744877101",
+              "mouser:994-MSD1278-104MLD",
+              "mouser:70-IHSM7832ER101L",
+              "mouser:994-XFL2010-104MEC",
+              "mouser:994-LPS8045B-104MRC",
+              "mouser:994-MSS1583-104KED",
+              "mouser:994-MSD1583-104KED",
+              "mouser:994-MSD1514-104KED",
+              "mouser:70-IHLE5050FHR101M51",
+              "mouser:994-PCV-0-104-05L",
+              "mouser:994-PCV-2-104-03L",
+              "mouser:994-PCV-2-104-10L",
+              "mouser:70-IHTH1125KZEB101M5",
+              "mouser:815-ATCA-01-101M-V"
+            ],
+            "query": "100uH inductor",
+            "query_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:504-HPAL1V1260-101-R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:504-HPAL1V1265-101-R"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-PCV-2-104-10L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSS6132T-104MLC"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:815-ACMS-Q3222F-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSS1583-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:871-B82442T1104K050"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-LPS4018-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-DO1608C-104MLC"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:815-ACMS-Q3225-101-T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-DO3316P-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:710-7447706101"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:70-IHSM7832ER101L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:70-ISC1210ER101K"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:81-LQH2HNH101J03L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:710-74477420"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:815-ACMS-Q4526C-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:810-NLFV32T-101K-EFT"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-PCV-2-104-03L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:710-744877101"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:710-74477820"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSD1514-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:70-IHLE5050FHR101M51"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:871-B82472G4104M"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSD1048-104MED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-XFL2010-104MEC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-RFC0807B-104KE"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-DO3308P-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:851-CDRH127LDNP101MC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:70-IHTH1125KZEB101M5"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-LPS4012-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-LPS4414-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-LPS3314-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:851-CDR6D23MNNP101NC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-DR0608-104L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-LPS8045B-104MRC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-PCV-0-104-05L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-RFB0807-101L"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSD1583-104KED"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-XFL2006-104MEC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MOS6020-104MLC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:542-PM5022-101M-RC"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:70-IMC1210ER101J"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSD1278-104MLD"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "excluded_by_query_constraints"
+                ],
+                "result_id": "mouser:815-ACMS-Q3225C-101T"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-MSD1260-104MLD"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:994-RFS1113-104ME"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:580-24101C"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:710-74477720"
+              },
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:815-ATCA-01-101M-V"
+              }
+            ],
+            "query_filtered_count": 45,
+            "rank_decisions": [
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.52,
+                "rank": 2,
+                "relevance_score": 8,
+                "result_id": "mouser:504-HPAL1V1260-101-R"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.52,
+                "rank": 3,
+                "relevance_score": 8,
+                "result_id": "mouser:504-HPAL1V1265-101-R"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 8.34,
+                "rank": 43,
+                "relevance_score": 8,
+                "result_id": "mouser:994-PCV-2-104-10L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.03,
+                "rank": 25,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSS6132T-104MLC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 3.03,
+                "rank": 37,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSS1583-104KED"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.99,
+                "rank": 9,
+                "relevance_score": 8,
+                "result_id": "mouser:871-B82442T1104K050"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.46,
+                "rank": 18,
+                "relevance_score": 8,
+                "result_id": "mouser:994-LPS4018-104MRC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.82,
+                "rank": 20,
+                "relevance_score": 8,
+                "result_id": "mouser:994-DO1608C-104MLC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.15,
+                "rank": 26,
+                "relevance_score": 8,
+                "result_id": "mouser:994-DO3316P-104MLD"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.24,
+                "rank": 13,
+                "relevance_score": 8,
+                "result_id": "mouser:710-7447706101"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.55,
+                "rank": 34,
+                "relevance_score": 8,
+                "result_id": "mouser:70-IHSM7832ER101L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.74,
+                "rank": 6,
+                "relevance_score": 8,
+                "result_id": "mouser:70-ISC1210ER101K"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.87,
+                "rank": 21,
+                "relevance_score": 8,
+                "result_id": "mouser:710-74477420"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.35,
+                "rank": 1,
+                "relevance_score": 8,
+                "result_id": "mouser:810-NLFV32T-101K-EFT"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 6.26,
+                "rank": 42,
+                "relevance_score": 8,
+                "result_id": "mouser:994-PCV-2-104-03L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.53,
+                "rank": 32,
+                "relevance_score": 8,
+                "result_id": "mouser:710-744877101"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.51,
+                "rank": 31,
+                "relevance_score": 8,
+                "result_id": "mouser:710-74477820"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 3.78,
+                "rank": 39,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSD1514-104KED"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 4.09,
+                "rank": 40,
+                "relevance_score": 8,
+                "result_id": "mouser:70-IHLE5050FHR101M51"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.82,
+                "rank": 7,
+                "relevance_score": 8,
+                "result_id": "mouser:871-B82472G4104M"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.42,
+                "rank": 29,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSD1048-104MED"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.72,
+                "rank": 35,
+                "relevance_score": 8,
+                "result_id": "mouser:994-XFL2010-104MEC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.02,
+                "rank": 11,
+                "relevance_score": 8,
+                "result_id": "mouser:994-RFC0807B-104KE"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.98,
+                "rank": 23,
+                "relevance_score": 8,
+                "result_id": "mouser:994-DO3308P-104MLD"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.21,
+                "rank": 12,
+                "relevance_score": 8,
+                "result_id": "mouser:851-CDRH127LDNP101MC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 9.05,
+                "rank": 44,
+                "relevance_score": 8,
+                "result_id": "mouser:70-IHTH1125KZEB101M5"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.46,
+                "rank": 17,
+                "relevance_score": 8,
+                "result_id": "mouser:994-LPS4012-104MRC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.41,
+                "rank": 15,
+                "relevance_score": 8,
+                "result_id": "mouser:994-LPS4414-104MRC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.52,
+                "rank": 19,
+                "relevance_score": 8,
+                "result_id": "mouser:994-LPS3314-104MRC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.97,
+                "rank": 8,
+                "relevance_score": 8,
+                "result_id": "mouser:851-CDR6D23MNNP101NC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.02,
+                "rank": 10,
+                "relevance_score": 8,
+                "result_id": "mouser:994-DR0608-104L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.92,
+                "rank": 36,
+                "relevance_score": 8,
+                "result_id": "mouser:994-LPS8045B-104MRC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 4.34,
+                "rank": 41,
+                "relevance_score": 8,
+                "result_id": "mouser:994-PCV-0-104-05L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.28,
+                "rank": 14,
+                "relevance_score": 8,
+                "result_id": "mouser:994-RFB0807-101L"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 3.37,
+                "rank": 38,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSD1583-104KED"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.33,
+                "rank": 27,
+                "relevance_score": 8,
+                "result_id": "mouser:994-XFL2006-104MEC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.02,
+                "rank": 24,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MOS6020-104MLC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.6,
+                "rank": 5,
+                "relevance_score": 8,
+                "result_id": "mouser:542-PM5022-101M-RC"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.42,
+                "rank": 16,
+                "relevance_score": 8,
+                "result_id": "mouser:70-IMC1210ER101J"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.54,
+                "rank": 33,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSD1278-104MLD"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.45,
+                "rank": 30,
+                "relevance_score": 8,
+                "result_id": "mouser:994-MSD1260-104MLD"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 1.94,
+                "rank": 22,
+                "relevance_score": 8,
+                "result_id": "mouser:994-RFS1113-104ME"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.58,
+                "rank": 4,
+                "relevance_score": 8,
+                "result_id": "mouser:580-24101C"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.37,
+                "rank": 28,
+                "relevance_score": 8,
+                "result_id": "mouser:710-74477720"
+              },
+              {
+                "canonical_value": 9.999999999999999e-05,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 2.28,
+                "rank": 45,
+                "relevance_score": 7,
+                "result_id": "mouser:815-ATCA-01-101M-V"
+              }
+            ],
+            "ranked_count": 45,
+            "raw_count": 50
+          },
+          "fixture": "mouser/keyword_inductor_100uh.json",
+          "summary": {
+            "default_filtered_count": 50,
+            "query_filtered_count": 45,
+            "ranked_count": 45,
+            "raw_count": 50,
+            "success": true,
+            "top_distributor_part_number": "810-NLFV32T-101K-EFT",
+            "top_manufacturer": "TDK",
+            "top_mpn": "NLFV32T-101K-EFT",
+            "top_price": "$0.35",
+            "top_result_id": "mouser:810-NLFV32T-101K-EFT",
+            "top_stock_quantity": 3587
+          }
+        }
+      }
+    },
+    {
+      "category": "LED",
+      "intent_id": "LED_GREEN_0603",
+      "query": "green LED 0603",
+      "suppliers": {
+        "lcsc": {
+          "diagnostics": {
+            "category": "LED",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": false,
+                "reasons": [
+                  "stock_quantity<=0"
+                ],
+                "result_id": "lcsc:C2286"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "stock_quantity<=0"
+                ],
+                "result_id": "lcsc:C21999"
+              }
+            ],
+            "default_filtered_count": 0,
+            "final_result_ids": [],
+            "query": "green LED 0603",
+            "query_filter_decisions": [],
+            "query_filtered_count": 0,
+            "rank_decisions": [],
+            "ranked_count": 0,
+            "raw_count": 2
+          },
+          "fixture": "lcsc/keyword_led_green_0603.json",
+          "summary": {
+            "default_filtered_count": 0,
+            "query_filtered_count": 0,
+            "ranked_count": 0,
+            "raw_count": 2,
+            "success": false,
+            "top_distributor_part_number": "",
+            "top_manufacturer": "",
+            "top_mpn": "",
+            "top_price": "",
+            "top_result_id": "",
+            "top_stock_quantity": 0
+          }
+        },
+        "mouser": {
+          "diagnostics": {
+            "category": "LED",
+            "contract_version": "1.0",
+            "default_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "passed_default_filters"
+                ],
+                "result_id": "mouser:604-KP-1608SGC"
+              },
+              {
+                "kept": false,
+                "reasons": [
+                  "lifecycle=not_recommended"
+                ],
+                "result_id": "mouser:999-LEG-0603-GREEN"
+              }
+            ],
+            "default_filtered_count": 1,
+            "final_result_ids": [
+              "mouser:604-KP-1608SGC"
+            ],
+            "query": "green LED 0603",
+            "query_filter_decisions": [
+              {
+                "kept": true,
+                "reasons": [
+                  "matched_query_constraints"
+                ],
+                "result_id": "mouser:604-KP-1608SGC"
+              }
+            ],
+            "query_filtered_count": 1,
+            "rank_decisions": [
+              {
+                "canonical_value": Infinity,
+                "component_library_tier": "",
+                "included": true,
+                "passive_stock_gate_kept": true,
+                "price_value": 0.08,
+                "rank": 1,
+                "relevance_score": 11,
+                "result_id": "mouser:604-KP-1608SGC"
+              }
+            ],
+            "ranked_count": 1,
+            "raw_count": 2
+          },
+          "fixture": "mouser/keyword_led_green_0603.json",
+          "summary": {
+            "default_filtered_count": 1,
+            "query_filtered_count": 1,
+            "ranked_count": 1,
+            "raw_count": 2,
+            "success": true,
+            "top_distributor_part_number": "604-KP-1608SGC",
+            "top_manufacturer": "Kingbright",
+            "top_mpn": "KP-1608SGC",
+            "top_price": "$0.08",
+            "top_result_id": "mouser:604-KP-1608SGC",
+            "top_stock_quantity": 15432
+          }
+        }
+      }
+    }
+  ],
+  "matrix_rows": [
+    {
+      "category": "RES",
+      "default_filtered_count": 50,
+      "intent_id": "RES_10K_0603",
+      "query": "10k resistor 0603",
+      "query_filtered_count": 16,
+      "ranked_count": 12,
+      "raw_count": 50,
+      "success": true,
+      "supplier": "mouser",
+      "top_distributor_part_number": "652-CR0603AFX1002EAS",
+      "top_manufacturer": "Bourns",
+      "top_mpn": "CR0603AFX-1002EAS",
+      "top_price": "$0.10",
+      "top_result_id": "mouser:652-CR0603AFX1002EAS",
+      "top_stock_quantity": 29024
+    },
+    {
+      "category": "RES",
+      "default_filtered_count": 2,
+      "intent_id": "RES_10K_0603",
+      "query": "10k resistor 0603",
+      "query_filtered_count": 2,
+      "ranked_count": 2,
+      "raw_count": 2,
+      "success": true,
+      "supplier": "lcsc",
+      "top_distributor_part_number": "C25804",
+      "top_manufacturer": "Yageo",
+      "top_mpn": "RC0603FR-0710KL",
+      "top_price": "0.004",
+      "top_result_id": "lcsc:C25804",
+      "top_stock_quantity": 236000
+    },
+    {
+      "category": "CAP",
+      "default_filtered_count": 50,
+      "intent_id": "CAP_1UF_0805",
+      "query": "1uF capacitor 0805",
+      "query_filtered_count": 37,
+      "ranked_count": 28,
+      "raw_count": 50,
+      "success": true,
+      "supplier": "mouser",
+      "top_distributor_part_number": "603-CC805KKX7R7BB105",
+      "top_manufacturer": "YAGEO",
+      "top_mpn": "CC0805KKX7R7BB105",
+      "top_price": "$0.13",
+      "top_result_id": "mouser:603-CC805KKX7R7BB105",
+      "top_stock_quantity": 133254
+    },
+    {
+      "category": "CAP",
+      "default_filtered_count": 2,
+      "intent_id": "CAP_1UF_0805",
+      "query": "1uF capacitor 0805",
+      "query_filtered_count": 1,
+      "ranked_count": 1,
+      "raw_count": 2,
+      "success": true,
+      "supplier": "lcsc",
+      "top_distributor_part_number": "C15849",
+      "top_manufacturer": "Samsung Electro-Mechanics",
+      "top_mpn": "CL21A105KAFNNNE",
+      "top_price": "0.009",
+      "top_result_id": "lcsc:C15849",
+      "top_stock_quantity": 112000
+    },
+    {
+      "category": "IND",
+      "default_filtered_count": 50,
+      "intent_id": "IND_100UH",
+      "query": "100uH inductor",
+      "query_filtered_count": 45,
+      "ranked_count": 45,
+      "raw_count": 50,
+      "success": true,
+      "supplier": "mouser",
+      "top_distributor_part_number": "810-NLFV32T-101K-EFT",
+      "top_manufacturer": "TDK",
+      "top_mpn": "NLFV32T-101K-EFT",
+      "top_price": "$0.35",
+      "top_result_id": "mouser:810-NLFV32T-101K-EFT",
+      "top_stock_quantity": 3587
+    },
+    {
+      "category": "IND",
+      "default_filtered_count": 2,
+      "intent_id": "IND_100UH",
+      "query": "100uH inductor",
+      "query_filtered_count": 2,
+      "ranked_count": 2,
+      "raw_count": 2,
+      "success": true,
+      "supplier": "lcsc",
+      "top_distributor_part_number": "C77654",
+      "top_manufacturer": "Murata",
+      "top_mpn": "LQH32CN101K53L",
+      "top_price": "0.044",
+      "top_result_id": "lcsc:C77654",
+      "top_stock_quantity": 24000
+    },
+    {
+      "category": "LED",
+      "default_filtered_count": 1,
+      "intent_id": "LED_GREEN_0603",
+      "query": "green LED 0603",
+      "query_filtered_count": 1,
+      "ranked_count": 1,
+      "raw_count": 2,
+      "success": true,
+      "supplier": "mouser",
+      "top_distributor_part_number": "604-KP-1608SGC",
+      "top_manufacturer": "Kingbright",
+      "top_mpn": "KP-1608SGC",
+      "top_price": "$0.08",
+      "top_result_id": "mouser:604-KP-1608SGC",
+      "top_stock_quantity": 15432
+    },
+    {
+      "category": "LED",
+      "default_filtered_count": 0,
+      "intent_id": "LED_GREEN_0603",
+      "query": "green LED 0603",
+      "query_filtered_count": 0,
+      "ranked_count": 0,
+      "raw_count": 2,
+      "success": false,
+      "supplier": "lcsc",
+      "top_distributor_part_number": "",
+      "top_manufacturer": "",
+      "top_mpn": "",
+      "top_price": "",
+      "top_result_id": "",
+      "top_stock_quantity": 0
+    }
+  ],
+  "parity_gaps": [
+    {
+      "impact": "high",
+      "intent_id": "LED_GREEN_0603",
+      "reason": "supplier_success_mismatch"
+    },
+    {
+      "impact": "medium",
+      "intent_id": "CAP_1UF_0805",
+      "reason": "top_result_mpn_mismatch"
+    },
+    {
+      "impact": "medium",
+      "intent_id": "IND_100UH",
+      "reason": "top_result_mpn_mismatch"
+    },
+    {
+      "impact": "medium",
+      "intent_id": "RES_10K_0603",
+      "reason": "top_result_mpn_mismatch"
+    }
+  ],
+  "suppliers": [
+    "mouser",
+    "lcsc"
+  ]
+}

--- a/tests/fixtures/search_parity/matrix.csv
+++ b/tests/fixtures/search_parity/matrix.csv
@@ -1,0 +1,9 @@
+intent_id,category,query,supplier,raw_count,default_filtered_count,query_filtered_count,ranked_count,success,top_result_id,top_distributor_part_number,top_mpn,top_manufacturer,top_price,top_stock_quantity
+RES_10K_0603,RES,10k resistor 0603,mouser,50,50,16,12,True,mouser:652-CR0603AFX1002EAS,652-CR0603AFX1002EAS,CR0603AFX-1002EAS,Bourns,$0.10,29024
+RES_10K_0603,RES,10k resistor 0603,lcsc,2,2,2,2,True,lcsc:C25804,C25804,RC0603FR-0710KL,Yageo,0.004,236000
+CAP_1UF_0805,CAP,1uF capacitor 0805,mouser,50,50,37,28,True,mouser:603-CC805KKX7R7BB105,603-CC805KKX7R7BB105,CC0805KKX7R7BB105,YAGEO,$0.13,133254
+CAP_1UF_0805,CAP,1uF capacitor 0805,lcsc,2,2,1,1,True,lcsc:C15849,C15849,CL21A105KAFNNNE,Samsung Electro-Mechanics,0.009,112000
+IND_100UH,IND,100uH inductor,mouser,50,50,45,45,True,mouser:810-NLFV32T-101K-EFT,810-NLFV32T-101K-EFT,NLFV32T-101K-EFT,TDK,$0.35,3587
+IND_100UH,IND,100uH inductor,lcsc,2,2,2,2,True,lcsc:C77654,C77654,LQH32CN101K53L,Murata,0.044,24000
+LED_GREEN_0603,LED,green LED 0603,mouser,2,1,1,1,True,mouser:604-KP-1608SGC,604-KP-1608SGC,KP-1608SGC,Kingbright,$0.08,15432
+LED_GREEN_0603,LED,green LED 0603,lcsc,2,0,0,0,False,,,,,,0

--- a/tests/services/search/test_parity_artifacts.py
+++ b/tests/services/search/test_parity_artifacts.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+
+from jbom.services.search.diagnostics import SEARCH_DIAGNOSTICS_CONTRACT_VERSION
+from jbom.services.search.parity_artifacts import (
+    PARITY_SUPPLIERS,
+    generate_search_parity_artifacts,
+    write_search_parity_artifacts,
+)
+
+
+def test_parity_artifact_generation_covers_required_categories_and_suppliers() -> None:
+    payload = generate_search_parity_artifacts(max_results_per_supplier=40)
+
+    assert payload["suppliers"] == list(PARITY_SUPPLIERS)
+
+    intents = payload["intents"]
+    categories = {intent["category"] for intent in intents}
+    assert categories == {"RES", "CAP", "IND", "LED"}
+
+    matrix_rows = payload["matrix_rows"]
+    assert len(matrix_rows) == len(intents) * len(PARITY_SUPPLIERS)
+
+    for intent in intents:
+        assert set(intent["suppliers"].keys()) == set(PARITY_SUPPLIERS)
+        for supplier in PARITY_SUPPLIERS:
+            summary = intent["suppliers"][supplier]["summary"]
+            assert summary["raw_count"] >= summary["ranked_count"]
+            assert summary["default_filtered_count"] >= summary["ranked_count"]
+
+
+def test_search_diagnostics_contract_shape_regression() -> None:
+    payload = generate_search_parity_artifacts(max_results_per_supplier=20)
+    first_intent = payload["intents"][0]
+    first_supplier = PARITY_SUPPLIERS[0]
+    diagnostics = first_intent["suppliers"][first_supplier]["diagnostics"]
+
+    assert diagnostics["contract_version"] == SEARCH_DIAGNOSTICS_CONTRACT_VERSION
+    assert set(diagnostics.keys()) == {
+        "contract_version",
+        "query",
+        "category",
+        "raw_count",
+        "default_filtered_count",
+        "query_filtered_count",
+        "ranked_count",
+        "final_result_ids",
+        "default_filter_decisions",
+        "query_filter_decisions",
+        "rank_decisions",
+    }
+
+    default_decision = diagnostics["default_filter_decisions"][0]
+    assert set(default_decision.keys()) == {"result_id", "kept", "reasons"}
+
+    query_decision = diagnostics["query_filter_decisions"][0]
+    assert set(query_decision.keys()) == {"result_id", "kept", "reasons"}
+
+    rank_decision = diagnostics["rank_decisions"][0]
+    assert set(rank_decision.keys()) == {
+        "result_id",
+        "included",
+        "rank",
+        "passive_stock_gate_kept",
+        "relevance_score",
+        "price_value",
+        "canonical_value",
+        "component_library_tier",
+    }
+
+
+def test_write_search_parity_artifacts_emits_expected_files(tmp_path) -> None:
+    matrix_path = tmp_path / "matrix.csv"
+    diagnostics_path = tmp_path / "diagnostics.json"
+
+    payload = write_search_parity_artifacts(
+        matrix_path=matrix_path,
+        diagnostics_path=diagnostics_path,
+        max_results_per_supplier=25,
+    )
+
+    assert matrix_path.exists()
+    assert diagnostics_path.exists()
+
+    loaded = json.loads(diagnostics_path.read_text(encoding="utf-8"))
+    assert loaded["contract_version"] == payload["contract_version"]
+    assert loaded["parity_gaps"] == payload["parity_gaps"]


### PR DESCRIPTION
## Summary
- add deterministic cross-supplier parity artifact generation for RES/CAP/IND/LED intents using committed fixtures
- add structured diagnostics plumbing for default filter, query filter, and ranking decisions (inspectable contract)
- add regression tests for parity matrix coverage and diagnostics contract shape
- document one-command artifact regeneration workflow

## Artifacts
- matrix: `tests/fixtures/search_parity/matrix.csv`
- diagnostics: `tests/fixtures/search_parity/diagnostics.json`
- regenerate: `python scripts/generate_search_parity_artifacts.py`

## Validation
- `pytest tests/services/search/test_filtering.py tests/services/search/test_parity_artifacts.py tests/services/search/test_mouser_contract.py`

## Issue linkage
- child: #199
- parent: #195

Co-Authored-By: Oz <oz-agent@warp.dev>