### PR TITLE
fix: unify natural reference sorting across outputs

### DIFF
--- a/src/jbom/common/reference_sort.py
+++ b/src/jbom/common/reference_sort.py
@@ -1,0 +1,26 @@
+"""Reference designator natural sorting helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+_NATURAL_TOKEN_SPLIT = re.compile(r"(\d+)")
+
+
+def natural_reference_sort_key(reference: str) -> list[object]:
+    """Return a natural sort key for a component reference designator."""
+    normalized_reference = str(reference or "")
+    key: list[object] = []
+    for token in _NATURAL_TOKEN_SPLIT.split(normalized_reference):
+        if token.isdigit():
+            key.append(int(token))
+        else:
+            key.append(token)
+    return key
+
+
+def natural_sort_references(references: Iterable[str]) -> list[str]:
+    """Return component references sorted in natural alphanumeric order."""
+    normalized_references = [str(reference or "") for reference in references]
+    return sorted(normalized_references, key=natural_reference_sort_key)

--- a/src/jbom/services/bom_generator.py
+++ b/src/jbom/services/bom_generator.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 from jbom.common.types import Component
 from jbom.common.component_filters import apply_component_filters
 from jbom.common.fields import normalize_field_name
+from jbom.common.reference_sort import (
+    natural_reference_sort_key,
+    natural_sort_references,
+)
 
 
 @dataclass
@@ -22,7 +26,7 @@ class BOMEntry:
     @property
     def references_string(self) -> str:
         """Comma-separated string of references for display."""
-        return ", ".join(BOMGenerator._natural_sort_references(self.references))
+        return ", ".join(natural_sort_references(self.references))
 
 
 @dataclass
@@ -78,7 +82,11 @@ class BOMGenerator:
         entries = self._aggregate_components(filtered_components)
 
         # Sort entries by first reference for consistent output
-        entries.sort(key=lambda e: e.references[0])
+        entries.sort(
+            key=lambda entry: natural_reference_sort_key(
+                entry.references[0] if entry.references else ""
+            )
+        )
 
         return BOMData(
             project_name=project_name,
@@ -128,7 +136,9 @@ class BOMGenerator:
 
         # Collect unique references (multi-unit components like dual op-amps
         # produce multiple symbol instances with the same reference)
-        references = list(dict.fromkeys(comp.reference for comp in components))
+        references = natural_sort_references(
+            dict.fromkeys(comp.reference for comp in components)
+        )
 
         # Merge properties from all components, normalizing keys to snake_case
         # so that _get_field_value() lookups (e.g. 'description', 'package') always match.
@@ -152,22 +162,3 @@ class BOMGenerator:
             quantity=len(references),
             attributes=merged_attributes,
         )
-
-    @staticmethod
-    def _natural_sort_references(references: List[str]) -> List[str]:
-        """Sort component references in natural order (R1, R2, R10 not R1, R10, R2)."""
-        import re
-
-        def natural_key(ref: str):
-            # Split reference into prefix and numeric parts
-            # E.g., "R10" -> [("R", 0), ("", 10)]
-            parts = re.split(r"(\d+)", ref)
-            result = []
-            for part in parts:
-                if part.isdigit():
-                    result.append(int(part))
-                else:
-                    result.append(part)
-            return result
-
-        return sorted(references, key=natural_key)

--- a/src/jbom/services/component_merge_service.py
+++ b/src/jbom/services/component_merge_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Literal
+from jbom.common.reference_sort import natural_reference_sort_key
 
 from jbom.services.project_component_collector import (
     ProjectComponentGraph,
@@ -152,7 +153,7 @@ def _resolve_grouped_annotation_field_value(
     for summary, references in sorted_groups:
         ordered_references = sorted(
             {str(reference or "").strip() for reference in references if reference},
-            key=_natural_reference_sort_key,
+            key=natural_reference_sort_key,
         )
         if not ordered_references:
             continue
@@ -214,26 +215,11 @@ def _group_reference_sort_key(references: list[str]) -> list[object]:
         return []
     ordered_references = sorted(
         {str(reference or "").strip() for reference in references if reference},
-        key=_natural_reference_sort_key,
+        key=natural_reference_sort_key,
     )
     if not ordered_references:
         return []
-    return _natural_reference_sort_key(ordered_references[0])
-
-
-def _natural_reference_sort_key(reference: str) -> list[object]:
-    """Generate natural sort keys for reference designators."""
-
-    import re
-
-    parts = re.split(r"(\d+)", str(reference or ""))
-    key: list[object] = []
-    for part in parts:
-        if part.isdigit():
-            key.append(int(part))
-        else:
-            key.append(part)
-    return key
+    return natural_reference_sort_key(ordered_references[0])
 
 
 class ComponentMergeService:

--- a/src/jbom/services/parts_list_generator.py
+++ b/src/jbom/services/parts_list_generator.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass, field
 
 from jbom.common.types import Component
 from jbom.common.component_filters import apply_component_filters
+from jbom.common.reference_sort import (
+    natural_reference_sort_key,
+    natural_sort_references,
+)
 
 
 @dataclass
@@ -76,7 +80,11 @@ class PartsListGenerator:
         entries = self._create_grouped_entries(filtered_components)
 
         # Sort groups by first reference in natural order
-        entries.sort(key=lambda e: self._natural_sort_key(e.refs[0] if e.refs else ""))
+        entries.sort(
+            key=lambda entry: natural_reference_sort_key(
+                entry.refs[0] if entry.refs else ""
+            )
+        )
 
         return PartsListData(
             project_name=project_name,
@@ -111,10 +119,7 @@ class PartsListGenerator:
         entries: List[PartsListEntry] = []
         for group in grouped_components.values():
             representative = group[0]
-            refs = sorted(
-                [component.reference for component in group],
-                key=self._natural_sort_key,
-            )
+            refs = natural_sort_references([component.reference for component in group])
             entry = PartsListEntry(
                 refs=refs,
                 value=representative.value,
@@ -167,18 +172,3 @@ class PartsListGenerator:
             if value:
                 return value
         return fallback
-
-    def _natural_sort_key(self, reference: str) -> List[Any]:
-        """Generate natural sort key for references (R1, R2, R10 not R1, R10, R2)."""
-        import re
-
-        # Split reference into prefix and numeric parts
-        # E.g., "R10" -> ["R", "10"] -> ["R", 10]
-        parts = re.split(r"(\d+)", reference)
-        result = []
-        for part in parts:
-            if part.isdigit():
-                result.append(int(part))
-            else:
-                result.append(part)
-        return result

--- a/src/jbom/services/pos_generator.py
+++ b/src/jbom/services/pos_generator.py
@@ -2,12 +2,12 @@
 
 This service generates component placement files from PCB data.
 """
-import re
 from typing import List
 
 from jbom.common.fields import normalize_field_name
 from jbom.common.pcb_types import BoardModel, PcbComponent
 from jbom.common.options import PlacementOptions
+from jbom.common.reference_sort import natural_reference_sort_key
 
 
 class POSGenerator:
@@ -70,7 +70,9 @@ class POSGenerator:
 
                 pos_entries.append(entry)
         pos_entries.sort(
-            key=lambda entry: self._natural_sort_key(str(entry.get("reference", "")))
+            key=lambda entry: natural_reference_sort_key(
+                str(entry.get("reference", ""))
+            )
         )
 
         return pos_entries
@@ -113,19 +115,6 @@ class POSGenerator:
         if not normalized:
             return False
         return normalized in {"1", "true", "t", "yes", "y", "x"}
-
-    @staticmethod
-    def _natural_sort_key(reference: str) -> list[object]:
-        """Return natural sort key for component references (R1, R2, R10)."""
-
-        parts = re.split(r"(\d+)", reference)
-        result: list[object] = []
-        for part in parts:
-            if part.isdigit():
-                result.append(int(part))
-            else:
-                result.append(part)
-        return result
 
     @staticmethod
     def _normalize_component_attributes(attributes: dict[str, str]) -> dict[str, str]:

--- a/tests/services/generators/test_bom_generator.py
+++ b/tests/services/generators/test_bom_generator.py
@@ -141,6 +141,65 @@ class TestBOMGenerator:
         assert entries[1].references == ["R1"]
         assert entries[1].value == "10K"
 
+    def test_generate_bom_data_sorts_entries_by_natural_reference(self):
+        """Test aggregated BOM rows are sorted by natural first reference."""
+        generator = BOMGenerator()
+        components = [
+            Component(
+                reference="J10",
+                lib_id="Connector_Generic:Conn_01x02",
+                value="ConnA",
+                footprint="Connector:Test",
+                uuid="uuid-j10",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="J1",
+                lib_id="Connector_Generic:Conn_01x02",
+                value="ConnB",
+                footprint="Connector:Test",
+                uuid="uuid-j1",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="LEDCOM0",
+                lib_id="Connector_Generic:Conn_01x02",
+                value="ConnC",
+                footprint="Connector:Grouped",
+                uuid="uuid-ledcom0",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+            Component(
+                reference="GND0",
+                lib_id="Connector_Generic:Conn_01x02",
+                value="ConnC",
+                footprint="Connector:Grouped",
+                uuid="uuid-gnd0",
+                properties={},
+                in_bom=True,
+                exclude_from_sim=False,
+                dnp=False,
+            ),
+        ]
+
+        bom_data = generator.generate_bom_data(components)
+
+        assert [entry.references[0] for entry in bom_data.entries] == [
+            "GND0",
+            "J1",
+            "J10",
+        ]
+        assert bom_data.entries[0].references == ["GND0", "LEDCOM0"]
+
     def test_apply_filters_exclude_dnp(self):
         """Test filtering excludes DNP components."""
         generator = BOMGenerator()

--- a/tests/unit/test_parts_list_generator.py
+++ b/tests/unit/test_parts_list_generator.py
@@ -113,3 +113,17 @@ def test_refs_are_sorted_naturally_within_aggregated_row() -> None:
 
     assert len(data.entries) == 1
     assert data.entries[0].refs == ["R1", "R2", "R10"]
+
+
+def test_groups_are_sorted_by_natural_first_reference() -> None:
+    components = [
+        _component("J10", "Connector-A", "Connector_A"),
+        _component("J1", "Connector-B", "Connector_B"),
+        _component("GND0", "Connector-C", "Connector_C"),
+    ]
+
+    data = PartsListGenerator().generate_parts_list_data(
+        components, project_name="Test"
+    )
+
+    assert [entry.refs[0] for entry in data.entries] == ["GND0", "J1", "J10"]

--- a/tests/unit/test_pos_generator.py
+++ b/tests/unit/test_pos_generator.py
@@ -76,3 +76,23 @@ def test_generate_pos_data_sorts_references_in_natural_order() -> None:
     )
 
     assert [row["reference"] for row in pos_data] == ["R1", "R2", "R10"]
+
+
+def test_generate_pos_data_sorts_by_prefix_and_numeric_suffix() -> None:
+    """POS output should sort by prefix first, then by natural numeric suffix."""
+
+    board = BoardModel(
+        path=Path("project.kicad_pcb"),
+        footprints=[
+            _pcb_component("J10", attributes={"mount_type": "smd"}),
+            _pcb_component("IO1", attributes={"mount_type": "smd"}),
+            _pcb_component("GND0", attributes={"mount_type": "smd"}),
+            _pcb_component("J1", attributes={"mount_type": "smd"}),
+        ],
+    )
+
+    pos_data = POSGenerator(options=PlacementOptions(smd_only=False)).generate_pos_data(
+        board
+    )
+
+    assert [row["reference"] for row in pos_data] == ["GND0", "IO1", "J1", "J10"]

--- a/tests/unit/test_reference_sort.py
+++ b/tests/unit/test_reference_sort.py
@@ -1,0 +1,26 @@
+"""Unit tests for shared reference sorting helpers."""
+
+from jbom.common.reference_sort import (
+    natural_reference_sort_key,
+    natural_sort_references,
+)
+
+
+def test_natural_sort_references_orders_numeric_suffixes() -> None:
+    """Natural sorting should order numeric suffixes by integer value."""
+
+    references = ["J10", "J2", "J1"]
+
+    assert natural_sort_references(references) == ["J1", "J2", "J10"]
+
+
+def test_natural_reference_sort_key_orders_prefixes_before_suffixes() -> None:
+    """Natural key sorting should prioritize alphabetic prefixes consistently."""
+
+    references = ["IO1", "GND0", "LEDCOM0"]
+
+    assert sorted(references, key=natural_reference_sort_key) == [
+        "GND0",
+        "IO1",
+        "LEDCOM0",
+    ]


### PR DESCRIPTION
## Summary
- Introduce shared natural reference sorting helpers in `jbom.common.reference_sort`
- Replace duplicated natural-sort implementations in BOM, POS, and PARTS generators
- Align grouped merge-annotation reference ordering with the same shared key
- Add regression coverage for numeric suffix ordering (`J1`, `J10`) and prefix ordering (`GND0`, `LEDCOM0`)

## Validation
- `pytest tests` (full suite): **990 passed**
- `behave features` (full suite): **42 features passed**, **233 scenarios passed**, **0 failed**
- `pre-commit run --all-files`: passed

## Context
- Conversation: https://app.warp.dev/conversation/0e1012e1-d635-401b-b090-c0dd473a4af1

Co-Authored-By: Oz <oz-agent@warp.dev>
