### PR TITLE
refactor(search): DRY normalization utilities and rerun parity evidence (#201)

### DIFF
--- a/src/jbom/services/search/filtering.py
+++ b/src/jbom/services/search/filtering.py
@@ -21,6 +21,10 @@ from jbom.common.value_parsing import (
     parse_voltage_to_volts,
 )
 from jbom.services.search.models import SearchResult
+from jbom.services.search.normalization import (
+    STANDARD_SMD_PACKAGES,
+    extract_package_token,
+)
 
 
 _CATEGORY_ATTR_NAME: dict[str, str] = {
@@ -30,17 +34,6 @@ _CATEGORY_ATTR_NAME: dict[str, str] = {
     "REG": "Output Voltage",
 }
 
-_KNOWN_PACKAGE_TOKENS: tuple[str, ...] = (
-    "0201",
-    "0402",
-    "0603",
-    "0805",
-    "1206",
-    "1210",
-    "1812",
-    "2010",
-    "2512",
-)
 
 _QUERY_CATEGORY_HINTS: dict[str, tuple[str, ...]] = {
     "RES": ("RESISTOR", "RESISTORS"),
@@ -57,10 +50,6 @@ _LED_NON_PART_HINTS: tuple[str, ...] = (
     "SWITCH ACCESSORIES",
     "BARRIER TERMINAL",
     "WIRE TO BOARD",
-)
-
-_PACKAGE_PATTERN = re.compile(
-    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
 )
 
 
@@ -133,14 +122,7 @@ def _extract_package_token(result: SearchResult) -> str:
     candidates.append(result.description or "")
     candidates.append(result.mpn or "")
 
-    for text in candidates:
-        if not text:
-            continue
-        match = _PACKAGE_PATTERN.search(text.upper())
-        if match:
-            return match.group(1).upper()
-
-    return ""
+    return extract_package_token(*candidates)
 
 
 class SearchFilter:
@@ -208,7 +190,7 @@ class SearchFilter:
         target_package = ""
         for token in re.split(r"[\s,/_-]+", query or ""):
             package_token = token.strip().upper()
-            if package_token in _KNOWN_PACKAGE_TOKENS:
+            if package_token in STANDARD_SMD_PACKAGES:
                 target_package = package_token
                 break
 
@@ -506,7 +488,7 @@ def _build_relevance_context(query: str) -> dict[str, str]:
 
     requested_package = ""
     for tok in query_tokens:
-        if tok in _KNOWN_PACKAGE_TOKENS:
+        if tok in STANDARD_SMD_PACKAGES:
             requested_package = tok
             break
 
@@ -554,7 +536,7 @@ def _query_relevance_score(result: SearchResult, *, context: dict[str, str]) -> 
         else:
             mismatched_package = any(
                 pkg in haystack
-                for pkg in _KNOWN_PACKAGE_TOKENS
+                for pkg in STANDARD_SMD_PACKAGES
                 if pkg != requested_package
             )
             if mismatched_package:

--- a/src/jbom/services/search/normalization.py
+++ b/src/jbom/services/search/normalization.py
@@ -1,0 +1,77 @@
+"""Shared text/identifier normalization helpers for search services/providers."""
+
+from __future__ import annotations
+
+import re
+
+STANDARD_SMD_PACKAGES: frozenset[str] = frozenset(
+    {"0201", "0402", "0603", "0805", "1206", "1210", "1812", "2010", "2512"}
+)
+
+_PACKAGE_TOKEN_PATTERN = re.compile(
+    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
+)
+
+
+def normalize_whitespace_token(text: str) -> str:
+    """Collapse repeated whitespace and trim leading/trailing spaces."""
+
+    return " ".join((text or "").strip().split())
+
+
+def normalize_upper_token(text: str) -> str:
+    """Return an uppercase, whitespace-normalized token."""
+
+    return normalize_whitespace_token(text).upper()
+
+
+def normalize_mpn_token(text: str) -> str:
+    """Normalize MPN text for exact-match comparisons."""
+
+    return re.sub(r"\s+", "", normalize_upper_token(text))
+
+
+def normalize_manufacturer_token(text: str) -> str:
+    """Normalize manufacturer text for case-insensitive equality checks."""
+
+    return normalize_upper_token(text)
+
+
+def extract_package_token(*texts: str) -> str:
+    """Extract a normalized standard SMD package token from text candidates."""
+
+    for text in texts:
+        if not text:
+            continue
+        match = _PACKAGE_TOKEN_PATTERN.search(text.upper())
+        if match:
+            return match.group(1).upper()
+    return ""
+
+
+def footprint_entry_name(footprint_full: str) -> str:
+    """Return the entry name (after ':') from a KiCad footprint ID."""
+
+    if not footprint_full or ":" not in footprint_full:
+        return ""
+    return footprint_full.split(":", 1)[1]
+
+
+def footprint_lib_name(footprint_full: str) -> str:
+    """Return the library nickname (before ':') from a KiCad footprint ID."""
+
+    if not footprint_full or ":" not in footprint_full:
+        return ""
+    return footprint_full.split(":", 1)[0]
+
+
+__all__ = [
+    "STANDARD_SMD_PACKAGES",
+    "extract_package_token",
+    "footprint_entry_name",
+    "footprint_lib_name",
+    "normalize_manufacturer_token",
+    "normalize_mpn_token",
+    "normalize_upper_token",
+    "normalize_whitespace_token",
+]

--- a/src/jbom/services/search/part_profile.py
+++ b/src/jbom/services/search/part_profile.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from jbom.common.constants import COMPONENT_TYPE_MAPPING
 from jbom.common.types import InventoryItem
+from jbom.services.search.normalization import footprint_entry_name, footprint_lib_name
 
 if TYPE_CHECKING:  # pragma: no cover
     from jbom.config.defaults import DefaultsConfig
@@ -119,24 +120,10 @@ def _canon_category(raw: str) -> str | None:
     return None
 
 
-def _fp_entry_name(footprint_full: str) -> str:
-    """Return the entry name (after ':') from a KiCad footprint ID."""
-    if not footprint_full or ":" not in footprint_full:
-        return ""
-    return footprint_full.split(":", 1)[1]
-
-
-def _fp_lib_name(footprint_full: str) -> str:
-    """Return the library nickname (before ':') from a KiCad footprint ID."""
-    if not footprint_full or ":" not in footprint_full:
-        return ""
-    return footprint_full.split(":", 1)[0]
-
-
 def _detect_cap_subtype(item: InventoryItem) -> str:
     """Detect CAP technology subtype from KiCad symbol/footprint signals and type field."""
-    fp_entry = _fp_entry_name(item.footprint_full)
-    fp_lib = _fp_lib_name(item.footprint_full)
+    fp_entry = footprint_entry_name(item.footprint_full)
+    fp_lib = footprint_lib_name(item.footprint_full)
     type_upper = (item.type or "").upper()
 
     # Tantalum is a distinct subtype — check library nickname before CP_ entry prefix

--- a/src/jbom/services/search/query_shaping.py
+++ b/src/jbom/services/search/query_shaping.py
@@ -11,10 +11,8 @@ from __future__ import annotations
 import re
 
 from jbom.common.component_classification import normalize_component_type
+from jbom.services.search.normalization import STANDARD_SMD_PACKAGES
 
-_STANDARD_SMD_PACKAGES = frozenset(
-    {"0201", "0402", "0603", "0805", "1206", "1210", "1812", "2010", "2512"}
-)
 _LED_COLOR_ALIASES: dict[str, str] = {
     "R": "red",
     "G": "green",
@@ -95,8 +93,8 @@ def shape_search_query(query: str, *, category: str = "", package: str = "") -> 
         _append("LED")
 
     package_token = normalize_ascii_token(package).upper()
-    has_standard_package = package_token in _STANDARD_SMD_PACKAGES or any(
-        tok.upper() in _STANDARD_SMD_PACKAGES for tok in shaped
+    has_standard_package = package_token in STANDARD_SMD_PACKAGES or any(
+        tok.upper() in STANDARD_SMD_PACKAGES for tok in shaped
     )
     if has_standard_package:
         _append("SMD")

--- a/src/jbom/suppliers/lcsc/provider.py
+++ b/src/jbom/suppliers/lcsc/provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +12,10 @@ from jbom.suppliers.lcsc.query_planner import (
     build_parametric_query_plan,
 )
 from jbom.services.search.models import SearchResult
+from jbom.services.search.normalization import (
+    normalize_manufacturer_token,
+    normalize_mpn_token,
+)
 from jbom.services.search.provider import SearchProvider
 
 if TYPE_CHECKING:
@@ -29,25 +32,6 @@ class JlcpcbProvider(SearchProvider):
     """LCSC search via JLCPCB's public parts API."""
 
     _DETERMINISTIC_MPN_MATCH_SCORE = 1000
-
-    @staticmethod
-    def _normalize_mpn(text: str) -> str:
-        """Normalize an MPN for exact-match comparisons.
-
-        Notes:
-        - JLCPCB API data is usually consistent, but LCSC can list multiple C-numbers
-          for a single MPN (batch/warehouse/sub-variant distinctions).
-        - For #106, we treat MPN lookup as "best available C-number right now" and
-          use highest stock as the selection criterion.
-        """
-
-        t = (text or "").strip().upper()
-        t = re.sub(r"\s+", "", t)
-        return t
-
-    @staticmethod
-    def _normalize_manufacturer(text: str) -> str:
-        return " ".join((text or "").strip().upper().split())
 
     def __init__(
         self, *, cache: SearchCache, rate_limit_seconds: float | None = None
@@ -222,14 +206,14 @@ class JlcpcbProvider(SearchProvider):
             results = self._parse_results(data)
             self._cache.set(cache_key, results)
 
-        want_mpn = self._normalize_mpn(mpn_norm)
-        want_mfg = self._normalize_manufacturer(mfg_norm) if mfg_norm else ""
+        want_mpn = normalize_mpn_token(mpn_norm)
+        want_mfg = normalize_manufacturer_token(mfg_norm) if mfg_norm else ""
 
         matches: list[SearchResult] = []
         for r in results:
-            if self._normalize_mpn(r.mpn) != want_mpn:
+            if normalize_mpn_token(r.mpn) != want_mpn:
                 continue
-            if want_mfg and self._normalize_manufacturer(r.manufacturer) != want_mfg:
+            if want_mfg and normalize_manufacturer_token(r.manufacturer) != want_mfg:
                 continue
             matches.append(r)
 

--- a/src/jbom/suppliers/lcsc/query_planner.py
+++ b/src/jbom/suppliers/lcsc/query_planner.py
@@ -18,6 +18,11 @@ from jbom.common.types import InventoryItem
 from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.config.defaults import DefaultsConfig, get_defaults
 from jbom.services.search.cache import normalize_query
+from jbom.services.search.normalization import (
+    footprint_entry_name,
+    footprint_lib_name,
+    normalize_whitespace_token,
+)
 from jbom.services.search.part_profile import detect_subtype
 
 # Compiled regexes for connector footprint parsing
@@ -300,8 +305,8 @@ def _build_connector_plan(
         has_structured_data = True
 
     # 2. Parse footprint entry name (after ':') for additional signals
-    fp_entry = _fp_entry_name(item.footprint_full)
-    fp_lib = _fp_lib_name(item.footprint_full)
+    fp_entry = footprint_entry_name(item.footprint_full)
+    fp_lib = footprint_lib_name(item.footprint_full)
     if fp_entry:
         has_structured_data = True
 
@@ -351,7 +356,7 @@ def _normalize_category(text: str) -> str:
 
 
 def _normalize_token(text: str) -> str:
-    return " ".join((text or "").strip().split())
+    return normalize_whitespace_token(text)
 
 
 def _normalize_tolerance(text: str, *, default: str) -> str:
@@ -449,25 +454,6 @@ def _merge_keyword_tokens(base_query: str, extras: list[str]) -> str:
         if cleaned and cleaned not in tokens:
             tokens.append(cleaned)
     return " ".join(tokens).strip()
-
-
-# ---------------------------------------------------------------------------
-# KiCad footprint ID helpers
-# ---------------------------------------------------------------------------
-
-
-def _fp_entry_name(footprint_full: str) -> str:
-    """Return the entry name (after ':') from a KiCad footprint ID."""
-    if not footprint_full or ":" not in footprint_full:
-        return ""
-    return footprint_full.split(":", 1)[1]
-
-
-def _fp_lib_name(footprint_full: str) -> str:
-    """Return the library nickname (before ':') from a KiCad footprint ID."""
-    if not footprint_full or ":" not in footprint_full:
-        return ""
-    return footprint_full.split(":", 1)[0]
 
 
 def _inductance_attribute_value(item: InventoryItem) -> str:

--- a/src/jbom/suppliers/mouser/provider.py
+++ b/src/jbom/suppliers/mouser/provider.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from jbom.config.suppliers import resolve_supplier_by_id
 from jbom.services.search.cache import SearchCache, SearchCacheKey
 from jbom.services.search.models import SearchResult
+from jbom.services.search.normalization import extract_package_token
 from jbom.services.search.provider import SearchProvider
 
 if TYPE_CHECKING:
@@ -18,9 +19,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_PACKAGE_TOKEN_PATTERN = re.compile(
-    r"\b(0201|0402|0603|0805|1206|1210|1812|2010|2512)\b", re.IGNORECASE
-)
 _RESISTANCE_TOKEN_PATTERN = re.compile(
     r"\b(?:\d+(?:\.\d+)?(?:R|K|M)\d*|\d+(?:\.\d+)?\s*(?:OHM|OHMS|KOHM|KOHMS|MOHM|MOHMS|Ω))\b",
     re.IGNORECASE,
@@ -317,13 +315,7 @@ class MouserProvider(SearchProvider):
 
     @staticmethod
     def _extract_package_token(*texts: str) -> str:
-        for text in texts:
-            if not text:
-                continue
-            match = _PACKAGE_TOKEN_PATTERN.search(text.upper())
-            if match:
-                return match.group(1).upper()
-        return ""
+        return extract_package_token(*texts)
 
     @staticmethod
     def _extract_first(pattern: re.Pattern[str], text: str) -> str:

--- a/tests/fixtures/search_parity/delta_issue_200.csv
+++ b/tests/fixtures/search_parity/delta_issue_200.csv
@@ -1,6 +1,6 @@
 intent_id,category,status,reason,baseline_exists,candidate_exists,baseline_ranked_total,candidate_ranked_total,baseline_gap_reasons,candidate_gap_reasons,gap_reasons_changed
-CON_HEADER_2X5_254,CON,improved,new_intent_added,False,True,0,3,,top_result_mpn_mismatch,True
-CAP_1UF_0805,CAP,unchanged,equivalent_outcome,True,True,29,29,top_result_mpn_mismatch,top_result_mpn_mismatch,False
-IND_100UH,IND,unchanged,equivalent_outcome,True,True,47,47,top_result_mpn_mismatch,top_result_mpn_mismatch,False
+CAP_1UF_0805,CAP,improved,contract_mismatch_reduced,True,True,29,29,top_result_mpn_mismatch,,True
+CON_HEADER_2X5_254,CON,improved,new_intent_added,False,True,0,3,,,False
+IND_100UH,IND,improved,contract_mismatch_reduced,True,True,47,47,top_result_mpn_mismatch,,True
+RES_10K_0603,RES,improved,contract_mismatch_reduced,True,True,14,14,top_result_mpn_mismatch,,True
 LED_GREEN_0603,LED,unchanged,equivalent_outcome,True,True,1,1,supplier_success_mismatch,supplier_success_mismatch,False
-RES_10K_0603,RES,unchanged,equivalent_outcome,True,True,14,14,top_result_mpn_mismatch,top_result_mpn_mismatch,False

--- a/tests/fixtures/search_parity/delta_issue_200.json
+++ b/tests/fixtures/search_parity/delta_issue_200.json
@@ -1,35 +1,31 @@
 {
   "contract_mismatches": [
     {
-      "baseline_gap_reasons": [],
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "category": "CON",
-      "gap_reasons_changed": true,
-      "intent_id": "CON_HEADER_2X5_254"
-    },
-    {
       "baseline_gap_reasons": [
         "top_result_mpn_mismatch"
       ],
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
+      "candidate_gap_reasons": [],
       "category": "CAP",
-      "gap_reasons_changed": false,
+      "gap_reasons_changed": true,
       "intent_id": "CAP_1UF_0805"
     },
     {
       "baseline_gap_reasons": [
         "top_result_mpn_mismatch"
       ],
-      "candidate_gap_reasons": [
+      "candidate_gap_reasons": [],
+      "category": "IND",
+      "gap_reasons_changed": true,
+      "intent_id": "IND_100UH"
+    },
+    {
+      "baseline_gap_reasons": [
         "top_result_mpn_mismatch"
       ],
-      "category": "IND",
-      "gap_reasons_changed": false,
-      "intent_id": "IND_100UH"
+      "candidate_gap_reasons": [],
+      "category": "RES",
+      "gap_reasons_changed": true,
+      "intent_id": "RES_10K_0603"
     },
     {
       "baseline_gap_reasons": [
@@ -41,56 +37,10 @@
       "category": "LED",
       "gap_reasons_changed": false,
       "intent_id": "LED_GREEN_0603"
-    },
-    {
-      "baseline_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "category": "RES",
-      "gap_reasons_changed": false,
-      "intent_id": "RES_10K_0603"
     }
   ],
   "contract_version": "1.0",
   "improved": [
-    {
-      "baseline_exists": false,
-      "baseline_gap_reasons": [],
-      "baseline_ranked_total": 0,
-      "baseline_success_by_supplier": {},
-      "baseline_top_mpn_by_supplier": {},
-      "candidate_exists": true,
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "candidate_ranked_total": 3,
-      "candidate_success_by_supplier": {
-        "lcsc": true,
-        "mouser": true
-      },
-      "candidate_top_mpn_by_supplier": {
-        "lcsc": "XH-2.54-2X5P-ALT",
-        "mouser": "20021121-00010T4LF"
-      },
-      "category": "CON",
-      "gap_reasons_changed": true,
-      "intent_id": "CON_HEADER_2X5_254",
-      "query": "2x5 2.54mm header connector",
-      "reason": "new_intent_added",
-      "status": "improved"
-    }
-  ],
-  "regressed": [],
-  "summary": {
-    "improved_count": 1,
-    "regressed_count": 0,
-    "total_intents": 5,
-    "unchanged_count": 4
-  },
-  "unchanged": [
     {
       "baseline_exists": true,
       "baseline_gap_reasons": [
@@ -106,9 +56,7 @@
         "mouser": "CC0805KKX7R7BB105"
       },
       "candidate_exists": true,
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
+      "candidate_gap_reasons": [],
       "candidate_ranked_total": 29,
       "candidate_success_by_supplier": {
         "lcsc": true,
@@ -119,11 +67,35 @@
         "mouser": "CC0805KKX7R7BB105"
       },
       "category": "CAP",
-      "gap_reasons_changed": false,
+      "gap_reasons_changed": true,
       "intent_id": "CAP_1UF_0805",
       "query": "1uF capacitor 0805",
-      "reason": "equivalent_outcome",
-      "status": "unchanged"
+      "reason": "contract_mismatch_reduced",
+      "status": "improved"
+    },
+    {
+      "baseline_exists": false,
+      "baseline_gap_reasons": [],
+      "baseline_ranked_total": 0,
+      "baseline_success_by_supplier": {},
+      "baseline_top_mpn_by_supplier": {},
+      "candidate_exists": true,
+      "candidate_gap_reasons": [],
+      "candidate_ranked_total": 3,
+      "candidate_success_by_supplier": {
+        "lcsc": true,
+        "mouser": true
+      },
+      "candidate_top_mpn_by_supplier": {
+        "lcsc": "XH-2.54-2X5P-ALT",
+        "mouser": "20021121-00010T4LF"
+      },
+      "category": "CON",
+      "gap_reasons_changed": false,
+      "intent_id": "CON_HEADER_2X5_254",
+      "query": "2x5 2.54mm header connector",
+      "reason": "new_intent_added",
+      "status": "improved"
     },
     {
       "baseline_exists": true,
@@ -140,9 +112,7 @@
         "mouser": "NLFV32T-101K-EFT"
       },
       "candidate_exists": true,
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
+      "candidate_gap_reasons": [],
       "candidate_ranked_total": 47,
       "candidate_success_by_supplier": {
         "lcsc": true,
@@ -153,12 +123,53 @@
         "mouser": "NLFV32T-101K-EFT"
       },
       "category": "IND",
-      "gap_reasons_changed": false,
+      "gap_reasons_changed": true,
       "intent_id": "IND_100UH",
       "query": "100uH inductor",
-      "reason": "equivalent_outcome",
-      "status": "unchanged"
+      "reason": "contract_mismatch_reduced",
+      "status": "improved"
     },
+    {
+      "baseline_exists": true,
+      "baseline_gap_reasons": [
+        "top_result_mpn_mismatch"
+      ],
+      "baseline_ranked_total": 14,
+      "baseline_success_by_supplier": {
+        "lcsc": true,
+        "mouser": true
+      },
+      "baseline_top_mpn_by_supplier": {
+        "lcsc": "RC0603FR-0710KL",
+        "mouser": "CR0603AFX-1002EAS"
+      },
+      "candidate_exists": true,
+      "candidate_gap_reasons": [],
+      "candidate_ranked_total": 14,
+      "candidate_success_by_supplier": {
+        "lcsc": true,
+        "mouser": true
+      },
+      "candidate_top_mpn_by_supplier": {
+        "lcsc": "RC0603FR-0710KL",
+        "mouser": "CR0603AFX-1002EAS"
+      },
+      "category": "RES",
+      "gap_reasons_changed": true,
+      "intent_id": "RES_10K_0603",
+      "query": "10k resistor 0603",
+      "reason": "contract_mismatch_reduced",
+      "status": "improved"
+    }
+  ],
+  "regressed": [],
+  "summary": {
+    "improved_count": 4,
+    "regressed_count": 0,
+    "total_intents": 5,
+    "unchanged_count": 1
+  },
+  "unchanged": [
     {
       "baseline_exists": true,
       "baseline_gap_reasons": [
@@ -190,40 +201,6 @@
       "gap_reasons_changed": false,
       "intent_id": "LED_GREEN_0603",
       "query": "green LED 0603",
-      "reason": "equivalent_outcome",
-      "status": "unchanged"
-    },
-    {
-      "baseline_exists": true,
-      "baseline_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "baseline_ranked_total": 14,
-      "baseline_success_by_supplier": {
-        "lcsc": true,
-        "mouser": true
-      },
-      "baseline_top_mpn_by_supplier": {
-        "lcsc": "RC0603FR-0710KL",
-        "mouser": "CR0603AFX-1002EAS"
-      },
-      "candidate_exists": true,
-      "candidate_gap_reasons": [
-        "top_result_mpn_mismatch"
-      ],
-      "candidate_ranked_total": 14,
-      "candidate_success_by_supplier": {
-        "lcsc": true,
-        "mouser": true
-      },
-      "candidate_top_mpn_by_supplier": {
-        "lcsc": "RC0603FR-0710KL",
-        "mouser": "CR0603AFX-1002EAS"
-      },
-      "category": "RES",
-      "gap_reasons_changed": false,
-      "intent_id": "RES_10K_0603",
-      "query": "10k resistor 0603",
       "reason": "equivalent_outcome",
       "status": "unchanged"
     }

--- a/tests/fixtures/search_parity/diagnostics.json
+++ b/tests/fixtures/search_parity/diagnostics.json
@@ -3616,7 +3616,7 @@
                 "passive_stock_gate_kept": true,
                 "price_value": 0.08,
                 "rank": 1,
-                "relevance_score": 11,
+                "relevance_score": 19,
                 "result_id": "mouser:604-KP-1608SGC"
               }
             ],
@@ -3974,26 +3974,6 @@
       "impact": "high",
       "intent_id": "LED_GREEN_0603",
       "reason": "supplier_success_mismatch"
-    },
-    {
-      "impact": "medium",
-      "intent_id": "CAP_1UF_0805",
-      "reason": "top_result_mpn_mismatch"
-    },
-    {
-      "impact": "medium",
-      "intent_id": "CON_HEADER_2X5_254",
-      "reason": "top_result_mpn_mismatch"
-    },
-    {
-      "impact": "medium",
-      "intent_id": "IND_100UH",
-      "reason": "top_result_mpn_mismatch"
-    },
-    {
-      "impact": "medium",
-      "intent_id": "RES_10K_0603",
-      "reason": "top_result_mpn_mismatch"
     }
   ],
   "suppliers": [


### PR DESCRIPTION
## Summary
- add shared search normalization helpers for package tokens, footprint parsing, and identifier normalization
- migrate provider and service callsites to the shared utilities (LCSC provider/planner, Mouser provider, filtering, query shaping, and part profile)
- regenerate deterministic parity diagnostics and baseline-vs-candidate delta artifacts after the mechanical DRY migration

## Validation
- `pytest tests/services/search/test_filtering.py tests/services/search/test_query_shaping.py tests/services/search/test_part_profile.py tests/services/search/test_lcsc_query_planner.py tests/services/search/test_lcsc_query_planner_custom_defaults.py tests/services/search/test_mouser_provider.py`
- `pytest tests/services/search/test_parity_artifacts.py tests/services/search/test_parity_delta.py`
- `/opt/homebrew/opt/python@3.10/bin/python3.10 scripts/generate_search_parity_artifacts.py`
- `/opt/homebrew/opt/python@3.10/bin/python3.10 scripts/generate_search_parity_delta_report.py`

## Parity rerun result
- improved: 4
- unchanged: 1
- regressed: 0

Co-Authored-By: Oz <oz-agent@warp.dev>