### PR TITLE
fix(safety): guard annotate writes against KiCad lock files (closes #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # CHANGELOG
+## Unreleased
+### Bug Fixes
+* fix(safety): guard `jbom annotate` writes against KiCad lock files (closes #213)
+
+Add `ProjectContext.lock_file` / `is_locked` properties and
+`jbom.common.kicad_runtime.check_write_permitted()`.  The annotate
+command now refuses to write schematics while a KiCad lock file is
+present, warns instead when `--dry-run` is active, and bypasses the
+guard entirely when running inside KiCad's plugin context.
 
 
-## v6.51.4 (2026-05-07)
+## v6.51.4
 
 ### Refactoring
 

--- a/src/jbom/cli/annotate.py
+++ b/src/jbom/cli/annotate.py
@@ -24,6 +24,7 @@ from jbom.services.annotation_service import (
     annotate_from_repairs,
     normalize_schematic_properties,
 )
+from jbom.common.kicad_runtime import check_write_permitted
 from jbom.services.project_file_resolver import ProjectFileResolver
 
 
@@ -92,6 +93,10 @@ def handle_annotate(args: argparse.Namespace) -> int:
         resolved = resolver.resolve_input(args.input)
         schematic_files = resolved.get_hierarchical_files()
 
+        # Refuse (or warn on --dry-run) if KiCad has the project open.
+        if resolved.project_context:
+            check_write_permitted(resolved.project_context, dry_run=args.dry_run)
+
         exit_code = 0
 
         # --normalize runs first (field renaming is a prerequisite for repairs).
@@ -117,6 +122,9 @@ def handle_annotate(args: argparse.Namespace) -> int:
         return exit_code
 
     except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except PermissionError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     except Exception as exc:

--- a/src/jbom/common/kicad_runtime.py
+++ b/src/jbom/common/kicad_runtime.py
@@ -1,0 +1,99 @@
+"""KiCad runtime environment detection and project write-guard utilities.
+
+Provides two related capabilities:
+
+1. ``is_running_inside_kicad()`` — detects whether jBOM is executing inside
+   KiCad's embedded Python context (ActionPlugin mode).  When True, the plugin
+   has direct in-memory access to board/schematic state; filesystem lock files
+   and ``kicad-cli`` subprocess fallbacks are irrelevant.
+
+2. ``check_write_permitted()`` — guards schematic write operations against
+   KiCad lock files.  Silently bypasses in plugin mode.  Raises
+   ``PermissionError`` on conflict in normal CLI mode; emits a warning instead
+   when ``dry_run=True``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jbom.services.project_context import ProjectContext
+
+__all__ = ["is_running_inside_kicad", "check_write_permitted"]
+
+
+def is_running_inside_kicad() -> bool:
+    """Return ``True`` if jBOM is executing within KiCad's embedded Python context.
+
+    Detection is based on whether the ``pcbnew`` C-extension module is
+    importable.  Outside KiCad this import always fails; inside it succeeds
+    because KiCad pre-loads the module into the interpreter.
+
+    When this function returns ``True``:
+
+    - Lock-file guards are not meaningful — KiCad holds the lock by design and
+      the plugin has direct in-memory access to the latest project state.
+    - ``kicad-cli`` subprocess fallbacks are unnecessary — native Python APIs
+      are available.
+
+    Returns:
+        ``True`` if running inside KiCad, ``False`` otherwise.
+    """
+    try:
+        import pcbnew  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def check_write_permitted(
+    project_context: "ProjectContext",
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Guard schematic write operations against KiCad lock files.
+
+    Call this once per write-capable command (e.g. ``jbom annotate``) *after*
+    project resolution but *before* any filesystem writes.
+
+    Behaviour matrix::
+
+        Mode         | Locked? | dry_run | Outcome
+        -------------|---------|---------|-----------------------------
+        plugin       |  any    |  any    | no-op (in-memory access)
+        CLI          |  no     |  any    | no-op
+        CLI          |  yes    |  False  | raises PermissionError
+        CLI          |  yes    |  True   | prints WARNING, continues
+
+    Args:
+        project_context: The resolved :class:`~jbom.services.project_context.ProjectContext`
+            to inspect.
+        dry_run: When ``True`` a warning is emitted instead of raising.
+
+    Raises:
+        PermissionError: If the project is locked and ``dry_run`` is ``False``.
+    """
+    # Plugin mode: KiCad holds the lock intentionally; bypass entirely.
+    if is_running_inside_kicad():
+        return
+
+    if not project_context.is_locked:
+        return
+
+    lock_name = project_context.lock_file.name
+    msg = (
+        f"KiCad lock file detected ({lock_name}). "
+        "The project appears to be open in KiCad. "
+        "Unsaved KiCad edits will not be visible to jBOM, and jBOM writes "
+        "may be overwritten when KiCad saves. "
+        "Close KiCad before running this command, or use --dry-run to "
+        "preview changes without writing."
+    )
+
+    if dry_run:
+        print(f"WARNING: {msg}", file=sys.stderr)
+    else:
+        raise PermissionError(msg)

--- a/src/jbom/services/project_context.py
+++ b/src/jbom/services/project_context.py
@@ -75,6 +75,27 @@ class ProjectContext:
         else:
             return self.project_directory.name
 
+    @property
+    def lock_file(self) -> Path:
+        """Path to the KiCad lock file for this project.
+
+        KiCad creates ``<project_name>.lck`` while the project is open.
+        The file's presence indicates that KiCad may hold in-memory edits
+        not yet flushed to disk, and that jBOM writes could be overwritten
+        when KiCad saves.
+        """
+        return self.project_directory / f"{self.project_base_name}.lck"
+
+    @property
+    def is_locked(self) -> bool:
+        """Return ``True`` if a KiCad lock file exists for this project.
+
+        Does **not** imply that writes are forbidden — use
+        :func:`~jbom.common.kicad_runtime.check_write_permitted` for
+        context-aware write guarding (plugin-mode bypass, dry-run handling).
+        """
+        return self.lock_file.exists()
+
     def get_expected_schematic_path(self) -> Path:
         """Get expected path for schematic file based on project base name."""
         return self.project_directory / f"{self.project_base_name}.kicad_sch"

--- a/tests/unit/test_kicad_lock_file.py
+++ b/tests/unit/test_kicad_lock_file.py
@@ -1,0 +1,168 @@
+"""Unit tests for KiCad lock file detection and write guard (issue #213).
+
+Covers:
+- ProjectContext.lock_file path derivation
+- ProjectContext.is_locked filesystem check
+- check_write_permitted: pass, raise, warn, plugin-mode bypass
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jbom.common.kicad_runtime import check_write_permitted, is_running_inside_kicad
+from jbom.services.project_context import ProjectContext
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_project(tmp_path: Path, name: str = "myboard") -> Path:
+    """Create a minimal KiCad project directory containing a .kicad_pro file."""
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / f"{name}.kicad_pro").write_text("{}", encoding="utf-8")
+    return project_dir
+
+
+# ---------------------------------------------------------------------------
+# ProjectContext.lock_file / is_locked
+# ---------------------------------------------------------------------------
+
+
+class TestProjectContextLockFile:
+    def test_lock_file_path_uses_project_base_name(self, tmp_path: Path) -> None:
+        """lock_file path is <project_dir>/<project_name>.lck."""
+        project_dir = _make_project(tmp_path, "widget")
+        ctx = ProjectContext(project_dir)
+        assert ctx.lock_file == project_dir / "widget.lck"
+
+    def test_is_locked_false_when_no_lock_file(self, tmp_path: Path) -> None:
+        """is_locked returns False when the lock file does not exist."""
+        project_dir = _make_project(tmp_path)
+        ctx = ProjectContext(project_dir)
+        assert ctx.is_locked is False
+
+    def test_is_locked_true_when_lock_file_present(self, tmp_path: Path) -> None:
+        """is_locked returns True when the lock file exists."""
+        project_dir = _make_project(tmp_path, "open_in_kicad")
+        (project_dir / "open_in_kicad.lck").write_text("", encoding="utf-8")
+        ctx = ProjectContext(project_dir)
+        assert ctx.is_locked is True
+
+    def test_is_locked_reflects_runtime_filesystem_state(self, tmp_path: Path) -> None:
+        """is_locked is evaluated fresh on each access (not cached at init)."""
+        project_dir = _make_project(tmp_path)
+        ctx = ProjectContext(project_dir)
+        lock_path = project_dir / "myboard.lck"
+
+        assert ctx.is_locked is False
+        lock_path.write_text("", encoding="utf-8")
+        assert ctx.is_locked is True
+        lock_path.unlink()
+        assert ctx.is_locked is False
+
+
+# ---------------------------------------------------------------------------
+# is_running_inside_kicad
+# ---------------------------------------------------------------------------
+
+
+class TestIsRunningInsideKicad:
+    def test_returns_false_outside_kicad(self) -> None:
+        """In the test environment pcbnew is not importable → False."""
+        # Guard: if the test machine somehow has pcbnew installed this test is
+        # vacuously True; skip it rather than fail spuriously.
+        try:
+            import pcbnew  # noqa: F401
+
+            pytest.skip("pcbnew is installed on this machine")
+        except ImportError:
+            pass
+        assert is_running_inside_kicad() is False
+
+    def test_returns_true_when_pcbnew_importable(self) -> None:
+        """Simulate plugin mode by patching pcbnew into sys.modules."""
+        import types
+
+        fake_pcbnew = types.ModuleType("pcbnew")
+        with patch.dict(sys.modules, {"pcbnew": fake_pcbnew}):
+            assert is_running_inside_kicad() is True
+
+
+# ---------------------------------------------------------------------------
+# check_write_permitted
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWritePermitted:
+    def test_passes_silently_when_not_locked(self, tmp_path: Path) -> None:
+        """No exception or output when project is not locked."""
+        project_dir = _make_project(tmp_path)
+        ctx = ProjectContext(project_dir)
+        # Should complete without raising
+        check_write_permitted(ctx, dry_run=False)
+
+    def test_raises_permission_error_when_locked(self, tmp_path: Path) -> None:
+        """Raises PermissionError when locked and dry_run=False."""
+        project_dir = _make_project(tmp_path, "locked_proj")
+        (project_dir / "locked_proj.lck").write_text("", encoding="utf-8")
+        ctx = ProjectContext(project_dir)
+
+        with pytest.raises(PermissionError) as exc_info:
+            check_write_permitted(ctx, dry_run=False)
+
+        msg = str(exc_info.value)
+        assert "locked_proj.lck" in msg
+        assert "KiCad lock file detected" in msg
+        assert "--dry-run" in msg
+
+    def test_warns_but_does_not_raise_on_dry_run(self, tmp_path: Path, capsys) -> None:
+        """dry_run=True emits a WARNING to stderr but does not raise."""
+        project_dir = _make_project(tmp_path, "open_proj")
+        (project_dir / "open_proj.lck").write_text("", encoding="utf-8")
+        ctx = ProjectContext(project_dir)
+
+        # Must not raise
+        check_write_permitted(ctx, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "open_proj.lck" in captured.err
+
+    def test_plugin_mode_bypasses_lock_check(self, tmp_path: Path) -> None:
+        """Plugin mode silently bypasses the write guard even when locked."""
+        project_dir = _make_project(tmp_path, "kicad_open")
+        (project_dir / "kicad_open.lck").write_text("", encoding="utf-8")
+        ctx = ProjectContext(project_dir)
+        assert ctx.is_locked is True
+
+        import types
+
+        fake_pcbnew = types.ModuleType("pcbnew")
+        with patch.dict(sys.modules, {"pcbnew": fake_pcbnew}):
+            # Must not raise even though project is locked
+            check_write_permitted(ctx, dry_run=False)
+
+    def test_plugin_mode_bypasses_dry_run_warning_too(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Plugin mode produces no output even with dry_run=True and a lock present."""
+        project_dir = _make_project(tmp_path, "kicad_open2")
+        (project_dir / "kicad_open2.lck").write_text("", encoding="utf-8")
+        ctx = ProjectContext(project_dir)
+
+        import types
+
+        fake_pcbnew = types.ModuleType("pcbnew")
+        with patch.dict(sys.modules, {"pcbnew": fake_pcbnew}):
+            check_write_permitted(ctx, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Summary

Addresses #213 — jBOM had no guard against writing to KiCad project files while the project was open in KiCad.

## What changed

### New: `src/jbom/common/kicad_runtime.py`
- `is_running_inside_kicad()` — detects plugin mode via `pcbnew` import probe; reusable by future plugin adapter code (`#227`)
- `check_write_permitted(project_context, *, dry_run)` — write guard with a clear behaviour contract:

| Mode | Locked? | dry_run | Outcome |
|---|---|---|---|
| plugin | any | any | no-op (in-memory access) |
| CLI | no | any | no-op |
| CLI | yes | False | raises `PermissionError` |
| CLI | yes | True | prints WARNING, continues |

### Updated: `src/jbom/services/project_context.py`
- `lock_file` property — returns `<project_dir>/<project_name>.lck` path
- `is_locked` property — live filesystem check (not cached at init)

### Updated: `src/jbom/cli/annotate.py`
- Calls `check_write_permitted()` once after project resolution, before any writes, covering both `--normalize` and `--repairs` paths
- Explicit `PermissionError` handler for clean error output and exit code 1

### New: `tests/unit/test_kicad_lock_file.py` — 11 tests
- `ProjectContext.lock_file` path derivation
- `is_locked` True/False and runtime-dynamic checks
- `is_running_inside_kicad()` with fake `pcbnew` module
- `check_write_permitted()` — pass, raise, warn, and plugin-mode bypass

## Validation
- `pytest tests/unit/test_kicad_lock_file.py` — 11 passed
- `pytest tests/` — 1008 passed

_Generated with [Warp](https://app.warp.dev/conversation/deec026a-908e-461d-977f-da7f776f772b)_

Co-Authored-By: Oz <oz-agent@warp.dev>