### PR TITLE
docs(architecture): define phased EagleLib2KiCad convergence boundary

### DIFF
--- a/docs/dev/architecture/README.md
+++ b/docs/dev/architecture/README.md
@@ -110,7 +110,9 @@ This architecture documentation is organized as the authoritative source of desi
 - **[Design Patterns](design-patterns.md)** - Established patterns used throughout jBOM
 - **[Integration Patterns](integration-patterns.md)** - Service composition and layer interaction
 - **[Component Attribute Enrichment](component-attribute-enrichment.md)** - 3-camp attribute model, lifecycle phases, domain defaults, and write-back rules
+- **[EagleLib2KiCad Adapter Requirements](eaglelib2kicad-adapter-requirements.md)** - Service-surface-first integration requirements for Eagle/KiCad library contexts
 - **[ADR 0003: Search Heuristic Signal Framework](adr/0003-search-heuristic-signal-framework.md)** - typed relevance signal contract, diagnostics explainability, and defaults-governed package token baseline
+- **[ADR 0004: EagleLib2KiCad Integration Boundary](adr/0004-eaglelib2kicad-adapter-boundary.md)** - service-surface-first contract policy and no-parallel-adapter-layer decision
 
 ## Architectural Evolution
 

--- a/docs/dev/architecture/adr/0004-eaglelib2kicad-adapter-boundary.md
+++ b/docs/dev/architecture/adr/0004-eaglelib2kicad-adapter-boundary.md
@@ -1,0 +1,51 @@
+# ADR 0004: EagleLib2KiCad Integration Boundary — Service-Surface-First, Phased Convergence
+Date: 2026-04-29
+Status: Proposed (awaiting review)
+Related: #214
+## Context
+jBOM already has service APIs for project context, inventory context, supplier search, and matching. EagleLib2KiCad integration requires additional contexts (Eagle libraries and KiCad symbol/footprint library management). A new parallel adapter model layer would duplicate contract surfaces and increase maintenance cost.
+## Decision drivers
+- Keep one stable contract model for jBOM and adjacent tooling.
+- Reduce contract drift and duplicated abstractions.
+- Preserve domain-centric layer boundaries.
+- Support iterative delivery where API surface quality can be production-grade before full backend maturity.
+- Keep implementation-heavy import/lib-manager policy in the adjacent repository until semantics stabilize.
+## Options considered
+### Option A: Introduce a dedicated adapter-model layer
+Define separate adapter entities/contracts and map them to service APIs.
+Result: Rejected.
+Reasons:
+- Duplicates contract definitions.
+- Creates synchronization risk between adapter contracts and service APIs.
+- Increases long-term maintenance and test burden.
+### Option B: Service-surface-first contract model with immediate in-jBOM implementation
+Treat jBOM service APIs as canonical contracts and implement new Eagle/KiCad library-manager services directly in jBOM now.
+Result: Deferred.
+Reasons:
+- Current library-manager semantics are still evolving and importer-specific.
+- Premature in-jBOM implementation would couple unstable policy into jBOM.
+### Option C: Service-surface-first contract model with phased convergence
+Treat service APIs as canonical contract pattern, incubate implementation-heavy services in `EagleLib2KiCad` first, and converge into jBOM in a future issue when APIs stabilize.
+Result: Accepted for issue #214 prep direction.
+## Decision
+Adopt Option C.
+- Existing jBOM service APIs remain the contract surfaces for reuse.
+- No parallel adapter entity hierarchy is introduced.
+- Implementation-heavy Eagle/KiCad library-manager services are incubated in `EagleLib2KiCad` for now.
+- A follow-up convergence issue will refactor mature service APIs into jBOM.
+## Consequences
+### Positive
+- One contract pattern for in-core and adjacent tools.
+- Lower cognitive and maintenance overhead from avoiding parallel model hierarchies.
+- Cleaner BDD contract testing strategy tied to service APIs.
+- Lower short-term risk of embedding unstable importer policy into jBOM.
+### Tradeoffs
+- Future convergence requires coordinated refactor across repositories.
+- Service API compatibility expectations must be explicit before merge-back into jBOM.
+## Contract testing policy
+- Behave/gherkin scenarios define and validate service contract behavior.
+- Pytest validates internal helper logic and implementation details behind those contracts.
+## Iteration-1 constraints
+- No destructive writes to KiCad artifacts from jBOM.
+- No required CLI changes in this jBOM prep slice.
+- jBOM focuses on architecture boundary documentation and future expansion seam.

--- a/docs/dev/architecture/eaglelib2kicad-adapter-requirements.md
+++ b/docs/dev/architecture/eaglelib2kicad-adapter-requirements.md
@@ -1,0 +1,29 @@
+# EagleLib2KiCad Adapter Requirements (Service-Surface-First)
+## Purpose
+Define the jBOM-side preparation boundary for Eagle→KiCad library-management integration while keeping implementation-heavy work in the `EagleLib2KiCad` repository for now.
+## Core policy
+- jBOM service APIs are the long-term contract model for both in-core workflows and adjacent tools/plugins.
+- Do not introduce a parallel adapter model hierarchy.
+- Short-term implementation-heavy service evolution for Eagle/KiCad library management is intentionally incubated in `EagleLib2KiCad`.
+- Future convergence work can merge mature service APIs into jBOM when semantics stabilize.
+## Existing jBOM service surfaces intended for reuse
+- KiCad project context and component collection (`ProjectContext`, `ProjectComponentCollector`).
+- Inventory context ingestion (`InventoryReader` and downstream matching services).
+- Supplier context/search (`InventorySearchService` and provider stack).
+- Matching/categorization behavior (`SophisticatedInventoryMatcher`, component classification utilities).
+## KiCad library-management semantics to be validated in adjacent tool first
+- Multi-library-set loading semantics (many symbol libraries + many footprint libraries).
+- Nickname-aware environment discovery semantics.
+- Footprint reference closure reporting (resolved, unresolved, ambiguous).
+- Library lifecycle semantics (add/remove/rename) aligned with KiCad workflows.
+## jBOM scope for this prep slice
+- Document service-surface-first integration boundary.
+- Preserve architecture links and future expansion direction.
+- Avoid implementation-heavy importer/library-manager services in jBOM at this time.
+## Contract validation strategy for this slice
+- Keep jBOM regression focused on existing stable behaviors.
+- Adjacent tool (`EagleLib2KiCad`) carries new service-contract behavior scenarios while APIs are still evolving.
+## Out of scope in this jBOM slice
+- New Eagle parsing services in jBOM.
+- New KiCad library environment management services in jBOM.
+- Importer analysis/review-queue workflow policy in jBOM.


### PR DESCRIPTION
## Summary
- document the phased convergence boundary for EagleLib2KiCad importer work in jBOM architecture docs
- keep jBOM changes minimal and prep-focused while implementation-heavy service evolution proceeds in importer repo
- update architecture index references for requirements and ADR visibility

## Context
- jBOM issue: https://github.com/plocher/jBOM/issues/214
- paired importer implementation PR: https://github.com/plocher/EagleLib2KiCad/pull/1

## Validation
- behave

## Cross-link
- companion importer PR: https://github.com/plocher/EagleLib2KiCad/pull/1

Co-Authored-By: Oz <oz-agent@warp.dev>