### PR TITLE
fix(gerber): discover kicad-cli via PATH then platform-specific install paths

### DIFF
--- a/src/jbom/services/gerber_service.py
+++ b/src/jbom/services/gerber_service.py
@@ -1,8 +1,9 @@
 """Gerber/drill/netlist export service for fabrication artifact generation.
 
 Tiered dispatch:
-1. ``kicad-cli pcb export`` subprocess — available whenever KiCad is installed
-   and ``kicad-cli`` is on the PATH.
+1. ``kicad-cli pcb export`` subprocess — located via PATH, then platform-specific
+   well-known installation directories (macOS app bundle, Windows Program Files,
+   common Linux paths).
 2. ``pcbnew`` Python API (plugin mode) — stub only; raises a diagnostic because
    the implementation is deferred to the plugin adapter issue (#227).
 3. Graceful degradation — when neither path is available the service returns a
@@ -28,6 +29,8 @@ Usage::
 
 from __future__ import annotations
 
+import os
+import platform
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -40,6 +43,72 @@ __all__ = [
     "GerberRequest",
     "GerberResult",
 ]
+
+
+def _find_kicad_cli() -> str | None:
+    """Return the path to the kicad-cli executable, or ``None`` if not found.
+
+    Search order:
+    1. ``PATH`` — covers Linux system installs and any user-configured PATH.
+    2. Platform-specific well-known installation directories:
+       - **macOS**: ``/Applications/KiCad/KiCad.app/Contents/MacOS/``
+       - **Windows**: ``%PROGRAMFILES%\\KiCad\\<version>\\bin\\`` (versions 7–9)
+       - **Linux**: ``/usr/bin/``, ``/usr/local/bin/``, ``/snap/bin/``
+    """
+    # Try both spellings; KiCad uses a hyphen but some older builds used underscore.
+    for name in ("kicad-cli", "kicad_cli"):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    system = platform.system()
+    candidates: list[Path] = []
+
+    if system == "Darwin":
+        bundle = Path("/Applications/KiCad/KiCad.app/Contents/MacOS")
+        candidates = [bundle / "kicad-cli", bundle / "kicad_cli"]
+
+    elif system == "Windows":
+        prog = Path(os.environ.get("PROGRAMFILES", r"C:\Program Files"))
+        for version in ("9.0", "8.0", "7.0"):
+            candidates.append(prog / "KiCad" / version / "bin" / "kicad-cli.exe")
+
+    else:  # Linux / BSD / other
+        candidates = [
+            Path("/usr/bin/kicad-cli"),
+            Path("/usr/local/bin/kicad-cli"),
+            Path("/snap/bin/kicad-cli"),
+        ]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+
+    return None
+
+
+def _kicad_cli_not_found_message() -> str:
+    """Return a platform-appropriate diagnostic when kicad-cli cannot be located."""
+    system = platform.system()
+    if system == "Darwin":
+        install_hint = (
+            "On macOS, install KiCad from https://www.kicad.org/download/ — "
+            "jBOM checks /Applications/KiCad/KiCad.app/Contents/MacOS/ automatically."
+        )
+    elif system == "Windows":
+        install_hint = (
+            r"On Windows, install KiCad from https://www.kicad.org/download/ — "
+            r"jBOM checks C:\Program Files\KiCad\<version>\bin\ automatically."
+        )
+    else:
+        install_hint = (
+            "On Linux, install KiCad via your package manager (e.g. "
+            "`sudo apt install kicad` or `sudo dnf install kicad`). "
+            "kicad-cli is usually placed on PATH automatically."
+        )
+    return (
+        f"kicad-cli not found. {install_hint} " "BOM and POS generation are unaffected."
+    )
 
 
 def _normalize_text(value: str, *, field_name: str) -> str:
@@ -163,15 +232,11 @@ class GerberExporter:
 
     def _generate_via_kicad_cli(self, request: GerberRequest) -> GerberResult:
         """Generate Gerbers by invoking kicad-cli as a subprocess."""
-        kicad_cli = shutil.which("kicad-cli")
+        kicad_cli = _find_kicad_cli()
         if kicad_cli is None:
             return GerberResult(
                 artifacts=(),
-                diagnostics=(
-                    "kicad-cli not found on PATH. "
-                    "Install KiCad and ensure kicad-cli is accessible to generate "
-                    "Gerber/drill files. BOM and POS files are unaffected.",
-                ),
+                diagnostics=(_kicad_cli_not_found_message(),),
                 skipped=True,
                 skip_reason="kicad_cli_not_found",
             )

--- a/tests/unit/test_gerber_service.py
+++ b/tests/unit/test_gerber_service.py
@@ -21,7 +21,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
+from jbom.services.gerber_service import (
+    GerberExporter,
+    GerberRequest,
+    GerberResult,
+    _find_kicad_cli,
+    _kicad_cli_not_found_message,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -93,12 +99,94 @@ class TestGerberResult:
 # ---------------------------------------------------------------------------
 
 
+class TestFindKicadCli:
+    """Tests for the _find_kicad_cli discovery helper."""
+
+    def test_returns_path_from_which_first(self) -> None:
+        with patch(
+            "jbom.services.gerber_service.shutil.which",
+            return_value="/usr/bin/kicad-cli",
+        ):
+            assert _find_kicad_cli() == "/usr/bin/kicad-cli"
+
+    def test_returns_none_when_not_on_path_and_no_known_locations(
+        self, tmp_path: Path
+    ) -> None:
+        # Redirect platform.system to a value with no real install paths on this machine.
+        with (
+            patch("jbom.services.gerber_service.shutil.which", return_value=None),
+            patch("jbom.services.gerber_service.platform.system", return_value="Linux"),
+            patch(
+                "jbom.services.gerber_service.Path.is_file",
+                return_value=False,
+            ),
+        ):
+            assert _find_kicad_cli() is None
+
+    def test_macos_bundle_path_returned_when_binary_exists(
+        self, tmp_path: Path
+    ) -> None:
+        # Create a fake kicad-cli binary so is_file() returns True for it.
+        fake_cli = tmp_path / "kicad-cli"
+        fake_cli.write_text("", encoding="utf-8")
+
+        import jbom.services.gerber_service as svc
+
+        original_path = svc.Path
+
+        class _FakePath(type(Path())):
+            """Intercept the macOS bundle path to redirect to tmp_path."""
+
+            def __new__(cls, *args, **kwargs):
+                p = original_path(*args, **kwargs)
+                # Redirect the macOS bundle directory to our tmp_path fixture
+                if str(p) == "/Applications/KiCad/KiCad.app/Contents/MacOS":
+                    return original_path(tmp_path)
+                return p
+
+        with (
+            patch("jbom.services.gerber_service.shutil.which", return_value=None),
+            patch(
+                "jbom.services.gerber_service.platform.system", return_value="Darwin"
+            ),
+            patch("jbom.services.gerber_service.Path", _FakePath),
+        ):
+            result = _find_kicad_cli()
+
+        assert result is not None
+        assert "kicad-cli" in result
+
+    def test_not_found_message_contains_kicad_cli(self) -> None:
+        msg = _kicad_cli_not_found_message()
+        assert "kicad-cli" in msg
+        assert "BOM and POS" in msg
+
+    def test_not_found_message_is_platform_specific(self) -> None:
+        with patch(
+            "jbom.services.gerber_service.platform.system", return_value="Darwin"
+        ):
+            msg = _kicad_cli_not_found_message()
+            assert "macOS" in msg or "/Applications/KiCad" in msg
+
+        with patch(
+            "jbom.services.gerber_service.platform.system", return_value="Windows"
+        ):
+            msg = _kicad_cli_not_found_message()
+            assert "Windows" in msg
+
+        with patch(
+            "jbom.services.gerber_service.platform.system", return_value="Linux"
+        ):
+            msg = _kicad_cli_not_found_message()
+            assert "Linux" in msg
+
+
 class TestGerberExporterNoKicadCli:
     def test_returns_skipped_when_kicad_cli_absent(self, tmp_path: Path) -> None:
         pcb = tmp_path / "board.kicad_pcb"
         pcb.write_text("", encoding="utf-8")
 
-        with patch("jbom.services.gerber_service.shutil.which", return_value=None):
+        with patch("jbom.services.gerber_service._find_kicad_cli", return_value=None):
             result = GerberExporter().generate(
                 GerberRequest(
                     pcb_file=pcb,
@@ -120,7 +208,7 @@ class TestGerberExporterNoKicadCli:
 class TestGerberExporterMissingPcb:
     def test_returns_skipped_when_pcb_missing(self, tmp_path: Path) -> None:
         with patch(
-            "jbom.services.gerber_service.shutil.which",
+            "jbom.services.gerber_service._find_kicad_cli",
             return_value="/usr/bin/kicad-cli",
         ):
             result = GerberExporter().generate(
@@ -177,7 +265,7 @@ class TestGerberExporterCliFailure:
 
         with (
             patch(
-                "jbom.services.gerber_service.shutil.which",
+                "jbom.services.gerber_service._find_kicad_cli",
                 return_value="/usr/bin/kicad-cli",
             ),
             patch(
@@ -228,7 +316,7 @@ class TestGerberExporterSuccess:
 
         with (
             patch(
-                "jbom.services.gerber_service.shutil.which",
+                "jbom.services.gerber_service._find_kicad_cli",
                 return_value="/usr/bin/kicad-cli",
             ),
             patch("jbom.services.gerber_service.subprocess.run", side_effect=fake_run),
@@ -259,7 +347,7 @@ class TestGerberExporterSuccess:
 
         with (
             patch(
-                "jbom.services.gerber_service.shutil.which",
+                "jbom.services.gerber_service._find_kicad_cli",
                 return_value="/usr/bin/kicad-cli",
             ),
             patch(


### PR DESCRIPTION
## Problem

On macOS, KiCad installs as an app bundle. `kicad-cli` lives at `/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli` and is not on PATH by default, causing `jbom gerbers` to report `kicad_cli_not_found` even when KiCad is installed.

## Fix

Replace the single `shutil.which("kicad-cli")` call with `_find_kicad_cli()` which:
1. Tries PATH first (`shutil.which`) with both `kicad-cli` and `kicad_cli` spellings.
2. Falls back to platform-specific well-known install paths:
   - **macOS**: `/Applications/KiCad/KiCad.app/Contents/MacOS/`
   - **Windows**: `%PROGRAMFILES%\KiCad\{9,8,7}.0\bin\`
   - **Linux**: `/usr/bin/`, `/usr/local/bin/`, `/snap/bin/`

Also adds `_kicad_cli_not_found_message()` with platform-aware install instructions, so the error message tells the user where jBOM looked.

## Tests
5 new tests (discovery logic and platform-specific messages). 1062 total pass.

Co-Authored-By: Oz <oz-agent@warp.dev>