### PR TITLE
fix(pos): honor exclude_from_pos_files and natural-sort POS output

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `jbom pos` now honors KiCad PCB `exclude_from_pos_files` markers (issue #210), so footprints explicitly excluded from placement files are no longer emitted in POS/CPL output by default.
 - PCB footprint parsing now preserves all `(attr ...)` tokens plus `layer` and `locked` metadata for downstream consumers, instead of only recording a single mount attribute.
 - POS output rows are now sorted in natural reference order (`R1`, `R2`, `R10`) for consistency with BOM/PARTS output ordering.
+- POS console tables now use data-aware preferred column widths, so wide terminals avoid unnecessary truncation while narrow terminals still shrink/truncate to fit.
 - `jbom audit PROJECT` now emits review-first CURRENT/SUGGESTED couplet rows with
   richer component context (`Value`, `Footprint`, `Package`, `Description`), concise
   per-reference missing-attribute notes, and safe default `Action=SKIP` guidance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   (e.g. wavelength) requires one entry here plus a new `make_component_id` parameter.
 
 ### Changed
+- `jbom pos` now honors KiCad PCB `exclude_from_pos_files` markers (issue #210), so footprints explicitly excluded from placement files are no longer emitted in POS/CPL output by default.
+- PCB footprint parsing now preserves all `(attr ...)` tokens plus `layer` and `locked` metadata for downstream consumers, instead of only recording a single mount attribute.
+- POS output rows are now sorted in natural reference order (`R1`, `R2`, `R10`) for consistency with BOM/PARTS output ordering.
 - `jbom audit PROJECT` now emits review-first CURRENT/SUGGESTED couplet rows with
   richer component context (`Value`, `Footprint`, `Package`, `Description`), concise
   per-reference missing-attribute notes, and safe default `Action=SKIP` guidance.

--- a/features/pos/filtering.feature
+++ b/features/pos/filtering.feature
@@ -55,6 +55,22 @@ Feature: POS Filtering
     And the output should contain "C1"
     And the output should not contain "R2"
     And the output should not contain "R3"
+  Scenario: Preserve PCB attr metadata and respect exclude_from_pos_files
+    Given a PCB that contains:
+      | Reference | X  | Y  | Rotation | Side | Footprint   | Attrs                            | Locked |
+      | R10       | 30 | 10 | 0        | TOP  | R_0805_2012 | smd exclude_from_bom             | Yes    |
+      | R2        | 20 | 10 | 0        | TOP  | R_0805_2012 | smd                              | No     |
+      | R1        | 10 | 10 | 0        | TOP  | R_0805_2012 | smd exclude_from_pos_files       | No     |
+      | V1        | 40 | 10 | 0        | TOP  | R_0805_2012 | virtual                          | No     |
+    When I run jbom command "pos -f reference,mount_type,exclude_from_bom,locked -o -"
+    Then the command should succeed
+    And the line count is 3
+    And R2 appears before R10 in the output
+    And the CSV output has rows where:
+      | Reference | Mount Type | Exclude From BOM | Locked |
+      | R2        | smd        |                  |        |
+      | R10       | smd        | yes              | yes    |
+      | V1        | virtual    |                  |        |
 
   # TODO: Should use --generic flag when Issue #26 (POS field selection) is implemented
 

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -343,6 +343,8 @@ def given_simple_pcb(context) -> None:
                 "Value": r.get("value", r.get("Value", "")),
                 "Package": r.get("package", r.get("Package", "")),
                 "SMD": r.get("smd", r.get("SMD", "")),
+                "Attrs": r.get("attrs", r.get("Attrs", "")),
+                "Locked": r.get("locked", r.get("Locked", "")),
             }
         )
     # Write PCB file in correct location
@@ -360,35 +362,46 @@ def given_simple_pcb(context) -> None:
         # Map TOP/BOTTOM to KiCad layer names
         layer = "F.Cu" if side == "TOP" else "B.Cu"
 
-        # Use explicit SMD data from table if provided, otherwise apply useful heuristics
-        smd_value = comp.get("SMD", "").upper()
-        if smd_value in ["SMD", "TRUE", "1"]:
-            attr = "(attr smd)"
-        elif smd_value in ["PTH", "THROUGH_HOLE", "FALSE", "0"]:
-            attr = "(attr through_hole)"
-        else:
-            # Apply heuristics for real-world footprint patterns (useful for actual usage)
-            smd_patterns = [
-                "_0603_",
-                "_0805_",
-                "_1206_",
-                "_SOT",
-                "_SOIC",
-                "_QFN",
-                "_BGA",
-                "_LGA",
+        attrs_value = str(comp.get("Attrs", "") or "").strip()
+        if attrs_value:
+            attr_tokens = [
+                token
+                for token in attrs_value.replace(",", " ").split()
+                if token.strip()
             ]
-            through_hole_patterns = ["_Axial_", "_Radial_", "_DIP", "_TO-"]
+            attr = f"(attr {' '.join(attr_tokens)})" if attr_tokens else ""
+        else:
+            # Use explicit SMD data from table if provided, otherwise apply useful heuristics
+            smd_value = comp.get("SMD", "").upper()
+            if smd_value in ["SMD", "TRUE", "1"]:
+                attr = "(attr smd)"
+            elif smd_value in ["PTH", "THROUGH_HOLE", "FALSE", "0"]:
+                attr = "(attr through_hole)"
+            else:
+                # Apply heuristics for real-world footprint patterns (useful for actual usage)
+                smd_patterns = [
+                    "_0603_",
+                    "_0805_",
+                    "_1206_",
+                    "_SOT",
+                    "_SOIC",
+                    "_QFN",
+                    "_BGA",
+                    "_LGA",
+                ]
+                through_hole_patterns = ["_Axial_", "_Radial_", "_DIP", "_TO-"]
 
-            attr = "(attr smd)"  # Default assumption
-            for pattern in smd_patterns:
-                if pattern in footprint:
-                    attr = "(attr smd)"
-                    break
-            for pattern in through_hole_patterns:
-                if pattern in footprint:
-                    attr = "(attr through_hole)"
-                    break
+                attr = "(attr smd)"  # Default assumption
+                for pattern in smd_patterns:
+                    if pattern in footprint:
+                        attr = "(attr smd)"
+                        break
+                for pattern in through_hole_patterns:
+                    if pattern in footprint:
+                        attr = "(attr through_hole)"
+                        break
+        locked_value = str(comp.get("Locked", "") or "").strip().lower()
+        is_locked = locked_value in {"yes", "true", "1", "locked"}
 
         # Build properties list
         properties = [f'(property "Reference" "{ref}")']
@@ -399,10 +412,16 @@ def given_simple_pcb(context) -> None:
 
         properties_str = "\n    ".join(properties)
 
-        # Always include attr since we always determine one (explicit or heuristic)
-        footprints.append(
-            f'  (footprint "{footprint}" (at {x} {y} {rotation}) (layer "{layer}")\n    {properties_str}\n    {attr}\n  )'
-        )
+        footprint_lines = [
+            f'  (footprint "{footprint}" (at {x} {y} {rotation}) (layer "{layer}")',
+            f"    {properties_str}",
+        ]
+        if attr:
+            footprint_lines.append(f"    {attr}")
+        if is_locked:
+            footprint_lines.append("    (locked)")
+        footprint_lines.append("  )")
+        footprints.append("\n".join(footprint_lines))
 
     pcb_content = f"""(kicad_pcb (version 20211014) (generator pcbnew)
   (paper "A4")

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -691,7 +691,8 @@ def _build_pos_console_columns(
     """Build POS console columns with data-aware preferred widths."""
 
     columns: list[Column] = []
-    for field_name, header in zip(selected_fields, headers):
+    last_column_index = len(headers) - 1
+    for column_index, (field_name, header) in enumerate(zip(selected_fields, headers)):
         max_value_width = max(
             (len(str(row.get(header, ""))) for row in rows), default=0
         )
@@ -699,6 +700,8 @@ def _build_pos_console_columns(
             len(header),
             min(max_value_width, _MAX_POS_CONSOLE_COLUMN_WIDTH),
         )
+        if column_index == last_column_index:
+            preferred_width += 1
         columns.append(
             Column(
                 header=header,

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -49,6 +49,7 @@ from jbom.services.fabricator_projection_service import FabricatorProjectionServ
 
 _NUMERIC_POS_FIELDS: frozenset[str] = frozenset({"x", "y", "rotation"})
 _POS_SOURCE_PRIORITY = "pis"
+_MAX_POS_CONSOLE_COLUMN_WIDTH = 50
 _POS_COMPUTED_FIELDS: tuple[str, ...] = (
     "reference",
     "x",
@@ -671,19 +672,43 @@ def _print_console_table(
         }
         for entry in pos_data
     ]
-    columns = [
-        Column(
-            header=h,
-            key=h,
-            preferred_width=max(10, len(h)),
-            wrap=False,
-            align="right" if f in _NUMERIC_POS_FIELDS else "left",
-        )
-        for f, h in zip(selected_fields, headers)
-    ]
+    columns = _build_pos_console_columns(
+        selected_fields=selected_fields,
+        headers=headers,
+        rows=rows,
+    )
     print_table(rows, columns, terminal_width=get_terminal_width())
 
     print(f"\nTotal: {len(pos_data)} components")
+
+
+def _build_pos_console_columns(
+    *,
+    selected_fields: list[str],
+    headers: list[str],
+    rows: list[dict[str, str]],
+) -> list[Column]:
+    """Build POS console columns with data-aware preferred widths."""
+
+    columns: list[Column] = []
+    for field_name, header in zip(selected_fields, headers):
+        max_value_width = max(
+            (len(str(row.get(header, ""))) for row in rows), default=0
+        )
+        preferred_width = max(
+            len(header),
+            min(max_value_width, _MAX_POS_CONSOLE_COLUMN_WIDTH),
+        )
+        columns.append(
+            Column(
+                header=header,
+                key=header,
+                preferred_width=preferred_width,
+                wrap=False,
+                align="right" if field_name in _NUMERIC_POS_FIELDS else "left",
+            )
+        )
+    return columns
 
 
 def _print_csv(

--- a/src/jbom/services/pcb_reader.py
+++ b/src/jbom/services/pcb_reader.py
@@ -174,6 +174,7 @@ class DefaultKiCadReaderService(KiCadReaderService):
             ):
                 layer_name = child[1]
                 side = "TOP" if layer_name.startswith("F.") else "BOTTOM"
+                attributes["layer"] = layer_name
 
             elif head == Symbol("at") and len(child) >= 3:
                 # (at x y [rot])
@@ -216,10 +217,34 @@ class DefaultKiCadReaderService(KiCadReaderService):
                     pass
 
             elif head == Symbol("attr"):
-                # (attr smd) or (attr through_hole)
-                if len(child) >= 2:
-                    attr_type = str(child[1])
-                    attributes["mount_type"] = attr_type
+                # (attr smd), (attr through_hole), and optional flags like
+                # exclude_from_pos_files / exclude_from_bom.
+                attr_tokens: list[str] = []
+                for raw_token in child[1:]:
+                    token = str(raw_token or "").strip()
+                    if not token:
+                        continue
+                    attr_tokens.append(token)
+                    attributes[token] = "yes"
+
+                mount_type = ""
+                for token in attr_tokens:
+                    if token in {
+                        "smd",
+                        "through_hole",
+                        "through-hole",
+                        "tht",
+                        "virtual",
+                    }:
+                        mount_type = token
+                        break
+                if not mount_type and attr_tokens:
+                    mount_type = attr_tokens[0]
+                if mount_type:
+                    attributes["mount_type"] = mount_type
+
+            elif head == Symbol("locked"):
+                attributes["locked"] = "yes"
 
         if not ref:
             return None

--- a/src/jbom/services/pos_generator.py
+++ b/src/jbom/services/pos_generator.py
@@ -2,6 +2,7 @@
 
 This service generates component placement files from PCB data.
 """
+import re
 from typing import List
 
 from jbom.common.fields import normalize_field_name
@@ -68,6 +69,9 @@ class POSGenerator:
                     entry.setdefault(attribute_key, attribute_value)
 
                 pos_entries.append(entry)
+        pos_entries.sort(
+            key=lambda entry: self._natural_sort_key(str(entry.get("reference", "")))
+        )
 
         return pos_entries
 
@@ -83,8 +87,45 @@ class POSGenerator:
         if self.options.layer_filter:
             if component.side.upper() != self.options.layer_filter:
                 return False
+        if self._is_excluded_from_position_files(component):
+            return False
 
         return True
+
+    def _is_excluded_from_position_files(self, component: PcbComponent) -> bool:
+        """Return True if PCB metadata marks the component as position-file excluded."""
+
+        normalized_attributes = self._normalize_component_attributes(
+            component.attributes
+        )
+        return any(
+            self._is_truthy_marker(normalized_attributes.get(flag_name))
+            for flag_name in ("exclude_from_pos_files", "exclude_from_position_files")
+        )
+
+    @staticmethod
+    def _is_truthy_marker(value: object) -> bool:
+        """Return True when a marker value should be interpreted as enabled."""
+
+        if isinstance(value, bool):
+            return value
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return False
+        return normalized in {"1", "true", "t", "yes", "y", "x"}
+
+    @staticmethod
+    def _natural_sort_key(reference: str) -> list[object]:
+        """Return natural sort key for component references (R1, R2, R10)."""
+
+        parts = re.split(r"(\d+)", reference)
+        result: list[object] = []
+        for part in parts:
+            if part.isdigit():
+                result.append(int(part))
+            else:
+                result.append(part)
+        return result
 
     @staticmethod
     def _normalize_component_attributes(attributes: dict[str, str]) -> dict[str, str]:

--- a/tests/unit/test_pcb_reader.py
+++ b/tests/unit/test_pcb_reader.py
@@ -1,0 +1,59 @@
+"""Unit tests for PCB reader attribute extraction behavior."""
+
+from __future__ import annotations
+
+from sexpdata import Symbol
+
+from jbom.services.pcb_reader import DefaultKiCadReaderService
+
+
+def _footprint_node(
+    attr_tokens: list[str],
+    *,
+    locked: bool = False,
+) -> list[object]:
+    """Build a minimal footprint S-expression node for parser unit tests."""
+
+    node: list[object] = [
+        Symbol("footprint"),
+        "Resistor_SMD:R_0805_2012Metric",
+        [Symbol("layer"), "F.Cu"],
+        [Symbol("at"), "10", "20", "90"],
+        [Symbol("property"), "Reference", "R1"],
+        [Symbol("property"), "Value", "10K"],
+    ]
+    if attr_tokens:
+        node.append([Symbol("attr"), *[Symbol(token) for token in attr_tokens]])
+    if locked:
+        node.append([Symbol("locked")])
+    return node
+
+
+def test_parse_footprint_node_records_all_attr_tokens_and_locked_flag() -> None:
+    """PCB reader should preserve all `attr` tokens, layer, and locked metadata."""
+
+    reader = DefaultKiCadReaderService()
+    parsed = reader._parse_footprint_node(
+        _footprint_node(
+            ["smd", "exclude_from_pos_files", "exclude_from_bom"],
+            locked=True,
+        )
+    )
+
+    assert parsed is not None
+    assert parsed.attributes["mount_type"] == "smd"
+    assert parsed.attributes["smd"] == "yes"
+    assert parsed.attributes["exclude_from_pos_files"] == "yes"
+    assert parsed.attributes["exclude_from_bom"] == "yes"
+    assert parsed.attributes["locked"] == "yes"
+    assert parsed.attributes["layer"] == "F.Cu"
+
+
+def test_parse_footprint_node_preserves_unknown_attr_tokens() -> None:
+    """Unexpected attr tokens should still be recorded for downstream consumers."""
+
+    reader = DefaultKiCadReaderService()
+    parsed = reader._parse_footprint_node(_footprint_node(["custom_attr_flag"]))
+
+    assert parsed is not None
+    assert parsed.attributes["custom_attr_flag"] == "yes"

--- a/tests/unit/test_pos_cli_field_resolution.py
+++ b/tests/unit/test_pos_cli_field_resolution.py
@@ -167,6 +167,23 @@ def test_build_pos_console_columns_uses_data_aware_widths() -> None:
     )
 
     package_column = next(column for column in columns if column.key == "Package")
+    assert package_column.preferred_width == len("Connector_Generic:Conn_01x03") + 1
+
+
+def test_build_pos_console_columns_does_not_pad_non_final_columns() -> None:
+    rows = [
+        {
+            "Designator": "J1",
+            "Package": "Connector_Generic:Conn_01x03",
+        }
+    ]
+    columns = _build_pos_console_columns(
+        selected_fields=["package", "reference"],
+        headers=["Package", "Designator"],
+        rows=rows,
+    )
+
+    package_column = next(column for column in columns if column.key == "Package")
     assert package_column.preferred_width == len("Connector_Generic:Conn_01x03")
 
 
@@ -200,3 +217,32 @@ def test_pos_console_table_respects_terminal_width_shrinking() -> None:
     ]
     assert lines_with_columns
     assert all(len(line) <= 70 for line in lines_with_columns)
+
+
+def test_pos_console_table_adds_trailing_padding_to_last_column() -> None:
+    pos_data = [
+        {
+            "reference": "J1",
+            "package": "Connector_Generic:Conn_01x03",
+        }
+    ]
+    selected_fields = ["reference", "package"]
+    headers = ["Designator", "Package"]
+
+    output = io.StringIO()
+    with patch("jbom.cli.pos.get_terminal_width", return_value=200):
+        with redirect_stdout(output):
+            _print_console_table(
+                pos_data,
+                selected_fields,
+                headers,
+                fabricator_id="generic",
+                fabricator_config=None,
+            )
+
+    data_line = next(
+        line
+        for line in output.getvalue().splitlines()
+        if "Connector_Generic:Conn_01x03" in line
+    )
+    assert data_line.endswith(" ")

--- a/tests/unit/test_pos_cli_field_resolution.py
+++ b/tests/unit/test_pos_cli_field_resolution.py
@@ -1,9 +1,14 @@
 """Unit tests for POS CLI projection and field resolution helpers."""
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
 
 from jbom.cli.pos import (
     _apply_pos_dnp_filter,
+    _build_pos_console_columns,
     _enrich_pos_with_merge_namespaces,
     _get_pos_field_value,
+    _print_console_table,
     _resolve_pos_output_projection,
 )
 from jbom.services.component_merge_service import (
@@ -146,3 +151,52 @@ def test_pos_dnp_filter_respects_include_dnp_flag() -> None:
     rows = [{"reference": "U1", "s:dnp": "Yes"}]
     filtered = _apply_pos_dnp_filter(rows, component_filters={"exclude_dnp": False})
     assert [row["reference"] for row in filtered] == ["U1"]
+
+
+def test_build_pos_console_columns_uses_data_aware_widths() -> None:
+    rows = [
+        {
+            "Designator": "J1",
+            "Package": "Connector_Generic:Conn_01x03",
+        }
+    ]
+    columns = _build_pos_console_columns(
+        selected_fields=["reference", "package"],
+        headers=["Designator", "Package"],
+        rows=rows,
+    )
+
+    package_column = next(column for column in columns if column.key == "Package")
+    assert package_column.preferred_width == len("Connector_Generic:Conn_01x03")
+
+
+def test_pos_console_table_respects_terminal_width_shrinking() -> None:
+    pos_data = [
+        {
+            "reference": "J1",
+            "x_mm": 123.4567,
+            "y_mm": 89.0123,
+            "rotation": 90.0,
+            "side": "TOP",
+            "package": "Connector_Generic:Conn_01x03",
+        }
+    ]
+    selected_fields = ["reference", "x", "y", "side", "rotation", "package"]
+    headers = ["Designator", "Mid X", "Mid Y", "Layer", "Rotation", "Package"]
+
+    output = io.StringIO()
+    with patch("jbom.cli.pos.get_terminal_width", return_value=70):
+        with redirect_stdout(output):
+            _print_console_table(
+                pos_data,
+                selected_fields,
+                headers,
+                fabricator_id="generic",
+                fabricator_config=None,
+            )
+
+    lines_with_columns = [
+        line for line in output.getvalue().splitlines() if " | " in line
+    ]
+    assert lines_with_columns
+    assert all(len(line) <= 70 for line in lines_with_columns)

--- a/tests/unit/test_pos_generator.py
+++ b/tests/unit/test_pos_generator.py
@@ -1,0 +1,78 @@
+"""Unit tests for POSGenerator filtering and ordering behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jbom.common.options import PlacementOptions
+from jbom.common.pcb_types import BoardModel, PcbComponent
+from jbom.services.pos_generator import POSGenerator
+
+
+def _pcb_component(
+    reference: str,
+    *,
+    attributes: dict[str, str] | None = None,
+) -> PcbComponent:
+    """Build a minimal PCB component for POS generator tests."""
+
+    return PcbComponent(
+        reference=reference,
+        footprint_name="Resistor_SMD:R_0805_2012Metric",
+        package_token="0805",
+        center_x_mm=10.0,
+        center_y_mm=20.0,
+        rotation_deg=0.0,
+        side="TOP",
+        attributes=attributes or {},
+    )
+
+
+def test_generate_pos_data_excludes_position_file_marked_components() -> None:
+    """POS output should omit references marked as excluded from position files."""
+
+    board = BoardModel(
+        path=Path("project.kicad_pcb"),
+        footprints=[
+            _pcb_component("R1", attributes={"mount_type": "smd"}),
+            _pcb_component(
+                "R2",
+                attributes={
+                    "mount_type": "smd",
+                    "exclude_from_pos_files": "yes",
+                },
+            ),
+            _pcb_component(
+                "R3",
+                attributes={
+                    "mount_type": "smd",
+                    "Exclude From Position Files": "Yes",
+                },
+            ),
+        ],
+    )
+
+    pos_data = POSGenerator(options=PlacementOptions(smd_only=False)).generate_pos_data(
+        board
+    )
+
+    assert [row["reference"] for row in pos_data] == ["R1"]
+
+
+def test_generate_pos_data_sorts_references_in_natural_order() -> None:
+    """POS output should use natural reference ordering for deterministic UX."""
+
+    board = BoardModel(
+        path=Path("project.kicad_pcb"),
+        footprints=[
+            _pcb_component("R10", attributes={"mount_type": "smd"}),
+            _pcb_component("R2", attributes={"mount_type": "smd"}),
+            _pcb_component("R1", attributes={"mount_type": "smd"}),
+        ],
+    )
+
+    pos_data = POSGenerator(options=PlacementOptions(smd_only=False)).generate_pos_data(
+        board
+    )
+
+    assert [row["reference"] for row in pos_data] == ["R1", "R2", "R10"]


### PR DESCRIPTION
## Summary
- fix issue #210 by honoring KiCad PCB `exclude_from_pos_files` markers in POS/CPL generation
- parse and preserve all footprint `(attr ...)` tokens plus `layer` and `locked` metadata for downstream consumers
- apply natural reference sorting to POS output for stable ordering (e.g. `R1, R2, R10`)
- add regression coverage in both unit tests and Behave POS scenarios, including fixture support for explicit PCB attrs/locked flags
- update docs changelog with the issue #210 behavior change

## Validation
- `pytest` (full suite): 985 passed
- `python -m behave --format progress` (full suite): 42 features passed

## Links
- Closes #210

Co-Authored-By: Oz <oz-agent@warp.dev>