### PR TITLE
refactor(naming): rename BOM/POS orchestration classes to new naming convention (#237)

### DIFF
--- a/docs/dev/architecture/design-patterns.md
+++ b/docs/dev/architecture/design-patterns.md
@@ -64,19 +64,19 @@ Application layer commands orchestrate domain services without containing busine
 5. Error Handling
 ```
 
-### CLI-to-Orchestration Extraction Pattern
-Each command family (`bom`, `pos`, and future `search`/`inventory`) follows the same adapter-thin extraction contract.
+### CLI-to-Workflow Extraction Pattern
+Each command family (`bom`, `pos`, `gerbers`, `fab`) follows the same adapter-thin extraction contract.
 
 **Purpose**: Make command refactors repeatable with one stable application-layer template
-**Implementation**: Move orchestration into `src/jbom/application/<command>_orchestration.py` and keep CLI files as adapters
-**Benefits**: Consistent contracts, easier cross-command reviews, predictable test shape
+**Implementation**: Workflow logic lives in `src/jbom/application/<command>_workflow.py`; CLI files are adapters only
+**Benefits**: Consistent contracts, easier cross-command reviews, predictable test shape, reusable across CLI and plugin adapters
 
 **Extraction Contract**:
-1. Define a request dataclass (`<Command>OrchestrationRequest`) that normalizes adapter input.
-2. Define explicit mode enum + result dataclass (`<Command>OrchestrationMode`, `<Command>OrchestrationResult`) with mode-gated payload invariants.
+1. Define a request dataclass (`<Command>Request`) that normalizes adapter input.
+2. Define explicit mode enum + result dataclass (`<Command>Mode`, `<Command>Result`) with mode-gated payload invariants.
 3. Carry diagnostics as immutable result data (`tuple[str, ...]`) rather than callback side effects.
 4. Keep CLI responsibilities limited to argument mapping, diagnostics rendering, output rendering, and exit code mapping.
-5. Keep compatibility wrappers in CLI modules only when needed for legacy tests during migration.
+5. Expose a single public method `.run(request)` — name reflects *what you do with the object*, not the internal mechanism.
 
 ### Input Translation Pattern
 Convert interface-specific arguments to type-safe domain configuration objects.
@@ -84,22 +84,6 @@ Convert interface-specific arguments to type-safe domain configuration objects.
 **Purpose**: Bridge between interface representations and domain concepts
 **Implementation**: Translation functions create domain objects from interface data
 **Benefits**: Type safety, domain validation, interface independence
-
-### CLI-to-Orchestration Extraction Pattern
-Move command sequencing from CLI modules into application orchestration services while keeping adapters thin.
-
-**Purpose**: Keep business sequencing reusable and adapter-neutral while preserving existing CLI UX behavior
-**Implementation**: Add `src/jbom/application/<command>_orchestration.py` with request/result contracts and migrate sequencing logic out of `src/jbom/cli/<command>.py`
-**Benefits**: Shared orchestration core for future adapters, reduced CLI complexity, clearer contract boundaries
-
-**Extraction Contract**:
-```
-1. Define a request value object (<Command>OrchestrationRequest) for adapter input.
-2. Define an explicit mode enum (<Command>OrchestrationMode) for result variants.
-3. Define mode-gated result payloads (<Command>OrchestrationResult with typed payloads).
-4. Keep diagnostics on result contracts (immutable tuple), not adapter callbacks.
-5. Restrict CLI adapters to argument parsing, request mapping, rendering, and exit-code mapping.
-```
 
 ### Output Adaptation Pattern
 Transform domain results for interface-appropriate presentation formats.
@@ -243,5 +227,20 @@ New behavior added through configuration objects rather than code modification.
 **Purpose**: Add capabilities through configuration rather than code changes
 **Implementation**: Configuration objects that enable new processing options
 **Benefits**: Runtime flexibility, backward compatibility, minimal code impact
+
+## Naming Convention
+
+Established in issues #224 and #237; documented in `src/WARP.md`.
+
+**Rule**: Names reflect the *promise* (what is produced/delivered), not the mechanism.
+
+| Principle | Correct | Avoid |
+|---|---|---|
+| Class names | `BOMWorkflow`, `GerberExporter` | `BOMOrchestrationService`, `GerberService` |
+| `Service` suffix | Omit when module path provides context | `jbom.application.BOMWorkflowService` |
+| `Orchestration` in names | Never — describes *how*, not *what* | `BOMOrchestrationRequest` |
+| Public workflow method | `.run(request)` | `.orchestrate(request)`, `.execute(request)` |
+| Private helpers | `_list_fields`, `_generate` | `_orchestrate_field_listing`, `_do_generation` |
+| Module file names | `bom_workflow.py`, `pos_workflow.py` | `bom_orchestration.py`, `pos_orchestration.py` |
 
 These design patterns provide the foundation for consistent, maintainable, and extensible software architecture throughout the jBOM system.

--- a/docs/dev/architecture/layer-responsibilities.md
+++ b/docs/dev/architecture/layer-responsibilities.md
@@ -135,17 +135,22 @@ Orchestrates domain services and manages interface workflows without containing 
 
 #### Adapter-Thin CLI Contract Pattern
 ```
-Application module: src/jbom/application/<command>_orchestration.py
-Service class: <Command>OrchestrationService
-Contracts: <Command>OrchestrationRequest, <Command>OrchestrationMode, <Command>OrchestrationResult
-Diagnostics: immutable tuple on result contract (not callback side effects)
+Application module: src/jbom/application/<command>_workflow.py
+Workflow class:    <Command>Workflow          (e.g. BOMWorkflow, POSWorkflow, FabricationWorkflow)
+Request:           <Command>Request           (e.g. BOMRequest, POSRequest)
+Result:            <Command>Result            (e.g. BOMResult, POSResult)
+Mode enum:         <Command>Mode              (e.g. BOMMode — for multi-mode workflows)
+Public method:     .run(request) -> result
+Diagnostics:       immutable tuple on result contract (not callback side effects)
 ```
 
 CLI adapter responsibilities are intentionally narrow:
 1. Parse CLI flags/arguments.
-2. Build request contract and call orchestration service.
+2. Build request contract and call `.run()` on the workflow.
 3. Render diagnostics and output payloads.
-4. Map orchestration exceptions/outcomes to process exit semantics.
+4. Map exceptions/outcomes to process exit semantics.
+
+See also: **Naming Convention** in `design-patterns.md` and `src/WARP.md`.
 
 #### Service Composition Pattern
 ```python
@@ -159,23 +164,6 @@ components = reader.read_schematic(file_path)
 bom_data = generator.generate_bom_data(components)
 enhanced_bom = matcher.enhance_bom_with_inventory(bom_data, inventory)
 ```
-
-#### Adapter-Thin CLI Contract Pattern
-```
-Application module: src/jbom/application/<command>_orchestration.py
-Service class: <Command>OrchestrationService
-Contracts:
-  - <Command>OrchestrationRequest
-  - <Command>OrchestrationMode
-  - <Command>OrchestrationResult (mode-gated payloads + diagnostics tuple)
-```
-
-CLI adapters should remain narrowly focused on:
-- Parsing CLI arguments
-- Mapping arguments to orchestration request contracts
-- Invoking orchestration services
-- Rendering payloads to console/CSV/file outputs
-- Mapping exceptions/results to process exit codes
 
 ## Interface Layer
 

--- a/src/WARP.md
+++ b/src/WARP.md
@@ -22,6 +22,14 @@
 - Agent behavior expectations
     - When uncertain about alternate paths or solutions, ask for guidance
 
+## Naming Convention (established in issues #224/#237)
+- Class names reflect the **promise** (what the class produces/delivers), not the mechanism.
+- The `Service` suffix is omitted when the module path already provides context (`jbom.application.*`, `jbom.services.*`).
+- `Orchestration` is omitted from names — it describes *how*, not *what*.
+- Examples: `BOMWorkflow`, `POSWorkflow`, `FabricationWorkflow`, `GerberExporter`.
+- Application workflow classes expose a single public method named `.run(request)` — functional, not mechanistic.
+- Private helpers use descriptive functional names: `_list_fields`, `_generate`, not `_orchestrate_*`.
+
 
 ## Component Matching Logic
 **Tolerance Substitution:** Tighter tolerances can substitute looser (1% can replace 5%)

--- a/src/jbom/application/bom_workflow.py
+++ b/src/jbom/application/bom_workflow.py
@@ -63,7 +63,7 @@ def _normalize_text(value: str, *, field_name: str) -> str:
     return normalized
 
 
-class BOMOrchestrationMode(str, Enum):
+class BOMMode(str, Enum):
     """Result modes supported by BOM orchestration."""
 
     LIST_FIELDS = "list_fields"
@@ -71,7 +71,7 @@ class BOMOrchestrationMode(str, Enum):
 
 
 @dataclass(frozen=True)
-class BOMOrchestrationRequest:
+class BOMRequest:
     """Adapter-neutral request payload for BOM orchestration."""
 
     input_path: str
@@ -131,17 +131,17 @@ class BOMGenerationPayload:
 
 
 @dataclass(frozen=True)
-class BOMOrchestrationResult:
+class BOMResult:
     """Result contract emitted by BOM application orchestration."""
 
-    mode: BOMOrchestrationMode
+    mode: BOMMode
     diagnostics: tuple[str, ...] = ()
     field_listing: BOMFieldListingPayload | None = None
     generation: BOMGenerationPayload | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
-        if self.mode == BOMOrchestrationMode.LIST_FIELDS:
+        if self.mode == BOMMode.LIST_FIELDS:
             if self.field_listing is None:
                 raise ValueError(
                     "field_listing payload is required for list_fields mode"
@@ -150,7 +150,7 @@ class BOMOrchestrationResult:
                 raise ValueError(
                     "generation payload must be empty for list_fields mode"
                 )
-        if self.mode == BOMOrchestrationMode.GENERATE:
+        if self.mode == BOMMode.GENERATE:
             if self.generation is None:
                 raise ValueError("generation payload is required for generate mode")
             if self.field_listing is not None:
@@ -159,19 +159,17 @@ class BOMOrchestrationResult:
                 )
 
 
-class BOMOrchestrationService:
+class BOMWorkflow:
     """Application-layer BOM orchestration service."""
 
-    def orchestrate(self, request: BOMOrchestrationRequest) -> BOMOrchestrationResult:
+    def run(self, request: BOMRequest) -> BOMResult:
         """Run BOM orchestration and return adapter-neutral result payloads."""
 
         if request.list_fields:
-            return self._orchestrate_field_listing(request)
-        return self._orchestrate_generation(request)
+            return self._list_fields(request)
+        return self._generate(request)
 
-    def _orchestrate_field_listing(
-        self, request: BOMOrchestrationRequest
-    ) -> BOMOrchestrationResult:
+    def _list_fields(self, request: BOMRequest) -> BOMResult:
         """Resolve dynamic field inventory for `--list-fields` behavior."""
 
         list_components: list = []
@@ -215,14 +213,12 @@ class BOMOrchestrationService:
             pcb_components=list_pcb_components,
             inventory_column_names=list_inventory_columns,
         )
-        return BOMOrchestrationResult(
-            mode=BOMOrchestrationMode.LIST_FIELDS,
+        return BOMResult(
+            mode=BOMMode.LIST_FIELDS,
             field_listing=BOMFieldListingPayload(known_fields=known_fields),
         )
 
-    def _orchestrate_generation(
-        self, request: BOMOrchestrationRequest
-    ) -> BOMOrchestrationResult:
+    def _generate(self, request: BOMRequest) -> BOMResult:
         """Run BOM generation sequencing independent from CLI adapter concerns."""
 
         diagnostics: list[str] = []
@@ -347,8 +343,8 @@ class BOMOrchestrationService:
         )
         diagnostics.extend(smd_diagnostics)
 
-        return BOMOrchestrationResult(
-            mode=BOMOrchestrationMode.GENERATE,
+        return BOMResult(
+            mode=BOMMode.GENERATE,
             diagnostics=tuple(diagnostics),
             generation=BOMGenerationPayload(
                 bom_data=bom_data,
@@ -757,12 +753,12 @@ def build_known_bom_fields(
 
 
 __all__ = [
-    "BOMOrchestrationService",
+    "BOMWorkflow",
     "BOMFieldListingPayload",
     "BOMGenerationPayload",
-    "BOMOrchestrationMode",
-    "BOMOrchestrationRequest",
-    "BOMOrchestrationResult",
+    "BOMMode",
+    "BOMRequest",
+    "BOMResult",
     "build_known_bom_fields",
     "enforce_bom_device_footprints",
     "enrich_bom_smd_from_project_pcb",

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -2,8 +2,8 @@
 
 Sequences three fabrication steps in order:
 
-1. BOM generation — delegates to :class:`~jbom.application.bom_orchestration.BOMOrchestrationService`.
-2. POS (placement) generation — delegates to :class:`~jbom.application.pos_orchestration.POSOrchestrationService`.
+1. BOM generation — delegates to :class:`~jbom.application.bom_workflow.BOMWorkflow`.
+2. POS (placement) generation — delegates to :class:`~jbom.application.pos_workflow.POSWorkflow`.
 3. Gerber/drill/netlist export — delegates to :class:`~jbom.services.gerber_service.GerberExporter`.
 
 Each step is independently skip-able.  If Gerbers cannot be generated
@@ -19,7 +19,7 @@ files from the BOM/POS payloads.
 Naming convention:
   New code in this module follows the naming convention established in #224:
   class names reflect the *promise* (what is produced), not the mechanism.
-  The existing ``BOMOrchestrationService`` / ``POSOrchestrationService`` names
+  The existing ``BOMWorkflow`` / ``POSWorkflow`` names
   are unchanged here — renaming them is tracked in issue #237.
 """
 
@@ -30,15 +30,15 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Mapping
 
-from jbom.application.bom_orchestration import (
-    BOMOrchestrationRequest,
-    BOMOrchestrationResult,
-    BOMOrchestrationService,
+from jbom.application.bom_workflow import (
+    BOMRequest,
+    BOMResult,
+    BOMWorkflow,
 )
-from jbom.application.pos_orchestration import (
-    POSOrchestrationRequest,
-    POSOrchestrationResult,
-    POSOrchestrationService,
+from jbom.application.pos_workflow import (
+    POSRequest,
+    POSResult,
+    POSWorkflow,
 )
 from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
 
@@ -183,8 +183,8 @@ class FabricationResult:
 
     artifacts: tuple[FabricationArtifact, ...]
     diagnostics: tuple[str, ...]
-    bom_result: BOMOrchestrationResult | None = None
-    pos_result: POSOrchestrationResult | None = None
+    bom_result: BOMResult | None = None
+    pos_result: POSResult | None = None
     gerber_result: GerberResult | None = None
 
     def __post_init__(self) -> None:
@@ -214,8 +214,8 @@ class FabricationWorkflow:
         """
         diagnostics: list[str] = []
         artifacts: list[FabricationArtifact] = []
-        bom_result: BOMOrchestrationResult | None = None
-        pos_result: POSOrchestrationResult | None = None
+        bom_result: BOMResult | None = None
+        pos_result: POSResult | None = None
         gerber_result: GerberResult | None = None
 
         # ------------------------------------------------------------------
@@ -292,17 +292,17 @@ class FabricationWorkflow:
 
     def _run_bom(
         self, request: FabricationRequest
-    ) -> tuple[BOMOrchestrationResult | None, list[str]]:
+    ) -> tuple[BOMResult | None, list[str]]:
         """Run BOM orchestration and return result + diagnostics."""
         diagnostics: list[str] = []
         try:
-            bom_request = BOMOrchestrationRequest(
+            bom_request = BOMRequest(
                 input_path=request.input_path,
                 fabricator=request.fabricator,
                 inventory_files=request.inventory_files,
                 verbose=request.verbose,
             )
-            result = BOMOrchestrationService().orchestrate(bom_request)
+            result = BOMWorkflow().run(bom_request)
             diagnostics.extend(result.diagnostics)
             return result, diagnostics
         except Exception as exc:
@@ -311,11 +311,11 @@ class FabricationWorkflow:
 
     def _run_pos(
         self, request: FabricationRequest
-    ) -> tuple[POSOrchestrationResult | None, list[str]]:
+    ) -> tuple[POSResult | None, list[str]]:
         """Run POS orchestration and return result + diagnostics."""
         diagnostics: list[str] = []
         try:
-            pos_request = POSOrchestrationRequest(
+            pos_request = POSRequest(
                 input_path=request.input_path,
                 fabricator=request.fabricator,
                 smd_only=request.smd_only,
@@ -323,7 +323,7 @@ class FabricationWorkflow:
                 origin=request.pos_origin,
                 verbose=request.verbose,
             )
-            result = POSOrchestrationService().orchestrate(pos_request)
+            result = POSWorkflow().run(pos_request)
             diagnostics.extend(result.diagnostics)
             return result, diagnostics
         except Exception as exc:

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -55,7 +55,7 @@ def _normalize_text(value: str, *, field_name: str) -> str:
     return normalized
 
 
-class POSOrchestrationMode(str, Enum):
+class POSMode(str, Enum):
     """Result modes supported by POS orchestration."""
 
     LIST_FIELDS = "list_fields"
@@ -63,7 +63,7 @@ class POSOrchestrationMode(str, Enum):
 
 
 @dataclass(frozen=True)
-class POSOrchestrationRequest:
+class POSRequest:
     """Adapter-neutral POS orchestration request data."""
 
     input_path: str
@@ -138,17 +138,17 @@ class POSGenerationPayload:
 
 
 @dataclass(frozen=True)
-class POSOrchestrationResult:
+class POSResult:
     """Result contract emitted by POS application orchestration."""
 
-    mode: POSOrchestrationMode
+    mode: POSMode
     diagnostics: tuple[str, ...] = ()
     field_listing: POSFieldListingPayload | None = None
     generation: POSGenerationPayload | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
-        if self.mode == POSOrchestrationMode.LIST_FIELDS:
+        if self.mode == POSMode.LIST_FIELDS:
             if self.field_listing is None:
                 raise ValueError(
                     "field_listing payload is required for list_fields mode"
@@ -157,7 +157,7 @@ class POSOrchestrationResult:
                 raise ValueError(
                     "generation payload must be empty for list_fields mode"
                 )
-        if self.mode == POSOrchestrationMode.GENERATE:
+        if self.mode == POSMode.GENERATE:
             if self.generation is None:
                 raise ValueError("generation payload is required for generate mode")
             if self.field_listing is not None:
@@ -375,20 +375,20 @@ def _parse_requested_field_tokens(raw_fields: str) -> list[str]:
     return parsed_tokens
 
 
-class POSOrchestrationService:
+class POSWorkflow:
     """Application-layer POS orchestration service."""
 
-    def orchestrate(self, request: POSOrchestrationRequest) -> POSOrchestrationResult:
+    def run(self, request: POSRequest) -> POSResult:
         """Execute POS orchestration for listing or generation flows."""
 
         if request.list_fields:
-            return self._orchestrate_field_listing(request)
-        return self._orchestrate_generation(request)
+            return self._list_fields(request)
+        return self._generate(request)
 
-    def _orchestrate_field_listing(
+    def _list_fields(
         self,
-        request: POSOrchestrationRequest,
-    ) -> POSOrchestrationResult:
+        request: POSRequest,
+    ) -> POSResult:
         """Build POS field-listing data from best-effort project discovery."""
 
         gen_options = (
@@ -434,18 +434,18 @@ class POSOrchestrationService:
         default_fields = tuple(
             get_fabricator_default_fields(request.fabricator, "pos") or ()
         )
-        return POSOrchestrationResult(
-            mode=POSOrchestrationMode.LIST_FIELDS,
+        return POSResult(
+            mode=POSMode.LIST_FIELDS,
             field_listing=POSFieldListingPayload(
                 known_fields=known_fields,
                 default_fields=default_fields,
             ),
         )
 
-    def _orchestrate_generation(
+    def _generate(
         self,
-        request: POSOrchestrationRequest,
-    ) -> POSOrchestrationResult:
+        request: POSRequest,
+    ) -> POSResult:
         """Execute POS orchestration and return adapter-ready output payloads."""
         diagnostics: list[str] = []
 
@@ -565,8 +565,8 @@ class POSOrchestrationService:
             fabricator=request.fabricator,
             user_specified_fields=user_specified_fields,
         )
-        return POSOrchestrationResult(
-            mode=POSOrchestrationMode.GENERATE,
+        return POSResult(
+            mode=POSMode.GENERATE,
             diagnostics=tuple(diagnostics),
             generation=POSGenerationPayload(
                 pos_data=tuple(pos_data),
@@ -582,10 +582,10 @@ class POSOrchestrationService:
 __all__ = [
     "POSFieldListingPayload",
     "POSGenerationPayload",
-    "POSOrchestrationMode",
-    "POSOrchestrationRequest",
-    "POSOrchestrationResult",
-    "POSOrchestrationService",
+    "POSMode",
+    "POSRequest",
+    "POSResult",
+    "POSWorkflow",
     "apply_pos_dnp_filter",
     "enrich_pos_with_merge_namespaces",
     "get_available_pos_fields",

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -40,10 +40,10 @@ from jbom.common.component_filters import (
 from jbom.common.component_utils import derive_package_from_footprint
 from jbom.common.package_matching import PackageType
 from jbom.cli.formatting import Column, print_table, get_terminal_width
-from jbom.application.bom_orchestration import (
-    BOMOrchestrationService,
-    BOMOrchestrationMode,
-    BOMOrchestrationRequest,
+from jbom.application.bom_workflow import (
+    BOMWorkflow,
+    BOMMode,
+    BOMRequest,
     enforce_bom_device_footprints as _service_enforce_bom_device_footprints,
     enrich_bom_smd_from_project_pcb as _service_enrich_bom_smd_from_project_pcb,
     enrich_bom_with_merge_namespaces as _service_enrich_bom_with_merge_namespaces,
@@ -268,7 +268,7 @@ def _execute_bom_command(args: argparse.Namespace) -> int:
     """Execute BOM command body with project-centric input resolution."""
     try:
         fabricator = _resolve_requested_fabricator(args)
-        request = BOMOrchestrationRequest(
+        request = BOMRequest(
             input_path=str(args.input or "."),
             fabricator=fabricator,
             fields_argument=args.fields,
@@ -277,11 +277,11 @@ def _execute_bom_command(args: argparse.Namespace) -> int:
             verbose=bool(args.verbose),
             list_fields=bool(args.list_fields),
         )
-        result = BOMOrchestrationService().orchestrate(request)
+        result = BOMWorkflow().run(request)
         for diagnostic in result.diagnostics:
             print(diagnostic, file=sys.stderr)
 
-        if result.mode == BOMOrchestrationMode.LIST_FIELDS:
+        if result.mode == BOMMode.LIST_FIELDS:
             if result.field_listing is None:
                 raise ValueError("Missing field listing payload for list-fields output")
             _list_available_fields(

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -15,10 +15,10 @@ from jbom.application.jobs.contracts import (
     JobRequest,
 )
 from jbom.application.jobs.runner import JobEventStream, JobRunPayload, JobRunner
-from jbom.application.pos_orchestration import (
+from jbom.application.pos_workflow import (
     POSFieldListingPayload,
-    POSOrchestrationRequest,
-    POSOrchestrationService,
+    POSRequest,
+    POSWorkflow,
     apply_pos_dnp_filter as _service_apply_pos_dnp_filter,
     enrich_pos_with_merge_namespaces as _service_enrich_pos_with_merge_namespaces,
     resolve_pos_output_projection as _service_resolve_pos_output_projection,
@@ -201,12 +201,12 @@ def _build_pos_job_request(args: argparse.Namespace) -> JobRequest:
     )
 
 
-def _build_pos_orchestration_request(
+def _build_pos_request(
     args: argparse.Namespace,
-) -> POSOrchestrationRequest:
+) -> POSRequest:
     """Map CLI args to an adapter-neutral POS orchestration request."""
 
-    return POSOrchestrationRequest(
+    return POSRequest(
         input_path=str(args.input or "."),
         output=str(args.output or ""),
         fabricator=resolve_fabricator_from_args(args),
@@ -279,15 +279,15 @@ def handle_pos(args: argparse.Namespace) -> int:
 def _execute_pos_command(args: argparse.Namespace) -> int:
     """Execute POS command via application-layer orchestration service."""
 
-    orchestration_service = POSOrchestrationService()
-    orchestration_request = _build_pos_orchestration_request(args)
+    orchestration_service = POSWorkflow()
+    pos_request = _build_pos_request(args)
     try:
-        result = orchestration_service.orchestrate(orchestration_request)
+        result = orchestration_service.run(pos_request)
         for diagnostic in result.diagnostics:
             _emit_cli_diagnostic(diagnostic)
         if result.field_listing is not None:
             _list_available_pos_fields(
-                orchestration_request.fabricator,
+                pos_request.fabricator,
                 field_listing=result.field_listing,
             )
             return 0

--- a/tests/services/test_bom_workflow.py
+++ b/tests/services/test_bom_workflow.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from jbom.application.bom_orchestration import (
-    BOMOrchestrationService,
-    BOMOrchestrationMode,
-    BOMOrchestrationRequest,
+from jbom.application.bom_workflow import (
+    BOMWorkflow,
+    BOMMode,
+    BOMRequest,
 )
 from jbom.services.bom_generator import BOMData, BOMEntry
 
@@ -49,33 +49,31 @@ class _FakeResolvedInput:
 def test_list_fields_orchestration_returns_known_contract_fields() -> None:
     """List-fields mode should still return stable known fields if runtime discovery fails."""
 
-    service = BOMOrchestrationService()
-    request = BOMOrchestrationRequest(
+    service = BOMWorkflow()
+    request = BOMRequest(
         input_path=".",
         fabricator="generic",
         list_fields=True,
     )
 
-    with patch(
-        "jbom.application.bom_orchestration.ProjectFileResolver"
-    ) as resolver_cls:
+    with patch("jbom.application.bom_workflow.ProjectFileResolver") as resolver_cls:
         resolver_cls.return_value.resolve_input.side_effect = ValueError("boom")
-        result = service.orchestrate(request)
+        result = service.run(request)
 
-    assert result.mode == BOMOrchestrationMode.LIST_FIELDS
+    assert result.mode == BOMMode.LIST_FIELDS
     assert result.field_listing is not None
     assert "reference" in result.field_listing.known_fields
     assert "fabricator_part_number" in result.field_listing.known_fields
 
 
-@patch("jbom.application.bom_orchestration.enrich_bom_smd_from_project_pcb")
-@patch("jbom.application.bom_orchestration.InventoryOverlayService")
-@patch("jbom.application.bom_orchestration.parse_fields_argument")
-@patch("jbom.application.bom_orchestration.get_fabricator_presets")
-@patch("jbom.application.bom_orchestration.run_component_merge")
-@patch("jbom.application.bom_orchestration.BOMGenerator")
-@patch("jbom.application.bom_orchestration.SchematicReader")
-@patch("jbom.application.bom_orchestration.ProjectFileResolver")
+@patch("jbom.application.bom_workflow.enrich_bom_smd_from_project_pcb")
+@patch("jbom.application.bom_workflow.InventoryOverlayService")
+@patch("jbom.application.bom_workflow.parse_fields_argument")
+@patch("jbom.application.bom_workflow.get_fabricator_presets")
+@patch("jbom.application.bom_workflow.run_component_merge")
+@patch("jbom.application.bom_workflow.BOMGenerator")
+@patch("jbom.application.bom_workflow.SchematicReader")
+@patch("jbom.application.bom_workflow.ProjectFileResolver")
 def test_generation_orchestration_handles_cross_resolution_and_returns_payload(
     mock_resolver_cls: MagicMock,
     mock_reader_cls: MagicMock,
@@ -137,7 +135,7 @@ def test_generation_orchestration_handles_cross_resolution_and_returns_payload(
     overlay_service.overlay_bom_data.return_value = SimpleNamespace(bom_data=bom_data)
     mock_enrich_smd.return_value = (bom_data, ())
 
-    request = BOMOrchestrationRequest(
+    request = BOMRequest(
         input_path=".",
         fabricator="generic",
         fields_argument="reference,quantity",
@@ -145,9 +143,9 @@ def test_generation_orchestration_handles_cross_resolution_and_returns_payload(
         verbose=True,
         list_fields=False,
     )
-    result = BOMOrchestrationService().orchestrate(request)
+    result = BOMWorkflow().run(request)
 
-    assert result.mode == BOMOrchestrationMode.GENERATE
+    assert result.mode == BOMMode.GENERATE
     assert result.generation is not None
     assert result.generation.default_output_path == Path(
         "/tmp/project-dir/project.bom.csv"

--- a/tests/services/test_fabrication_orchestration.py
+++ b/tests/services/test_fabrication_orchestration.py
@@ -104,7 +104,7 @@ class TestFabricationWorkflowSkipFlags:
             skip_gerbers=True,
         )
         with patch(
-            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+            "jbom.application.fabrication_orchestration.BOMWorkflow"
         ) as mock_bom:
             FabricationWorkflow().run(request)
             mock_bom.assert_not_called()
@@ -117,7 +117,7 @@ class TestFabricationWorkflowSkipFlags:
             skip_gerbers=True,
         )
         with patch(
-            "jbom.application.fabrication_orchestration.POSOrchestrationService"
+            "jbom.application.fabrication_orchestration.POSWorkflow"
         ) as mock_pos:
             FabricationWorkflow().run(request)
             mock_pos.assert_not_called()
@@ -176,16 +176,16 @@ class TestFabricationWorkflowDryRun:
         )
         with (
             patch(
-                "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+                "jbom.application.fabrication_orchestration.BOMWorkflow"
             ) as mock_bom_cls,
             patch(
                 "jbom.application.fabrication_orchestration.GerberExporter"
             ) as mock_gerber,
         ):
-            mock_bom_cls.return_value.orchestrate.return_value = bom_mock_result
+            mock_bom_cls.return_value.run.return_value = bom_mock_result
             result = FabricationWorkflow().run(request)
 
-        mock_bom_cls.return_value.orchestrate.assert_called_once()
+        mock_bom_cls.return_value.run.assert_called_once()
         mock_gerber.assert_not_called()
         assert result.bom_result is bom_mock_result
 
@@ -218,14 +218,14 @@ class TestFabricationWorkflowFabricatorPropagation:
 
         with (
             patch(
-                "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+                "jbom.application.fabrication_orchestration.BOMWorkflow"
             ) as mock_bom_cls,
             patch(
-                "jbom.application.fabrication_orchestration.POSOrchestrationService"
+                "jbom.application.fabrication_orchestration.POSWorkflow"
             ) as mock_pos_cls,
         ):
-            mock_bom_cls.return_value.orchestrate.side_effect = _capture_bom
-            mock_pos_cls.return_value.orchestrate.side_effect = _capture_pos
+            mock_bom_cls.return_value.run.side_effect = _capture_bom
+            mock_pos_cls.return_value.run.side_effect = _capture_pos
             FabricationWorkflow().run(request)
 
         assert len(captured_bom_requests) == 1
@@ -247,9 +247,9 @@ class TestFabricationWorkflowSubServiceFailure:
             skip_gerbers=True,
         )
         with patch(
-            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+            "jbom.application.fabrication_orchestration.BOMWorkflow"
         ) as mock_bom_cls:
-            mock_bom_cls.return_value.orchestrate.side_effect = RuntimeError(
+            mock_bom_cls.return_value.run.side_effect = RuntimeError(
                 "schematic not found"
             )
             result = FabricationWorkflow().run(request)
@@ -264,11 +264,9 @@ class TestFabricationWorkflowSubServiceFailure:
             skip_gerbers=True,
         )
         with patch(
-            "jbom.application.fabrication_orchestration.POSOrchestrationService"
+            "jbom.application.fabrication_orchestration.POSWorkflow"
         ) as mock_pos_cls:
-            mock_pos_cls.return_value.orchestrate.side_effect = RuntimeError(
-                "pcb not found"
-            )
+            mock_pos_cls.return_value.run.side_effect = RuntimeError("pcb not found")
             result = FabricationWorkflow().run(request)
 
         assert result.pos_result is None

--- a/tests/services/test_pos_workflow.py
+++ b/tests/services/test_pos_workflow.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from jbom.application.pos_orchestration import (
-    POSOrchestrationRequest,
-    POSOrchestrationService,
+from jbom.application.pos_workflow import (
+    POSRequest,
+    POSWorkflow,
     resolve_pos_output_projection,
 )
 
 
-def test_pos_orchestration_service_runs_without_cli_import(
+def test_pos_workflow_runs_without_cli_import(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -73,23 +73,21 @@ def test_pos_orchestration_service_runs_without_cli_import(
             ]
 
     monkeypatch.setattr(
-        "jbom.application.pos_orchestration.ProjectFileResolver", _FakeResolver
+        "jbom.application.pos_workflow.ProjectFileResolver", _FakeResolver
     )
     monkeypatch.setattr(
-        "jbom.application.pos_orchestration.DefaultKiCadReaderService",
+        "jbom.application.pos_workflow.DefaultKiCadReaderService",
         _FakeReader,
     )
+    monkeypatch.setattr("jbom.application.pos_workflow.POSGenerator", _FakeGenerator)
     monkeypatch.setattr(
-        "jbom.application.pos_orchestration.POSGenerator", _FakeGenerator
-    )
-    monkeypatch.setattr(
-        "jbom.application.pos_orchestration.run_pos_component_merge",
+        "jbom.application.pos_workflow.run_pos_component_merge",
         lambda **_kwargs: (None, ()),
     )
 
-    service = POSOrchestrationService()
-    result = service.orchestrate(
-        POSOrchestrationRequest(
+    service = POSWorkflow()
+    result = service.run(
+        POSRequest(
             input_path=str(tmp_path),
             fields="reference,x,y",
             include_dnp=False,
@@ -103,7 +101,7 @@ def test_pos_orchestration_service_runs_without_cli_import(
     assert result.generation.default_output_path == tmp_path / "demo.pos.csv"
 
 
-def test_pos_orchestration_list_fields_falls_back_when_discovery_errors(
+def test_pos_workflow_list_fields_falls_back_when_discovery_errors(
     monkeypatch,
 ) -> None:
     """Field listing should still succeed when runtime discovery fails."""
@@ -117,13 +115,13 @@ def test_pos_orchestration_list_fields_falls_back_when_discovery_errors(
             raise RuntimeError("resolver failed")
 
     monkeypatch.setattr(
-        "jbom.application.pos_orchestration.ProjectFileResolver",
+        "jbom.application.pos_workflow.ProjectFileResolver",
         _FailingResolver,
     )
 
-    service = POSOrchestrationService()
-    result = service.orchestrate(
-        POSOrchestrationRequest(
+    service = POSWorkflow()
+    result = service.run(
+        POSRequest(
             input_path=".",
             list_fields=True,
             fabricator="jlc",

--- a/tests/unit/test_fabrication_cli.py
+++ b/tests/unit/test_fabrication_cli.py
@@ -110,7 +110,7 @@ class TestHandleFabAllSkip:
 
         args = self._make_all_skip_args()
         with patch(
-            "jbom.application.fabrication_orchestration.BOMOrchestrationService"
+            "jbom.application.fabrication_orchestration.BOMWorkflow"
         ) as mock_bom:
             handle_fab(args)
             mock_bom.assert_not_called()


### PR DESCRIPTION
Closes #237

Clean rename — no backward-compat shims.

## Rename map

| Old | New |
|---|---|
| `BOMOrchestrationService` | `BOMWorkflow` |
| `BOMOrchestrationRequest` | `BOMRequest` |
| `BOMOrchestrationResult` | `BOMResult` |
| `BOMOrchestrationMode` | `BOMMode` |
| `POSOrchestrationService` | `POSWorkflow` |
| `POSOrchestrationRequest` | `POSRequest` |
| `POSOrchestrationResult` | `POSResult` |
| `POSOrchestrationMode` | `POSMode` |
| `.orchestrate()` | `.run()` |
| `_orchestrate_field_listing` | `_list_fields` |
| `_orchestrate_generation` | `_generate` |
| `bom_orchestration.py` | `bom_workflow.py` |
| `pos_orchestration.py` | `pos_workflow.py` |
| `test_bom_orchestration_service.py` | `test_bom_workflow.py` |
| `test_pos_orchestration_service.py` | `test_pos_workflow.py` |

Class names now reflect the promise (what is produced), not the mechanism. `src/WARP.md` documents the convention for future reference.

1057 tests pass.

Co-Authored-By: Oz <oz-agent@warp.dev>