### PR TITLE
feat(fabrication): add GerberExporter, FabricationWorkflow, jbom gerbers, jbom fab (#224)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **Fabrication artifact services and orchestration** (issue #224 — ADR 0005 Phase 3):
+  - `GerberExporter` service (`services/gerber_service.py`) with tiered dispatch:
+    1. `kicad-cli pcb export` subprocess when KiCad is installed.
+    2. `pcbnew` API stub (plugin mode — deferred to issue #227).
+    3. Graceful degradation: `GerberResult(skipped=True)` with actionable diagnostic when neither path is available; BOM and POS generation are unaffected.
+  - `FabricationWorkflow` application service (`application/fabrication_orchestration.py`): adapter-neutral orchestrator that sequences BOM → POS → Gerbers in one coordinated run.  Each step is independently skip-able.  Failures in one step are captured as diagnostics without aborting subsequent steps.
+  - `jbom gerbers` CLI command: standalone Gerber/drill/IPC-D-356 generation for validating `GerberExporter` in isolation.  Options: `--fabricator`, `-o/--output-dir`, `--no-drill`, `--netlist`, `--dry-run`.
+  - `jbom fab` CLI command: one-shot BOM + POS + Gerber generation.  Equivalent to running `jbom bom`, `jbom pos`, `jbom gerbers` in sequence with the same fabricator profile.  Supports `--skip-bom`, `--skip-pos`, `--skip-gerbers`, `--dry-run`, `--inventory`, `--smd-only`, `--layer`, `--origin`.
+  - **Naming convention** for new code (#224 establishes; cleanup of existing `BOMOrchestrationService`/`POSOrchestrationService` names tracked in issue #237): class names reflect the promise (what is produced), not the mechanism; `Service`/`Orchestration` suffixes omitted where the module path provides context.
+
 ### Breaking Changes
 - **Inventory CSV schema cutover** (issue #218): per-supplier columns (`LCSC`,
   `Mouser`, etc.) are replaced by a normalized two-column model:

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -1,0 +1,412 @@
+"""Adapter-neutral fabrication workflow orchestration.
+
+Sequences three fabrication steps in order:
+
+1. BOM generation — delegates to :class:`~jbom.application.bom_orchestration.BOMOrchestrationService`.
+2. POS (placement) generation — delegates to :class:`~jbom.application.pos_orchestration.POSOrchestrationService`.
+3. Gerber/drill/netlist export — delegates to :class:`~jbom.services.gerber_service.GerberExporter`.
+
+Each step is independently skip-able.  If Gerbers cannot be generated
+(``kicad-cli`` absent, PCB file missing, or ``dry_run=True``) the workflow
+still succeeds and returns BOM/POS results — the ``gerber_result`` payload
+carries a diagnostic and ``skipped=True``.
+
+The :class:`FabricationWorkflow` is an adapter-neutral application service:
+it contains no CLI concerns (no argparse, no stdout, no exit codes).  Adapter
+layers (CLI, plugin) are responsible for rendering results and writing CSV
+files from the BOM/POS payloads.
+
+Naming convention:
+  New code in this module follows the naming convention established in #224:
+  class names reflect the *promise* (what is produced), not the mechanism.
+  The existing ``BOMOrchestrationService`` / ``POSOrchestrationService`` names
+  are unchanged here — renaming them is tracked in issue #237.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from jbom.application.bom_orchestration import (
+    BOMOrchestrationRequest,
+    BOMOrchestrationResult,
+    BOMOrchestrationService,
+)
+from jbom.application.pos_orchestration import (
+    POSOrchestrationRequest,
+    POSOrchestrationResult,
+    POSOrchestrationService,
+)
+from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
+
+__all__ = [
+    "FabricationArtifact",
+    "FabricationRequest",
+    "FabricationResult",
+    "FabricationWorkflow",
+]
+
+
+def _freeze_mapping(values: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    """Return an immutable copy of a metadata mapping."""
+    return MappingProxyType(dict(values or {}))
+
+
+def _normalize_text(value: str, *, field_name: str) -> str:
+    """Validate and normalise a required non-empty text field."""
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+@dataclass(frozen=True)
+class FabricationRequest:
+    """Adapter-neutral request for the fabrication workflow.
+
+    Attributes:
+        input_path: Path to the KiCad project directory, ``.kicad_pro``,
+            ``.kicad_pcb``, or ``.kicad_sch`` file.  Passed unchanged to
+            BOM and POS orchestration services.
+        fabricator: Fabricator profile identifier (e.g. ``"jlc"``, ``"generic"``).
+            Controls default field sets for both BOM and POS outputs.
+            Field customisation beyond fabricator defaults requires using
+            ``jbom bom`` and ``jbom pos`` individually.
+        output_directory: If non-empty, Gerbers are written to
+            ``<output_directory>/gerbers/``.  BOM/POS default output paths
+            come from their respective orchestration results; adapter layers
+            may override them.
+        skip_bom: When ``True`` skip BOM generation entirely.
+        skip_pos: When ``True`` skip POS generation entirely.
+        skip_gerbers: When ``True`` skip Gerber/drill/netlist generation.
+        verbose: Forward verbose flag to sub-services.
+        dry_run: When ``True`` generate BOM/POS data but skip Gerber file
+            generation (no filesystem writes for Gerbers).
+        inventory_files: Inventory CSV paths forwarded to BOM generation.
+        smd_only: Forward SMD-only filter to POS generation.
+        pos_layer: Forward layer filter (``"TOP"`` / ``"BOTTOM"``) to POS.
+        pos_origin: Forward origin reference (``"board"`` / ``"aux"``) to POS.
+    """
+
+    input_path: str
+    fabricator: str = "generic"
+    output_directory: str = ""
+    skip_bom: bool = False
+    skip_pos: bool = False
+    skip_gerbers: bool = False
+    verbose: bool = False
+    dry_run: bool = False
+    inventory_files: tuple[str, ...] = field(default_factory=tuple)
+    smd_only: bool = False
+    pos_layer: str = ""
+    pos_origin: str = "board"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "input_path",
+            _normalize_text(self.input_path, field_name="input_path"),
+        )
+        object.__setattr__(
+            self,
+            "fabricator",
+            _normalize_text(self.fabricator or "generic", field_name="fabricator"),
+        )
+        object.__setattr__(
+            self, "output_directory", str(self.output_directory or "").strip()
+        )
+        object.__setattr__(self, "skip_bom", bool(self.skip_bom))
+        object.__setattr__(self, "skip_pos", bool(self.skip_pos))
+        object.__setattr__(self, "skip_gerbers", bool(self.skip_gerbers))
+        object.__setattr__(self, "verbose", bool(self.verbose))
+        object.__setattr__(self, "dry_run", bool(self.dry_run))
+        object.__setattr__(
+            self,
+            "inventory_files",
+            tuple(str(p) for p in self.inventory_files),
+        )
+        object.__setattr__(self, "smd_only", bool(self.smd_only))
+        object.__setattr__(self, "pos_layer", str(self.pos_layer or "").strip())
+        object.__setattr__(
+            self,
+            "pos_origin",
+            _normalize_text(self.pos_origin or "board", field_name="pos_origin"),
+        )
+
+
+@dataclass(frozen=True)
+class FabricationArtifact:
+    """Descriptor for one fabrication artifact produced by the workflow.
+
+    Attributes:
+        artifact_type: Semantic type token: ``"bom"``, ``"pos"``,
+            ``"gerber"``, ``"drill"``, or ``"netlist"``.
+        path: Filesystem path where the artifact resides.  For BOM/POS this
+            is the orchestration default path; adapter layers may redirect
+            actual writes to a different location.  For Gerbers this is the
+            actual written path (Gerber generation is handled inside the
+            workflow).
+        media_type: MIME type string (e.g. ``"text/csv"``).
+    """
+
+    artifact_type: str
+    path: Path | None
+    media_type: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "artifact_type",
+            _normalize_text(self.artifact_type, field_name="artifact_type"),
+        )
+        if self.path is not None:
+            object.__setattr__(self, "path", Path(self.path))
+        object.__setattr__(self, "media_type", str(self.media_type or "").strip())
+
+
+@dataclass(frozen=True)
+class FabricationResult:
+    """Result produced by :class:`FabricationWorkflow`.
+
+    Attributes:
+        artifacts: All artifact descriptors produced during the workflow.
+            BOM/POS entries carry default output paths; Gerber entries carry
+            actual written paths.
+        diagnostics: Ordered human-readable messages from all sub-services.
+        bom_result: Full BOM orchestration result (``None`` when skipped).
+        pos_result: Full POS orchestration result (``None`` when skipped).
+        gerber_result: Gerber generation result (``None`` when skipped).
+    """
+
+    artifacts: tuple[FabricationArtifact, ...]
+    diagnostics: tuple[str, ...]
+    bom_result: BOMOrchestrationResult | None = None
+    pos_result: POSOrchestrationResult | None = None
+    gerber_result: GerberResult | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artifacts", tuple(self.artifacts))
+        object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
+
+
+class FabricationWorkflow:
+    """Adapter-neutral fabrication workflow: sequences BOM → POS → Gerbers.
+
+    Calls existing orchestration services and ``GerberExporter`` in order.
+    Each step is gated by its ``skip_*`` flag.  Failures in one step are
+    captured as diagnostics and do not abort subsequent steps (except that a
+    missing PCB file prevents Gerber generation).
+
+    This class contains no CLI or UI concerns.
+    """
+
+    def run(self, request: FabricationRequest) -> FabricationResult:
+        """Execute the fabrication workflow and return all results.
+
+        Args:
+            request: Options governing which steps to run and with what inputs.
+
+        Returns:
+            :class:`FabricationResult` aggregating BOM, POS, and Gerber outputs.
+        """
+        diagnostics: list[str] = []
+        artifacts: list[FabricationArtifact] = []
+        bom_result: BOMOrchestrationResult | None = None
+        pos_result: POSOrchestrationResult | None = None
+        gerber_result: GerberResult | None = None
+
+        # ------------------------------------------------------------------
+        # Step 1: BOM
+        # ------------------------------------------------------------------
+        if not request.skip_bom:
+            bom_result, bom_diagnostics = self._run_bom(request)
+            diagnostics.extend(bom_diagnostics)
+            if bom_result is not None and bom_result.generation is not None:
+                artifacts.append(
+                    FabricationArtifact(
+                        artifact_type="bom",
+                        path=bom_result.generation.default_output_path,
+                        media_type="text/csv",
+                    )
+                )
+
+        # ------------------------------------------------------------------
+        # Step 2: POS
+        # ------------------------------------------------------------------
+        if not request.skip_pos:
+            pos_result, pos_diagnostics = self._run_pos(request)
+            diagnostics.extend(pos_diagnostics)
+            if pos_result is not None and pos_result.generation is not None:
+                artifacts.append(
+                    FabricationArtifact(
+                        artifact_type="pos",
+                        path=pos_result.generation.default_output_path,
+                        media_type="text/csv",
+                    )
+                )
+
+        # ------------------------------------------------------------------
+        # Step 3: Gerbers (skipped in dry_run mode)
+        # ------------------------------------------------------------------
+        if not request.skip_gerbers:
+            if request.dry_run:
+                diagnostics.append(
+                    "Dry run: Gerber generation skipped (no files written)."
+                )
+            else:
+                gerber_result, gerber_diagnostics = self._run_gerbers(request)
+                diagnostics.extend(gerber_diagnostics)
+                if gerber_result is not None and not gerber_result.skipped:
+                    for artifact_path in gerber_result.artifacts:
+                        # Infer type from extension; default to "gerber"
+                        ext = artifact_path.suffix.lower()
+                        artifact_type = (
+                            "drill"
+                            if ext == ".drl"
+                            else "netlist"
+                            if ext == ".ipc"
+                            else "gerber"
+                        )
+                        artifacts.append(
+                            FabricationArtifact(
+                                artifact_type=artifact_type,
+                                path=artifact_path,
+                                media_type=_media_type_for(artifact_type),
+                            )
+                        )
+
+        return FabricationResult(
+            artifacts=tuple(artifacts),
+            diagnostics=tuple(diagnostics),
+            bom_result=bom_result,
+            pos_result=pos_result,
+            gerber_result=gerber_result,
+        )
+
+    # ------------------------------------------------------------------
+    # Private step runners
+    # ------------------------------------------------------------------
+
+    def _run_bom(
+        self, request: FabricationRequest
+    ) -> tuple[BOMOrchestrationResult | None, list[str]]:
+        """Run BOM orchestration and return result + diagnostics."""
+        diagnostics: list[str] = []
+        try:
+            bom_request = BOMOrchestrationRequest(
+                input_path=request.input_path,
+                fabricator=request.fabricator,
+                inventory_files=request.inventory_files,
+                verbose=request.verbose,
+            )
+            result = BOMOrchestrationService().orchestrate(bom_request)
+            diagnostics.extend(result.diagnostics)
+            return result, diagnostics
+        except Exception as exc:
+            diagnostics.append(f"BOM generation failed: {exc}")
+            return None, diagnostics
+
+    def _run_pos(
+        self, request: FabricationRequest
+    ) -> tuple[POSOrchestrationResult | None, list[str]]:
+        """Run POS orchestration and return result + diagnostics."""
+        diagnostics: list[str] = []
+        try:
+            pos_request = POSOrchestrationRequest(
+                input_path=request.input_path,
+                fabricator=request.fabricator,
+                smd_only=request.smd_only,
+                layer=request.pos_layer,
+                origin=request.pos_origin,
+                verbose=request.verbose,
+            )
+            result = POSOrchestrationService().orchestrate(pos_request)
+            diagnostics.extend(result.diagnostics)
+            return result, diagnostics
+        except Exception as exc:
+            diagnostics.append(f"POS generation failed: {exc}")
+            return None, diagnostics
+
+    def _run_gerbers(
+        self, request: FabricationRequest
+    ) -> tuple[GerberResult | None, list[str]]:
+        """Resolve PCB file and run GerberExporter."""
+        diagnostics: list[str] = []
+
+        pcb_file, project_dir, resolve_diags = self._resolve_pcb_and_project_dir(
+            request
+        )
+        diagnostics.extend(resolve_diags)
+
+        if pcb_file is None:
+            diagnostics.append(
+                "Gerber generation skipped: PCB file could not be resolved "
+                "from the given input path."
+            )
+            return None, diagnostics
+
+        gerber_dir = self._resolve_gerber_output_dir(request, project_dir)
+        gerber_request = GerberRequest(
+            pcb_file=pcb_file,
+            output_directory=gerber_dir,
+            fabricator=request.fabricator,
+        )
+        try:
+            result = GerberExporter().generate(gerber_request)
+            return result, diagnostics
+        except Exception as exc:
+            diagnostics.append(f"Gerber generation failed unexpectedly: {exc}")
+            return None, diagnostics
+
+    def _resolve_pcb_and_project_dir(
+        self, request: FabricationRequest
+    ) -> tuple[Path | None, Path | None, list[str]]:
+        """Resolve PCB file path and project directory from input_path.
+
+        Returns:
+            ``(pcb_file, project_directory, diagnostics)``
+        """
+        diagnostics: list[str] = []
+        try:
+            from jbom.services.project_file_resolver import ProjectFileResolver
+
+            resolver = ProjectFileResolver(prefer_pcb=True, target_file_type="pcb")
+            resolved = resolver.resolve_input(request.input_path)
+            if not resolved.is_pcb:
+                resolved = resolver.resolve_for_wrong_file_type(resolved, "pcb")
+            pcb_file = resolved.resolved_path
+            project_dir: Path | None = None
+            if resolved.project_context:
+                project_dir = resolved.project_context.project_directory
+            if project_dir is None:
+                project_dir = pcb_file.parent
+            return pcb_file, project_dir, diagnostics
+        except Exception as exc:
+            if request.verbose:
+                diagnostics.append(f"Note: could not resolve PCB file: {exc}")
+            return None, None, diagnostics
+
+    def _resolve_gerber_output_dir(
+        self, request: FabricationRequest, project_dir: Path | None
+    ) -> Path:
+        """Return the directory where Gerber files should be written."""
+        if request.output_directory:
+            return Path(request.output_directory) / "gerbers"
+        if project_dir is not None:
+            return project_dir / "gerbers"
+        return Path("gerbers")
+
+
+def _media_type_for(artifact_type: str) -> str:
+    """Return MIME type string for a fabrication artifact type token."""
+    mapping = {
+        "bom": "text/csv",
+        "pos": "text/csv",
+        "gerber": "application/x-gerber",
+        "drill": "application/x-excellon",
+        "netlist": "text/plain",
+    }
+    return mapping.get(artifact_type, "application/octet-stream")

--- a/src/jbom/cli/fabrication.py
+++ b/src/jbom/cli/fabrication.py
@@ -1,0 +1,363 @@
+"""Fabrication command — one-shot BOM + POS + Gerber generation.
+
+``jbom fab`` is a convenience orchestrator equivalent to running::
+
+    jbom bom   <project> --fabricator <fab>
+    jbom pos   <project> --fabricator <fab>
+    jbom gerbers <project> --fabricator <fab>
+
+in sequence.  It delegates all generation logic to
+:class:`~jbom.application.fabrication_orchestration.FabricationWorkflow`.
+
+Field customisation is intentionally not supported here: ``--fabricator``
+selects the profile and its configured default fields are used for both BOM
+and POS.  Users who need per-field control should run ``jbom bom`` and
+``jbom pos`` individually, or define a custom fabricator config.
+
+This module imports ``_output_bom`` and ``_output_pos`` from the sibling CLI
+modules to reuse their field-resolution and CSV-writing logic.  This coupling
+is within the CLI adapter layer and is acceptable; the layering cleanup is
+tracked in issue #237.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from jbom.application.fabrication_orchestration import (
+    FabricationRequest,
+    FabricationResult,
+    FabricationWorkflow,
+)
+from jbom.application.jobs.contracts import (
+    JobContext,
+    JobDiagnosticSeverity,
+    JobOutcome,
+    JobRequest,
+)
+from jbom.application.jobs.runner import JobEventStream, JobRunPayload, JobRunner
+from jbom.cli.bom import _output_bom
+from jbom.cli.output import add_force_argument
+from jbom.cli.pos import _output_pos
+from jbom.common.cli_fabricator import (
+    add_fabricator_arguments,
+    resolve_fabricator_from_args,
+)
+
+
+def register_command(subparsers) -> None:  # type: ignore[type-arg]
+    """Register the ``fab`` command with the argument parser."""
+    parser = subparsers.add_parser(
+        "fab",
+        help="Generate BOM, placement, and Gerber fabrication files in one shot",
+        description=(
+            "Run BOM, POS (placement), and Gerber/drill generation for a KiCad "
+            "project in one coordinated step.  "
+            "Equivalent to running `jbom bom`, `jbom pos`, and `jbom gerbers` "
+            "in sequence with the same fabricator profile.\n\n"
+            "For per-field control use the individual commands.  "
+            "For non-default field sets define a custom fabricator config "
+            "(e.g. myspecialfab.yaml) and pass --fabricator myspecialfab."
+        ),
+    )
+
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=".",
+        help=(
+            "Path to KiCad project directory, .kicad_pro, .kicad_pcb, "
+            "or .kicad_sch file (default: current directory)"
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        metavar="DIR",
+        default=None,
+        help=(
+            "Override output directory for all generated files.  "
+            "BOM and POS CSVs are written here; Gerbers go to <DIR>/gerbers/.  "
+            "Default: project directory for BOM/POS, <project_dir>/gerbers/ for Gerbers."
+        ),
+    )
+    add_force_argument(parser)
+
+    # Step-skipping flags
+    parser.add_argument(
+        "--skip-bom",
+        action="store_true",
+        help="Skip BOM generation",
+    )
+    parser.add_argument(
+        "--skip-pos",
+        action="store_true",
+        help="Skip POS (placement) generation",
+    )
+    parser.add_argument(
+        "--skip-gerbers",
+        action="store_true",
+        help="Skip Gerber/drill generation",
+    )
+
+    # Gerber netlist opt-in
+    parser.add_argument(
+        "--netlist",
+        action="store_true",
+        help="Also generate an IPC-D-356 netlist during Gerber step",
+    )
+
+    # Inventory enhancement (forwarded to BOM)
+    parser.add_argument(
+        "--inventory",
+        action="append",
+        dest="inventory_files",
+        metavar="FILE",
+        help="Inventory CSV to enhance BOM (repeatable)",
+    )
+
+    # POS options (forwarded to POS orchestration)
+    parser.add_argument(
+        "--smd-only",
+        action="store_true",
+        help="Include only SMD components in POS output",
+    )
+    parser.add_argument(
+        "--layer",
+        choices=["TOP", "BOTTOM"],
+        help="Include only components on specified layer in POS output",
+    )
+    parser.add_argument(
+        "--origin",
+        choices=["board", "aux"],
+        default="board",
+        help="Origin reference for POS coordinates (default: board)",
+    )
+
+    # Dry-run
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Generate BOM/POS data but do not write files; "
+            "skip Gerber generation entirely"
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    add_fabricator_arguments(parser)
+    parser.set_defaults(handler=handle_fab)
+
+
+def handle_fab(args) -> int:  # type: ignore[type-arg]
+    """Handle the ``jbom fab`` command through the shared job runner."""
+    request = _build_fab_job_request(args)
+    context = JobContext(
+        adapter_id="cli",
+        session_id="local-process",
+        capabilities={
+            "event_stream": True,
+            "diagnostics": True,
+            "cancellation": False,
+        },
+    )
+    runner = JobRunner()
+
+    def _execute(events: JobEventStream) -> JobRunPayload:
+        events.progress(
+            phase="resolve",
+            message="Resolving project input and fabrication plan",
+        )
+        exit_code = _execute_fab_command(args)
+        if exit_code == 0:
+            events.progress(phase="emit", message="Fabrication outputs emitted")
+        else:
+            events.diagnostic(
+                severity=JobDiagnosticSeverity.ERROR,
+                message="Fabrication command execution failed",
+                code="fab_execution_failed",
+                details={"exit_code": exit_code},
+            )
+        return JobRunPayload(
+            outcome=JobOutcome.SUCCEEDED if exit_code == 0 else JobOutcome.FAILED,
+            artifacts=(),
+            metadata={"exit_code": exit_code, "command": "fab"},
+        )
+
+    result = runner.run(request=request, context=context, execute=_execute)
+    if result.outcome == JobOutcome.CANCELLED:
+        return 130
+    return int(result.metadata.get("exit_code", 1))
+
+
+def _build_fab_job_request(args) -> JobRequest:  # type: ignore[type-arg]
+    """Build adapter-neutral JobRequest for fab execution."""
+    fabricator = resolve_fabricator_from_args(args)
+    return JobRequest(
+        job_type="fab",
+        intent="generate_fabrication_artifacts",
+        project_ref=str(args.input or "."),
+        options={
+            "input": str(args.input or "."),
+            "fabricator": fabricator,
+            "skip_bom": bool(args.skip_bom),
+            "skip_pos": bool(args.skip_pos),
+            "skip_gerbers": bool(args.skip_gerbers),
+            "dry_run": bool(args.dry_run),
+        },
+        metadata={"adapter": "cli"},
+    )
+
+
+def _execute_fab_command(args) -> int:  # type: ignore[type-arg]
+    """Build FabricationRequest, run FabricationWorkflow, write outputs."""
+    try:
+        fabricator = resolve_fabricator_from_args(args)
+        output_dir: Optional[Path] = Path(args.output_dir) if args.output_dir else None
+        dry_run = bool(args.dry_run)
+        force = bool(args.force)
+
+        request = FabricationRequest(
+            input_path=str(args.input or "."),
+            fabricator=fabricator,
+            output_directory=str(output_dir) if output_dir else "",
+            skip_bom=bool(args.skip_bom),
+            skip_pos=bool(args.skip_pos),
+            skip_gerbers=bool(args.skip_gerbers),
+            verbose=bool(args.verbose),
+            dry_run=dry_run,
+            inventory_files=tuple(str(p) for p in (args.inventory_files or [])),
+            smd_only=bool(args.smd_only),
+            pos_layer=str(args.layer or ""),
+            pos_origin=str(args.origin or "board"),
+        )
+
+        # Create output directory if explicitly specified
+        if output_dir is not None:
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+        result = FabricationWorkflow().run(request)
+
+        # Emit diagnostics
+        for diag in result.diagnostics:
+            print(diag, file=sys.stderr)
+
+        exit_code = 0
+
+        # --- Write BOM ---
+        if not request.skip_bom:
+            exit_code = max(
+                exit_code,
+                _write_bom_output(result, fabricator, output_dir, dry_run, force),
+            )
+
+        # --- Write POS ---
+        if not request.skip_pos:
+            exit_code = max(
+                exit_code,
+                _write_pos_output(result, output_dir, dry_run, force),
+            )
+
+        # --- Report Gerbers ---
+        if not request.skip_gerbers and not dry_run:
+            _report_gerber_output(result)
+
+        return exit_code
+
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _write_bom_output(
+    result: FabricationResult,
+    fabricator: str,
+    output_dir: Optional[Path],
+    dry_run: bool,
+    force: bool,
+) -> int:
+    """Write the BOM CSV from a FabricationResult payload."""
+    if result.bom_result is None or result.bom_result.generation is None:
+        print("Note: BOM generation produced no output.", file=sys.stderr)
+        return 0
+
+    gen = result.bom_result.generation
+    bom_output: Optional[str] = None
+    if output_dir is not None:
+        bom_output = str(output_dir / gen.default_output_path.name)
+
+    if dry_run:
+        dest = bom_output or str(gen.default_output_path)
+        print(f"Dry run: BOM would be written to {dest}")
+        return 0
+
+    return _output_bom(
+        gen.bom_data,
+        bom_output,
+        list(gen.selected_fields),
+        fabricator,
+        default_output_path=gen.default_output_path,
+        force=force,
+    )
+
+
+def _write_pos_output(
+    result: FabricationResult,
+    output_dir: Optional[Path],
+    dry_run: bool,
+    force: bool,
+) -> int:
+    """Write the POS CSV from a FabricationResult payload."""
+    if result.pos_result is None or result.pos_result.generation is None:
+        print("Note: POS generation produced no output.", file=sys.stderr)
+        return 0
+
+    gen = result.pos_result.generation
+    pos_output: Optional[str] = None
+    if output_dir is not None:
+        pos_output = str(output_dir / gen.default_output_path.name)
+
+    if dry_run:
+        dest = pos_output or str(gen.default_output_path)
+        print(f"Dry run: POS would be written to {dest}")
+        return 0
+
+    return _output_pos(
+        list(gen.pos_data),
+        pos_output,
+        selected_fields=list(gen.selected_fields),
+        headers=list(gen.headers),
+        fabricator=gen.fabricator,
+        fabricator_config=gen.fabricator_config,
+        default_output_path=gen.default_output_path,
+        force=force,
+    )
+
+
+def _report_gerber_output(result: FabricationResult) -> None:
+    """Print Gerber artifact paths or skip reason to stdout/stderr."""
+    if result.gerber_result is None:
+        print(
+            "Note: Gerber generation produced no result. " "Check diagnostics above.",
+            file=sys.stderr,
+        )
+        return
+
+    if result.gerber_result.skipped:
+        print(
+            f"Note: Gerber generation skipped "
+            f"({result.gerber_result.skip_reason}). "
+            "Check diagnostics above.",
+            file=sys.stderr,
+        )
+        return
+
+    for artifact in result.artifacts:
+        if artifact.artifact_type in ("gerber", "drill", "netlist"):
+            print(f"Gerber: {artifact.path}")

--- a/src/jbom/cli/gerbers.py
+++ b/src/jbom/cli/gerbers.py
@@ -1,0 +1,211 @@
+"""Gerbers command — standalone Gerber/drill/netlist generation.
+
+``jbom gerbers`` is the correctness-validation path for KiCad Gerber generation:
+it exercises :class:`~jbom.services.gerber_service.GerberExporter` in isolation
+before the ``fab`` workflow calls it as part of a larger run.
+
+It follows the same thin adapter pattern as ``bom.py`` and ``pos.py``:
+argument parsing and output rendering only; all generation logic is in the
+application/service layer.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from jbom.common.cli_fabricator import (
+    add_fabricator_arguments,
+    resolve_fabricator_from_args,
+)
+from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
+from jbom.services.project_file_resolver import ProjectFileResolver
+
+
+def register_command(subparsers) -> None:  # type: ignore[type-arg]
+    """Register the ``gerbers`` command with the argument parser."""
+    parser = subparsers.add_parser(
+        "gerbers",
+        help="Generate Gerber/drill/netlist fabrication files from a KiCad PCB",
+        description=(
+            "Generate Gerber, drill, and IPC-D-356 netlist fabrication files "
+            "from a KiCad PCB file using kicad-cli.  "
+            "Requires KiCad with kicad-cli on the system PATH."
+        ),
+    )
+
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=".",
+        help=(
+            "Path to .kicad_pcb file, project directory, or base name "
+            "(default: current directory)"
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        metavar="DIR",
+        default=None,
+        help=(
+            "Output directory for Gerber/drill files "
+            "(default: <project_dir>/gerbers/)"
+        ),
+    )
+    parser.add_argument(
+        "--no-drill",
+        action="store_true",
+        help="Skip drill file generation",
+    )
+    parser.add_argument(
+        "--no-netlist",
+        action="store_true",
+        help="Skip IPC-D-356 netlist generation (default: netlist not generated)",
+    )
+    parser.add_argument(
+        "--netlist",
+        action="store_true",
+        help="Also generate an IPC-D-356 netlist",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Check prerequisites (kicad-cli, PCB file) without generating files",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    add_fabricator_arguments(parser)
+    parser.set_defaults(handler=handle_gerbers)
+
+
+def handle_gerbers(args) -> int:  # type: ignore[type-arg]
+    """Handle the ``jbom gerbers`` command."""
+    try:
+        return _execute_gerbers_command(args)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _execute_gerbers_command(args) -> int:  # type: ignore[type-arg]
+    """Resolve PCB file, build a GerberRequest, and call GerberExporter."""
+    fabricator = resolve_fabricator_from_args(args)
+    input_path = str(args.input or ".")
+    include_drill = not bool(args.no_drill)
+    include_netlist = bool(args.netlist) and not bool(args.no_netlist)
+    dry_run = bool(args.dry_run)
+    verbose = bool(args.verbose)
+
+    # Resolve PCB file from the input path
+    pcb_file, project_dir = _resolve_pcb_file(input_path, verbose=verbose)
+    if pcb_file is None:
+        print(
+            f"Error: could not resolve a KiCad PCB file from '{input_path}'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Determine output directory
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    elif project_dir is not None:
+        output_dir = project_dir / "gerbers"
+    else:
+        output_dir = pcb_file.parent / "gerbers"
+
+    if dry_run:
+        print(f"Dry run: PCB file  : {pcb_file}")
+        print(f"Dry run: Output dir: {output_dir}")
+        print(f"Dry run: Fabricator: {fabricator}")
+        print(f"Dry run: Drill     : {'yes' if include_drill else 'no'}")
+        print(f"Dry run: Netlist   : {'yes' if include_netlist else 'no'}")
+        # Check prerequisites without generating
+        import shutil
+
+        if shutil.which("kicad-cli") is None:
+            print(
+                "Warning: kicad-cli not found on PATH — "
+                "Gerber generation would be skipped.",
+                file=sys.stderr,
+            )
+            return 1
+        if not pcb_file.exists():
+            print(
+                f"Warning: PCB file '{pcb_file}' does not exist — "
+                "Gerber generation would be skipped.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Dry run: Prerequisites OK.")
+        return 0
+
+    request = GerberRequest(
+        pcb_file=pcb_file,
+        output_directory=output_dir,
+        fabricator=fabricator,
+        include_drill=include_drill,
+        include_netlist=include_netlist,
+    )
+
+    result = GerberExporter().generate(request)
+    return _render_gerber_result(result, verbose=verbose)
+
+
+def _render_gerber_result(result: GerberResult, *, verbose: bool) -> int:
+    """Print GerberResult diagnostics and artifact paths; return exit code."""
+    for diagnostic in result.diagnostics:
+        print(diagnostic, file=sys.stderr)
+
+    if result.skipped:
+        print(
+            f"Gerber generation skipped ({result.skip_reason}). " "See messages above.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not result.artifacts:
+        print(
+            "Warning: kicad-cli succeeded but no output files were found.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for path in result.artifacts:
+        print(f"Written: {path}")
+
+    if verbose:
+        print(f"\n{len(result.artifacts)} fabrication file(s) generated.")
+    return 0
+
+
+def _resolve_pcb_file(
+    input_path: str,
+    *,
+    verbose: bool,
+) -> tuple[Path | None, Path | None]:
+    """Resolve the PCB file from an input path.
+
+    Returns:
+        ``(pcb_file, project_directory)`` — both ``None`` on failure.
+    """
+    try:
+        resolver = ProjectFileResolver(prefer_pcb=True, target_file_type="pcb")
+        resolved = resolver.resolve_input(input_path)
+        if not resolved.is_pcb:
+            resolved = resolver.resolve_for_wrong_file_type(resolved, "pcb")
+        pcb_file = resolved.resolved_path
+        project_dir: Path | None = None
+        if resolved.project_context:
+            project_dir = resolved.project_context.project_directory
+        if project_dir is None:
+            project_dir = pcb_file.parent
+        return pcb_file, project_dir
+    except Exception as exc:
+        if verbose:
+            print(f"Note: PCB resolution failed: {exc}", file=sys.stderr)
+        return None, None

--- a/src/jbom/cli/main.py
+++ b/src/jbom/cli/main.py
@@ -9,6 +9,8 @@ from jbom.cli import (
     annotate,
     audit,
     bom,
+    fabrication,
+    gerbers,
     inventory,
     pos,
     parts,
@@ -51,6 +53,8 @@ def create_parser() -> argparse.ArgumentParser:
     audit.register_command(subparsers)
     bom.register_command(subparsers)
     annotate.register_command(subparsers)
+    fabrication.register_command(subparsers)
+    gerbers.register_command(subparsers)
     inventory.register_command(subparsers)
     pos.register_command(subparsers)
     parts.register_command(subparsers)

--- a/src/jbom/services/gerber_service.py
+++ b/src/jbom/services/gerber_service.py
@@ -1,0 +1,297 @@
+"""Gerber/drill/netlist export service for fabrication artifact generation.
+
+Tiered dispatch:
+1. ``kicad-cli pcb export`` subprocess — available whenever KiCad is installed
+   and ``kicad-cli`` is on the PATH.
+2. ``pcbnew`` Python API (plugin mode) — stub only; raises a diagnostic because
+   the implementation is deferred to the plugin adapter issue (#227).
+3. Graceful degradation — when neither path is available the service returns a
+   ``GerberResult`` with ``skipped=True`` and an actionable diagnostic.  BOM
+   and POS generation are unaffected.
+
+Usage::
+
+    from jbom.services.gerber_service import GerberExporter, GerberRequest
+
+    result = GerberExporter().generate(
+        GerberRequest(
+            pcb_file=Path("myproject.kicad_pcb"),
+            output_directory=Path("fab/gerbers"),
+        )
+    )
+    if result.skipped:
+        print(result.skip_reason)
+    else:
+        for path in result.artifacts:
+            print(path)
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from jbom.common.kicad_runtime import is_running_inside_kicad
+
+__all__ = [
+    "GerberExporter",
+    "GerberRequest",
+    "GerberResult",
+]
+
+
+def _normalize_text(value: str, *, field_name: str) -> str:
+    """Validate and normalise a required non-empty text field."""
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+@dataclass(frozen=True)
+class GerberRequest:
+    """Adapter-neutral request for Gerber/drill/netlist generation.
+
+    Attributes:
+        pcb_file: Path to the ``.kicad_pcb`` source file.
+        output_directory: Directory where fabrication artifacts are written.
+            Created automatically if it does not exist.
+        fabricator: Fabricator profile identifier (e.g. ``"jlc"``).  Reserved
+            for future plot-option customisation per fabricator; currently
+            used only for diagnostics.
+        include_drill: When ``True`` (default) also run ``kicad-cli pcb export
+            drill`` to produce PTH/NPTH drill files.
+        include_netlist: When ``True`` also run ``kicad-cli pcb export ipc356``
+            to produce an IPC-D-356 netlist.  Defaults to ``False`` as most
+            fabricators do not require it.
+    """
+
+    pcb_file: Path
+    output_directory: Path
+    fabricator: str = "generic"
+    include_drill: bool = True
+    include_netlist: bool = False
+
+    def __post_init__(self) -> None:
+        # Validate raw input *before* Path coercion: Path("") → Path(".") in Python,
+        # so checking str() of the already-coerced value would silently accept "".
+        if not str(self.pcb_file or "").strip():
+            raise ValueError("pcb_file must be non-empty")
+        if not str(self.output_directory or "").strip():
+            raise ValueError("output_directory must be non-empty")
+        object.__setattr__(self, "pcb_file", Path(self.pcb_file))
+        object.__setattr__(self, "output_directory", Path(self.output_directory))
+        object.__setattr__(
+            self,
+            "fabricator",
+            _normalize_text(self.fabricator or "generic", field_name="fabricator"),
+        )
+        object.__setattr__(self, "include_drill", bool(self.include_drill))
+        object.__setattr__(self, "include_netlist", bool(self.include_netlist))
+
+
+@dataclass(frozen=True)
+class GerberResult:
+    """Result from a Gerber/drill/netlist generation attempt.
+
+    Attributes:
+        artifacts: Paths of all files written to ``output_directory``.
+            Empty when ``skipped`` is ``True``.
+        diagnostics: Human-readable messages emitted during generation.
+            Always present; may be empty on clean success.
+        skipped: ``True`` when generation could not proceed (e.g. missing
+            ``kicad-cli``, missing PCB file, or plugin-mode stub).
+        skip_reason: Short machine-readable token explaining why generation
+            was skipped (e.g. ``"kicad_cli_not_found"``).  Empty string when
+            ``skipped`` is ``False``.
+    """
+
+    artifacts: tuple[Path, ...]
+    diagnostics: tuple[str, ...]
+    skipped: bool = False
+    skip_reason: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artifacts", tuple(self.artifacts))
+        object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
+        object.__setattr__(self, "skipped", bool(self.skipped))
+        object.__setattr__(self, "skip_reason", str(self.skip_reason or ""))
+
+
+class GerberExporter:
+    """Generate Gerber, drill, and netlist fabrication artifacts from a KiCad PCB.
+
+    Dispatch priority:
+    1. When **not** running inside KiCad: ``kicad-cli`` subprocess.
+    2. When running inside KiCad (plugin mode): ``pcbnew`` API stub —
+       returns a diagnostic because the implementation is deferred to #227.
+    """
+
+    def generate(self, request: GerberRequest) -> GerberResult:
+        """Generate fabrication artifacts for the given PCB file.
+
+        Args:
+            request: Options for Gerber/drill/netlist generation.
+
+        Returns:
+            :class:`GerberResult` with artifact paths and diagnostics.
+            ``skipped`` is ``True`` when generation was not possible.
+        """
+        if is_running_inside_kicad():
+            return self._generate_via_pcbnew(request)
+        return self._generate_via_kicad_cli(request)
+
+    # ------------------------------------------------------------------
+    # Private dispatch implementations
+    # ------------------------------------------------------------------
+
+    def _generate_via_pcbnew(self, request: GerberRequest) -> GerberResult:
+        """Plugin-mode stub — pcbnew API generation is not yet implemented."""
+        return GerberResult(
+            artifacts=(),
+            diagnostics=(
+                "Gerber generation via the pcbnew Python API is not yet implemented "
+                "(tracked in issue #227). "
+                "To generate Gerbers, run `jbom gerbers` from the command line "
+                "where kicad-cli is available.",
+            ),
+            skipped=True,
+            skip_reason="pcbnew_api_not_implemented",
+        )
+
+    def _generate_via_kicad_cli(self, request: GerberRequest) -> GerberResult:
+        """Generate Gerbers by invoking kicad-cli as a subprocess."""
+        kicad_cli = shutil.which("kicad-cli")
+        if kicad_cli is None:
+            return GerberResult(
+                artifacts=(),
+                diagnostics=(
+                    "kicad-cli not found on PATH. "
+                    "Install KiCad and ensure kicad-cli is accessible to generate "
+                    "Gerber/drill files. BOM and POS files are unaffected.",
+                ),
+                skipped=True,
+                skip_reason="kicad_cli_not_found",
+            )
+
+        if not request.pcb_file.exists():
+            return GerberResult(
+                artifacts=(),
+                diagnostics=(
+                    f"PCB file not found: {request.pcb_file}. "
+                    "Gerber generation skipped.",
+                ),
+                skipped=True,
+                skip_reason="pcb_file_not_found",
+            )
+
+        request.output_directory.mkdir(parents=True, exist_ok=True)
+
+        diagnostics: list[str] = []
+        artifacts: list[Path] = []
+
+        # --- Gerbers ---
+        before = set(request.output_directory.iterdir())
+        err = self._run_kicad_cli(
+            kicad_cli,
+            args=[
+                "pcb",
+                "export",
+                "gerbers",
+                "--output",
+                str(request.output_directory),
+                str(request.pcb_file),
+            ],
+            step="gerbers",
+        )
+        if err:
+            diagnostics.append(err)
+            return GerberResult(
+                artifacts=(),
+                diagnostics=tuple(diagnostics),
+                skipped=True,
+                skip_reason="gerber_export_failed",
+            )
+        after = set(request.output_directory.iterdir())
+        artifacts.extend(sorted(after - before))
+
+        # --- Drill files ---
+        if request.include_drill:
+            before = set(request.output_directory.iterdir())
+            err = self._run_kicad_cli(
+                kicad_cli,
+                args=[
+                    "pcb",
+                    "export",
+                    "drill",
+                    "--output",
+                    str(request.output_directory),
+                    str(request.pcb_file),
+                ],
+                step="drill",
+            )
+            if err:
+                diagnostics.append(err)
+            else:
+                after = set(request.output_directory.iterdir())
+                artifacts.extend(sorted(after - before))
+
+        # --- IPC-D-356 netlist ---
+        if request.include_netlist:
+            netlist_file = request.output_directory / f"{request.pcb_file.stem}.ipc"
+            before = set(request.output_directory.iterdir())
+            err = self._run_kicad_cli(
+                kicad_cli,
+                args=[
+                    "pcb",
+                    "export",
+                    "ipc356",
+                    "--output",
+                    str(netlist_file),
+                    str(request.pcb_file),
+                ],
+                step="netlist",
+            )
+            if err:
+                diagnostics.append(err)
+            else:
+                after = set(request.output_directory.iterdir())
+                artifacts.extend(sorted(after - before))
+
+        return GerberResult(
+            artifacts=tuple(artifacts),
+            diagnostics=tuple(diagnostics),
+            skipped=False,
+        )
+
+    def _run_kicad_cli(
+        self,
+        kicad_cli: str,
+        *,
+        args: list[str],
+        step: str,
+    ) -> str | None:
+        """Run a kicad-cli command.
+
+        Returns:
+            An error message string on failure, or ``None`` on success.
+        """
+        try:
+            result = subprocess.run(
+                [kicad_cli, *args],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "(no output)").strip()
+                return (
+                    f"kicad-cli {step} failed " f"(exit {result.returncode}): {detail}"
+                )
+            return None
+        except subprocess.TimeoutExpired:
+            return f"kicad-cli {step} timed out after 120 seconds"
+        except OSError as exc:
+            return f"kicad-cli {step} invocation failed: {exc}"

--- a/tests/services/test_fabrication_orchestration.py
+++ b/tests/services/test_fabrication_orchestration.py
@@ -1,0 +1,302 @@
+"""Service-level tests for FabricationWorkflow (issue #224).
+
+Covers:
+- FabricationRequest validation (empty input_path raises)
+- FabricationWorkflow.run with all steps skipped → empty result
+- BOM step skipped when skip_bom=True
+- POS step skipped when skip_pos=True
+- Gerber step skipped when skip_gerbers=True
+- Gerber step skipped in dry_run mode with diagnostic
+- Fabricator propagated to BOM and POS sub-services
+- Sub-service failures captured as diagnostics, not exceptions
+- FabricationResult structure: artifacts, diagnostics, sub-results
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from jbom.application.fabrication_orchestration import (
+    FabricationRequest,
+    FabricationResult,
+    FabricationWorkflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# FabricationRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationRequestValidation:
+    def test_raises_when_input_path_empty(self) -> None:
+        with pytest.raises(ValueError, match="input_path"):
+            FabricationRequest(input_path="")
+
+    def test_raises_when_input_path_whitespace(self) -> None:
+        with pytest.raises(ValueError, match="input_path"):
+            FabricationRequest(input_path="   ")
+
+    def test_defaults_are_sane(self) -> None:
+        req = FabricationRequest(input_path=".")
+        assert req.fabricator == "generic"
+        assert req.skip_bom is False
+        assert req.skip_pos is False
+        assert req.skip_gerbers is False
+        assert req.dry_run is False
+        assert req.inventory_files == ()
+        assert req.pos_origin == "board"
+
+    def test_inventory_files_coerced_to_tuple(self) -> None:
+        req = FabricationRequest(
+            input_path=".",
+            inventory_files=["a.csv", "b.csv"],  # type: ignore[arg-type]
+        )
+        assert req.inventory_files == ("a.csv", "b.csv")
+        assert isinstance(req.inventory_files, tuple)
+
+
+# ---------------------------------------------------------------------------
+# All-skipped: empty result
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationWorkflowAllSkipped:
+    def test_all_skipped_returns_empty_artifacts(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        result = FabricationWorkflow().run(request)
+        assert result.artifacts == ()
+        assert result.bom_result is None
+        assert result.pos_result is None
+        assert result.gerber_result is None
+
+    def test_all_skipped_returns_empty_diagnostics(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        result = FabricationWorkflow().run(request)
+        assert result.diagnostics == ()
+
+
+# ---------------------------------------------------------------------------
+# Skip flags gate their respective services
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationWorkflowSkipFlags:
+    def test_skip_bom_does_not_call_bom_service(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+        ) as mock_bom:
+            FabricationWorkflow().run(request)
+            mock_bom.assert_not_called()
+
+    def test_skip_pos_does_not_call_pos_service(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.POSOrchestrationService"
+        ) as mock_pos:
+            FabricationWorkflow().run(request)
+            mock_pos.assert_not_called()
+
+    def test_skip_gerbers_does_not_call_gerber_exporter(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.GerberExporter"
+        ) as mock_gerber:
+            FabricationWorkflow().run(request)
+            mock_gerber.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# dry_run skips Gerbers with a diagnostic
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationWorkflowDryRun:
+    def test_dry_run_skips_gerbers(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            dry_run=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.GerberExporter"
+        ) as mock_gerber:
+            result = FabricationWorkflow().run(request)
+            mock_gerber.assert_not_called()
+
+        assert result.gerber_result is None
+        assert any("Dry run" in d for d in result.diagnostics)
+
+    def test_dry_run_still_processes_bom(self) -> None:
+        """dry_run=True should NOT block BOM generation (only Gerbers)."""
+        bom_mock_result = SimpleNamespace(
+            diagnostics=(),
+            generation=SimpleNamespace(
+                default_output_path=Path("/tmp/proj.bom.csv"),
+                bom_data=SimpleNamespace(entries=[]),
+                selected_fields=("reference",),
+            ),
+        )
+        request = FabricationRequest(
+            input_path=".",
+            skip_pos=True,
+            skip_gerbers=False,
+            dry_run=True,
+        )
+        with (
+            patch(
+                "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+            ) as mock_bom_cls,
+            patch(
+                "jbom.application.fabrication_orchestration.GerberExporter"
+            ) as mock_gerber,
+        ):
+            mock_bom_cls.return_value.orchestrate.return_value = bom_mock_result
+            result = FabricationWorkflow().run(request)
+
+        mock_bom_cls.return_value.orchestrate.assert_called_once()
+        mock_gerber.assert_not_called()
+        assert result.bom_result is bom_mock_result
+
+
+# ---------------------------------------------------------------------------
+# Fabricator propagation
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationWorkflowFabricatorPropagation:
+    def test_fabricator_forwarded_to_bom(self) -> None:
+        bom_mock_result = SimpleNamespace(diagnostics=(), generation=None)
+        pos_mock_result = SimpleNamespace(diagnostics=(), generation=None)
+
+        request = FabricationRequest(
+            input_path=".",
+            fabricator="jlc",
+            skip_gerbers=True,
+        )
+        captured_bom_requests = []
+        captured_pos_requests = []
+
+        def _capture_bom(req):
+            captured_bom_requests.append(req)
+            return bom_mock_result
+
+        def _capture_pos(req):
+            captured_pos_requests.append(req)
+            return pos_mock_result
+
+        with (
+            patch(
+                "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+            ) as mock_bom_cls,
+            patch(
+                "jbom.application.fabrication_orchestration.POSOrchestrationService"
+            ) as mock_pos_cls,
+        ):
+            mock_bom_cls.return_value.orchestrate.side_effect = _capture_bom
+            mock_pos_cls.return_value.orchestrate.side_effect = _capture_pos
+            FabricationWorkflow().run(request)
+
+        assert len(captured_bom_requests) == 1
+        assert captured_bom_requests[0].fabricator == "jlc"
+        assert len(captured_pos_requests) == 1
+        assert captured_pos_requests[0].fabricator == "jlc"
+
+
+# ---------------------------------------------------------------------------
+# Sub-service failure captured as diagnostic
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationWorkflowSubServiceFailure:
+    def test_bom_failure_captured_as_diagnostic(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+        ) as mock_bom_cls:
+            mock_bom_cls.return_value.orchestrate.side_effect = RuntimeError(
+                "schematic not found"
+            )
+            result = FabricationWorkflow().run(request)
+
+        assert result.bom_result is None
+        assert any("BOM generation failed" in d for d in result.diagnostics)
+
+    def test_pos_failure_captured_as_diagnostic(self) -> None:
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.POSOrchestrationService"
+        ) as mock_pos_cls:
+            mock_pos_cls.return_value.orchestrate.side_effect = RuntimeError(
+                "pcb not found"
+            )
+            result = FabricationWorkflow().run(request)
+
+        assert result.pos_result is None
+        assert any("POS generation failed" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# FabricationResult structure
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationResultStructure:
+    def test_result_is_frozen(self) -> None:
+        result = FabricationResult(artifacts=(), diagnostics=())
+        with pytest.raises(Exception):
+            result.diagnostics = ("mutated",)  # type: ignore[misc]
+
+    def test_artifacts_tuple_coercion(self) -> None:
+        from jbom.application.fabrication_orchestration import FabricationArtifact
+
+        artifact = FabricationArtifact(
+            artifact_type="bom",
+            path=Path("/tmp/test.bom.csv"),
+            media_type="text/csv",
+        )
+        result = FabricationResult(
+            artifacts=[artifact],  # type: ignore[arg-type]
+            diagnostics=(),
+        )
+        assert isinstance(result.artifacts, tuple)
+        assert len(result.artifacts) == 1

--- a/tests/unit/test_fabrication_cli.py
+++ b/tests/unit/test_fabrication_cli.py
@@ -1,0 +1,189 @@
+"""Unit tests for the ``jbom fab`` CLI command (issue #224).
+
+Covers:
+- Command registration in the main parser
+- Argument defaults (skip-bom, skip-pos, skip-gerbers, dry-run)
+- ``--skip-gerbers`` flag correctly set
+- handle_fab routes through FabricationWorkflow
+- Dry-run outputs projected paths without writing files
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from jbom.cli.main import create_parser
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestFabCommandRegistration:
+    def test_fab_registered_in_main_parser(self) -> None:
+        parser = create_parser()
+        subparsers_action = None
+        for action in parser._subparsers._group_actions:  # type: ignore[attr-defined]
+            if hasattr(action, "choices"):
+                subparsers_action = action
+                break
+        assert subparsers_action is not None
+        assert "fab" in subparsers_action.choices
+
+    def test_fab_default_arguments(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["fab", "."])
+        assert args.skip_bom is False
+        assert args.skip_pos is False
+        assert args.skip_gerbers is False
+        assert args.dry_run is False
+        assert args.origin == "board"
+
+    def test_skip_flags_are_parseable(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(
+            ["fab", ".", "--skip-bom", "--skip-pos", "--skip-gerbers"]
+        )
+        assert args.skip_bom is True
+        assert args.skip_pos is True
+        assert args.skip_gerbers is True
+
+    def test_dry_run_parseable(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["fab", ".", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_inventory_repeatable(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(
+            ["fab", ".", "--inventory", "a.csv", "--inventory", "b.csv"]
+        )
+        assert args.inventory_files == ["a.csv", "b.csv"]
+
+    def test_output_dir_argument(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["fab", ".", "-o", "/tmp/fab_out"])
+        assert args.output_dir == "/tmp/fab_out"
+
+
+# ---------------------------------------------------------------------------
+# handle_fab: all-skip (no-op) run
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFabAllSkip:
+    def _make_all_skip_args(self) -> SimpleNamespace:
+        args = SimpleNamespace(
+            input=".",
+            output_dir=None,
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+            dry_run=False,
+            verbose=False,
+            force=False,
+            netlist=False,
+            inventory_files=None,
+            smd_only=False,
+            layer=None,
+            origin="board",
+            fabricator=None,
+            defaults="generic",
+        )
+        from jbom.config.fabricators import get_available_fabricators
+
+        for fid in get_available_fabricators():
+            setattr(args, f"fabricator_flag_{fid}", False)
+        return args
+
+    def test_all_skip_exits_0(self) -> None:
+        from jbom.cli.fabrication import handle_fab
+
+        args = self._make_all_skip_args()
+        rc = handle_fab(args)
+        assert rc == 0
+
+    def test_all_skip_does_not_call_bom_service(self) -> None:
+        from jbom.cli.fabrication import handle_fab
+
+        args = self._make_all_skip_args()
+        with patch(
+            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+        ) as mock_bom:
+            handle_fab(args)
+            mock_bom.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# handle_fab: dry_run with all-skip
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFabDryRun:
+    def test_dry_run_all_skip_exits_0(self) -> None:
+        from jbom.cli.fabrication import handle_fab
+
+        args = SimpleNamespace(
+            input=".",
+            output_dir=None,
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+            dry_run=True,
+            verbose=False,
+            force=False,
+            netlist=False,
+            inventory_files=None,
+            smd_only=False,
+            layer=None,
+            origin="board",
+            fabricator=None,
+            defaults="generic",
+        )
+        from jbom.config.fabricators import get_available_fabricators
+
+        for fid in get_available_fabricators():
+            setattr(args, f"fabricator_flag_{fid}", False)
+
+        rc = handle_fab(args)
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# FabricationWorkflow routing
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFabWorkflowRouting:
+    def test_skip_gerbers_does_not_invoke_gerber_exporter(self) -> None:
+        from jbom.cli.fabrication import handle_fab
+
+        args = SimpleNamespace(
+            input=".",
+            output_dir=None,
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+            dry_run=False,
+            verbose=False,
+            force=False,
+            netlist=False,
+            inventory_files=None,
+            smd_only=False,
+            layer=None,
+            origin="board",
+            fabricator=None,
+            defaults="generic",
+        )
+        from jbom.config.fabricators import get_available_fabricators
+
+        for fid in get_available_fabricators():
+            setattr(args, f"fabricator_flag_{fid}", False)
+
+        with patch(
+            "jbom.application.fabrication_orchestration.GerberExporter"
+        ) as mock_gerber:
+            handle_fab(args)
+            mock_gerber.assert_not_called()

--- a/tests/unit/test_gerber_service.py
+++ b/tests/unit/test_gerber_service.py
@@ -1,0 +1,277 @@
+"""Unit tests for GerberExporter, GerberRequest, and GerberResult (issue #224).
+
+Covers:
+- GerberRequest validation (empty fields raise ValueError)
+- GerberResult structure and post-init normalisation
+- GerberExporter: kicad-cli not on PATH → skipped result
+- GerberExporter: PCB file not found → skipped result
+- GerberExporter: plugin mode (pcbnew importable) → stub skipped result
+- GerberExporter: kicad-cli succeeds → artifacts collected
+- GerberExporter: kicad-cli gerber step fails → skipped result with error
+- GerberExporter: drill step failure produces diagnostic but does not skip whole result
+- output_directory is created when it does not exist
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
+
+
+# ---------------------------------------------------------------------------
+# GerberRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestGerberRequestValidation:
+    def test_raises_when_pcb_file_empty(self, tmp_path: Path) -> None:
+        # Use a plain empty string — Path("") → Path(".") so it would not raise.
+        with pytest.raises(ValueError):
+            GerberRequest(pcb_file="", output_directory=tmp_path)  # type: ignore[arg-type]
+
+    def test_raises_when_output_directory_empty(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            GerberRequest(
+                pcb_file=tmp_path / "board.kicad_pcb",
+                output_directory="",  # type: ignore[arg-type]
+            )
+
+    def test_defaults_are_sane(self, tmp_path: Path) -> None:
+        req = GerberRequest(
+            pcb_file=tmp_path / "board.kicad_pcb",
+            output_directory=tmp_path / "gerbers",
+        )
+        assert req.fabricator == "generic"
+        assert req.include_drill is True
+        assert req.include_netlist is False
+
+    def test_path_coercion(self, tmp_path: Path) -> None:
+        req = GerberRequest(
+            pcb_file=str(tmp_path / "board.kicad_pcb"),  # type: ignore[arg-type]
+            output_directory=str(tmp_path / "gerbers"),  # type: ignore[arg-type]
+        )
+        assert isinstance(req.pcb_file, Path)
+        assert isinstance(req.output_directory, Path)
+
+
+# ---------------------------------------------------------------------------
+# GerberResult structure
+# ---------------------------------------------------------------------------
+
+
+class TestGerberResult:
+    def test_skipped_defaults(self) -> None:
+        result = GerberResult(artifacts=(), diagnostics=())
+        assert result.skipped is False
+        assert result.skip_reason == ""
+
+    def test_skipped_result(self) -> None:
+        result = GerberResult(
+            artifacts=(),
+            diagnostics=("reason",),
+            skipped=True,
+            skip_reason="kicad_cli_not_found",
+        )
+        assert result.skipped is True
+        assert result.skip_reason == "kicad_cli_not_found"
+        assert result.artifacts == ()
+
+    def test_artifacts_immutable(self, tmp_path: Path) -> None:
+        p = tmp_path / "a.gbr"
+        result = GerberResult(artifacts=(p,), diagnostics=())
+        assert isinstance(result.artifacts, tuple)
+
+
+# ---------------------------------------------------------------------------
+# GerberExporter: kicad-cli not found
+# ---------------------------------------------------------------------------
+
+
+class TestGerberExporterNoKicadCli:
+    def test_returns_skipped_when_kicad_cli_absent(self, tmp_path: Path) -> None:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+
+        with patch("jbom.services.gerber_service.shutil.which", return_value=None):
+            result = GerberExporter().generate(
+                GerberRequest(
+                    pcb_file=pcb,
+                    output_directory=tmp_path / "gerbers",
+                )
+            )
+
+        assert result.skipped is True
+        assert result.skip_reason == "kicad_cli_not_found"
+        assert any("kicad-cli" in d for d in result.diagnostics)
+        assert result.artifacts == ()
+
+
+# ---------------------------------------------------------------------------
+# GerberExporter: PCB file missing
+# ---------------------------------------------------------------------------
+
+
+class TestGerberExporterMissingPcb:
+    def test_returns_skipped_when_pcb_missing(self, tmp_path: Path) -> None:
+        with patch(
+            "jbom.services.gerber_service.shutil.which",
+            return_value="/usr/bin/kicad-cli",
+        ):
+            result = GerberExporter().generate(
+                GerberRequest(
+                    pcb_file=tmp_path / "nonexistent.kicad_pcb",
+                    output_directory=tmp_path / "gerbers",
+                )
+            )
+
+        assert result.skipped is True
+        assert result.skip_reason == "pcb_file_not_found"
+        assert any("PCB file not found" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# GerberExporter: plugin mode stub
+# ---------------------------------------------------------------------------
+
+
+class TestGerberExporterPluginMode:
+    def test_plugin_mode_returns_stub_skipped(self, tmp_path: Path) -> None:
+        fake_pcbnew = types.ModuleType("pcbnew")
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+
+        with patch.dict(sys.modules, {"pcbnew": fake_pcbnew}):
+            result = GerberExporter().generate(
+                GerberRequest(
+                    pcb_file=pcb,
+                    output_directory=tmp_path / "gerbers",
+                )
+            )
+
+        assert result.skipped is True
+        assert result.skip_reason == "pcbnew_api_not_implemented"
+        assert any("not yet implemented" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# GerberExporter: kicad-cli gerber step fails
+# ---------------------------------------------------------------------------
+
+
+class TestGerberExporterCliFailure:
+    def test_skipped_when_gerber_command_fails(self, tmp_path: Path) -> None:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+        output_dir = tmp_path / "gerbers"
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "plot failed"
+        mock_result.stdout = ""
+
+        with (
+            patch(
+                "jbom.services.gerber_service.shutil.which",
+                return_value="/usr/bin/kicad-cli",
+            ),
+            patch(
+                "jbom.services.gerber_service.subprocess.run", return_value=mock_result
+            ),
+        ):
+            result = GerberExporter().generate(
+                GerberRequest(pcb_file=pcb, output_directory=output_dir)
+            )
+
+        assert result.skipped is True
+        assert result.skip_reason == "gerber_export_failed"
+        assert any("failed" in d for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# GerberExporter: successful run collects new artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestGerberExporterSuccess:
+    def _make_fake_run(self, output_dir: Path, filenames: list[str]):
+        """Return a subprocess.run mock that creates files on first call."""
+        call_count = [0]
+
+        def _fake_run(cmd, **_kwargs):
+            call_count[0] += 1
+            # First call is the gerbers export — create fake gerber files
+            if call_count[0] == 1:
+                for name in filenames:
+                    (output_dir / name).write_text("", encoding="utf-8")
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stderr = ""
+            mock.stdout = ""
+            return mock
+
+        return _fake_run
+
+    def test_artifacts_collected_after_successful_gerber_export(
+        self, tmp_path: Path
+    ) -> None:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+        output_dir = tmp_path / "gerbers"
+
+        fake_run = self._make_fake_run(output_dir, ["board-F.Cu.gbr", "board-B.Cu.gbr"])
+
+        with (
+            patch(
+                "jbom.services.gerber_service.shutil.which",
+                return_value="/usr/bin/kicad-cli",
+            ),
+            patch("jbom.services.gerber_service.subprocess.run", side_effect=fake_run),
+        ):
+            result = GerberExporter().generate(
+                GerberRequest(
+                    pcb_file=pcb,
+                    output_directory=output_dir,
+                    include_drill=False,
+                    include_netlist=False,
+                )
+            )
+
+        assert result.skipped is False
+        assert len(result.artifacts) == 2
+        assert all(a.suffix == ".gbr" for a in result.artifacts)
+
+    def test_output_directory_is_created_if_absent(self, tmp_path: Path) -> None:
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+        output_dir = tmp_path / "new" / "gerbers"
+        assert not output_dir.exists()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        mock_result.stdout = ""
+
+        with (
+            patch(
+                "jbom.services.gerber_service.shutil.which",
+                return_value="/usr/bin/kicad-cli",
+            ),
+            patch(
+                "jbom.services.gerber_service.subprocess.run", return_value=mock_result
+            ),
+        ):
+            GerberExporter().generate(
+                GerberRequest(
+                    pcb_file=pcb,
+                    output_directory=output_dir,
+                    include_drill=False,
+                )
+            )
+
+        assert output_dir.exists()

--- a/tests/unit/test_gerbers_cli.py
+++ b/tests/unit/test_gerbers_cli.py
@@ -1,0 +1,156 @@
+"""Unit tests for the ``jbom gerbers`` CLI command (issue #224).
+
+Covers:
+- Command registration in the main parser
+- ``--no-drill`` / ``--no-netlist`` / ``--netlist`` argument defaults
+- Graceful degradation when kicad-cli is unavailable (exit code 1, no crash)
+- Dry-run output when PCB file cannot be resolved
+- ``_render_gerber_result`` rendering for skipped and success states
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from jbom.cli.gerbers import _render_gerber_result
+from jbom.cli.main import create_parser
+from jbom.services.gerber_service import GerberResult
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestGerbersCommandRegistration:
+    def test_gerbers_registered_in_main_parser(self) -> None:
+        parser = create_parser()
+        # Triggers SystemExit(0) with help text; use parse_known_args to probe
+        subparsers_action = None
+        for action in parser._subparsers._group_actions:  # type: ignore[attr-defined]
+            if hasattr(action, "choices"):
+                subparsers_action = action
+                break
+        assert subparsers_action is not None
+        assert "gerbers" in subparsers_action.choices
+
+    def test_gerbers_has_expected_arguments(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(
+            ["gerbers", "--no-drill", "--netlist", "--dry-run", "."]
+        )
+        assert args.no_drill is True
+        assert args.netlist is True
+        assert args.dry_run is True
+
+    def test_no_drill_default_is_false(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["gerbers", "."])
+        assert args.no_drill is False
+
+    def test_netlist_default_is_false(self) -> None:
+        parser = create_parser()
+        args = parser.parse_args(["gerbers", "."])
+        assert args.netlist is False
+
+
+# ---------------------------------------------------------------------------
+# _render_gerber_result
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGerberResult:
+    def test_skipped_result_returns_exit_1(self, capsys) -> None:
+        result = GerberResult(
+            artifacts=(),
+            diagnostics=("kicad-cli not found",),
+            skipped=True,
+            skip_reason="kicad_cli_not_found",
+        )
+        rc = _render_gerber_result(result, verbose=False)
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "kicad_cli_not_found" in captured.err
+
+    def test_success_result_returns_exit_0(self, tmp_path: Path, capsys) -> None:
+        gbr = tmp_path / "board-F.Cu.gbr"
+        gbr.write_text("", encoding="utf-8")
+        result = GerberResult(artifacts=(gbr,), diagnostics=(), skipped=False)
+        rc = _render_gerber_result(result, verbose=False)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Written:" in captured.out
+
+    def test_verbose_prints_count(self, tmp_path: Path, capsys) -> None:
+        gbr = tmp_path / "board-F.Cu.gbr"
+        gbr.write_text("", encoding="utf-8")
+        result = GerberResult(artifacts=(gbr,), diagnostics=(), skipped=False)
+        _render_gerber_result(result, verbose=True)
+        captured = capsys.readouterr()
+        assert "1 fabrication file" in captured.out
+
+    def test_empty_artifacts_returns_exit_1(self, capsys) -> None:
+        result = GerberResult(artifacts=(), diagnostics=(), skipped=False)
+        rc = _render_gerber_result(result, verbose=False)
+        assert rc == 1
+        assert "no output files" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# handle_gerbers: graceful degradation without kicad-cli
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGerbersNoCli:
+    def test_handle_gerbers_returns_1_when_pcb_unresolvable(self, capsys) -> None:
+        """When PCB resolution fails, handle_gerbers must exit 1 not crash."""
+        from jbom.cli.gerbers import handle_gerbers
+
+        args = SimpleNamespace(
+            input="nonexistent_project_xyz",
+            output_dir=None,
+            no_drill=False,
+            no_netlist=False,
+            netlist=False,
+            dry_run=False,
+            verbose=False,
+            fabricator=None,
+        )
+        # Patch fabricator resolution flags
+        for fid in ["jlc", "pcbway", "seeed", "generic"]:
+            setattr(args, f"fabricator_flag_{fid}", False)
+
+        rc = handle_gerbers(args)
+        assert rc == 1
+
+    def test_handle_gerbers_kicad_cli_absent_exits_1(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """When kicad-cli is not installed, command exits 1 with diagnostic."""
+        from jbom.cli.gerbers import handle_gerbers
+
+        pcb = tmp_path / "board.kicad_pcb"
+        pcb.write_text("", encoding="utf-8")
+        (tmp_path / "board.kicad_pro").write_text("{}", encoding="utf-8")
+
+        args = SimpleNamespace(
+            input=str(tmp_path),
+            output_dir=None,
+            no_drill=False,
+            no_netlist=False,
+            netlist=False,
+            dry_run=False,
+            verbose=False,
+            fabricator=None,
+        )
+        for fid in ["jlc", "pcbway", "seeed", "generic"]:
+            setattr(args, f"fabricator_flag_{fid}", False)
+
+        with patch("jbom.services.gerber_service.shutil.which", return_value=None):
+            rc = handle_gerbers(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "kicad-cli" in captured.err


### PR DESCRIPTION
Closes #224

## Summary

Implements ADR 0005 Phase 3: fabrication artifact services and orchestration.

## What's included

### New service: `GerberExporter` (`services/gerber_service.py`)
Tiered Gerber/drill/IPC-D-356 generation:
1. `kicad-cli pcb export` subprocess (when KiCad is installed)
2. `pcbnew` Python API stub — returns actionable diagnostic; deferred to #227
3. Graceful degradation — `GerberResult(skipped=True)` with diagnostic when unavailable; BOM and POS are unaffected

### New application service: `FabricationWorkflow` (`application/fabrication_orchestration.py`)
Adapter-neutral orchestrator sequencing BOM → POS → Gerbers. Each step is independently skip-able. Sub-service failures are captured as diagnostics without aborting subsequent steps.

### New CLI command: `jbom gerbers`
Standalone Gerber/drill/netlist generation. This is the correctness-validation path for `GerberExporter` before `jbom fab` relies on it. Options: `--fabricator`, `-o/--output-dir`, `--no-drill`, `--netlist`, `--dry-run`.

### New CLI command: `jbom fab`
One-shot BOM + POS + Gerber generation. Equivalent to running `jbom bom`, `jbom pos`, `jbom gerbers` in sequence with the same fabricator profile. No `--fields` flag by design (use individual commands or a custom fabricator config for field control).

### Naming convention established
New code names classes after what they *produce*, not how they work. `Service`/`Orchestration` suffixes omitted. Cleanup of existing `BOMOrchestrationService`/`POSOrchestrationService` tracked in #237.

## Tests
49 new tests; 1057 total pass.

## Related
- Closes #224
- Tech-debt naming cleanup: #237
- Gerber plugin-mode implementation: #227

---
_This PR was created with [Oz](https://app.warp.dev/conversation/deec026a-908e-461d-977f-da7f776f772b) — [Implementation plan](https://app.warp.dev/drive/notebook/BdhOnNrHsId9DroUvHZTts)_

Co-Authored-By: Oz <oz-agent@warp.dev>