### PR TITLE
architecture(cli): rewire BOM/POS adapters through shared job runner

### DIFF
--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -57,6 +57,14 @@ from jbom.common.component_filters import (
 from jbom.common.component_utils import derive_package_from_footprint
 from jbom.common.package_matching import PackageType
 from jbom.cli.formatting import Column, print_table, get_terminal_width
+from jbom.workflows.job_contracts import (
+    JobArtifact,
+    JobContext,
+    JobDiagnosticSeverity,
+    JobOutcome,
+    JobRequest,
+)
+from jbom.workflows.job_runner import JobEventStream, JobRunPayload, JobRunner
 
 _BOM_SOURCE_PRIORITY = "pis"
 _BOM_COMPUTED_FIELDS: tuple[str, ...] = (
@@ -263,23 +271,132 @@ def register_command(subparsers) -> None:
 
     parser.set_defaults(handler=handle_bom)
 
+def _resolve_requested_fabricator(args: argparse.Namespace) -> str:
+    """Resolve effective fabricator selector from command arguments."""
+
+    fabricator = args.fabricator
+    if not fabricator:
+        if args.jlc:
+            fabricator = "jlc"
+        elif args.pcbway:
+            fabricator = "pcbway"
+        elif args.seeed:
+            fabricator = "seeed"
+        elif args.generic:
+            fabricator = "generic"
+    if not fabricator:
+        fabricator = "generic"
+    return str(fabricator)
+
+
+def _predict_bom_artifacts(args: argparse.Namespace) -> tuple[JobArtifact, ...]:
+    """Predict adapter-level BOM artifact descriptors from CLI output arguments."""
+
+    output = str(args.output or "").strip()
+    if output.lower() == "console":
+        return ()
+    if output == "-":
+        return (
+            JobArtifact(
+                name="bom.csv",
+                location="stdout://bom.csv",
+                media_type="text/csv",
+            ),
+        )
+    if output:
+        output_path = Path(output)
+        return (
+            JobArtifact(
+                name=output_path.name or "bom.csv",
+                location=str(output_path),
+                media_type="text/csv",
+            ),
+        )
+    return (
+        JobArtifact(
+            name="bom.csv",
+            location="project-default://bom.csv",
+            media_type="text/csv",
+        ),
+    )
+
+
+def _build_bom_job_request(args: argparse.Namespace) -> JobRequest:
+    """Build adapter-neutral `JobRequest` contract for BOM execution."""
+
+    inventory_files = tuple(str(path) for path in (args.inventory_files or []))
+    options: dict[str, object] = {
+        "input": str(args.input or "."),
+        "output": str(args.output or ""),
+        "fabricator": _resolve_requested_fabricator(args),
+        "inventory_files": inventory_files,
+        "verbose": bool(args.verbose),
+        "list_fields": bool(args.list_fields),
+    }
+    return JobRequest(
+        job_type="bom",
+        intent="generate_bom",
+        project_ref=str(args.input or "."),
+        options=options,
+        metadata={"adapter": "cli"},
+    )
+
 
 def handle_bom(args: argparse.Namespace) -> int:
-    """Handle BOM command with project-centric input resolution."""
+    """Handle BOM command through the shared adapter-neutral job runner."""
+
+    request = _build_bom_job_request(args)
+    context = JobContext(
+        adapter_id="cli",
+        session_id="local-process",
+        capabilities={
+            "event_stream": True,
+            "diagnostics": True,
+            "cancellation": False,
+        },
+    )
+    runner = JobRunner()
+
+    def _execute(events: JobEventStream) -> JobRunPayload:
+        events.progress(
+            phase="resolve",
+            message="Resolving project input and BOM orchestration plan",
+        )
+        exit_code = _execute_bom_command(args)
+        if exit_code == 0:
+            events.progress(
+                phase="emit",
+                message="BOM output emitted",
+            )
+        else:
+            events.diagnostic(
+                severity=JobDiagnosticSeverity.ERROR,
+                message="BOM command execution failed",
+                code="bom_execution_failed",
+                details={"exit_code": exit_code},
+            )
+
+        return JobRunPayload(
+            outcome=JobOutcome.SUCCEEDED if exit_code == 0 else JobOutcome.FAILED,
+            artifacts=_predict_bom_artifacts(args) if exit_code == 0 else (),
+            metadata={
+                "exit_code": exit_code,
+                "command": "bom",
+                "fabricator": request.options.get("fabricator", "generic"),
+            },
+        )
+
+    result = runner.run(request=request, context=context, execute=_execute)
+    if result.outcome == JobOutcome.CANCELLED:
+        return 130
+    return int(result.metadata.get("exit_code", 1))
+
+
+def _execute_bom_command(args: argparse.Namespace) -> int:
+    """Execute BOM command body with project-centric input resolution."""
     try:
         # Determine effective fabricator early (needed for --list-fields)
-        fabricator = args.fabricator
-        if not fabricator:
-            if args.jlc:
-                fabricator = "jlc"
-            elif args.pcbway:
-                fabricator = "pcbway"
-            elif args.seeed:
-                fabricator = "seeed"
-            elif args.generic:
-                fabricator = "generic"
-        if not fabricator:
-            fabricator = "generic"
+        fabricator = _resolve_requested_fabricator(args)
 
         # Handle --list-fields - best-effort: try to load runtime data for richer output
         if args.list_fields:

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -51,6 +51,14 @@ from jbom.config.fabricators import (
 )
 from jbom.cli.formatting import Column, print_table, get_terminal_width
 from jbom.services.fabricator_projection_service import FabricatorProjectionService
+from jbom.workflows.job_contracts import (
+    JobArtifact,
+    JobContext,
+    JobDiagnosticSeverity,
+    JobOutcome,
+    JobRequest,
+)
+from jbom.workflows.job_runner import JobEventStream, JobRunPayload, JobRunner
 
 _NUMERIC_POS_FIELDS: frozenset[str] = frozenset({"x", "y", "rotation"})
 _POS_SOURCE_PRIORITY = "pis"
@@ -230,9 +238,111 @@ def register_command(subparsers) -> None:
 
     parser.set_defaults(handler=handle_pos)
 
+def _predict_pos_artifacts(args: argparse.Namespace) -> tuple[JobArtifact, ...]:
+    """Predict adapter-level POS artifact descriptors from CLI output arguments."""
+
+    output = str(args.output or "").strip()
+    if output.lower() == "console":
+        return ()
+    if output == "-":
+        return (
+            JobArtifact(
+                name="pos.csv",
+                location="stdout://pos.csv",
+                media_type="text/csv",
+            ),
+        )
+    if output:
+        output_path = Path(output)
+        return (
+            JobArtifact(
+                name=output_path.name or "pos.csv",
+                location=str(output_path),
+                media_type="text/csv",
+            ),
+        )
+    return (
+        JobArtifact(
+            name="pos.csv",
+            location="project-default://pos.csv",
+            media_type="text/csv",
+        ),
+    )
+
+
+def _build_pos_job_request(args: argparse.Namespace) -> JobRequest:
+    """Build adapter-neutral `JobRequest` contract for POS execution."""
+
+    options: dict[str, object] = {
+        "input": str(args.input or "."),
+        "output": str(args.output or ""),
+        "fabricator": resolve_fabricator_from_args(args),
+        "smd_only": bool(args.smd_only),
+        "layer": str(args.layer or ""),
+        "origin": str(args.origin or "board"),
+        "verbose": bool(args.verbose),
+        "list_fields": bool(args.list_fields),
+    }
+    return JobRequest(
+        job_type="pos",
+        intent="generate_pos",
+        project_ref=str(args.input or "."),
+        options=options,
+        metadata={"adapter": "cli"},
+    )
+
 
 def handle_pos(args: argparse.Namespace) -> int:
-    """Handle POS command with project-centric input resolution."""
+    """Handle POS command through the shared adapter-neutral job runner."""
+
+    request = _build_pos_job_request(args)
+    context = JobContext(
+        adapter_id="cli",
+        session_id="local-process",
+        capabilities={
+            "event_stream": True,
+            "diagnostics": True,
+            "cancellation": False,
+        },
+    )
+    runner = JobRunner()
+
+    def _execute(events: JobEventStream) -> JobRunPayload:
+        events.progress(
+            phase="resolve",
+            message="Resolving project input and POS orchestration plan",
+        )
+        exit_code = _execute_pos_command(args)
+        if exit_code == 0:
+            events.progress(
+                phase="emit",
+                message="POS output emitted",
+            )
+        else:
+            events.diagnostic(
+                severity=JobDiagnosticSeverity.ERROR,
+                message="POS command execution failed",
+                code="pos_execution_failed",
+                details={"exit_code": exit_code},
+            )
+        return JobRunPayload(
+            outcome=JobOutcome.SUCCEEDED if exit_code == 0 else JobOutcome.FAILED,
+            artifacts=_predict_pos_artifacts(args) if exit_code == 0 else (),
+            metadata={
+                "exit_code": exit_code,
+                "command": "pos",
+                "fabricator": request.options.get("fabricator", "generic"),
+            },
+        )
+
+    result = runner.run(request=request, context=context, execute=_execute)
+    if result.outcome == JobOutcome.CANCELLED:
+        return 130
+    return int(result.metadata.get("exit_code", 1))
+
+
+def _execute_pos_command(args: argparse.Namespace) -> int:
+    """Execute POS command body with project-centric input resolution."""
     try:
         # Create options
         gen_options = GeneratorOptions(verbose=args.verbose) if args.verbose else None


### PR DESCRIPTION
## Summary
- rewire `src/jbom/cli/bom.py` to execute through the shared `JobRunner` entry contract
- rewire `src/jbom/cli/pos.py` to execute through the shared `JobRunner` entry contract
- keep scope limited to CLI adapter routing only (no additional contract-surface changes)

## Scope
This PR is intentionally stacked on top of #230 and contains only:
- `src/jbom/cli/bom.py`
- `src/jbom/cli/pos.py`

## Validation
- `pytest -c /tmp/jbom-issue-222/pyproject.toml /tmp/jbom-issue-222/tests`
  - 994 passed
- `PYTHONPATH=/tmp/jbom-issue-222/src python -m behave /tmp/jbom-issue-222/features`
  - 42 features passed, 233 scenarios passed, 1529 steps passed

Closes #223

Co-Authored-By: Oz <oz-agent@warp.dev>