### PR TITLE
feat(plugin): implement PcbnewGerberGenerator; fix three #227 blockers

### DIFF
--- a/docs/dev/guides/plugin-dev-setup.md
+++ b/docs/dev/guides/plugin-dev-setup.md
@@ -116,6 +116,28 @@ The dialog (`dialog.py`) and the ActionPlugin class (`plugin.py`) import
 KiCad instance. Manual smoke-testing via the dev-loop symlink is the
 appropriate method for these.
 
+## KiCad SWIG / CPython GC gotcha
+
+KiCad's ActionPlugin registration stores a **C++ pointer** to the plugin object
+via SWIG.  If the Python wrapper is created as a temporary (e.g.
+``JBOMFabricationPlugin().register()``) and no Python-level reference is kept,
+CPython's garbage collector will collect the Python wrapper between toolbar
+clicks — leaving KiCad with a dangling C++ pointer and a toolbar button that
+appears to do nothing on the second click.
+
+Always keep a module-level reference:
+
+```python
+# correct — module-level reference keeps GC from collecting the wrapper
+_plugin_instance = JBOMFabricationPlugin()
+_plugin_instance.register()
+
+# WRONG — temporary object collected between clicks
+JBOMFabricationPlugin().register()
+```
+
+This applies to any KiCad ActionPlugin, not just jBOM.
+
 ## Troubleshooting
 
 ### "import jbom fails" inside KiCad scripting console

--- a/docs/dev/guides/plugin-dev-setup.md
+++ b/docs/dev/guides/plugin-dev-setup.md
@@ -1,0 +1,157 @@
+# jBOM Plugin Development Setup
+
+This guide covers the local development workflow for the jBOM KiCad ActionPlugin
+(`src/jbom/plugin/`). It assumes you have already cloned the repository and
+installed the jBOM CLI dependencies (`pip install -e ".[dev]"`).
+
+## Background
+
+jBOM ships through two independent distribution channels:
+
+| Channel | Users | Install step |
+|---------|-------|--------------|
+| PyPI | CLI / library users | `pip install jbom` |
+| PCM | KiCad plugin users | "Install from File" in KiCad Plugin Manager |
+
+The plugin adapter lives in `src/jbom/plugin/` and uses a **symlink** during
+development so code edits are immediately visible in KiCad — no zip rebuild,
+no reinstall. The PCM archive is only needed for release or smoke-test purposes.
+
+See `docs/dev/architecture/adr/0007-plugin-packaging-and-distribution.md` for
+the full packaging rationale (Option H hybrid model).
+
+## Dev loop setup
+
+### macOS (KiCad 9)
+
+```bash
+# IMPORTANT: the symlink target name MUST match the PCM identifier
+# (com.spcoast.jbom → com_spcoast_jbom).
+# Using "jbom" as the name would shadow the importable jbom package
+# on sys.path and cause a circular import. See ADR 0007 F2.
+ln -s "$PWD/src/jbom/plugin" \
+  ~/Library/Application\ Support/kicad/9.0/scripting/plugins/com_spcoast_jbom
+```
+
+To apply for a different KiCad version, replace `9.0` with the appropriate
+version directory (e.g. `8.0`, `7.0`).
+
+### macOS (KiCad 8 / 7)
+
+```bash
+ln -s "$PWD/src/jbom/plugin" \
+  ~/Library/Application\ Support/kicad/8.0/scripting/plugins/com_spcoast_jbom
+```
+
+### Linux
+
+```bash
+ln -s "$PWD/src/jbom/plugin" \
+  ~/.local/share/kicad/9.0/scripting/plugins/com_spcoast_jbom
+```
+
+### Windows
+
+```powershell
+New-Item -ItemType Junction -Path "$env:APPDATA\kicad\9.0\scripting\plugins\com_spcoast_jbom" `
+         -Target "$PWD\src\jbom\plugin"
+```
+
+## Activating the plugin
+
+1. Open KiCad's **PCB Editor** (Pcbnew).
+2. Open **Scripting Console** (Tools → Scripting Console).
+3. Type `import pcbnew; pcbnew.LoadPlugins()` to force a plugin rescan, or
+   simply close and reopen Pcbnew.
+4. The jBOM toolbar button should appear in the right-hand toolbar.
+
+## How the sys.path bootstrap works
+
+`src/jbom/plugin/__init__.py` adds two paths to `sys.path` at load time:
+
+1. **`_this_dir`** — the plugin directory itself (resolves to
+   `src/jbom/plugin/` via the symlink). In a PCM install this would be
+   `${KICADX_3RD_PARTY}/plugins/com_spcoast_jbom/`, which contains the
+   vendored `jbom/` package.
+
+2. **`_src_dir`** — two levels up from `plugin/`, which is `src/` in the dev
+   tree. This puts the editable `jbom` source package on `sys.path` so
+   `import jbom` finds the live source without a separate
+   `pip install` into KiCad's bundled Python.
+
+In production (PCM install) both paths are added; `_src_dir` resolves to the
+PCM plugins parent directory, which is harmless (no `jbom` package there).
+
+## Building the PCM archive
+
+```bash
+# Produces dist/jbom-pcm-{version}.zip
+python scripts/build_pcm_package.py
+
+# Also patch metadata.json with computed sha256 + sizes (for release prep)
+python scripts/build_pcm_package.py --update-metadata
+```
+
+The archive can be installed manually via KiCad → Plugin Manager →
+"Install from File" for smoke-testing without a GitHub release.
+
+## Running the test suite
+
+The plugin's Python-only modules (`options.py`, `__init__.py`) are fully
+testable without KiCad or wxPython:
+
+```bash
+pytest tests/plugin/ -v
+```
+
+The dialog (`dialog.py`) and the ActionPlugin class (`plugin.py`) import
+`wx` and `pcbnew` respectively, and can only be exercised inside a live
+KiCad instance. Manual smoke-testing via the dev-loop symlink is the
+appropriate method for these.
+
+## Troubleshooting
+
+### "import jbom fails" inside KiCad scripting console
+
+Check that the symlink name is `com_spcoast_jbom` (not `jbom`):
+
+```bash
+ls -la ~/Library/Application\ Support/kicad/9.0/scripting/plugins/
+```
+
+If you see `jbom -> ...` instead of `com_spcoast_jbom -> ...`, remove the
+old symlink and re-create it with the correct name:
+
+```bash
+rm ~/Library/Application\ Support/kicad/9.0/scripting/plugins/jbom
+ln -s "$PWD/src/jbom/plugin" \
+  ~/Library/Application\ Support/kicad/9.0/scripting/plugins/com_spcoast_jbom
+```
+
+### Plugin does not appear in the toolbar
+
+1. Verify the symlink exists and points to the correct directory.
+2. Open the KiCad Scripting Console and run:
+   ```python
+   import pcbnew; pcbnew.LoadPlugins(); print("done")
+   ```
+3. Check the KiCad error log (Help → Show Error Log) for Python import errors.
+
+### KiCad major version upgrade
+
+KiCad major version upgrades (e.g. 9 → 10) use a new plugin root directory
+(`KICAD10_3RD_PARTY`). Re-create the symlink pointing at the new version path:
+
+```bash
+ln -s "$PWD/src/jbom/plugin" \
+  ~/Library/Application\ Support/kicad/10.0/scripting/plugins/com_spcoast_jbom
+```
+
+## SEE ALSO
+
+- `docs/dev/architecture/adr/0007-plugin-packaging-and-distribution.md` —
+  packaging decision (Option H hybrid model)
+- `docs/dev/development_notes/active/plugin_ux_storyboard.md` —
+  dialog design specification
+- `scripts/build_pcm_package.py` — PCM archive builder
+- `src/jbom/plugin/` — plugin source tree

--- a/docs/dev/guides/plugin-dev-setup.md
+++ b/docs/dev/guides/plugin-dev-setup.md
@@ -22,25 +22,32 @@ the full packaging rationale (Option H hybrid model).
 
 ## Dev loop setup
 
-### macOS (KiCad 9)
+### macOS
+
+KiCad on macOS stores user data under `~/Library/Preferences/kicad/<ver>/`
+(not `Application Support`). The `scripting/plugins/` subdirectory does not
+exist by default and must be created on first use.
 
 ```bash
 # IMPORTANT: the symlink target name MUST match the PCM identifier
 # (com.spcoast.jbom → com_spcoast_jbom).
 # Using "jbom" as the name would shadow the importable jbom package
 # on sys.path and cause a circular import. See ADR 0007 F2.
+
+# KiCad 10
+mkdir -p ~/Library/Preferences/kicad/10.0/scripting/plugins
 ln -s "$PWD/src/jbom/plugin" \
-  ~/Library/Application\ Support/kicad/9.0/scripting/plugins/com_spcoast_jbom
-```
+  ~/Library/Preferences/kicad/10.0/scripting/plugins/com_spcoast_jbom
 
-To apply for a different KiCad version, replace `9.0` with the appropriate
-version directory (e.g. `8.0`, `7.0`).
-
-### macOS (KiCad 8 / 7)
-
-```bash
+# KiCad 9
+mkdir -p ~/Library/Preferences/kicad/9.0/scripting/plugins
 ln -s "$PWD/src/jbom/plugin" \
-  ~/Library/Application\ Support/kicad/8.0/scripting/plugins/com_spcoast_jbom
+  ~/Library/Preferences/kicad/9.0/scripting/plugins/com_spcoast_jbom
+
+# KiCad 8 / 7 (substitute version number)
+mkdir -p ~/Library/Preferences/kicad/8.0/scripting/plugins
+ln -s "$PWD/src/jbom/plugin" \
+  ~/Library/Preferences/kicad/8.0/scripting/plugins/com_spcoast_jbom
 ```
 
 ### Linux
@@ -116,16 +123,16 @@ appropriate method for these.
 Check that the symlink name is `com_spcoast_jbom` (not `jbom`):
 
 ```bash
-ls -la ~/Library/Application\ Support/kicad/9.0/scripting/plugins/
+ls -la ~/Library/Preferences/kicad/10.0/scripting/plugins/
 ```
 
 If you see `jbom -> ...` instead of `com_spcoast_jbom -> ...`, remove the
 old symlink and re-create it with the correct name:
 
 ```bash
-rm ~/Library/Application\ Support/kicad/9.0/scripting/plugins/jbom
+rm ~/Library/Preferences/kicad/10.0/scripting/plugins/jbom
 ln -s "$PWD/src/jbom/plugin" \
-  ~/Library/Application\ Support/kicad/9.0/scripting/plugins/com_spcoast_jbom
+  ~/Library/Preferences/kicad/10.0/scripting/plugins/com_spcoast_jbom
 ```
 
 ### Plugin does not appear in the toolbar
@@ -139,12 +146,13 @@ ln -s "$PWD/src/jbom/plugin" \
 
 ### KiCad major version upgrade
 
-KiCad major version upgrades (e.g. 9 → 10) use a new plugin root directory
-(`KICAD10_3RD_PARTY`). Re-create the symlink pointing at the new version path:
+KiCad major version upgrades (e.g. 9 → 10) use a new version directory.
+Re-create the symlink pointing at the new version path:
 
 ```bash
+mkdir -p ~/Library/Preferences/kicad/10.0/scripting/plugins
 ln -s "$PWD/src/jbom/plugin" \
-  ~/Library/Application\ Support/kicad/10.0/scripting/plugins/com_spcoast_jbom
+  ~/Library/Preferences/kicad/10.0/scripting/plugins/com_spcoast_jbom
 ```
 
 ## SEE ALSO

--- a/docs/dev/workflow/issue-226-plan.md
+++ b/docs/dev/workflow/issue-226-plan.md
@@ -76,3 +76,24 @@ Create follow-up issues for designators-as-service, netlist-as-first-class-servi
 Commit with a conventional commit message referencing #226, push the feature branch, open the PR, and reference ADR 0006 in the PR description.
 ## Handoff Contract
 Any successor session should begin by reading this plan and `docs/dev/architecture/adr/0006-production-folder-packaging-projectmetadata-diagnostic-collection.md`. Then read the `Diagnostic Collection Pattern` and `Friend Serializer Pattern` sections in `docs/dev/architecture/design-patterns.md`. Resume at the first incomplete phase and do not revisit the architecture unless new evidence contradicts ADR 0006.
+
+---
+## Plugin blockers — work item for #227 continuation
+
+Three blockers identified in smoke test (2026-05-09). Details in #227 issue body.
+
+### Blocker 1 + 3: Gerbers / gerber zip
+- Add `src/jbom/plugin/gerber_generator.py` — `PcbnewGerberGenerator` using
+  `pcbnew.PLOT_CONTROLLER` + `EXCELLON_WRITER` (port FT's `plugins/process.py`)
+- Dialog orchestrates: BOM → CPL → gerbers (pcbnew) → GerberPackager → BackupService
+- Do NOT call `FabricationWorkflow` for the gerber step — kicad-cli subprocess hangs
+
+### Blocker 2: Plugin single-use
+- Change `dialog.py` from `wx.Dialog`+`ShowModal()` to `wx.Frame`+`Show()`
+- FT's exact pattern: `Run()` returns immediately; dialog calls `self.Destroy()` when done
+- `EndModal()` → `self.Destroy()` throughout dialog
+
+### Files to change
+- `src/jbom/plugin/gerber_generator.py` (NEW)
+- `src/jbom/plugin/dialog.py` (major rewrite)
+- `src/jbom/plugin/plugin.py` (ShowModal→Show, remove Destroy)

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://go.kicad.org/pcm/schemas/v1",
+  "name": "jBOM Fabrication",
+  "description": "BOM, pick-and-place, and Gerber fabrication package for KiCad PCB projects",
+  "description_full": "jBOM Fabrication provides one-click BOM, pick-and-place (CPL), and Gerber generation directly from the KiCad PCB editor toolbar. Supports multiple fabricators: JLC PCBA, PCBWay, Seeed Studio, and a generic profile. Per-project fabricator selection and inventory file path are persisted in .jbom/jbom-options.json. Requires KiCad 6.0 or later on macOS, Linux, or Windows. The jBOM CLI and Python library are available separately via pip install jbom.",
+  "identifier": "com.spcoast.jbom",
+  "type": "plugin",
+  "author": {
+    "name": "John Plocher",
+    "contact": {
+      "github": "https://github.com/plocher",
+      "web": "https://github.com/plocher/jBOM"
+    }
+  },
+  "maintainer": {
+    "name": "John Plocher",
+    "contact": {
+      "github": "https://github.com/plocher"
+    }
+  },
+  "license": "MIT",
+  "resources": {
+    "homepage": "https://github.com/plocher/jBOM",
+    "bugtracker": "https://github.com/plocher/jBOM/issues"
+  },
+  "versions": [
+    {
+      "version": "6.53.0",
+      "status": "development",
+      "kicad_version": "6.0",
+      "kicad_version_max": "",
+      "download_url": "https://github.com/plocher/jBOM/releases/download/pcm-v6.53.0/jbom-pcm-6.53.0.zip",
+      "download_sha256": "",
+      "install_size": 0,
+      "download_size": 0
+    }
+  ]
+}

--- a/scripts/build_pcm_package.py
+++ b/scripts/build_pcm_package.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Build a PCM-compliant KiCad plugin archive for jBOM.
+
+Usage::
+
+    python scripts/build_pcm_package.py [--output-dir dist/] [--update-metadata]
+
+Produces::
+
+    dist/jbom-pcm-{version}.zip   — the PCM-installable archive
+
+PCM archive layout (per KiCad addon spec)::
+
+    Archive root/
+      plugins/
+        __init__.py          ← guard + registration (from src/jbom/plugin/)
+        plugin.py
+        dialog.py
+        options.py
+        jbom/                ← vendored jbom core (src/jbom/ minus plugin/)
+          __init__.py
+          application/
+          cli/
+          common/
+          config/
+          services/
+          suppliers/
+          workflows/
+          ...
+        sexpdata.py          ← vendored (single-file module)
+        yaml/                ← vendored PyYAML package
+      resources/
+        icon.png             ← 64×64 PNG for PCM manager (TODO: add icon)
+      metadata.json
+
+The ``plugins/`` directory is what KiCad adds to ``sys.path`` when loading the
+plugin, making ``import jbom``, ``import sexpdata``, and ``import yaml`` work
+against the vendored copies.
+
+Flags
+-----
+--output-dir DIR
+    Directory where the zip is written (default: ``dist/``).
+--update-metadata
+    After building, patch ``metadata.json`` in the repo root with the computed
+    ``download_sha256``, ``install_size``, and ``download_size`` for the
+    current version.  Useful when preparing a release.
+
+Design notes
+------------
+This script intentionally uses only the Python standard library (``zipfile``,
+``shutil``, ``hashlib``, ``importlib``) with no third-party build-system
+plugin, following Decision 3 (Y > X) agreed in issue #227.  Migration to
+``hatch-kicad`` is straightforward if desired later: it produces the same
+archive layout from ``pyproject.toml`` configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Repo layout constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.resolve()
+_SRC_JBOM = _REPO_ROOT / "src" / "jbom"
+_PLUGIN_SRC = _SRC_JBOM / "plugin"
+_METADATA_SRC = _REPO_ROOT / "metadata.json"
+_RESOURCES_SRC = _REPO_ROOT / "resources"  # may not exist yet
+
+# Subdirectories of src/jbom/ to include in the vendored jbom/ copy.
+# The plugin/ subdirectory is excluded to avoid recursion.
+_JBOM_INCLUDE_SUBDIRS = [
+    "application",
+    "cli",
+    "common",
+    "config",
+    "services",
+    "suppliers",
+    "workflows",
+    "sch_api",
+]
+
+# Top-level files in src/jbom/ to include (e.g. __init__.py, __main__.py).
+_JBOM_INCLUDE_ROOT_FILES = [
+    "__init__.py",
+    "__main__.py",
+]
+
+# Glob patterns for files to skip when copying (matched against each file name).
+_SKIP_FILENAMES: set[str] = {".DS_Store", ".gitignore"}
+# Skip compiled extensions (platform- and Python-version-specific binaries).
+# PyYAML falls back gracefully to its pure-Python loader when the C extension
+# is absent, so excluding _yaml.cpython-*.so is safe and desirable.
+_SKIP_SUFFIXES: tuple[str, ...] = (".pyc", ".so", ".pyd")
+
+# Python packages to vendor from the current environment.
+# Keys are import names; values control how to vendor them.
+_VENDOR_PACKAGES = {
+    "sexpdata": {"single_file": True},  # sexpdata.py
+    "yaml": {"single_file": False},  # yaml/ package directory (PyYAML)
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(path: Path) -> bool:
+    """Return True if *path* should be excluded from the archive."""
+    return (
+        path.name in _SKIP_FILENAMES
+        or path.suffix in _SKIP_SUFFIXES
+        or path.name == "__pycache__"
+        or any(part == "__pycache__" for part in path.parts)
+    )
+
+
+def _copy_tree_filtered(src: Path, dst: Path) -> int:
+    """Recursively copy *src* to *dst*, skipping junk files.
+
+    Returns the total uncompressed byte count copied.
+    """
+    total_bytes = 0
+    dst.mkdir(parents=True, exist_ok=True)
+    for item in src.rglob("*"):
+        if _should_skip(item):
+            continue
+        rel = item.relative_to(src)
+        target = dst / rel
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+            total_bytes += item.stat().st_size
+    return total_bytes
+
+
+def _vendor_package(name: str, single_file: bool, dest_dir: Path) -> int:
+    """Copy a vendored package into *dest_dir*.
+
+    For single-file packages (e.g. ``sexpdata``), copies ``sexpdata.py``.
+    For package directories (e.g. ``yaml``), copies the whole directory.
+
+    Returns the total uncompressed byte count copied.
+    """
+    spec = importlib.util.find_spec(name)
+    if spec is None:
+        print(
+            f"  WARNING: package {name!r} not found in current environment; skipping vendor step.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if single_file:
+        # e.g. sexpdata.py — spec.origin is the file path
+        origin = Path(spec.origin)
+        target = dest_dir / origin.name
+        shutil.copy2(origin, target)
+        size = origin.stat().st_size
+        print(f"  vendored {name} ({origin.name}, {size:,} bytes)")
+        return size
+    else:
+        # Package directory — spec.submodule_search_locations[0] is the dir
+        locs = list(spec.submodule_search_locations or [])
+        if not locs:
+            print(
+                f"  WARNING: cannot locate package directory for {name!r}; skipping.",
+                file=sys.stderr,
+            )
+            return 0
+        pkg_dir = Path(locs[0])
+        target_dir = dest_dir / name
+        size = _copy_tree_filtered(pkg_dir, target_dir)
+        print(f"  vendored {name}/ ({size:,} bytes uncompressed)")
+        return size
+
+
+def _zip_directory(source_dir: Path, output_zip: Path) -> int:
+    """Create a zip archive of *source_dir* and return the compressed size."""
+    output_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output_zip, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for item in sorted(source_dir.rglob("*")):
+            if item.is_file():
+                arcname = item.relative_to(source_dir)
+                zf.write(item, arcname)
+    return output_zip.stat().st_size
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the lowercase hex SHA-256 digest of *path*."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_version() -> str:
+    """Read __version__ from src/jbom/__init__.py without importing the package."""
+    init_py = _SRC_JBOM / "__init__.py"
+    for line in init_py.read_text(encoding="utf-8").splitlines():
+        if line.startswith("__version__"):
+            # e.g.  __version__ = "6.53.0"
+            _, _, rhs = line.partition("=")
+            return rhs.strip().strip('"').strip("'")
+    raise RuntimeError(f"Cannot read __version__ from {init_py}")
+
+
+def _update_metadata(
+    version: str,
+    sha256: str,
+    install_size: int,
+    download_size: int,
+) -> None:
+    """Patch the repo-root metadata.json with computed release values."""
+    data = json.loads(_METADATA_SRC.read_text(encoding="utf-8"))
+    for v in data.get("versions", []):
+        if v.get("version") == version:
+            v["download_sha256"] = sha256
+            v["install_size"] = install_size
+            v["download_size"] = download_size
+    _METADATA_SRC.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"  updated metadata.json with sha256={sha256[:16]}…")
+
+
+# ---------------------------------------------------------------------------
+# Main build logic
+# ---------------------------------------------------------------------------
+
+
+def build(output_dir: Path, update_metadata: bool = False) -> Path:
+    """Build the PCM archive and return its path.
+
+    Args:
+        output_dir: Directory where the zip will be written.
+        update_metadata: When True, patch repo-root metadata.json.
+
+    Returns:
+        Path to the produced zip file.
+    """
+    version = _read_version()
+    archive_name = f"jbom-pcm-{version}.zip"
+    output_zip = output_dir / archive_name
+
+    print(f"Building jBOM PCM archive v{version} → {output_zip}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        stage = Path(tmp) / "archive"
+        plugins_dir = stage / "plugins"
+        plugins_dir.mkdir(parents=True)
+
+        # ------------------------------------------------------------------
+        # 1. Plugin adapter files → plugins/
+        # ------------------------------------------------------------------
+        print("  copying plugin adapter files…")
+        plugin_total = 0
+        for f in sorted(_PLUGIN_SRC.iterdir()):
+            if f.is_file() and not _should_skip(f):
+                dest = plugins_dir / f.name
+                shutil.copy2(f, dest)
+                plugin_total += f.stat().st_size
+        print(f"    {plugin_total:,} bytes")
+
+        # ------------------------------------------------------------------
+        # 2. Vendored jbom core → plugins/jbom/
+        # ------------------------------------------------------------------
+        print("  vendoring jbom core…")
+        jbom_vendor_dir = plugins_dir / "jbom"
+        jbom_vendor_dir.mkdir()
+
+        core_total = 0
+        # Root-level files
+        for fname in _JBOM_INCLUDE_ROOT_FILES:
+            src_file = _SRC_JBOM / fname
+            if src_file.is_file():
+                shutil.copy2(src_file, jbom_vendor_dir / fname)
+                core_total += src_file.stat().st_size
+
+        # Subdirectories
+        for subdir in _JBOM_INCLUDE_SUBDIRS:
+            src_subdir = _SRC_JBOM / subdir
+            if src_subdir.is_dir():
+                core_total += _copy_tree_filtered(src_subdir, jbom_vendor_dir / subdir)
+
+        print(f"    {core_total:,} bytes")
+
+        # ------------------------------------------------------------------
+        # 3. Vendored runtime deps → plugins/
+        # ------------------------------------------------------------------
+        print("  vendoring runtime dependencies…")
+        vendor_total = 0
+        for pkg_name, cfg in _VENDOR_PACKAGES.items():
+            vendor_total += _vendor_package(
+                pkg_name,
+                single_file=cfg["single_file"],  # type: ignore[index]
+                dest_dir=plugins_dir,
+            )
+
+        # ------------------------------------------------------------------
+        # 4. metadata.json → archive root
+        # ------------------------------------------------------------------
+        print("  copying metadata.json…")
+        shutil.copy2(_METADATA_SRC, stage / "metadata.json")
+
+        # ------------------------------------------------------------------
+        # 5. resources/ → archive root (optional)
+        # ------------------------------------------------------------------
+        if _RESOURCES_SRC.is_dir():
+            print("  copying resources/…")
+            _copy_tree_filtered(_RESOURCES_SRC, stage / "resources")
+        else:
+            print("  resources/ not found — skipping (add a 64×64 icon.png later)")
+
+        # ------------------------------------------------------------------
+        # 6. Zip it up
+        # ------------------------------------------------------------------
+        print("  zipping…")
+        install_size = plugin_total + core_total + vendor_total
+        download_size = _zip_directory(stage, output_zip)
+        sha256 = _sha256_file(output_zip)
+
+        print()
+        print(f"  archive : {output_zip}")
+        print(f"  sha256  : {sha256}")
+        print(f"  install : {install_size:,} bytes (uncompressed)")
+        print(f"  download: {download_size:,} bytes (compressed)")
+
+        if update_metadata:
+            _update_metadata(version, sha256, install_size, download_size)
+
+        return output_zip
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build a PCM-compliant KiCad plugin archive for jBOM.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--output-dir",
+        default="dist",
+        metavar="DIR",
+        help="Directory to write the zip into (default: dist/)",
+    )
+    p.add_argument(
+        "--update-metadata",
+        action="store_true",
+        help="Patch metadata.json with computed sha256 and sizes after build",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output_dir = (_REPO_ROOT / args.output_dir).resolve()
+    try:
+        build(output_dir, update_metadata=args.update_metadata)
+        return 0
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -30,7 +30,7 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from jbom.application.bom_workflow import (
     BOMRequest,
@@ -219,11 +219,37 @@ class FabricationWorkflow:
     This class contains no CLI or UI concerns.
     """
 
-    def run(self, request: FabricationRequest) -> FabricationResult:
+    def run(
+        self,
+        request: FabricationRequest,
+        *,
+        step_callback: Callable[[str, str], None] | None = None,
+    ) -> FabricationResult:
         """Execute the fabrication workflow and return all results.
 
         Args:
             request: Options governing which steps to run and with what inputs.
+            step_callback: Optional notification sink invoked at each step
+                boundary.  Signature: ``callback(step: str, status: str)``
+                where *step* is one of ``"bom"``, ``"pos"``, ``"gerbers"``,
+                ``"backup"`` and *status* is ``"start"`` or ``"done"``.
+
+                This is a naked ``Callable`` — the workflow has no knowledge of
+                wx, asyncio, or any specific event loop.  Each adapter is
+                responsible for its own dispatch:
+
+                - **Plugin adapter** passes a lambda that calls
+                  ``wx.CallAfter(dialog.on_step, step, status)`` so that UI
+                  updates are safely dispatched to the main thread.
+                - **CLI adapter** currently passes ``None``.  A future
+                  ``--verbose`` / ``--progress`` flag would pass
+                  ``lambda step, status: print(f"{step}: {status}")``
+                  instead — the contract already supports this without any
+                  changes to this method.
+
+                The callback is invoked from the **same thread** that calls
+                :meth:`run`; callers in a background thread must dispatch
+                UI updates themselves (e.g. via ``wx.CallAfter``).
 
         Returns:
             :class:`FabricationResult` aggregating BOM, POS, and Gerber outputs,
@@ -263,8 +289,12 @@ class FabricationWorkflow:
         # Step 1: BOM
         # ------------------------------------------------------------------
         if not request.skip_bom:
+            if step_callback:
+                step_callback("bom", "start")
             bom_result, bom_diagnostics = self._run_bom(request)
             diagnostics.extend(bom_diagnostics)
+            if step_callback:
+                step_callback("bom", "done")
             if bom_result is not None and bom_result.generation is not None:
                 bom_path = None
                 if not request.dry_run and production_dir is not None:
@@ -293,8 +323,12 @@ class FabricationWorkflow:
         # Step 2: POS
         # ------------------------------------------------------------------
         if not request.skip_pos:
+            if step_callback:
+                step_callback("pos", "start")
             pos_result, pos_diagnostics = self._run_pos(request)
             diagnostics.extend(pos_diagnostics)
+            if step_callback:
+                step_callback("pos", "done")
             if pos_result is not None and pos_result.generation is not None:
                 pos_path = None
                 if not request.dry_run and production_dir is not None:
@@ -323,6 +357,8 @@ class FabricationWorkflow:
         # Step 3: Gerbers (skipped in dry_run mode)
         # ------------------------------------------------------------------
         if not request.skip_gerbers:
+            if step_callback:
+                step_callback("gerbers", "start")
             if request.dry_run:
                 diagnostics.append(
                     "Dry run: Gerber generation skipped (no files written)."
@@ -335,6 +371,8 @@ class FabricationWorkflow:
                 ) = self._run_gerbers_with_packaging(request, production_dir)
                 diagnostics.extend(gerber_packaging_diags)
                 artifacts.extend(gerber_artifacts)
+            if step_callback:
+                step_callback("gerbers", "done")
 
         # ------------------------------------------------------------------
         # Step 4: Backup (if any files were written)
@@ -342,10 +380,14 @@ class FabricationWorkflow:
         if not request.dry_run and production_dir is not None and artifacts:
             artifact_paths = [a.path for a in artifacts if a.path is not None]
             if artifact_paths:
+                if step_callback:
+                    step_callback("backup", "start")
                 backup_archive, backup_diags = self._create_backup(
                     request, artifact_paths, production_dir
                 )
                 diagnostics.extend(backup_diags)
+                if step_callback:
+                    step_callback("backup", "done")
                 if backup_archive is not None:
                     artifacts.append(
                         FabricationArtifact(

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -93,6 +93,13 @@ class FabricationRequest:
         pos_origin: Forward origin reference (``"board"`` / ``"aux"``) to POS.
         debug: When ``True`` preserve intermediate gerber directory after
             packaging for inspection.
+        archive_stem: Pre-expanded archive base name (e.g. ``"MyBoard_1.0"``)
+            used as the stem for the gerber zip and backup archives.  When
+            non-empty, the workflow uses this value directly without reading
+            the project metadata from disk.  Adapters that have access to the
+            live board (e.g. the KiCad plugin) should pre-expand text variables
+            and pass the result here; CLI adapters may leave this empty to let
+            the workflow derive it from ``ProjectMetadata``.
     """
 
     input_path: str
@@ -109,6 +116,7 @@ class FabricationRequest:
     pos_layer: str = ""
     pos_origin: str = "board"
     debug: bool = False
+    archive_stem: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -145,6 +153,7 @@ class FabricationRequest:
             _normalize_text(self.pos_origin or "board", field_name="pos_origin"),
         )
         object.__setattr__(self, "debug", bool(self.debug))
+        object.__setattr__(self, "archive_stem", str(self.archive_stem or "").strip())
 
 
 @dataclass(frozen=True)
@@ -510,6 +519,40 @@ class FabricationWorkflow:
                 diagnostics.append(f"Note: could not resolve PCB file: {exc}")
             return None, None, diagnostics
 
+    def _resolve_archive_stem(
+        self,
+        request: FabricationRequest,
+        project_dir: Path | None,
+        pcb_file: Path | None,
+    ) -> str:
+        """Return the archive base name for gerber zip and backup archives.
+
+        When ``request.archive_stem`` is non-empty it is used directly (caller
+        has pre-expanded any text variables).  Otherwise the stem is derived
+        from :func:`~jbom.services.project_metadata.create_metadata` using the
+        project directory and PCB file.
+        """
+        if request.archive_stem:
+            return request.archive_stem
+        try:
+            from jbom.services.project_metadata import (
+                create_metadata,
+                normalize_archive_stem,
+            )
+
+            effective_project_dir = project_dir or (
+                pcb_file.parent if pcb_file else None
+            )
+            if effective_project_dir is None:
+                return "jbom-production"
+            project_file = (
+                effective_project_dir / f"{effective_project_dir.name}.kicad_pro"
+            )
+            metadata = create_metadata(project_file, pcb_file=pcb_file)
+            return normalize_archive_stem(metadata.project_name) or "jbom-production"
+        except Exception:
+            return "jbom-production"
+
     def _resolve_production_root(
         self, request: FabricationRequest, project_dir: Path | None
     ) -> Path:
@@ -571,19 +614,10 @@ class FabricationWorkflow:
                     )
                     return artifacts, gerber_result, diagnostics
 
-                # Resolve archive stem from project metadata
-                from jbom.services.project_metadata import (
-                    create_metadata,
-                    normalize_archive_stem,
+                # Resolve archive stem (honours request.archive_stem override)
+                archive_stem = self._resolve_archive_stem(
+                    request, project_dir, pcb_file
                 )
-
-                project_file = project_dir / f"{project_dir.name}.kicad_pro"
-                if not project_file.exists():
-                    # Fallback to stem of PCB file
-                    project_file = project_dir / f"{project_dir.name}.kicad_pro"
-
-                metadata = create_metadata(project_file, pcb_file=pcb_file)
-                archive_stem = normalize_archive_stem(metadata.project_name)
 
                 # Package gerbers with GerberPackager
                 from jbom.services.gerber_packager import GerberPackager
@@ -627,12 +661,8 @@ class FabricationWorkflow:
 
         try:
             from jbom.services.backup_service import BackupService
-            from jbom.services.project_metadata import (
-                create_metadata,
-                normalize_archive_stem,
-            )
 
-            # Resolve project metadata for archive naming
+            # Resolve project files for archive naming
             pcb_file, project_dir, resolve_diags = self._resolve_pcb_and_project_dir(
                 request
             )
@@ -641,9 +671,7 @@ class FabricationWorkflow:
             if project_dir is None:
                 project_dir = production_dir.parent
 
-            project_file = project_dir / f"{project_dir.name}.kicad_pro"
-            metadata = create_metadata(project_file, pcb_file=pcb_file)
-            archive_stem = normalize_archive_stem(metadata.project_name)
+            archive_stem = self._resolve_archive_stem(request, project_dir, pcb_file)
 
             backup_service = BackupService()
             backup_dir = production_dir / "backups"

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -1,4 +1,5 @@
 """BOM command - thin CLI wrapper over BOM workflows."""
+from __future__ import annotations
 
 import argparse
 import csv

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -1,4 +1,5 @@
 """Parts command - thin CLI wrapper over Parts List workflows."""
+from __future__ import annotations
 
 import argparse
 import csv

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -1,4 +1,5 @@
 """POS (Position) command - generate component placement files."""
+from __future__ import annotations
 
 import argparse
 import csv

--- a/src/jbom/common/types.py
+++ b/src/jbom/common/types.py
@@ -15,10 +15,14 @@ class TitleBlockMetadata:
     Both schematic (.kicad_sch) and PCB (.kicad_pcb) files contain a title block
     section with project metadata including title, revision, date, company, etc.
     This dataclass represents the common extracted metadata from either source.
+
+    All fields default to empty string; callers must handle absent data gracefully.
     """
 
     title: str = ""
     revision: str = ""
+    date: str = ""  # issue_date from title block (YYYY-MM-DD or designer-formatted)
+    company: str = ""  # company / organisation field from title block
 
 
 @dataclass

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -443,6 +443,32 @@ def get_available_fabricators() -> list[str]:
     return fabricators if fabricators else ["generic"]
 
 
+def get_fabricators_with_names() -> list[tuple[str, str]]:
+    """Return (id, display_name) pairs for all available fabricators.
+
+    Loads each fabricator config to read its human-readable ``name`` field
+    (e.g. ``"jlc"`` → ``"JLC"``).  Fabricators whose config cannot be loaded
+    are included with the ID title-cased as a fallback display name.
+
+    Returns:
+        List of ``(fabricator_id, display_name)`` tuples sorted by ID.
+
+    Example::
+
+        get_fabricators_with_names()
+        # → [("generic", "Generic"), ("jlc", "JLC"),
+        #    ("pcbway", "PCBWay"), ("seeed", "Seeed Studio")]
+    """
+    result: list[tuple[str, str]] = []
+    for fid in get_available_fabricators():
+        try:
+            display_name = load_fabricator(fid).name
+        except (ValueError, Exception):
+            display_name = fid.upper() if len(fid) <= 4 else fid.title()
+        result.append((fid, display_name))
+    return result
+
+
 def load_fabricator(fid: str) -> FabricatorConfig:
     """Load fabricator configuration from YAML file.
 

--- a/src/jbom/plugin/__init__.py
+++ b/src/jbom/plugin/__init__.py
@@ -50,7 +50,12 @@ import sys
 # sys.path bootstrapping
 # ---------------------------------------------------------------------------
 
-_this_dir = os.path.dirname(os.path.abspath(__file__))
+# os.path.realpath (not abspath) is required here: abspath makes a path
+# absolute but does NOT follow symlinks.  In the dev loop the plugin directory
+# is a symlink, so abspath would resolve relative to the symlink location
+# (e.g. .../scripting/plugins/com_spcoast_jbom/) instead of the actual source
+# tree (src/jbom/plugin/).  realpath follows the symlink first.
+_this_dir = os.path.dirname(os.path.realpath(__file__))
 
 # Two levels up from ``src/jbom/plugin/`` lands at ``src/`` in the dev tree.
 # In PCM mode (``${KICADX_3RD_PARTY}/plugins/com_spcoast_jbom/``) this

--- a/src/jbom/plugin/__init__.py
+++ b/src/jbom/plugin/__init__.py
@@ -1,0 +1,81 @@
+"""jBOM KiCad ActionPlugin adapter.
+
+This is the PCM-installable plugin entry point for the jBOM fabrication
+workflow.  Importing this module in a CLI or test environment is safe and
+inert — no ``pcbnew`` import is attempted and no ActionPlugin is registered.
+
+Guard pattern
+-------------
+Mirrors Fabrication Toolkit's ``plugins/__init__.py``:
+
+.. code-block:: python
+
+    _is_standalone = "pcbnew" not in sys.modules or __name__ == "__main__"
+    if not _is_standalone:
+        from .plugin import JBOMFabricationPlugin
+        JBOMFabricationPlugin().register()
+
+``sys.path`` bootstrapping
+--------------------------
+This module adds two candidate directories to ``sys.path`` so that
+``import jbom`` (and vendored runtime deps) succeeds in both deployment modes:
+
+* **PCM install** — ``jbom/`` is vendored *inside* this plugin directory.
+  Adding the plugin directory itself (``_this_dir``) makes it discoverable.
+
+* **Dev loop (symlink)** — this directory is ``src/jbom/plugin/``, symlinked
+  into KiCad's scripting plugins folder as ``com_spcoast_jbom``.  Adding
+  ``src/`` (two levels up from ``plugin/``) makes the editable source tree
+  discoverable without a separate ``pip install`` into KiCad's bundled Python.
+
+The two paths are tried in order; the first one that contains a ``jbom``
+package wins.
+
+Dev-loop setup (macOS, KiCad 9)::
+
+    ln -s "$PWD/src/jbom/plugin" \\
+      ~/Library/Application\\ Support/kicad/9.0/scripting/plugins/com_spcoast_jbom
+
+Important: use ``com_spcoast_jbom`` (not ``jbom``) as the symlink target name
+to avoid a naming conflict with the importable ``jbom`` package when KiCad
+adds the scripting plugins directory to ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# sys.path bootstrapping
+# ---------------------------------------------------------------------------
+
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Two levels up from ``src/jbom/plugin/`` lands at ``src/`` in the dev tree.
+# In PCM mode (``${KICADX_3RD_PARTY}/plugins/com_spcoast_jbom/``) this
+# resolves to ``${KICADX_3RD_PARTY}/plugins/``, which is already in sys.path
+# by the time KiCad loads us — adding it again is harmless.
+_src_dir = os.path.dirname(os.path.dirname(_this_dir))
+
+for _p in (_this_dir, _src_dir):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# ---------------------------------------------------------------------------
+# ActionPlugin registration — KiCad context only
+# ---------------------------------------------------------------------------
+
+# ``pcbnew`` is pre-loaded by KiCad's embedded Python before any plugin
+# ``__init__.py`` runs.  In CLI/test environments it is never present.
+_is_standalone = "pcbnew" not in sys.modules or __name__ == "__main__"
+
+if not _is_standalone:  # pragma: no cover — only executes inside KiCad
+    try:
+        from .plugin import JBOMFabricationPlugin
+
+        JBOMFabricationPlugin().register()
+    except Exception:
+        import traceback
+
+        traceback.print_exc()

--- a/src/jbom/plugin/__init__.py
+++ b/src/jbom/plugin/__init__.py
@@ -13,7 +13,8 @@ Mirrors Fabrication Toolkit's ``plugins/__init__.py``:
     _is_standalone = "pcbnew" not in sys.modules or __name__ == "__main__"
     if not _is_standalone:
         from .plugin import JBOMFabricationPlugin
-        JBOMFabricationPlugin().register()
+        _plugin_instance = JBOMFabricationPlugin()
+        _plugin_instance.register()
 
 ``sys.path`` bootstrapping
 --------------------------
@@ -79,7 +80,15 @@ if not _is_standalone:  # pragma: no cover — only executes inside KiCad
     try:
         from .plugin import JBOMFabricationPlugin
 
-        JBOMFabricationPlugin().register()
+        # Store the instance at module level — mirrors FT's `plugin = Plugin(); plugin.register()`.
+        # Without this, the temporary JBOMFabricationPlugin() object may be GC'd immediately
+        # after register() returns (CPython reference counting).  If KiCad's ActionPlugin
+        # registry holds only a C++ pointer without a Python refcount, a GC'd wrapper causes
+        # KiCad to silently suppress subsequent Run() calls — the toolbar button appears to
+        # work once and then becomes inert.  Retaining a module-level Python reference
+        # prevents GC for the lifetime of the KiCad session.
+        _plugin_instance = JBOMFabricationPlugin()
+        _plugin_instance.register()
     except Exception:
         import traceback
 

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -81,6 +81,8 @@ class JBOMFabricationDialog(wx.Dialog):
         self._fab_ids: list[str] = []
         self._gauges: dict[str, wx.Gauge] = {}
         self._status_texts: dict[str, wx.StaticText] = {}
+        # _archive_preview is set by _build_input_panel; updated when template changes
+        self._archive_preview: wx.StaticText | None = None
 
         # Load persisted options; fall back to defaults when absent.
         from jbom.plugin.options import PluginOptions, load_options
@@ -120,18 +122,31 @@ class JBOMFabricationDialog(wx.Dialog):
         sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
 
         # -- Project info grid -------------------------------------------
-        grid = wx.FlexGridSizer(rows=3, cols=2, vgap=6, hgap=8)
+        grid = wx.FlexGridSizer(rows=4, cols=2, vgap=4, hgap=8)
         grid.AddGrowableCol(1, 1)
 
-        # Archive (read-only)
+        # Archive template (editable) + preview label
         grid.Add(
             wx.StaticText(panel, label="Archive:"),
             flag=wx.ALIGN_CENTER_VERTICAL,
         )
-        grid.Add(
-            wx.StaticText(panel, label=self._archive_name),
-            flag=wx.ALIGN_CENTER_VERTICAL | wx.EXPAND,
+        self._archive_tpl = wx.TextCtrl(
+            panel,
+            value=self._options.archive_name_template,
+            style=wx.TE_PROCESS_ENTER,
         )
+        self._archive_tpl.Bind(wx.EVT_TEXT, self._on_archive_template_changed)
+        grid.Add(self._archive_tpl, flag=wx.EXPAND)
+
+        # Preview row — blank label + expanded-name label
+        grid.Add(wx.StaticText(panel, label=""), flag=wx.ALIGN_CENTER_VERTICAL)
+        self._archive_preview = wx.StaticText(
+            panel, label=self._archive_name, style=wx.ST_ELLIPSIZE_END
+        )
+        preview_font = self._archive_preview.GetFont()
+        preview_font.SetStyle(wx.FONTSTYLE_ITALIC)
+        self._archive_preview.SetFont(preview_font)
+        grid.Add(self._archive_preview, flag=wx.EXPAND)
 
         # Fabricator dropdown + Config button
         grid.Add(
@@ -303,6 +318,16 @@ class JBOMFabricationDialog(wx.Dialog):
     # Event handlers — input panel
     # ------------------------------------------------------------------
 
+    def _on_archive_template_changed(self, _evt: wx.CommandEvent) -> None:
+        """Update the preview label when the archive template is edited."""
+        if self._archive_preview is None:
+            return
+        # Re-expand on the fly using the pre-computed archive_name (passed at
+        # construction time by plugin.py after pcbnew.ExpandTextVars).  A
+        # simpler heuristic: show the template itself as the preview when the
+        # expanded name is unavailable.
+        self._archive_preview.SetLabel(self._archive_name)
+
     def _on_browse_inventory(self, _evt: wx.CommandEvent) -> None:
         """Open a file dialog to select the inventory file."""
         dlg = wx.FileDialog(
@@ -323,9 +348,11 @@ class JBOMFabricationDialog(wx.Dialog):
 
         from jbom.plugin.options import PluginOptions, save_options
 
+        archive_template = self._archive_tpl.GetValue().strip()
         updated = PluginOptions(
             fabricator=fab_id,
             inventory_path=inventory_path,
+            archive_name_template=archive_template,
         )
         if self._pcb_path:
             try:
@@ -357,6 +384,10 @@ class JBOMFabricationDialog(wx.Dialog):
             inventory_files=(inventory_path,) if inventory_path else (),
             smd_only=self._cb_smd_only.GetValue(),
             debug=self._cb_debug.GetValue(),
+            # Pre-expanded archive stem from pcbnew.ExpandTextVars (set by
+            # plugin.py before opening the dialog).  Passed through so the
+            # workflow uses the correct name without re-reading disk.
+            archive_stem=self._archive_name,
             # Gerbers via kicad-cli subprocess can hang when called from inside
             # a KiCad plugin (two KiCad instances conflict on macOS/Windows).
             # Disable until the pcbnew PLOT_CONTROLLER path is implemented.

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -63,12 +63,6 @@ from pathlib import Path
 
 import wx
 
-
-def _log(msg: str) -> None:
-    """Diagnostic trace — visible in KiCad scripting console (Tools → Scripting Console)."""
-    print(f"[jBOM dialog] {msg}", file=sys.stderr, flush=True)
-
-
 try:
     from jbom import __version__ as _jbom_version
 except ImportError:  # pragma: no cover
@@ -106,13 +100,11 @@ class JBOMFabricationDialog(wx.Dialog):
         pcb_path: str = "",
         archive_name: str = "",
     ) -> None:
-        _log(f"__init__ start (pcb={pcb_path!r})")
         super().__init__(
             None,  # parent=None — required for correct KiCad toolbar re-enable
             title="jBOM Fabrication",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
-        _log("wx.Dialog.__init__ complete")
 
         self._pcb_path = pcb_path
         self._archive_name = archive_name or "(unknown)"
@@ -146,7 +138,6 @@ class JBOMFabricationDialog(wx.Dialog):
         # EVT_CLOSE fires when the user clicks the X button.  The default
         # wx.Dialog behaviour is Show(False) (hide); we override it to Destroy.
         self.Bind(wx.EVT_CLOSE, self._on_close)
-        _log("__init__ complete — dialog ready")
 
     # ------------------------------------------------------------------
     # Input panel
@@ -726,17 +717,13 @@ class JBOMFabricationDialog(wx.Dialog):
         Mirrors Fabrication-Toolkit's ``updateDisplay`` which always calls
         ``pcbnew.Refresh()`` before ``self.Destroy()``.
         """
-        _log("_refresh_and_destroy() called")
         try:
             import pcbnew  # noqa: PLC0415
 
             pcbnew.Refresh()
-            _log("pcbnew.Refresh() returned")
-        except Exception as exc:  # pragma: no cover
-            _log(f"pcbnew.Refresh() raised: {exc}")
-        _log("calling self.Destroy()")
+        except Exception:  # pragma: no cover
+            pass  # Non-fatal: Destroy() still runs
         self.Destroy()
-        _log("self.Destroy() returned")
 
     @staticmethod
     def _open_folder(path: Path) -> None:

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -11,8 +11,8 @@ Dialog has two panels that swap on Generate:
    and a Cancel button sit at the bottom.
 
 2. **Progress panel** — four :class:`wx.Gauge` widgets for BOM, CPL, Gerbers,
-   and Backup, driven by :attr:`FabricationWorkflow.step_callback` via
-   :func:`wx.CallAfter` from the background thread.
+   and Backup, driven by step callbacks via :func:`wx.CallAfter` from the
+   background thread.
 
 Completion behaviour:
 
@@ -25,6 +25,28 @@ Options are loaded from :func:`~jbom.plugin.options.load_options` when the
 dialog opens and persisted by :func:`~jbom.plugin.options.save_options` when
 Generate is pressed.
 
+Orchestration (Blocker 1 + 3 from issue #227):
+The background ``_worker`` directly sequences:
+
+1. ``BOMWorkflow().run()`` → ``BOMWriter`` → ``production/jbom.csv``
+2. ``POSWorkflow().run()`` → ``POSWriter`` → ``production/cpl.csv``
+3. ``PcbnewGerberGenerator(board).generate()`` → ``GerberPackager``
+   → ``production/{stem}.zip``
+4. ``BackupService().backup()``
+   → ``production/backups/{stem}_{timestamp}.zip``
+
+``FabricationWorkflow`` is intentionally **not** used from the plugin: its
+internal ``kicad-cli`` subprocess path hangs inside KiCad, and its backup
+runs before plugin-generated Gerbers are available.  Plugin knowledge stays
+in the plugin layer.  The CLI path (``GerberExporter`` / ``kicad-cli``)
+is unchanged.
+
+wx.Frame vs wx.Dialog (Blocker 2 from issue #227):
+``ShowModal()`` blocks ``Run()`` and prevents the toolbar button from being
+re-activated.  Using ``wx.Frame`` + ``Show()`` returns immediately so KiCad
+can re-invoke the plugin.  The frame owns its lifecycle and calls
+``self.Destroy()`` when done.
+
 Reference: ``docs/dev/development_notes/active/plugin_ux_storyboard.md``
 """
 
@@ -32,7 +54,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 import threading
+import types
 from pathlib import Path
 
 import wx
@@ -52,8 +76,12 @@ _STEP_LABELS: dict[str, str] = {
 }
 
 
-class JBOMFabricationDialog(wx.Dialog):
-    """Full storyboard fabrication dialog (Session B).
+class JBOMFabricationDialog(wx.Frame):
+    """Full storyboard fabrication frame (Session B).
+
+    Uses ``wx.Frame`` (not ``wx.Dialog``) so that ``plugin.Run()`` can return
+    immediately after calling ``Show()`` — this lets the KiCad toolbar button
+    be re-activated while the frame is still open (Blocker 2, issue #227).
 
     Args:
         parent: Parent window (the KiCad main frame, or ``None``).
@@ -72,7 +100,7 @@ class JBOMFabricationDialog(wx.Dialog):
         super().__init__(
             parent,
             title="jBOM Fabrication",
-            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+            style=wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT,
         )
 
         self._pcb_path = pcb_path
@@ -103,6 +131,9 @@ class JBOMFabricationDialog(wx.Dialog):
         self.SetSizer(outer)
         outer.Fit(self)
         self.Centre()
+
+        # With wx.Frame, the X button does not automatically call Destroy.
+        self.Bind(wx.EVT_CLOSE, self._on_frame_close)
 
     # ------------------------------------------------------------------
     # Input panel
@@ -222,6 +253,8 @@ class JBOMFabricationDialog(wx.Dialog):
         self._generate_btn = wx.Button(panel, label="Generate")
         self._generate_btn.SetDefault()
         cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        # wx.Frame does not auto-handle wx.ID_CANCEL — bind explicitly.
+        cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
         self._generate_btn.Bind(wx.EVT_BUTTON, self._on_generate)
         btn_row.AddStretchSpacer(1)
         btn_row.Add(self._generate_btn, flag=wx.RIGHT, border=8)
@@ -381,10 +414,16 @@ class JBOMFabricationDialog(wx.Dialog):
 
     def _on_generate(self, _evt: wx.CommandEvent) -> None:
         """Validate, save options, fill zones if requested, then start the thread."""
-        # Persist selections
+        # Capture all UI values on the main thread before the worker starts.
         fab_id = self._selected_fabricator_id()
         inventory_path = self._inv_text.GetValue().strip()
+        smd_only = self._cb_smd_only.GetValue()
+        open_folder = self._cb_open_folder.GetValue()
+        debug_mode = self._cb_debug.GetValue()
+        archive_stem = self._archive_name
+        pcb_path = self._pcb_path
 
+        # Persist selections
         from jbom.plugin.options import PluginOptions, save_options
 
         archive_template = self._archive_tpl.GetValue().strip()
@@ -393,9 +432,9 @@ class JBOMFabricationDialog(wx.Dialog):
             inventory_path=inventory_path,
             archive_name_template=archive_template,
         )
-        if self._pcb_path:
+        if pcb_path:
             try:
-                save_options(updated, Path(self._pcb_path))
+                save_options(updated, Path(pcb_path))
             except OSError:
                 pass  # Non-fatal; proceed with generation
 
@@ -411,44 +450,139 @@ class JBOMFabricationDialog(wx.Dialog):
         self.GetSizer().Fit(self)
         self.Centre()
 
-        # Build request
-        from jbom.application.fabrication_orchestration import (
-            FabricationRequest,
-            FabricationWorkflow,
-        )
+        def _step(step: str, status: str) -> None:
+            wx.CallAfter(self._on_step, step, status)
 
-        request = FabricationRequest(
-            input_path=self._pcb_path or ".",
-            fabricator=fab_id,
-            inventory_files=(inventory_path,) if inventory_path else (),
-            smd_only=self._cb_smd_only.GetValue(),
-            debug=self._cb_debug.GetValue(),
-            # Pre-expanded archive stem from pcbnew.ExpandTextVars (set by
-            # plugin.py before opening the dialog).  Passed through so the
-            # workflow uses the correct name without re-reading disk.
-            archive_stem=self._archive_name,
-            # Gerbers via kicad-cli subprocess can hang when called from inside
-            # a KiCad plugin (two KiCad instances conflict on macOS/Windows).
-            # Disable until the pcbnew PLOT_CONTROLLER path is implemented.
-            # TODO: remove when native pcbnew Gerber generation lands.
-            skip_gerbers=True,
-        )
-        open_folder = self._cb_open_folder.GetValue()
-        debug_mode = self._cb_debug.GetValue()
-        # Note: backup is always created by FabricationWorkflow when artifacts
-        # are present. A skip_backup flag on FabricationRequest would be needed
-        # to honour self._cb_backup; tracked as a future enhancement.
-
-        # Launch background thread
         def _worker() -> None:
+            """Background thread: BOM → POS → Gerbers → Backup (A2 orchestration)."""
             try:
-                result = FabricationWorkflow().run(
-                    request,
-                    step_callback=lambda step, status: wx.CallAfter(
-                        self._on_step, step, status
-                    ),
+                import pcbnew  # noqa: PLC0415
+
+                board = pcbnew.GetBoard()
+
+                project_dir = Path(pcb_path).parent if pcb_path else Path(".")
+                production_dir = project_dir / "production"
+                production_dir.mkdir(parents=True, exist_ok=True)
+
+                diagnostics: list[str] = []
+                artifact_paths: list[Path] = []
+
+                def cancelled() -> bool:
+                    return self._cancel_requested.is_set()
+
+                # ----------------------------------------------------------
+                # Step 1: BOM
+                # ----------------------------------------------------------
+                _step("bom", "start")
+                if not cancelled():
+                    try:
+                        from jbom.application.bom_workflow import (
+                            BOMRequest,
+                            BOMWorkflow,
+                        )
+                        from jbom.services.bom_writer import BOMWriter
+
+                        bom_request = BOMRequest(
+                            input_path=pcb_path or ".",
+                            fabricator=fab_id,
+                            inventory_files=(
+                                (inventory_path,) if inventory_path else ()
+                            ),
+                        )
+                        bom_result = BOMWorkflow().run(bom_request)
+                        diagnostics.extend(bom_result.diagnostics)
+                        if bom_result.generation is not None:
+                            bom_path = production_dir / "jbom.csv"
+                            BOMWriter.write(bom_result.generation, bom_path, force=True)
+                            artifact_paths.append(bom_path)
+                    except Exception as exc:
+                        diagnostics.append(f"BOM generation failed: {exc}")
+                _step("bom", "done")
+
+                # ----------------------------------------------------------
+                # Step 2: POS
+                # ----------------------------------------------------------
+                _step("pos", "start")
+                if not cancelled():
+                    try:
+                        from jbom.application.pos_workflow import (
+                            POSRequest,
+                            POSWorkflow,
+                        )
+                        from jbom.services.pos_writer import POSWriter
+
+                        pos_request = POSRequest(
+                            input_path=pcb_path or ".",
+                            fabricator=fab_id,
+                            smd_only=smd_only,
+                        )
+                        pos_result = POSWorkflow().run(pos_request)
+                        diagnostics.extend(pos_result.diagnostics)
+                        if pos_result.generation is not None:
+                            pos_path = production_dir / "cpl.csv"
+                            POSWriter.write(pos_result.generation, pos_path, force=True)
+                            artifact_paths.append(pos_path)
+                    except Exception as exc:
+                        diagnostics.append(f"POS generation failed: {exc}")
+                _step("pos", "done")
+
+                # ----------------------------------------------------------
+                # Step 3: Gerbers (pcbnew PLOT_CONTROLLER — no kicad-cli)
+                # ----------------------------------------------------------
+                _step("gerbers", "start")
+                if not cancelled():
+                    try:
+                        from jbom.plugin.gerber_generator import (
+                            PcbnewGerberGenerator,
+                        )
+                        from jbom.services.gerber_packager import GerberPackager
+
+                        with tempfile.TemporaryDirectory() as tmp:
+                            temp_gerber_dir = Path(tmp) / "gerbers"
+                            temp_gerber_dir.mkdir()
+                            gerber_result = PcbnewGerberGenerator(board).generate(
+                                temp_gerber_dir,
+                                fabricator=fab_id,
+                                debug=debug_mode,
+                            )
+                            diagnostics.extend(gerber_result.diagnostics)
+                            if not gerber_result.skipped:
+                                gerber_zip = production_dir / f"{archive_stem}.zip"
+                                GerberPackager().package(
+                                    gerber_result.artifacts,
+                                    gerber_zip,
+                                    debug=debug_mode,
+                                )
+                                artifact_paths.append(gerber_zip)
+                    except Exception as exc:
+                        diagnostics.append(f"Gerber generation failed: {exc}")
+                _step("gerbers", "done")
+
+                # ----------------------------------------------------------
+                # Step 4: Backup (all three artifacts in one archive)
+                # ----------------------------------------------------------
+                _step("backup", "start")
+                if not cancelled() and artifact_paths:
+                    try:
+                        from jbom.services.backup_service import BackupService
+
+                        backup_dir = production_dir / "backups"
+                        BackupService().backup(
+                            artifact_paths,
+                            backup_dir,
+                            archive_stem,
+                        )
+                    except Exception as exc:
+                        diagnostics.append(f"Backup creation failed: {exc}")
+                _step("backup", "done")
+
+                # Build a lightweight result carrier for _on_complete.
+                result = types.SimpleNamespace(
+                    production_dir=(production_dir if artifact_paths else None),
+                    diagnostics=tuple(diagnostics),
                 )
                 wx.CallAfter(self._on_complete, result, open_folder, debug_mode)
+
             except Exception as exc:
                 wx.CallAfter(self._on_error, str(exc))
 
@@ -514,10 +648,10 @@ class JBOMFabricationDialog(wx.Dialog):
         diagnostics = getattr(result, "diagnostics", ())
         production_dir = getattr(result, "production_dir", None)
 
-        # Distinguish errors (production_dir is None — nothing was written) from
-        # info-level diagnostics (resolution notes that are always present).  Only
-        # stay open when there was an actual failure or debug mode is requested.
-        has_error = production_dir is None and not getattr(result, "skip_bom", False)
+        # Distinguish errors (no artifacts produced — production_dir is None)
+        # from info-level diagnostics.  Stay open when there was an actual
+        # failure or when the user requested debug mode.
+        has_error = production_dir is None
         stay_open = debug_mode or has_error
 
         if stay_open:
@@ -527,18 +661,16 @@ class JBOMFabricationDialog(wx.Dialog):
                 self._diag_text.Show()
                 self.GetSizer().Layout()
                 self.GetSizer().Fit(self)
-            # Rebind the button so it actually closes the dialog.
+            # Rebind the button so it actually closes the frame.
             self._progress_cancel_btn.SetLabel("Close")
             self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
-            self._progress_cancel_btn.Bind(
-                wx.EVT_BUTTON, lambda _e: self.EndModal(wx.ID_OK)
-            )
+            self._progress_cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
             self._progress_cancel_btn.Enable()
         else:
             # Auto-close + open folder
             if open_folder and production_dir is not None:
                 self._open_folder(Path(production_dir))
-            self.EndModal(wx.ID_OK)
+            self.Destroy()
 
     def _on_error(self, message: str) -> None:
         """Handle unexpected thread exception; called via ``wx.CallAfter``."""
@@ -546,12 +678,16 @@ class JBOMFabricationDialog(wx.Dialog):
         self._diag_text.Show()
         self._progress_cancel_btn.SetLabel("Close")
         self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
-        self._progress_cancel_btn.Bind(
-            wx.EVT_BUTTON, lambda _e: self.EndModal(wx.ID_CANCEL)
-        )
+        self._progress_cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
         self._progress_cancel_btn.Enable()
         self.GetSizer().Layout()
         self.GetSizer().Fit(self)
+
+    def _on_frame_close(self, evt: wx.CloseEvent) -> None:
+        """Handle frame close (X button) — signal cancel and destroy."""
+        # If the worker thread is active, signal it to stop gracefully.
+        self._cancel_requested.set()
+        self.Destroy()
 
     @staticmethod
     def _open_folder(path: Path) -> None:

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -1,0 +1,95 @@
+"""jBOM Fabrication stub dialog (Session A POC).
+
+This module is imported only inside KiCad's embedded Python interpreter, so
+top-level ``import wx`` is safe here — KiCad bundles wxPython.
+
+Session A acceptance criteria
+------------------------------
+- Dialog appears when the toolbar button is clicked.
+- Displays the current jBOM version.
+- Displays the PCB file path received from ``pcbnew.GetBoard()``.
+- Has a *Cancel* button that dismisses the dialog cleanly.
+- Does not crash on macOS with KiCad's bundled Python.
+
+Session B will replace this stub with the full storyboard dialog defined in
+``docs/dev/development_notes/active/plugin_ux_storyboard.md``, including
+the fabricator dropdown, inventory picker, checkboxes, and per-step progress
+view.
+"""
+
+from __future__ import annotations
+
+import wx
+
+try:
+    from jbom import __version__ as _jbom_version
+except ImportError:  # pragma: no cover — defensive; should always be importable
+    _jbom_version = "unknown"
+
+
+class JBOMStubDialog(wx.Dialog):
+    """Minimal stub dialog that validates plugin load and user interaction.
+
+    Args:
+        parent: Parent window (the KiCad main frame, or ``None``).
+        pcb_path: Filesystem path of the active PCB file, or empty string.
+    """
+
+    def __init__(self, parent: wx.Window | None, *, pcb_path: str = "") -> None:
+        super().__init__(
+            parent,
+            title="jBOM Fabrication",
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+
+        root = wx.BoxSizer(wx.VERTICAL)
+
+        # ------------------------------------------------------------------
+        # Version banner
+        # ------------------------------------------------------------------
+        banner = wx.StaticText(self, label=f"jBOM  v{_jbom_version}")
+        font = banner.GetFont()
+        font.SetPointSize(font.GetPointSize() + 2)
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        banner.SetFont(font)
+        root.Add(banner, flag=wx.ALL, border=12)
+
+        # ------------------------------------------------------------------
+        # PCB path (informational)
+        # ------------------------------------------------------------------
+        pcb_text = pcb_path if pcb_path else "(no board loaded)"
+        pcb_label = wx.StaticText(self, label=f"PCB: {pcb_text}")
+        root.Add(pcb_label, flag=wx.LEFT | wx.RIGHT | wx.BOTTOM, border=12)
+
+        root.Add(
+            wx.StaticLine(self),
+            flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
+            border=8,
+        )
+
+        # ------------------------------------------------------------------
+        # Placeholder notice
+        # ------------------------------------------------------------------
+        notice = wx.StaticText(
+            self,
+            label=(
+                "Full fabrication dialog — fabricator selection,\n"
+                "inventory picker, zone fill, and Gerber generation —\n"
+                "will be available in the next release (Session B)."
+            ),
+        )
+        root.Add(notice, flag=wx.ALL, border=12)
+
+        # ------------------------------------------------------------------
+        # Button row
+        # ------------------------------------------------------------------
+        btn_sizer = wx.StdDialogButtonSizer()
+        cancel_btn = wx.Button(self, wx.ID_CANCEL, "Cancel")
+        cancel_btn.SetDefault()
+        btn_sizer.AddButton(cancel_btn)
+        btn_sizer.Realize()
+        root.Add(btn_sizer, flag=wx.ALIGN_RIGHT | wx.ALL, border=8)
+
+        self.SetSizer(root)
+        root.Fit(self)
+        self.Centre()

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -319,13 +319,28 @@ class JBOMFabricationDialog(wx.Dialog):
     # ------------------------------------------------------------------
 
     def _on_archive_template_changed(self, _evt: wx.CommandEvent) -> None:
-        """Update the preview label when the archive template is edited."""
+        """Re-expand the template and update the preview + archive_name.
+
+        Called on every keystroke in the Archive text field.  Updates
+        ``self._archive_name`` so that Generate uses the new expansion.
+        """
         if self._archive_preview is None:
             return
-        # Re-expand on the fly using the pre-computed archive_name (passed at
-        # construction time by plugin.py after pcbnew.ExpandTextVars).  A
-        # simpler heuristic: show the template itself as the preview when the
-        # expanded name is unavailable.
+        new_template = self._archive_tpl.GetValue()
+        try:
+            import re
+
+            import pcbnew  # noqa: PLC0415 — safe inside KiCad
+
+            board = pcbnew.GetBoard()
+            project = board.GetProject()
+            expanded = pcbnew.ExpandTextVars(new_template, project)
+            # Apply the same normalisation as plugin.py._expand_archive_template
+            cleaned = re.sub(r"[^\w.-]", "_", expanded).strip("_")
+            self._archive_name = cleaned or new_template
+        except Exception:
+            # Fallback: show the literal template as the preview
+            self._archive_name = new_template
         self._archive_preview.SetLabel(self._archive_name)
 
     def _on_browse_inventory(self, _evt: wx.CommandEvent) -> None:

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -467,15 +467,25 @@ class JBOMFabricationDialog(wx.Dialog):
         diagnostics = getattr(result, "diagnostics", ())
         production_dir = getattr(result, "production_dir", None)
 
-        if debug_mode or diagnostics:
-            # Stay open — show diagnostics
+        # Distinguish errors (production_dir is None — nothing was written) from
+        # info-level diagnostics (resolution notes that are always present).  Only
+        # stay open when there was an actual failure or debug mode is requested.
+        has_error = production_dir is None and not getattr(result, "skip_bom", False)
+        stay_open = debug_mode or has_error
+
+        if stay_open:
+            # Show diagnostics and switch Cancel → Close.
             if diagnostics:
                 self._diag_text.SetValue("\n".join(str(d) for d in diagnostics))
                 self._diag_text.Show()
                 self.GetSizer().Layout()
                 self.GetSizer().Fit(self)
-            # Re-enable cancel button as a "Close" button
+            # Rebind the button so it actually closes the dialog.
             self._progress_cancel_btn.SetLabel("Close")
+            self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
+            self._progress_cancel_btn.Bind(
+                wx.EVT_BUTTON, lambda _e: self.EndModal(wx.ID_OK)
+            )
             self._progress_cancel_btn.Enable()
         else:
             # Auto-close + open folder
@@ -488,6 +498,10 @@ class JBOMFabricationDialog(wx.Dialog):
         self._diag_text.SetValue(f"Error: {message}")
         self._diag_text.Show()
         self._progress_cancel_btn.SetLabel("Close")
+        self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
+        self._progress_cancel_btn.Bind(
+            wx.EVT_BUTTON, lambda _e: self.EndModal(wx.ID_CANCEL)
+        )
         self._progress_cancel_btn.Enable()
         self.GetSizer().Layout()
         self.GetSizer().Fit(self)

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -1,95 +1,468 @@
-"""jBOM Fabrication stub dialog (Session A POC).
+"""jBOM Fabrication dialog (Session B — full storyboard implementation).
 
 This module is imported only inside KiCad's embedded Python interpreter, so
 top-level ``import wx`` is safe here — KiCad bundles wxPython.
 
-Session A acceptance criteria
-------------------------------
-- Dialog appears when the toolbar button is clicked.
-- Displays the current jBOM version.
-- Displays the PCB file path received from ``pcbnew.GetBoard()``.
-- Has a *Cancel* button that dismisses the dialog cleanly.
-- Does not crash on macOS with KiCad's bundled Python.
+Dialog has two panels that swap on Generate:
 
-Session B will replace this stub with the full storyboard dialog defined in
-``docs/dev/development_notes/active/plugin_ux_storyboard.md``, including
-the fabricator dropdown, inventory picker, checkboxes, and per-step progress
-view.
+1. **Input panel** — fabricator dropdown, inventory file picker, option
+   checkboxes (SMD only, Exclude DNP, Fill zones, Create backup, Open folder,
+   Apply corrections [grayed/pending #249], Debug mode).  A Generate button
+   and a Cancel button sit at the bottom.
+
+2. **Progress panel** — four :class:`wx.Gauge` widgets for BOM, CPL, Gerbers,
+   and Backup, driven by :attr:`FabricationWorkflow.step_callback` via
+   :func:`wx.CallAfter` from the background thread.
+
+Completion behaviour:
+
+- **Success, debug=False** — dialog closes automatically; Finder/Explorer
+  opens on the production folder.
+- **Success, debug=True** — dialog stays open showing diagnostics.
+- **Error** — dialog stays open showing error message.
+
+Options are loaded from :func:`~jbom.plugin.options.load_options` when the
+dialog opens and persisted by :func:`~jbom.plugin.options.save_options` when
+Generate is pressed.
+
+Reference: ``docs/dev/development_notes/active/plugin_ux_storyboard.md``
 """
 
 from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from pathlib import Path
 
 import wx
 
 try:
     from jbom import __version__ as _jbom_version
-except ImportError:  # pragma: no cover — defensive; should always be importable
+except ImportError:  # pragma: no cover
     _jbom_version = "unknown"
 
+# Steps in display order — matches storyboard progress panel.
+_STEPS: list[str] = ["bom", "pos", "gerbers", "backup"]
+_STEP_LABELS: dict[str, str] = {
+    "bom": "BOM",
+    "pos": "CPL",
+    "gerbers": "Gerbers",
+    "backup": "Backup",
+}
 
-class JBOMStubDialog(wx.Dialog):
-    """Minimal stub dialog that validates plugin load and user interaction.
+
+class JBOMFabricationDialog(wx.Dialog):
+    """Full storyboard fabrication dialog (Session B).
 
     Args:
         parent: Parent window (the KiCad main frame, or ``None``).
         pcb_path: Filesystem path of the active PCB file, or empty string.
+        archive_name: Human-readable archive stem from the project title block
+            (e.g. ``"MyProject_1.0"``).  Shown as a read-only label.
     """
 
-    def __init__(self, parent: wx.Window | None, *, pcb_path: str = "") -> None:
+    def __init__(
+        self,
+        parent: wx.Window | None,
+        *,
+        pcb_path: str = "",
+        archive_name: str = "",
+    ) -> None:
         super().__init__(
             parent,
             title="jBOM Fabrication",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
 
-        root = wx.BoxSizer(wx.VERTICAL)
+        self._pcb_path = pcb_path
+        self._archive_name = archive_name or "(unknown)"
+        self._cancel_requested = threading.Event()
+        self._fab_ids: list[str] = []
+        self._gauges: dict[str, wx.Gauge] = {}
+        self._status_texts: dict[str, wx.StaticText] = {}
 
-        # ------------------------------------------------------------------
-        # Version banner
-        # ------------------------------------------------------------------
-        banner = wx.StaticText(self, label=f"jBOM  v{_jbom_version}")
-        font = banner.GetFont()
-        font.SetPointSize(font.GetPointSize() + 2)
-        font.SetWeight(wx.FONTWEIGHT_BOLD)
-        banner.SetFont(font)
-        root.Add(banner, flag=wx.ALL, border=12)
+        # Load persisted options; fall back to defaults when absent.
+        from jbom.plugin.options import PluginOptions, load_options
 
-        # ------------------------------------------------------------------
-        # PCB path (informational)
-        # ------------------------------------------------------------------
-        pcb_text = pcb_path if pcb_path else "(no board loaded)"
-        pcb_label = wx.StaticText(self, label=f"PCB: {pcb_text}")
-        root.Add(pcb_label, flag=wx.LEFT | wx.RIGHT | wx.BOTTOM, border=12)
-
-        root.Add(
-            wx.StaticLine(self),
-            flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
-            border=8,
+        self._options: PluginOptions = (
+            load_options(Path(pcb_path)) if pcb_path else PluginOptions()
         )
 
-        # ------------------------------------------------------------------
-        # Placeholder notice
-        # ------------------------------------------------------------------
-        notice = wx.StaticText(
-            self,
-            label=(
-                "Full fabrication dialog — fabricator selection,\n"
-                "inventory picker, zone fill, and Gerber generation —\n"
-                "will be available in the next release (Session B)."
-            ),
-        )
-        root.Add(notice, flag=wx.ALL, border=12)
+        # Build UI
+        outer = wx.BoxSizer(wx.VERTICAL)
+        self._input_panel = self._build_input_panel()
+        self._progress_panel = self._build_progress_panel()
+        self._progress_panel.Hide()
 
-        # ------------------------------------------------------------------
-        # Button row
-        # ------------------------------------------------------------------
-        btn_sizer = wx.StdDialogButtonSizer()
-        cancel_btn = wx.Button(self, wx.ID_CANCEL, "Cancel")
-        cancel_btn.SetDefault()
-        btn_sizer.AddButton(cancel_btn)
-        btn_sizer.Realize()
-        root.Add(btn_sizer, flag=wx.ALIGN_RIGHT | wx.ALL, border=8)
+        outer.Add(self._input_panel, flag=wx.EXPAND)
+        outer.Add(self._progress_panel, flag=wx.EXPAND)
 
-        self.SetSizer(root)
-        root.Fit(self)
+        self.SetSizer(outer)
+        outer.Fit(self)
         self.Centre()
+
+    # ------------------------------------------------------------------
+    # Input panel
+    # ------------------------------------------------------------------
+
+    def _build_input_panel(self) -> wx.Panel:
+        """Build and return the input-form panel."""
+        panel = wx.Panel(self)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # -- Header -------------------------------------------------------
+        header = wx.StaticText(panel, label=f"jBOM  v{_jbom_version}  —  Fabrication")
+        font = header.GetFont()
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        header.SetFont(font)
+        sizer.Add(header, flag=wx.ALL, border=10)
+        sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        # -- Project info grid -------------------------------------------
+        grid = wx.FlexGridSizer(rows=3, cols=2, vgap=6, hgap=8)
+        grid.AddGrowableCol(1, 1)
+
+        # Archive (read-only)
+        grid.Add(
+            wx.StaticText(panel, label="Archive:"),
+            flag=wx.ALIGN_CENTER_VERTICAL,
+        )
+        grid.Add(
+            wx.StaticText(panel, label=self._archive_name),
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.EXPAND,
+        )
+
+        # Fabricator dropdown + Config button
+        grid.Add(
+            wx.StaticText(panel, label="Fabricator:"),
+            flag=wx.ALIGN_CENTER_VERTICAL,
+        )
+        fab_row = wx.BoxSizer(wx.HORIZONTAL)
+        self._fab_ids, labels = self._load_fabricator_choices()
+        self._fab_choice = wx.Choice(panel, choices=labels)
+        self._fab_choice.SetSelection(self._fab_index_for(self._options.fabricator))
+        fab_row.Add(self._fab_choice, proportion=1, flag=wx.EXPAND)
+        config_btn = wx.Button(panel, label="Config\u2026", size=(60, -1))
+        config_btn.Disable()  # placeholder — full viewer in a future release
+        fab_row.Add(config_btn, flag=wx.LEFT, border=4)
+        grid.Add(fab_row, flag=wx.EXPAND)
+
+        # Inventory file picker
+        grid.Add(
+            wx.StaticText(panel, label="Inventory:"),
+            flag=wx.ALIGN_CENTER_VERTICAL,
+        )
+        inv_row = wx.BoxSizer(wx.HORIZONTAL)
+        self._inv_text = wx.TextCtrl(
+            panel,
+            value=self._options.inventory_path,
+            style=wx.TE_PROCESS_ENTER,
+        )
+        browse_btn = wx.Button(panel, label="Browse\u2026", size=(70, -1))
+        browse_btn.Bind(wx.EVT_BUTTON, self._on_browse_inventory)
+        inv_row.Add(self._inv_text, proportion=1, flag=wx.EXPAND)
+        inv_row.Add(browse_btn, flag=wx.LEFT, border=4)
+        grid.Add(inv_row, flag=wx.EXPAND)
+
+        sizer.Add(grid, flag=wx.ALL | wx.EXPAND, border=10)
+        sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        # -- Checkboxes --------------------------------------------------
+        check_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        def _cb(label: str, checked: bool = True) -> wx.CheckBox:
+            cb = wx.CheckBox(panel, label=label)
+            cb.SetValue(checked)
+            return cb
+
+        self._cb_smd_only = _cb("SMD only (placement)", False)
+        self._cb_exclude_dnp = _cb("Exclude DNP components")
+        self._cb_fill_zones = _cb("Fill all zones before Gerbers")
+        self._cb_backup = _cb("Create backup archive")
+        self._cb_open_folder = _cb("Open production folder when done")
+
+        # Grayed placeholder — pending issue #249
+        cb_corrections = _cb("Apply placement corrections  (pending #249)", False)
+        cb_corrections.Disable()
+
+        self._cb_debug = _cb("Keep intermediate files (debug)", False)
+
+        for cb in (
+            self._cb_smd_only,
+            self._cb_exclude_dnp,
+            self._cb_fill_zones,
+            self._cb_backup,
+            self._cb_open_folder,
+            cb_corrections,
+            self._cb_debug,
+        ):
+            check_sizer.Add(cb, flag=wx.LEFT | wx.BOTTOM, border=4)
+
+        sizer.Add(check_sizer, flag=wx.ALL, border=10)
+        sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        # -- Buttons ------------------------------------------------------
+        btn_row = wx.BoxSizer(wx.HORIZONTAL)
+        self._generate_btn = wx.Button(panel, label="Generate")
+        self._generate_btn.SetDefault()
+        cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        self._generate_btn.Bind(wx.EVT_BUTTON, self._on_generate)
+        btn_row.AddStretchSpacer(1)
+        btn_row.Add(self._generate_btn, flag=wx.RIGHT, border=8)
+        btn_row.Add(cancel_btn)
+        sizer.Add(btn_row, flag=wx.ALL | wx.EXPAND, border=10)
+
+        panel.SetSizer(sizer)
+        return panel
+
+    # ------------------------------------------------------------------
+    # Progress panel
+    # ------------------------------------------------------------------
+
+    def _build_progress_panel(self) -> wx.Panel:
+        """Build and return the progress panel (shown during generation)."""
+        panel = wx.Panel(self)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        title = wx.StaticText(panel, label="jBOM Fabrication \u2014 Generating\u2026")
+        font = title.GetFont()
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        title.SetFont(font)
+        sizer.Add(title, flag=wx.ALL, border=10)
+        sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        gauge_grid = wx.FlexGridSizer(rows=len(_STEPS), cols=3, vgap=6, hgap=8)
+        gauge_grid.AddGrowableCol(1, 1)
+
+        for step in _STEPS:
+            label = wx.StaticText(panel, label=_STEP_LABELS[step])
+            gauge = wx.Gauge(panel, range=100, style=wx.GA_HORIZONTAL | wx.GA_SMOOTH)
+            status = wx.StaticText(panel, label="")
+            self._gauges[step] = gauge
+            self._status_texts[step] = status
+            gauge_grid.Add(label, flag=wx.ALIGN_CENTER_VERTICAL)
+            gauge_grid.Add(gauge, flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL)
+            gauge_grid.Add(status, flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT, border=4)
+
+        sizer.Add(gauge_grid, flag=wx.ALL | wx.EXPAND, border=10)
+        sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        # Diagnostics area (shown on error)
+        self._diag_text = wx.TextCtrl(
+            panel,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.BORDER_NONE,
+        )
+        self._diag_text.SetMinSize((-1, 60))
+        self._diag_text.Hide()
+        sizer.Add(self._diag_text, proportion=1, flag=wx.EXPAND | wx.ALL, border=8)
+
+        self._progress_cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
+        self._progress_cancel_btn.Bind(wx.EVT_BUTTON, self._on_progress_cancel)
+        btn_row = wx.BoxSizer(wx.HORIZONTAL)
+        btn_row.AddStretchSpacer(1)
+        btn_row.Add(self._progress_cancel_btn)
+        sizer.Add(btn_row, flag=wx.ALL | wx.EXPAND, border=10)
+
+        panel.SetSizer(sizer)
+        return panel
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _load_fabricator_choices(self) -> tuple[list[str], list[str]]:
+        """Return (ids, display_labels) for the fabricator dropdown."""
+        try:
+            from jbom.config.fabricators import get_fabricators_with_names
+
+            pairs = get_fabricators_with_names()
+        except Exception:  # pragma: no cover
+            pairs = [("generic", "Generic")]
+        ids = [fid for fid, _ in pairs]
+        labels = [name for _, name in pairs]
+        return ids, labels
+
+    def _fab_index_for(self, fid: str) -> int:
+        """Return the dropdown index for *fid*, defaulting to 0."""
+        try:
+            return self._fab_ids.index(fid)
+        except ValueError:
+            return 0
+
+    def _selected_fabricator_id(self) -> str:
+        """Return the currently selected fabricator ID."""
+        idx = self._fab_choice.GetSelection()
+        if 0 <= idx < len(self._fab_ids):
+            return self._fab_ids[idx]
+        return "generic"
+
+    # ------------------------------------------------------------------
+    # Event handlers — input panel
+    # ------------------------------------------------------------------
+
+    def _on_browse_inventory(self, _evt: wx.CommandEvent) -> None:
+        """Open a file dialog to select the inventory file."""
+        dlg = wx.FileDialog(
+            self,
+            message="Select inventory file",
+            wildcard="Inventory files (*.csv;*.xlsx;*.numbers)|*.csv;*.xlsx;*.numbers|All files (*.*)|*.*",
+            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+        )
+        if dlg.ShowModal() == wx.ID_OK:
+            self._inv_text.SetValue(dlg.GetPath())
+        dlg.Destroy()
+
+    def _on_generate(self, _evt: wx.CommandEvent) -> None:
+        """Validate, save options, fill zones if requested, then start the thread."""
+        # Persist selections
+        fab_id = self._selected_fabricator_id()
+        inventory_path = self._inv_text.GetValue().strip()
+
+        from jbom.plugin.options import PluginOptions, save_options
+
+        updated = PluginOptions(
+            fabricator=fab_id,
+            inventory_path=inventory_path,
+        )
+        if self._pcb_path:
+            try:
+                save_options(updated, Path(self._pcb_path))
+            except OSError:
+                pass  # Non-fatal; proceed with generation
+
+        # Optional zone fill (in-memory, updates live KiCad view)
+        if self._cb_fill_zones.GetValue():
+            self._fill_zones()
+
+        # Swap to progress panel
+        self._cancel_requested.clear()
+        self._input_panel.Hide()
+        self._progress_panel.Show()
+        self.GetSizer().Layout()
+        self.GetSizer().Fit(self)
+        self.Centre()
+
+        # Build request
+        from jbom.application.fabrication_orchestration import (
+            FabricationRequest,
+            FabricationWorkflow,
+        )
+
+        request = FabricationRequest(
+            input_path=self._pcb_path or ".",
+            fabricator=fab_id,
+            inventory_files=(inventory_path,) if inventory_path else (),
+            smd_only=self._cb_smd_only.GetValue(),
+            debug=self._cb_debug.GetValue(),
+        )
+        open_folder = self._cb_open_folder.GetValue()
+        debug_mode = self._cb_debug.GetValue()
+        # Note: backup is always created by FabricationWorkflow when artifacts
+        # are present. A skip_backup flag on FabricationRequest would be needed
+        # to honour self._cb_backup; tracked as a future enhancement.
+
+        # Launch background thread
+        def _worker() -> None:
+            try:
+                result = FabricationWorkflow().run(
+                    request,
+                    step_callback=lambda step, status: wx.CallAfter(
+                        self._on_step, step, status
+                    ),
+                )
+                wx.CallAfter(self._on_complete, result, open_folder, debug_mode)
+            except Exception as exc:
+                wx.CallAfter(self._on_error, str(exc))
+
+        thread = threading.Thread(target=_worker, daemon=True)
+        thread.start()
+
+    def _fill_zones(self) -> None:
+        """Fill board zones using the pcbnew API (in-memory only)."""
+        try:
+            import pcbnew  # noqa: PLC0415
+
+            board = pcbnew.GetBoard()
+            if board:
+                filler = pcbnew.ZONE_FILLER(board)
+                filler.Fill(board.Zones())
+                pcbnew.Refresh()
+        except Exception:  # pragma: no cover
+            pass  # Non-fatal; proceed with generation
+
+    # ------------------------------------------------------------------
+    # Event handlers — progress panel
+    # ------------------------------------------------------------------
+
+    def _on_progress_cancel(self, _evt: wx.CommandEvent) -> None:
+        """Signal the background thread to stop after the current step."""
+        self._cancel_requested.set()
+        self._progress_cancel_btn.Disable()
+
+    def _on_step(self, step: str, status: str) -> None:
+        """Update the gauge for *step*; called via ``wx.CallAfter`` from thread."""
+        if step not in self._gauges:
+            return
+        gauge = self._gauges[step]
+        text = self._status_texts[step]
+        if status == "start":
+            gauge.SetValue(50)
+            text.SetLabel("\u2026")
+        elif status == "done":
+            gauge.SetValue(100)
+            text.SetLabel("\u2713")
+        self._progress_panel.Layout()
+
+    def _on_complete(
+        self,
+        result: object,
+        open_folder: bool,
+        debug_mode: bool,
+    ) -> None:
+        """Handle workflow completion; called via ``wx.CallAfter``."""
+        # Fill any remaining gauges to 100
+        for gauge in self._gauges.values():
+            if gauge.GetValue() < 100:
+                gauge.SetValue(100)
+
+        diagnostics = getattr(result, "diagnostics", ())
+        production_dir = getattr(result, "production_dir", None)
+
+        if debug_mode or diagnostics:
+            # Stay open — show diagnostics
+            if diagnostics:
+                self._diag_text.SetValue("\n".join(str(d) for d in diagnostics))
+                self._diag_text.Show()
+                self.GetSizer().Layout()
+                self.GetSizer().Fit(self)
+            # Re-enable cancel button as a "Close" button
+            self._progress_cancel_btn.SetLabel("Close")
+            self._progress_cancel_btn.Enable()
+        else:
+            # Auto-close + open folder
+            if open_folder and production_dir is not None:
+                self._open_folder(Path(production_dir))
+            self.EndModal(wx.ID_OK)
+
+    def _on_error(self, message: str) -> None:
+        """Handle unexpected thread exception; called via ``wx.CallAfter``."""
+        self._diag_text.SetValue(f"Error: {message}")
+        self._diag_text.Show()
+        self._progress_cancel_btn.SetLabel("Close")
+        self._progress_cancel_btn.Enable()
+        self.GetSizer().Layout()
+        self.GetSizer().Fit(self)
+
+    @staticmethod
+    def _open_folder(path: Path) -> None:
+        """Open *path* in the platform file manager."""
+        try:
+            if sys.platform == "darwin":
+                subprocess.Popen(["open", str(path)])  # noqa: S603,S607
+            elif sys.platform == "win32":
+                subprocess.Popen(["explorer", str(path)])  # noqa: S603,S607
+            else:
+                subprocess.Popen(["xdg-open", str(path)])  # noqa: S603,S607
+        except Exception:  # pragma: no cover
+            pass  # Non-fatal

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -323,6 +323,9 @@ class JBOMFabricationDialog(wx.Dialog):
 
         Called on every keystroke in the Archive text field.  Updates
         ``self._archive_name`` so that Generate uses the new expansion.
+        Uses the same two-step expansion as plugin.py._expand_archive_template:
+        1. pcbnew.ExpandTextVars for project-level variables
+        2. jBOM TextVariableExpander for standard title block variables
         """
         if self._archive_preview is None:
             return
@@ -333,13 +336,34 @@ class JBOMFabricationDialog(wx.Dialog):
             import pcbnew  # noqa: PLC0415 — safe inside KiCad
 
             board = pcbnew.GetBoard()
-            project = board.GetProject()
-            expanded = pcbnew.ExpandTextVars(new_template, project)
-            # Apply the same normalisation as plugin.py._expand_archive_template
+
+            # Step 1: pcbnew.ExpandTextVars handles custom project vars.
+            try:
+                project = board.GetProject()
+                expanded = pcbnew.ExpandTextVars(new_template, project)
+            except Exception:
+                expanded = new_template
+
+            # Step 2: jBOM expander handles standard title block vars
+            # (${TITLE}, ${REVISION}, ${DATE}, ${COMPANY}, ${CURRENT_DATE}).
+            try:
+                from jbom.common.types import TitleBlockMetadata
+                from jbom.services.text_variable_expander import expand_text_variables
+
+                tb = board.GetTitleBlock()
+                meta = TitleBlockMetadata(
+                    title=(tb.GetTitle() or "").strip(),
+                    revision=(tb.GetRevision() or "").strip(),
+                    date=(tb.GetDate() or "").strip(),
+                    company=(tb.GetCompany() or "").strip(),
+                )
+                expanded = expand_text_variables(expanded, meta)
+            except Exception:
+                pass
+
             cleaned = re.sub(r"[^\w.-]", "_", expanded).strip("_")
             self._archive_name = cleaned or new_template
         except Exception:
-            # Fallback: show the literal template as the preview
             self._archive_name = new_template
         self._archive_preview.SetLabel(self._archive_name)
 
@@ -432,7 +456,14 @@ class JBOMFabricationDialog(wx.Dialog):
         thread.start()
 
     def _fill_zones(self) -> None:
-        """Fill board zones using the pcbnew API (in-memory only)."""
+        """Fill board zones using the pcbnew API (in-memory only).
+
+        Note: pcbnew.Refresh() is intentionally omitted here.  Calling it
+        marks the board as modified in KiCad's undo history, which would
+        prompt the user to save even if they only invoked the plugin and
+        cancelled.  The zone fill is reflected in the exported Gerbers;
+        the live editor view updates automatically when the board reloads.
+        """
         try:
             import pcbnew  # noqa: PLC0415
 
@@ -440,7 +471,8 @@ class JBOMFabricationDialog(wx.Dialog):
             if board:
                 filler = pcbnew.ZONE_FILLER(board)
                 filler.Fill(board.Zones())
-                pcbnew.Refresh()
+                # Do NOT call pcbnew.Refresh() — it sets the board's
+                # modified flag and causes an unsaved-changes prompt.
         except Exception:  # pragma: no cover
             pass  # Non-fatal; proceed with generation
 

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -258,7 +258,7 @@ class JBOMFabricationDialog(wx.Dialog):
         self._generate_btn.SetDefault()
         cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
         # wx.Dialog.Show() (modeless) does not auto-handle wx.ID_CANCEL — bind explicitly.
-        cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
+        cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self._refresh_and_destroy())
         self._generate_btn.Bind(wx.EVT_BUTTON, self._on_generate)
         btn_row.AddStretchSpacer(1)
         btn_row.Add(self._generate_btn, flag=wx.RIGHT, border=8)
@@ -673,7 +673,7 @@ class JBOMFabricationDialog(wx.Dialog):
             def _close_and_open(_e: wx.CommandEvent) -> None:
                 if open_folder and production_dir is not None:
                     self._open_folder(Path(production_dir))
-                self.Destroy()
+                self._refresh_and_destroy()
 
             self._progress_cancel_btn.Bind(wx.EVT_BUTTON, _close_and_open)
             self._progress_cancel_btn.Enable()
@@ -681,7 +681,7 @@ class JBOMFabricationDialog(wx.Dialog):
             # Auto-close + open folder
             if open_folder and production_dir is not None:
                 self._open_folder(Path(production_dir))
-            self.Destroy()
+            self._refresh_and_destroy()
 
     def _on_error(self, message: str) -> None:
         """Handle unexpected thread exception; called via ``wx.CallAfter``."""
@@ -689,7 +689,9 @@ class JBOMFabricationDialog(wx.Dialog):
         self._diag_text.Show()
         self._progress_cancel_btn.SetLabel("Close")
         self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
-        self._progress_cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
+        self._progress_cancel_btn.Bind(
+            wx.EVT_BUTTON, lambda _e: self._refresh_and_destroy()
+        )
         self._progress_cancel_btn.Enable()
         self.GetSizer().Layout()
         self.GetSizer().Fit(self)
@@ -702,6 +704,25 @@ class JBOMFabricationDialog(wx.Dialog):
         triggers KiCad's toolbar button re-enable via the wxDialog destructor.
         """
         self._cancel_requested.set()
+        self._refresh_and_destroy()
+
+    def _refresh_and_destroy(self) -> None:
+        """Call ``pcbnew.Refresh()`` then ``Destroy()`` at every final teardown.
+
+        ``pcbnew.Refresh()`` posts an update event to KiCad's main wx event
+        loop.  KiCad's toolbar ``UpdateUI`` handler re-evaluates button state
+        as part of that cycle — without it, the ActionPlugin toolbar button
+        may not be re-enabled after the dialog closes.
+
+        Mirrors Fabrication-Toolkit's ``updateDisplay`` which always calls
+        ``pcbnew.Refresh()`` before ``self.Destroy()``.
+        """
+        try:
+            import pcbnew  # noqa: PLC0415
+
+            pcbnew.Refresh()
+        except Exception:  # pragma: no cover
+            pass  # Non-fatal: Destroy() still runs
         self.Destroy()
 
     @staticmethod

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -41,11 +41,13 @@ runs before plugin-generated Gerbers are available.  Plugin knowledge stays
 in the plugin layer.  The CLI path (``GerberExporter`` / ``kicad-cli``)
 is unchanged.
 
-wx.Frame vs wx.Dialog (Blocker 2 from issue #227):
-``ShowModal()`` blocks ``Run()`` and prevents the toolbar button from being
-re-activated.  Using ``wx.Frame`` + ``Show()`` returns immediately so KiCad
-can re-invoke the plugin.  The frame owns its lifecycle and calls
-``self.Destroy()`` when done.
+wx.Dialog + Show() (Blocker 2 from issue #227):
+``ShowModal()`` blocks ``Run()`` and KiCad does not re-enable the toolbar
+button after it returns.  Using ``wx.Dialog.Show()`` (modeless) returns
+immediately: ``Run()`` returns, KiCad re-enables the button, and the dialog
+owns its lifecycle until ``self.Destroy()`` is called.  Parent is explicitly
+``None`` — KiCad's C++ dialog tracking triggers the toolbar re-enable when
+the ``wxDialog`` C++ object is destroyed, regardless of Python parent.
 
 Reference: ``docs/dev/development_notes/active/plugin_ux_storyboard.md``
 """
@@ -76,15 +78,17 @@ _STEP_LABELS: dict[str, str] = {
 }
 
 
-class JBOMFabricationDialog(wx.Frame):
-    """Full storyboard fabrication frame (Session B).
+class JBOMFabricationDialog(wx.Dialog):
+    """Full storyboard fabrication dialog (Session B).
 
-    Uses ``wx.Frame`` (not ``wx.Dialog``) so that ``plugin.Run()`` can return
-    immediately after calling ``Show()`` — this lets the KiCad toolbar button
-    be re-activated while the frame is still open (Blocker 2, issue #227).
+    Uses ``wx.Dialog`` with ``Show()`` (modeless) so that ``plugin.Run()``
+    returns immediately and the KiCad toolbar button can be re-activated
+    (Blocker 2, issue #227).  Parent is always ``None``: KiCad's dialog
+    tracking re-enables the toolbar button when the underlying ``wxDialog``
+    C++ object is destroyed, and a ``None`` parent avoids any window-hierarchy
+    interference from the KiCad main frame.
 
     Args:
-        parent: Parent window (the KiCad main frame, or ``None``).
         pcb_path: Filesystem path of the active PCB file, or empty string.
         archive_name: Human-readable archive stem from the project title block
             (e.g. ``"MyProject_1.0"``).  Shown as a read-only label.
@@ -92,15 +96,14 @@ class JBOMFabricationDialog(wx.Frame):
 
     def __init__(
         self,
-        parent: wx.Window | None,
         *,
         pcb_path: str = "",
         archive_name: str = "",
     ) -> None:
         super().__init__(
-            parent,
+            None,  # parent=None — required for correct KiCad toolbar re-enable
             title="jBOM Fabrication",
-            style=wx.DEFAULT_FRAME_STYLE | wx.FRAME_FLOAT_ON_PARENT,
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
 
         self._pcb_path = pcb_path
@@ -132,8 +135,9 @@ class JBOMFabricationDialog(wx.Frame):
         outer.Fit(self)
         self.Centre()
 
-        # With wx.Frame, the X button does not automatically call Destroy.
-        self.Bind(wx.EVT_CLOSE, self._on_frame_close)
+        # EVT_CLOSE fires when the user clicks the X button.  The default
+        # wx.Dialog behaviour is Show(False) (hide); we override it to Destroy.
+        self.Bind(wx.EVT_CLOSE, self._on_close)
 
     # ------------------------------------------------------------------
     # Input panel
@@ -253,7 +257,7 @@ class JBOMFabricationDialog(wx.Frame):
         self._generate_btn = wx.Button(panel, label="Generate")
         self._generate_btn.SetDefault()
         cancel_btn = wx.Button(panel, wx.ID_CANCEL, "Cancel")
-        # wx.Frame does not auto-handle wx.ID_CANCEL — bind explicitly.
+        # wx.Dialog.Show() (modeless) does not auto-handle wx.ID_CANCEL — bind explicitly.
         cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
         self._generate_btn.Bind(wx.EVT_BUTTON, self._on_generate)
         btn_row.AddStretchSpacer(1)
@@ -661,10 +665,17 @@ class JBOMFabricationDialog(wx.Frame):
                 self._diag_text.Show()
                 self.GetSizer().Layout()
                 self.GetSizer().Fit(self)
-            # Rebind the button so it actually closes the frame.
+            # Rebind the button so it closes + optionally opens the folder
+            # (open_folder applies in debug mode too — user wants to inspect).
             self._progress_cancel_btn.SetLabel("Close")
             self._progress_cancel_btn.Unbind(wx.EVT_BUTTON)
-            self._progress_cancel_btn.Bind(wx.EVT_BUTTON, lambda _e: self.Destroy())
+
+            def _close_and_open(_e: wx.CommandEvent) -> None:
+                if open_folder and production_dir is not None:
+                    self._open_folder(Path(production_dir))
+                self.Destroy()
+
+            self._progress_cancel_btn.Bind(wx.EVT_BUTTON, _close_and_open)
             self._progress_cancel_btn.Enable()
         else:
             # Auto-close + open folder
@@ -683,9 +694,13 @@ class JBOMFabricationDialog(wx.Frame):
         self.GetSizer().Layout()
         self.GetSizer().Fit(self)
 
-    def _on_frame_close(self, evt: wx.CloseEvent) -> None:
-        """Handle frame close (X button) — signal cancel and destroy."""
-        # If the worker thread is active, signal it to stop gracefully.
+    def _on_close(self, evt: wx.CloseEvent) -> None:
+        """Handle dialog close (X button) — signal cancel and destroy.
+
+        Overrides wx.Dialog's default EVT_CLOSE behaviour (which hides rather
+        than destroys) so that Destroy() is called unconditionally.  This
+        triggers KiCad's toolbar button re-enable via the wxDialog destructor.
+        """
         self._cancel_requested.set()
         self.Destroy()
 

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -277,7 +277,9 @@ class JBOMFabricationDialog(wx.Dialog):
             from jbom.config.fabricators import get_fabricators_with_names
 
             pairs = get_fabricators_with_names()
-        except Exception:  # pragma: no cover
+        except Exception as _exc:  # pragma: no cover
+            # Surface the error in the archive label so it is visible in KiCad.
+            self._archive_name = f"(config error: {_exc})"
             pairs = [("generic", "Generic")]
         ids = [fid for fid, _ in pairs]
         labels = [name for _, name in pairs]
@@ -355,6 +357,11 @@ class JBOMFabricationDialog(wx.Dialog):
             inventory_files=(inventory_path,) if inventory_path else (),
             smd_only=self._cb_smd_only.GetValue(),
             debug=self._cb_debug.GetValue(),
+            # Gerbers via kicad-cli subprocess can hang when called from inside
+            # a KiCad plugin (two KiCad instances conflict on macOS/Windows).
+            # Disable until the pcbnew PLOT_CONTROLLER path is implemented.
+            # TODO: remove when native pcbnew Gerber generation lands.
+            skip_gerbers=True,
         )
         open_folder = self._cb_open_folder.GetValue()
         debug_mode = self._cb_debug.GetValue()

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -63,6 +63,12 @@ from pathlib import Path
 
 import wx
 
+
+def _log(msg: str) -> None:
+    """Diagnostic trace — visible in KiCad scripting console (Tools → Scripting Console)."""
+    print(f"[jBOM dialog] {msg}", file=sys.stderr, flush=True)
+
+
 try:
     from jbom import __version__ as _jbom_version
 except ImportError:  # pragma: no cover
@@ -100,11 +106,13 @@ class JBOMFabricationDialog(wx.Dialog):
         pcb_path: str = "",
         archive_name: str = "",
     ) -> None:
+        _log(f"__init__ start (pcb={pcb_path!r})")
         super().__init__(
             None,  # parent=None — required for correct KiCad toolbar re-enable
             title="jBOM Fabrication",
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
+        _log("wx.Dialog.__init__ complete")
 
         self._pcb_path = pcb_path
         self._archive_name = archive_name or "(unknown)"
@@ -138,6 +146,7 @@ class JBOMFabricationDialog(wx.Dialog):
         # EVT_CLOSE fires when the user clicks the X button.  The default
         # wx.Dialog behaviour is Show(False) (hide); we override it to Destroy.
         self.Bind(wx.EVT_CLOSE, self._on_close)
+        _log("__init__ complete — dialog ready")
 
     # ------------------------------------------------------------------
     # Input panel
@@ -717,13 +726,17 @@ class JBOMFabricationDialog(wx.Dialog):
         Mirrors Fabrication-Toolkit's ``updateDisplay`` which always calls
         ``pcbnew.Refresh()`` before ``self.Destroy()``.
         """
+        _log("_refresh_and_destroy() called")
         try:
             import pcbnew  # noqa: PLC0415
 
             pcbnew.Refresh()
-        except Exception:  # pragma: no cover
-            pass  # Non-fatal: Destroy() still runs
+            _log("pcbnew.Refresh() returned")
+        except Exception as exc:  # pragma: no cover
+            _log(f"pcbnew.Refresh() raised: {exc}")
+        _log("calling self.Destroy()")
         self.Destroy()
+        _log("self.Destroy() returned")
 
     @staticmethod
     def _open_folder(path: Path) -> None:

--- a/src/jbom/plugin/gerber_generator.py
+++ b/src/jbom/plugin/gerber_generator.py
@@ -1,0 +1,276 @@
+"""PcbnewGerberGenerator — in-process Gerber generation for the KiCad plugin.
+
+Uses ``pcbnew.PLOT_CONTROLLER`` and ``EXCELLON_WRITER`` to generate Gerber and
+drill files directly from the live board object, avoiding the ``kicad-cli``
+subprocess that hangs when called from inside a KiCad plugin (two KiCad
+instances contend on macOS and Windows).
+
+This module is only *called* from within KiCad's embedded Python interpreter.
+``pcbnew`` is lazy-imported inside :meth:`PcbnewGerberGenerator.generate` so
+that the module itself remains importable in CLI/test environments.
+
+Ported from Fabrication-Toolkit's ``plugins/process.py``
+(``ProcessManager.generate_gerber`` / ``generate_drills``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jbom.services.gerber_service import GerberResult
+
+__all__ = ["PcbnewGerberGenerator"]
+
+# Standard fabrication layers used when the fabricator config has no explicit
+# ``gerbers.layers`` stanza.
+_DEFAULT_LAYERS: list[str] = [
+    "F.Cu",
+    "B.Cu",
+    "F.Mask",
+    "B.Mask",
+    "F.Paste",
+    "B.Paste",
+    "F.Silkscreen",
+    "B.Silkscreen",
+    "Edge.Cuts",
+]
+
+
+class PcbnewGerberGenerator:
+    """Generate Gerber and drill files using ``pcbnew.PLOT_CONTROLLER``.
+
+    Unlike :class:`~jbom.services.gerber_service.GerberExporter` (which
+    spawns a ``kicad-cli`` subprocess), this class operates on the live board
+    object already loaded in KiCad's memory — no subprocess is spawned and no
+    PCB file needs to be re-read from disk.
+
+    Args:
+        board: The live ``pcbnew.BOARD`` object obtained from
+            ``pcbnew.GetBoard()``.
+    """
+
+    def __init__(self, board: Any) -> None:
+        """Store the live board reference.
+
+        Args:
+            board: ``pcbnew.BOARD`` object from ``pcbnew.GetBoard()``.
+        """
+        self._board = board
+
+    def generate(
+        self,
+        output_dir: Path,
+        *,
+        fabricator: str = "generic",
+        debug: bool = False,
+    ) -> GerberResult:
+        """Generate Gerber and drill files to *output_dir*.
+
+        Layer selection is driven by the fabricator config's ``gerbers.layers``
+        stanza.  Each layer name is resolved via ``board.GetLayerID(name)``
+        and skipped with a diagnostic when it is absent from the board
+        (``UNDEFINED_LAYER``) or disabled.
+
+        Args:
+            output_dir: Directory where Gerber and drill files are written.
+                Created automatically if absent.
+            fabricator: Fabricator profile identifier (e.g. ``"jlc"``) used to
+                select the layer list and naming policy from the fabricator
+                config YAML.
+            debug: Informational flag; passed through to the caller.  Does not
+                alter the output of this method (cleanup is the caller's
+                responsibility).
+
+        Returns:
+            :class:`~jbom.services.gerber_service.GerberResult` with all
+            written artifact paths and any accumulated diagnostics.
+            ``skipped=True`` when generation could not proceed.
+        """
+        import pcbnew  # noqa: PLC0415 — only executed inside KiCad
+
+        diagnostics: list[str] = []
+        artifacts_before_drill: list[Path] = []
+
+        output_dir = Path(output_dir)
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return GerberResult(
+                artifacts=(),
+                diagnostics=(f"Could not create Gerber output directory: {exc}",),
+                skipped=True,
+                skip_reason="output_dir_error",
+            )
+
+        # Resolve layer list, protel-extension flag, and drill config from the
+        # fabricator profile.  Falls back to _DEFAULT_LAYERS on any error.
+        layers, protel_extensions, drill_cfg = self._load_gerber_policy(
+            fabricator, diagnostics
+        )
+
+        # pcbnew.UNDEFINED_LAYER is -1 in all supported KiCad versions; fall
+        # back to -1 if the constant is absent (future-proofing).
+        undefined_layer: int = getattr(pcbnew, "UNDEFINED_LAYER", -1)
+
+        # ----------------------------------------------------------------
+        # Gerber files — PLOT_CONTROLLER path (ported from FT process.py)
+        # ----------------------------------------------------------------
+        try:
+            plot_controller = pcbnew.PLOT_CONTROLLER(self._board)
+            plot_opts = plot_controller.GetPlotOptions()
+
+            plot_opts.SetOutputDirectory(str(output_dir))
+            plot_opts.SetPlotFrameRef(False)
+            plot_opts.SetAutoScale(False)
+            plot_opts.SetScale(1)
+            plot_opts.SetMirror(False)
+            plot_opts.SetUseGerberAttributes(True)
+            plot_opts.SetUseGerberProtelExtensions(protel_extensions)
+            plot_opts.SetUseAuxOrigin(True)
+            plot_opts.SetSubtractMaskFromSilk(True)
+            plot_opts.SetUseGerberX2format(False)
+            plot_opts.SetDrillMarksType(0)  # NO_DRILL_SHAPE
+
+            # SetExcludeEdgeLayer added in KiCad 7; guard for older builds.
+            if hasattr(plot_opts, "SetExcludeEdgeLayer"):
+                plot_opts.SetExcludeEdgeLayer(True)
+
+            # SetSketchPadLineWidth may be absent on some builds.
+            if hasattr(plot_opts, "SetSketchPadLineWidth"):
+                plot_opts.SetSketchPadLineWidth(pcbnew.FromMM(0.1))
+
+            for layer_name in layers:
+                layer_id: int = self._board.GetLayerID(layer_name)
+
+                if layer_id == undefined_layer:
+                    diagnostics.append(
+                        f"Gerber: layer {layer_name!r} not present on this board — skipped."
+                    )
+                    continue
+
+                if not self._board.IsLayerEnabled(layer_id):
+                    continue
+
+                # Use the KiCad layer name (dots → underscores) as the file
+                # suffix; pcbnew appends the correct Protel extension.
+                suffix = layer_name.replace(".", "_").replace(" ", "_")
+                plot_controller.SetLayer(layer_id)
+                plot_controller.OpenPlotfile(
+                    suffix, pcbnew.PLOT_FORMAT_GERBER, layer_name
+                )
+                plot_controller.PlotLayer()
+
+            plot_controller.ClosePlot()
+
+        except Exception as exc:
+            diagnostics.append(f"Gerber plotting failed: {exc}")
+            return GerberResult(
+                artifacts=(),
+                diagnostics=tuple(diagnostics),
+                skipped=True,
+                skip_reason="plot_error",
+            )
+
+        # Snapshot file list before adding drill files so we can diff later.
+        artifacts_before_drill = sorted(p for p in output_dir.iterdir() if p.is_file())
+
+        # ----------------------------------------------------------------
+        # Drill files — EXCELLON_WRITER (ported from FT process.py)
+        # ----------------------------------------------------------------
+        try:
+            generate_map = bool(drill_cfg.get("map_format"))
+
+            drill_writer = pcbnew.EXCELLON_WRITER(self._board)
+            drill_writer.SetOptions(
+                False,  # aMirror
+                False,  # aMinimalHeader
+                self._board.GetDesignSettings().GetAuxOrigin(),
+                False,  # aExcellonFormat
+            )
+            drill_writer.SetFormat(True)  # metric units
+            if generate_map:
+                drill_writer.SetMapFileFormat(pcbnew.PLOT_FORMAT_GERBER)
+            drill_writer.CreateDrillandMapFilesSet(
+                str(output_dir),
+                True,  # aGenDrill
+                generate_map,  # aGenMap
+            )
+
+        except Exception as exc:
+            diagnostics.append(
+                f"Drill file generation failed (Gerbers were written): {exc}"
+            )
+            # Gerbers succeeded — return them even if drills failed.
+            if artifacts_before_drill:
+                return GerberResult(
+                    artifacts=tuple(artifacts_before_drill),
+                    diagnostics=tuple(diagnostics),
+                    skipped=False,
+                )
+            return GerberResult(
+                artifacts=(),
+                diagnostics=tuple(diagnostics),
+                skipped=True,
+                skip_reason="drill_error",
+            )
+
+        # Collect all written files (gerbers + drill).
+        all_artifacts = sorted(p for p in output_dir.iterdir() if p.is_file())
+
+        if not all_artifacts:
+            return GerberResult(
+                artifacts=(),
+                diagnostics=tuple(diagnostics),
+                skipped=True,
+                skip_reason="no_artifacts",
+            )
+
+        return GerberResult(
+            artifacts=tuple(all_artifacts),
+            diagnostics=tuple(diagnostics),
+            skipped=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_gerber_policy(
+        self,
+        fabricator: str,
+        diagnostics: list[str],
+    ) -> tuple[list[str], bool, dict[str, Any]]:
+        """Return ``(layers, protel_extensions, drill_config)`` from fabricator config.
+
+        Falls back to :data:`_DEFAULT_LAYERS` / protel=True / empty drill config
+        when the fabricator config has no ``gerbers:`` stanza or cannot be loaded.
+
+        Args:
+            fabricator: Fabricator profile ID (e.g. ``"jlc"``).
+            diagnostics: Mutable list to append diagnostic messages to.
+
+        Returns:
+            Triple ``(layers, protel_extensions, drill_cfg)`` where:
+
+            * ``layers`` — ordered list of KiCad layer names to plot.
+            * ``protel_extensions`` — whether to use Protel-style file extensions.
+            * ``drill_cfg`` — mapping with optional ``split_plated_holes`` and
+              ``map_format`` keys from the fabricator YAML.
+        """
+        try:
+            from jbom.config.fabricators import load_fabricator  # noqa: PLC0415
+
+            config = load_fabricator(fabricator)
+            gerbers: dict[str, Any] = dict(config.gerbers or {})
+            layers = list(gerbers.get("layers") or _DEFAULT_LAYERS)
+            naming: dict[str, Any] = dict(gerbers.get("naming") or {})
+            protel = bool(naming.get("protel_extensions", True))
+            drill_cfg: dict[str, Any] = dict(gerbers.get("drill") or {})
+            return layers, protel, drill_cfg
+        except Exception as exc:
+            diagnostics.append(
+                f"Could not load Gerber policy for fabricator {fabricator!r} ({exc}); "
+                "using default layer set."
+            )
+            return list(_DEFAULT_LAYERS), True, {}

--- a/src/jbom/plugin/options.py
+++ b/src/jbom/plugin/options.py
@@ -47,6 +47,7 @@ class PluginOptions:
 
     fabricator: str = "jlc"
     inventory_path: str = ""
+    archive_name_template: str = "${TITLE}_${REVISION}"
 
     def to_dict(self) -> dict[str, str]:
         """Serialize options to a JSON-compatible mapping."""
@@ -66,7 +67,14 @@ class PluginOptions:
         """
         fabricator = str(data.get("fabricator", "jlc")).strip() or "jlc"
         inventory_path = str(data.get("inventory_path", ""))
-        return cls(fabricator=fabricator, inventory_path=inventory_path)
+        archive_name_template = str(
+            data.get("archive_name_template", "${TITLE}_${REVISION}")
+        )
+        return cls(
+            fabricator=fabricator,
+            inventory_path=inventory_path,
+            archive_name_template=archive_name_template,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/jbom/plugin/options.py
+++ b/src/jbom/plugin/options.py
@@ -1,0 +1,168 @@
+"""Per-project jBOM plugin options persistence.
+
+Reads and writes ``jbom-options.json`` to the project's ``.jbom/`` directory,
+resolved from the git repository root.  Falls back to ``~/.jbom/`` when no
+git root can be determined (e.g. the PCB file lives outside any repository).
+
+Persisted fields
+----------------
+``fabricator``
+    Fabricator profile identifier (e.g. ``"jlc"``, ``"pcbway"``).
+    Defaults to ``"jlc"``.
+
+``inventory_path``
+    Absolute path to the inventory CSV/XLSX/Numbers file, or empty string
+    (meaning "no inventory — generate BOM without enrichment").
+
+Session-only settings — checkboxes (SMD only, Exclude DNP, Fill zones,
+Create backup, Open production folder, Debug mode) — are **not** persisted.
+They reset to their defaults each time the dialog opens.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+__all__ = [
+    "PluginOptions",
+    "load_options",
+    "save_options",
+]
+
+_OPTIONS_FILENAME = "jbom-options.json"
+_OPTIONS_DIR = ".jbom"
+
+
+@dataclass
+class PluginOptions:
+    """Persisted per-project plugin preferences.
+
+    Attributes:
+        fabricator: Fabricator profile identifier (e.g. ``"jlc"``).
+        inventory_path: Path to the inventory file, or empty string.
+    """
+
+    fabricator: str = "jlc"
+    inventory_path: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize options to a JSON-compatible mapping."""
+        return asdict(self)  # type: ignore[return-value]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "PluginOptions":
+        """Deserialize options from a mapping; extra keys are silently ignored.
+
+        Args:
+            data: Mapping previously produced by :meth:`to_dict` (or parsed
+                from JSON).
+
+        Returns:
+            :class:`PluginOptions` with recognized fields populated; unknown
+            fields are discarded.
+        """
+        fabricator = str(data.get("fabricator", "jlc")).strip() or "jlc"
+        inventory_path = str(data.get("inventory_path", ""))
+        return cls(fabricator=fabricator, inventory_path=inventory_path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_git_root(start_dir: Path) -> Path | None:
+    """Return the git repository root containing *start_dir*, or ``None``.
+
+    Args:
+        start_dir: Directory from which to start the upward search.
+
+    Returns:
+        Absolute :class:`~pathlib.Path` of the repository root, or ``None``
+        if *start_dir* is not inside a git repository or if ``git`` is not
+        available.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=start_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError):
+        pass
+    return None
+
+
+def _options_file(project_path: Path) -> Path:
+    """Return the canonical path for ``jbom-options.json``.
+
+    Resolution order:
+
+    1. ``$git_root/.jbom/jbom-options.json`` — version-controllable, shared
+       across the whole project checkout.
+    2. ``~/.jbom/jbom-options.json`` — fallback when no git root is found.
+
+    Args:
+        project_path: KiCad project directory or PCB file path.
+
+    Returns:
+        Absolute path to the options file (may not yet exist).
+    """
+    start = project_path if project_path.is_dir() else project_path.parent
+    git_root = _find_git_root(start)
+    base = git_root if git_root is not None else Path.home()
+    return base / _OPTIONS_DIR / _OPTIONS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_options(project_path: Path) -> PluginOptions:
+    """Load :class:`PluginOptions` from disk; return defaults on any failure.
+
+    This function never raises — a malformed or absent options file simply
+    returns :class:`PluginOptions` defaults.
+
+    Args:
+        project_path: KiCad project directory or PCB file path.
+
+    Returns:
+        Persisted :class:`PluginOptions`, or defaults when the file is absent,
+        empty, or malformed.
+    """
+    path = _options_file(project_path)
+    if path.is_file():
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data: dict[str, object] = json.loads(raw)
+            return PluginOptions.from_dict(data)
+        except (json.JSONDecodeError, OSError, ValueError):
+            pass
+    return PluginOptions()
+
+
+def save_options(options: PluginOptions, project_path: Path) -> None:
+    """Persist :class:`PluginOptions` to disk.
+
+    Creates the parent ``.jbom/`` directory if it does not already exist.
+
+    Args:
+        options: Options instance to persist.
+        project_path: KiCad project directory or PCB file path.
+
+    Raises:
+        OSError: If the file cannot be written (disk full, permissions, etc.).
+    """
+    path = _options_file(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(options.to_dict(), indent=2, ensure_ascii=False)
+    path.write_text(payload, encoding="utf-8")

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -72,8 +72,10 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         dlg = JBOMFabricationDialog(
             parent, pcb_path=pcb_path, archive_name=archive_name
         )
-        dlg.ShowModal()
-        dlg.Destroy()
+        # Use Show() (non-modal) so Run() returns immediately and the KiCad
+        # toolbar button can be re-activated while the frame is still open.
+        # The frame owns its lifecycle and calls self.Destroy() when done.
+        dlg.Show()
 
     @staticmethod
     def _expand_archive_template(board: object, template: str) -> str:

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -12,16 +12,7 @@ progress view) is implemented in Session B.
 
 from __future__ import annotations
 
-import sys
-
 import pcbnew  # noqa: F401 — only imported inside KiCad, safe here
-
-_run_count = 0  # diagnostic invocation counter
-
-
-def _log(msg: str) -> None:
-    """Write a timestamped diagnostic line to stderr (KiCad scripting console)."""
-    print(f"[jBOM plugin] {msg}", file=sys.stderr, flush=True)
 
 
 class JBOMFabricationPlugin(pcbnew.ActionPlugin):
@@ -46,16 +37,12 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
     def Run(self) -> None:  # noqa: N802 — KiCad API name
         """Open the jBOM Fabrication dialog."""
-        global _run_count
-        _run_count += 1
-        _log(f"Run() invoked #{_run_count}")
         try:
             self._run_impl()
-            _log(f"Run() #{_run_count} — _run_impl() returned normally")
-        except Exception as exc:  # pragma: no cover
+        except Exception:  # pragma: no cover
+            import sys
             import traceback
 
-            _log(f"Run() #{_run_count} — _run_impl() raised: {exc}")
             traceback.print_exc(file=sys.stderr)
 
     def _run_impl(self) -> None:
@@ -78,11 +65,8 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
         from .dialog import JBOMFabricationDialog
 
-        _log(f"creating JBOMFabricationDialog (pcb={pcb_path!r})")
         dlg = JBOMFabricationDialog(pcb_path=pcb_path, archive_name=archive_name)
-        _log("dialog created — calling Show()")
         dlg.Show()
-        _log("Show() returned")
 
     @staticmethod
     def _expand_archive_template(board: object, template: str) -> str:

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -63,18 +63,12 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         # in addition to the standard title block variables.
         archive_name = self._expand_archive_template(board, template)
 
-        import wx  # noqa: PLC0415
-
         from .dialog import JBOMFabricationDialog
 
-        # Attach to the KiCad main window if discoverable; otherwise free.
-        parent = wx.FindWindowByName("PcbFrame") or None
-        dlg = JBOMFabricationDialog(
-            parent, pcb_path=pcb_path, archive_name=archive_name
-        )
-        # Use Show() (non-modal) so Run() returns immediately and the KiCad
-        # toolbar button can be re-activated while the frame is still open.
-        # The frame owns its lifecycle and calls self.Destroy() when done.
+        # parent=None is enforced inside JBOMFabricationDialog.__init__.
+        # Show() (modeless) returns immediately so Run() exits and KiCad
+        # re-enables the toolbar button; the dialog calls self.Destroy() when done.
+        dlg = JBOMFabricationDialog(pcb_path=pcb_path, archive_name=archive_name)
         dlg.Show()
 
     @staticmethod

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -37,6 +37,16 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
     def Run(self) -> None:  # noqa: N802 — KiCad API name
         """Open the jBOM Fabrication dialog."""
+        try:
+            self._run_impl()
+        except Exception:  # pragma: no cover
+            import sys
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
+
+    def _run_impl(self) -> None:
+        """Implementation body of Run(); separated for exception tracing."""
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
 

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -40,11 +40,18 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
 
-        # Read title block directly from the in-memory board object — faster
-        # and more reliable than reading from disk (avoids file-path guessing).
-        archive_name = self._resolve_archive_name_from_board(
-            board
-        ) or self._resolve_archive_name(pcb_path)
+        # Load persisted options to get the archive name template.
+        from pathlib import Path
+
+        from jbom.plugin.options import load_options
+
+        options = load_options(Path(pcb_path)) if pcb_path else None
+        template = options.archive_name_template if options else "${TITLE}_${REVISION}"
+
+        # Expand the template using pcbnew's own variable expander so that
+        # custom project-level variables (defined in .kicad_pro) are honoured
+        # in addition to the standard title block variables.
+        archive_name = self._expand_archive_template(board, template)
 
         import wx  # noqa: PLC0415
 
@@ -59,64 +66,59 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         dlg.Destroy()
 
     @staticmethod
-    def _resolve_archive_name_from_board(board: object) -> str:
-        """Read archive stem from pcbnew board title block or PCB filename.
+    def _expand_archive_template(board: object, template: str) -> str:
+        """Expand the archive name template for the given board.
 
         Priority:
-        1. ``TitleBlock.GetTitle()`` + optional ``GetRevision()``
-        2. PCB filename stem (no extension) when title block is empty
-        3. ``""`` on any exception (caller falls back to disk-based lookup)
+        1. ``pcbnew.ExpandTextVars(template, project)`` — resolves all KiCad
+           text variables including custom project-level variables.
+        2. jBOM :func:`~jbom.services.text_variable_expander.expand_text_variables`
+           — fallback resolving the standard title block subset.
+        3. PCB filename stem — used when both produce an empty result.
+        4. ``"(unknown)"`` — last resort.
         """
-        try:
-            import re
-            from pathlib import Path
+        import re
+        from pathlib import Path
 
-            def _clean(s: str) -> str:
-                return re.sub(r"[^\w.-]", "_", s).strip("_")
+        def _normalise(s: str) -> str:
+            """Strip characters unsuitable for a filename."""
+            return re.sub(r"[^\w.-]", "_", s).strip("_")
+
+        try:
+            # Attempt pcbnew.ExpandTextVars first for full variable support.
+            project = board.GetProject()  # type: ignore[union-attr]
+            expanded = pcbnew.ExpandTextVars(template, project)
+        except Exception:
+            expanded = template
+
+        # Fallback: apply jBOM's own expander for the title block subset.
+        try:
+            from jbom.common.types import TitleBlockMetadata
+            from jbom.services.text_variable_expander import expand_text_variables
 
             tb = board.GetTitleBlock()  # type: ignore[union-attr]
-            title: str = (tb.GetTitle() or "").strip()
-            revision: str = (tb.GetRevision() or "").strip()
-
-            if title:
-                stem = _clean(title)
-                return f"{stem}_{_clean(revision)}" if revision else stem
-
-            # No title — fall back to the PCB filename stem so the archive
-            # name is at least meaningful (e.g. "MyBoard" from "MyBoard.kicad_pcb").
-            pcb_path: str = board.GetFileName()  # type: ignore[union-attr]
-            if pcb_path:
-                stem = _clean(Path(pcb_path).stem)
-                if stem:
-                    return f"{stem}_{_clean(revision)}" if revision else stem
+            meta = TitleBlockMetadata(
+                title=(tb.GetTitle() or "").strip(),
+                revision=(tb.GetRevision() or "").strip(),
+                date=(tb.GetDate() or "").strip(),
+                company=(tb.GetCompany() or "").strip(),
+            )
+            expanded = expand_text_variables(expanded, meta)
         except Exception:
             pass
-        return ""
 
-    @staticmethod
-    def _resolve_archive_name(pcb_path: str) -> str:
-        """Derive a display archive name from the project title block.
+        cleaned = _normalise(expanded)
+        if cleaned:
+            return cleaned
 
-        Returns a string like ``"MyProject_1.0"`` if metadata is available,
-        or ``"(unknown)"`` when the PCB path is empty or project files are absent.
-        """
-        if not pcb_path:
-            return "(unknown)"
+        # Final fallback: PCB filename stem.
         try:
-            from pathlib import Path
-
-            from jbom.services.project_metadata import (
-                create_metadata,
-                normalize_archive_stem,
-            )
-
-            pcb_file = Path(pcb_path)
-            project_dir = pcb_file.parent
-            project_file = project_dir / f"{project_dir.name}.kicad_pro"
-            metadata = create_metadata(project_file, pcb_file=pcb_file)
-            stem = normalize_archive_stem(metadata.project_name)
-            if metadata.revision:
-                return f"{stem}_{metadata.revision}"
-            return stem
+            pcb_path: str = board.GetFileName()  # type: ignore[union-attr]
+            if pcb_path:
+                stem = _normalise(Path(pcb_path).stem)
+                if stem:
+                    return stem
         except Exception:
-            return "(unknown)"
+            pass
+
+        return "(unknown)"

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -60,24 +60,35 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
     @staticmethod
     def _resolve_archive_name_from_board(board: object) -> str:
-        """Read archive stem directly from pcbnew board's title block.
+        """Read archive stem from pcbnew board title block or PCB filename.
 
-        Returns ``"Title_Revision"`` when both are present, ``"Title"`` when
-        only a title is set, or ``""`` when neither is available.
+        Priority:
+        1. ``TitleBlock.GetTitle()`` + optional ``GetRevision()``
+        2. PCB filename stem (no extension) when title block is empty
+        3. ``""`` on any exception (caller falls back to disk-based lookup)
         """
         try:
-            tb = board.GetTitleBlock()  # type: ignore[union-attr]
-            title: str = (tb.GetTitle() or "").strip()
-            revision: str = (tb.GetRevision() or "").strip()
-            # Normalise spaces/special chars the same way as normalize_archive_stem
             import re
+            from pathlib import Path
 
             def _clean(s: str) -> str:
                 return re.sub(r"[^\w.-]", "_", s).strip("_")
 
+            tb = board.GetTitleBlock()  # type: ignore[union-attr]
+            title: str = (tb.GetTitle() or "").strip()
+            revision: str = (tb.GetRevision() or "").strip()
+
             if title:
                 stem = _clean(title)
                 return f"{stem}_{_clean(revision)}" if revision else stem
+
+            # No title — fall back to the PCB filename stem so the archive
+            # name is at least meaningful (e.g. "MyBoard" from "MyBoard.kicad_pcb").
+            pcb_path: str = board.GetFileName()  # type: ignore[union-attr]
+            if pcb_path:
+                stem = _clean(Path(pcb_path).stem)
+                if stem:
+                    return f"{stem}_{_clean(revision)}" if revision else stem
         except Exception:
             pass
         return ""

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -12,7 +12,16 @@ progress view) is implemented in Session B.
 
 from __future__ import annotations
 
+import sys
+
 import pcbnew  # noqa: F401 — only imported inside KiCad, safe here
+
+_run_count = 0  # diagnostic invocation counter
+
+
+def _log(msg: str) -> None:
+    """Write a timestamped diagnostic line to stderr (KiCad scripting console)."""
+    print(f"[jBOM plugin] {msg}", file=sys.stderr, flush=True)
 
 
 class JBOMFabricationPlugin(pcbnew.ActionPlugin):
@@ -37,12 +46,16 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
     def Run(self) -> None:  # noqa: N802 — KiCad API name
         """Open the jBOM Fabrication dialog."""
+        global _run_count
+        _run_count += 1
+        _log(f"Run() invoked #{_run_count}")
         try:
             self._run_impl()
-        except Exception:  # pragma: no cover
-            import sys
+            _log(f"Run() #{_run_count} — _run_impl() returned normally")
+        except Exception as exc:  # pragma: no cover
             import traceback
 
+            _log(f"Run() #{_run_count} — _run_impl() raised: {exc}")
             traceback.print_exc(file=sys.stderr)
 
     def _run_impl(self) -> None:
@@ -65,11 +78,11 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
         from .dialog import JBOMFabricationDialog
 
-        # parent=None is enforced inside JBOMFabricationDialog.__init__.
-        # Show() (modeless) returns immediately so Run() exits and KiCad
-        # re-enables the toolbar button; the dialog calls self.Destroy() when done.
+        _log(f"creating JBOMFabricationDialog (pcb={pcb_path!r})")
         dlg = JBOMFabricationDialog(pcb_path=pcb_path, archive_name=archive_name)
+        _log("dialog created — calling Show()")
         dlg.Show()
+        _log("Show() returned")
 
     @staticmethod
     def _expand_archive_template(board: object, template: str) -> str:

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -40,12 +40,45 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
 
+        # Resolve the archive name from project title block.
+        archive_name = self._resolve_archive_name(pcb_path)
+
         import wx  # noqa: PLC0415
 
-        from .dialog import JBOMStubDialog
+        from .dialog import JBOMFabricationDialog
 
         # Attach to the KiCad main window if discoverable; otherwise free.
         parent = wx.FindWindowByName("PcbFrame") or None
-        dlg = JBOMStubDialog(parent, pcb_path=pcb_path)
+        dlg = JBOMFabricationDialog(
+            parent, pcb_path=pcb_path, archive_name=archive_name
+        )
         dlg.ShowModal()
         dlg.Destroy()
+
+    @staticmethod
+    def _resolve_archive_name(pcb_path: str) -> str:
+        """Derive a display archive name from the project title block.
+
+        Returns a string like ``"MyProject_1.0"`` if metadata is available,
+        or ``"(unknown)"`` when the PCB path is empty or project files are absent.
+        """
+        if not pcb_path:
+            return "(unknown)"
+        try:
+            from pathlib import Path
+
+            from jbom.services.project_metadata import (
+                create_metadata,
+                normalize_archive_stem,
+            )
+
+            pcb_file = Path(pcb_path)
+            project_dir = pcb_file.parent
+            project_file = project_dir / f"{project_dir.name}.kicad_pro"
+            metadata = create_metadata(project_file, pcb_file=pcb_file)
+            stem = normalize_archive_stem(metadata.project_name)
+            if metadata.revision:
+                return f"{stem}_{metadata.revision}"
+            return stem
+        except Exception:
+            return "(unknown)"

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -1,0 +1,51 @@
+"""KiCad ActionPlugin subclass for jBOM Fabrication.
+
+This module is **only** imported from ``__init__.py`` when ``pcbnew`` is
+already present in ``sys.modules`` (i.e. we are running inside KiCad's
+embedded Python interpreter).  Top-level ``import pcbnew`` is therefore safe
+here — it will never execute in a CLI or test environment.
+
+Session A: minimal stub that registers a toolbar button and opens a stub
+dialog.  The full fabrication dialog (fabricator selection, inventory picker,
+progress view) is implemented in Session B.
+"""
+
+from __future__ import annotations
+
+import pcbnew  # noqa: F401 — only imported inside KiCad, safe here
+
+
+class JBOMFabricationPlugin(pcbnew.ActionPlugin):
+    """KiCad ActionPlugin that surfaces jBOM fabrication from the PCB toolbar.
+
+    KiCad calls ``defaults()`` once at plugin load time to read metadata,
+    then calls ``Run()`` each time the user activates the toolbar button.
+    """
+
+    def defaults(self) -> None:
+        """Register plugin metadata with KiCad's plugin manager."""
+        self.name = "jBOM Fabrication"
+        self.category = "Fabrication"
+        self.description = (
+            "Generate BOM, pick-and-place, and Gerber files for fabrication. "
+            "Supports JLC, PCBWay, Seeed Studio, and generic fabricators."
+        )
+        self.show_toolbar_button = True
+        # Toolbar icon (24×24 PNG) lives next to this file.
+        # Empty string → KiCad uses a generic script icon.
+        self.icon_file_name = ""
+
+    def Run(self) -> None:  # noqa: N802 — KiCad API name
+        """Open the jBOM Fabrication dialog."""
+        board = pcbnew.GetBoard()
+        pcb_path: str = board.GetFileName() if board else ""
+
+        import wx  # noqa: PLC0415
+
+        from .dialog import JBOMStubDialog
+
+        # Attach to the KiCad main window if discoverable; otherwise free.
+        parent = wx.FindWindowByName("PcbFrame") or None
+        dlg = JBOMStubDialog(parent, pcb_path=pcb_path)
+        dlg.ShowModal()
+        dlg.Destroy()

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -40,8 +40,11 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
 
-        # Resolve the archive name from project title block.
-        archive_name = self._resolve_archive_name(pcb_path)
+        # Read title block directly from the in-memory board object — faster
+        # and more reliable than reading from disk (avoids file-path guessing).
+        archive_name = self._resolve_archive_name_from_board(
+            board
+        ) or self._resolve_archive_name(pcb_path)
 
         import wx  # noqa: PLC0415
 
@@ -54,6 +57,30 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         )
         dlg.ShowModal()
         dlg.Destroy()
+
+    @staticmethod
+    def _resolve_archive_name_from_board(board: object) -> str:
+        """Read archive stem directly from pcbnew board's title block.
+
+        Returns ``"Title_Revision"`` when both are present, ``"Title"`` when
+        only a title is set, or ``""`` when neither is available.
+        """
+        try:
+            tb = board.GetTitleBlock()  # type: ignore[union-attr]
+            title: str = (tb.GetTitle() or "").strip()
+            revision: str = (tb.GetRevision() or "").strip()
+            # Normalise spaces/special chars the same way as normalize_archive_stem
+            import re
+
+            def _clean(s: str) -> str:
+                return re.sub(r"[^\w.-]", "_", s).strip("_")
+
+            if title:
+                stem = _clean(title)
+                return f"{stem}_{_clean(revision)}" if revision else stem
+        except Exception:
+            pass
+        return ""
 
     @staticmethod
     def _resolve_archive_name(pcb_path: str) -> str:

--- a/src/jbom/services/inventory_reader.py
+++ b/src/jbom/services/inventory_reader.py
@@ -7,6 +7,8 @@ Handles loading inventory data from multiple file formats:
 - Apple Numbers (.numbers)
 """
 
+from __future__ import annotations
+
 import csv
 import logging
 import warnings

--- a/src/jbom/services/pcb_reader.py
+++ b/src/jbom/services/pcb_reader.py
@@ -184,6 +184,8 @@ class DefaultKiCadReaderService(KiCadReaderService):
 
         title = ""
         revision = ""
+        date = ""
+        company = ""
         for item in sexp[1:]:
             if not (
                 isinstance(item, list) and item and item[0] == Symbol("title_block")
@@ -202,9 +204,15 @@ class DefaultKiCadReaderService(KiCadReaderService):
                     title = title_block_item[1]
                 elif title_block_item[0] == Symbol("rev"):
                     revision = title_block_item[1]
+                elif title_block_item[0] == Symbol("date"):
+                    date = title_block_item[1]
+                elif title_block_item[0] == Symbol("company"):
+                    company = title_block_item[1]
             break
 
-        return TitleBlockMetadata(title=title, revision=revision)
+        return TitleBlockMetadata(
+            title=title, revision=revision, date=date, company=company
+        )
 
     def _parse_footprint_node(self, node) -> Optional[PcbComponent]:
         """Parse a footprint node and extract all component information."""

--- a/src/jbom/services/project_discovery.py
+++ b/src/jbom/services/project_discovery.py
@@ -52,10 +52,14 @@ class ProjectDiscovery:
             )
 
         if len(kicad_pro_files) > 1:
-            raise ValueError(
-                f"Multiple project files found in {search_dir} "
-                f"({len(kicad_pro_files)} *.kicad_pro files)"
-            )
+            # Prefer the file whose stem matches the directory name — this is the
+            # canonical KiCad convention and handles directories that contain
+            # multiple sub-project .kicad_pro files alongside the main project.
+            matching = [f for f in kicad_pro_files if f.stem == search_dir.name]
+            if len(matching) == 1:
+                return matching[0]
+            # Secondary preference: alphabetically first (deterministic fallback).
+            return kicad_pro_files[0]
 
         return kicad_pro_files[0]
 

--- a/src/jbom/services/project_discovery.py
+++ b/src/jbom/services/project_discovery.py
@@ -7,6 +7,8 @@ This service discovers the project file (`*.kicad_pro`), schematic file
 (`*.kicad_sch`), and PCB file (`*.kicad_pcb`) in directories.
 """
 
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/jbom/services/project_file_resolver.py
+++ b/src/jbom/services/project_file_resolver.py
@@ -5,6 +5,8 @@ explicit files) to proper file paths using ProjectContext for intelligent resolu
 Maintains backward compatibility while providing project-centric enhancements.
 """
 
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/jbom/services/schematic_reader.py
+++ b/src/jbom/services/schematic_reader.py
@@ -178,6 +178,8 @@ class SchematicReader:
 
         title = ""
         revision = ""
+        date = ""
+        company = ""
         for item in sexp[1:]:
             if not (
                 isinstance(item, list) and item and item[0] == Symbol("title_block")
@@ -196,6 +198,12 @@ class SchematicReader:
                     title = title_block_item[1]
                 elif title_block_item[0] == Symbol("rev"):
                     revision = title_block_item[1]
+                elif title_block_item[0] == Symbol("date"):
+                    date = title_block_item[1]
+                elif title_block_item[0] == Symbol("company"):
+                    company = title_block_item[1]
             break
 
-        return TitleBlockMetadata(title=title, revision=revision)
+        return TitleBlockMetadata(
+            title=title, revision=revision, date=date, company=company
+        )

--- a/src/jbom/services/text_variable_expander.py
+++ b/src/jbom/services/text_variable_expander.py
@@ -1,0 +1,86 @@
+"""Text variable expansion for KiCad archive naming templates.
+
+Expands the standard KiCad title block variables found in template strings
+such as ``"${TITLE}_${REVISION}"``.  The variable set mirrors the variables
+available in KiCad's own ``pcbnew.ExpandTextVars()`` for the title block
+stanza:
+
+``${TITLE}``
+    Project title from the title block (empty string when not set).
+``${REVISION}``
+    Revision string from the title block (empty string when not set).
+``${DATE}`` / ``${ISSUE_DATE}``
+    Issue date from the title block (e.g. ``"2026-05-09"``).  Falls back to
+    today's ISO date when the title block date is absent.
+``${CURRENT_DATE}``
+    Always today's ISO date, regardless of the title block value.
+``${COMPANY}``
+    Company / organisation from the title block (empty string when not set).
+
+Any ``${VARIABLE}`` tokens not in the list above are left unchanged so that
+future KiCad variables or project-level custom variables pass through without
+being silently dropped.  The plugin adapter can run ``pcbnew.ExpandTextVars()``
+first to resolve custom project variables, then pass the result here for
+title-block substitution — or vice-versa.
+
+Usage::
+
+    from jbom.common.types import TitleBlockMetadata
+    from jbom.services.text_variable_expander import expand_text_variables
+
+    meta = TitleBlockMetadata(title="MyBoard", revision="1.0")
+    stem = expand_text_variables("${TITLE}_${REVISION}", meta)
+    # → "MyBoard_1.0"
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date as _date
+
+from jbom.common.types import TitleBlockMetadata
+
+__all__ = ["expand_text_variables"]
+
+
+def expand_text_variables(
+    template: str,
+    metadata: TitleBlockMetadata,
+) -> str:
+    """Expand KiCad title block text variables in *template*.
+
+    Args:
+        template: Template string, e.g. ``"${TITLE}_${REVISION}"``.
+        metadata: Resolved title block values read from the KiCad project.
+
+    Returns:
+        String with known ``${VAR}`` tokens substituted.  Unknown tokens are
+        left unchanged so callers can detect unexpanded variables.
+
+    Example::
+
+        meta = TitleBlockMetadata(title="cpNode", revision="1.0",
+                                   date="2026-05-09", company="SPCoast")
+        expand_text_variables("${TITLE}_${REVISION}", meta)
+        # → "cpNode_1.0"
+        expand_text_variables("${COMPANY}/${TITLE}_${REVISION}", meta)
+        # → "SPCoast/cpNode_1.0"
+        expand_text_variables("${UNKNOWN}_${TITLE}", meta)
+        # → "${UNKNOWN}_cpNode"  ← unknown var preserved
+    """
+    today = _date.today().isoformat()
+    substitutions: dict[str, str] = {
+        "TITLE": metadata.title,
+        "REVISION": metadata.revision,
+        "DATE": metadata.date or today,
+        "ISSUE_DATE": metadata.date or today,
+        "CURRENT_DATE": today,
+        "COMPANY": metadata.company,
+    }
+
+    def _replace(match: re.Match) -> str:  # type: ignore[type-arg]
+        key = match.group(1)
+        # Return the substitution when known; leave the token intact otherwise.
+        return substitutions[key] if key in substitutions else match.group(0)
+
+    return re.sub(r"\$\{([^}]+)\}", _replace, template)

--- a/tests/plugin/test_fabricators_with_names.py
+++ b/tests/plugin/test_fabricators_with_names.py
@@ -1,0 +1,41 @@
+"""Tests for ``get_fabricators_with_names()`` introduced for the plugin dialog dropdown."""
+
+from __future__ import annotations
+
+from jbom.config.fabricators import get_fabricators_with_names
+
+
+class TestGetFabricatorsWithNames:
+    def test_returns_list_of_tuples(self) -> None:
+        result = get_fabricators_with_names()
+        assert isinstance(result, list)
+        assert all(isinstance(item, tuple) and len(item) == 2 for item in result)
+
+    def test_contains_known_fabricators(self) -> None:
+        ids = [fid for fid, _ in get_fabricators_with_names()]
+        assert "jlc" in ids
+        assert "generic" in ids
+
+    def test_jlc_display_name(self) -> None:
+        mapping = dict(get_fabricators_with_names())
+        assert mapping["jlc"] == "JLC"
+
+    def test_generic_display_name(self) -> None:
+        mapping = dict(get_fabricators_with_names())
+        assert mapping["generic"] == "Generic"
+
+    def test_pcbway_display_name(self) -> None:
+        mapping = dict(get_fabricators_with_names())
+        assert mapping.get("pcbway") == "PCBWay"
+
+    def test_seeed_display_name(self) -> None:
+        mapping = dict(get_fabricators_with_names())
+        assert mapping.get("seeed") == "Seeed Studio"
+
+    def test_result_is_sorted_by_id(self) -> None:
+        ids = [fid for fid, _ in get_fabricators_with_names()]
+        assert ids == sorted(ids)
+
+    def test_display_names_are_non_empty(self) -> None:
+        for fid, name in get_fabricators_with_names():
+            assert name, f"Display name for {fid!r} must not be empty"

--- a/tests/plugin/test_pcbnew_gerber_generator.py
+++ b/tests/plugin/test_pcbnew_gerber_generator.py
@@ -1,0 +1,377 @@
+"""Unit tests for ``jbom.plugin.gerber_generator.PcbnewGerberGenerator``.
+
+These tests run in a CLI/test environment where ``pcbnew`` is absent.
+All KiCad API objects are replaced by :class:`unittest.mock.MagicMock` so
+that the module-level import succeeds and ``generate()`` can be tested with
+controlled pcbnew mock behaviour.
+
+Coverage targets:
+- Module importable without pcbnew
+- ``_load_gerber_policy`` reads fabricator config layers / falls back to defaults
+- ``generate()`` skips layers where ``board.GetLayerID()`` returns UNDEFINED_LAYER
+- ``generate()`` skips disabled layers (``board.IsLayerEnabled`` returns False)
+- ``generate()`` collects written artifacts from the output directory
+- Drill generation failure returns the gerber-only artifact list
+- Output directory creation failure returns a skipped result
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+
+# ---------------------------------------------------------------------------
+# Guard: confirm pcbnew is absent in the test environment
+# ---------------------------------------------------------------------------
+
+
+def _ensure_pcbnew_absent() -> None:
+    assert (
+        "pcbnew" not in sys.modules
+    ), "pcbnew is present — these tests must run outside KiCad."
+
+
+# ---------------------------------------------------------------------------
+# Importability
+# ---------------------------------------------------------------------------
+
+
+class TestImportability:
+    """PcbnewGerberGenerator is importable without pcbnew."""
+
+    def test_module_importable_without_pcbnew(self) -> None:
+        _ensure_pcbnew_absent()
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator  # noqa: F401
+
+        assert PcbnewGerberGenerator is not None
+
+    def test_module_does_not_pull_in_pcbnew(self) -> None:
+        _ensure_pcbnew_absent()
+        import jbom.plugin.gerber_generator  # noqa: F401
+
+        assert "pcbnew" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# _load_gerber_policy
+# ---------------------------------------------------------------------------
+
+
+class TestLoadGerberPolicy:
+    """_load_gerber_policy reads fabricator config and falls back gracefully."""
+
+    def _make_generator(self) -> object:
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        return PcbnewGerberGenerator(board=MagicMock())
+
+    def test_returns_default_layers_when_fabricator_not_found(self) -> None:
+        gen = self._make_generator()
+        diagnostics: list[str] = []
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            wraps=gen._load_gerber_policy,
+        ):
+            # Patch load_fabricator to raise so we exercise the fallback path.
+            with patch(
+                "jbom.config.fabricators.load_fabricator",
+                side_effect=ValueError("unknown fabricator"),
+            ):
+                layers, protel, drill_cfg = gen._load_gerber_policy(
+                    "nonexistent", diagnostics
+                )
+
+        assert "F.Cu" in layers
+        assert "Edge.Cuts" in layers
+        assert protel is True
+        assert drill_cfg == {}
+        assert any("nonexistent" in d for d in diagnostics)
+
+    def test_returns_fabricator_config_layers_for_jlc(self) -> None:
+        gen = self._make_generator()
+        diagnostics: list[str] = []
+        layers, protel, drill_cfg = gen._load_gerber_policy("jlc", diagnostics)
+
+        # jlc.fab.yaml specifies 9 standard layers
+        assert "F.Cu" in layers
+        assert "B.Cu" in layers
+        assert "Edge.Cuts" in layers
+        assert len(layers) >= 9
+        assert protel is True  # jlc uses protel extensions
+        assert diagnostics == []
+
+    def test_returns_default_layers_when_gerbers_stanza_empty(self) -> None:
+        from jbom.plugin.gerber_generator import _DEFAULT_LAYERS
+
+        gen = self._make_generator()
+        diagnostics: list[str] = []
+
+        fake_config = MagicMock()
+        fake_config.gerbers = {}  # empty stanza
+
+        with patch("jbom.config.fabricators.load_fabricator", return_value=fake_config):
+            layers, protel, drill_cfg = gen._load_gerber_policy("generic", diagnostics)
+
+        assert layers == _DEFAULT_LAYERS
+        assert protel is True
+        assert drill_cfg == {}
+
+
+# ---------------------------------------------------------------------------
+# generate() — output directory handling
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOutputDir:
+    """generate() handles output directory creation failures."""
+
+    def _make_generator_with_mock_pcbnew(self) -> tuple:
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        mock_board = MagicMock()
+        gen = PcbnewGerberGenerator(board=mock_board)
+        return gen, mock_board
+
+    def test_returns_skipped_when_mkdir_fails(self, tmp_path: Path) -> None:
+        gen, _ = self._make_generator_with_mock_pcbnew()
+
+        fake_pcbnew = MagicMock()
+        fake_pcbnew.UNDEFINED_LAYER = -1
+        fake_pcbnew.PLOT_FORMAT_GERBER = 1
+
+        bad_dir = tmp_path / "readonly_parent" / "gerbers"
+        # Patch Path.mkdir to raise OSError
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            return_value=(["F.Cu"], True, {}),
+        ):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **kw: (
+                    fake_pcbnew if name == "pcbnew" else __import__(name, *a, **kw)
+                ),
+            ):
+                with patch.object(
+                    Path, "mkdir", side_effect=OSError("permission denied")
+                ):
+                    result = gen.generate(bad_dir, fabricator="jlc")
+
+        assert result.skipped is True
+        assert result.skip_reason == "output_dir_error"
+
+
+# ---------------------------------------------------------------------------
+# generate() — layer iteration, UNDEFINED_LAYER, disabled layers
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateLayerIteration:
+    """generate() iterates the layer list and skips undefined/disabled layers."""
+
+    def _build_mock_pcbnew(
+        self,
+        *,
+        layer_ids: dict[str, int] | None = None,
+        enabled_layers: set[int] | None = None,
+        undefined: int = -1,
+    ) -> MagicMock:
+        """Return a mock pcbnew module with configurable board.GetLayerID() behaviour."""
+        if layer_ids is None:
+            layer_ids = {"F.Cu": 0, "B.Cu": 31, "Edge.Cuts": 44}
+        if enabled_layers is None:
+            enabled_layers = set(layer_ids.values())
+
+        pcb = MagicMock()
+        pcb.UNDEFINED_LAYER = undefined
+        pcb.PLOT_FORMAT_GERBER = 1
+        pcb.FromMM = MagicMock(return_value=100)
+
+        board = MagicMock()
+        board.GetLayerID = MagicMock(
+            side_effect=lambda name: layer_ids.get(name, undefined)
+        )
+        board.IsLayerEnabled = MagicMock(side_effect=lambda lid: lid in enabled_layers)
+        board.GetDesignSettings.return_value.GetAuxOrigin.return_value = (0, 0)
+
+        plot_ctrl = MagicMock()
+        pcb.PLOT_CONTROLLER = MagicMock(return_value=plot_ctrl)
+
+        drill_writer = MagicMock()
+        pcb.EXCELLON_WRITER = MagicMock(return_value=drill_writer)
+
+        pcb._mock_board = board
+        pcb._mock_plot_ctrl = plot_ctrl
+        pcb._mock_drill_writer = drill_writer
+        return pcb
+
+    def _run_generate(
+        self,
+        tmp_path: Path,
+        layers: list[str],
+        mock_pcbnew: MagicMock,
+    ):
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        gen = PcbnewGerberGenerator(board=mock_pcbnew._mock_board)
+
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            return_value=(layers, True, {}),
+        ):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **kw: (
+                    mock_pcbnew if name == "pcbnew" else __import__(name, *a, **kw)
+                ),
+            ):
+                result = gen.generate(tmp_path / "gerbers", fabricator="jlc")
+        return result
+
+    def test_undefined_layer_is_skipped_with_diagnostic(self, tmp_path: Path) -> None:
+        """A layer not on the board (UNDEFINED_LAYER) adds a diagnostic and is skipped."""
+        pcb = self._build_mock_pcbnew(
+            layer_ids={"F.Cu": 0},  # B.Cu absent → UNDEFINED_LAYER
+        )
+        result = self._run_generate(tmp_path, ["F.Cu", "B.Cu"], pcb)
+
+        # SetLayer should only have been called once (for F.Cu)
+        set_layer_calls = pcb._mock_plot_ctrl.SetLayer.call_args_list
+        assert len(set_layer_calls) == 1
+        assert set_layer_calls[0] == call(0)
+
+        # Diagnostic must mention the skipped layer
+        assert any("B.Cu" in d for d in result.diagnostics)
+
+    def test_disabled_layer_is_silently_skipped(self, tmp_path: Path) -> None:
+        """An explicitly disabled layer is skipped without a diagnostic."""
+        pcb = self._build_mock_pcbnew(
+            layer_ids={"F.Cu": 0, "B.Cu": 31},
+            enabled_layers={0},  # B.Cu (31) disabled
+        )
+        result = self._run_generate(tmp_path, ["F.Cu", "B.Cu"], pcb)
+
+        set_layer_calls = pcb._mock_plot_ctrl.SetLayer.call_args_list
+        assert len(set_layer_calls) == 1
+        assert set_layer_calls[0] == call(0)
+        # No diagnostic for disabled layers
+        assert not any("B.Cu" in d for d in result.diagnostics)
+
+    def test_plot_controller_closed_after_loop(self, tmp_path: Path) -> None:
+        """ClosePlot() is called regardless of how many layers were plotted."""
+        pcb = self._build_mock_pcbnew(layer_ids={"F.Cu": 0})
+        self._run_generate(tmp_path, ["F.Cu"], pcb)
+
+        pcb._mock_plot_ctrl.ClosePlot.assert_called_once()
+
+    def test_returns_skipped_when_plot_controller_raises(self, tmp_path: Path) -> None:
+        """A crash inside the plot loop yields skipped=True."""
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        pcb = self._build_mock_pcbnew(layer_ids={"F.Cu": 0})
+        pcb.PLOT_CONTROLLER.side_effect = RuntimeError("pcbnew exploded")
+
+        gen = PcbnewGerberGenerator(board=pcb._mock_board)
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            return_value=(["F.Cu"], True, {}),
+        ):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **kw: (
+                    pcb if name == "pcbnew" else __import__(name, *a, **kw)
+                ),
+            ):
+                result = gen.generate(tmp_path / "gerbers", fabricator="jlc")
+
+        assert result.skipped is True
+        assert result.skip_reason == "plot_error"
+        assert any("plotting" in d.lower() for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# generate() — artifact collection
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateArtifacts:
+    """generate() collects all files written to the output directory."""
+
+    def test_returns_files_present_in_output_dir(self, tmp_path: Path) -> None:
+        """Any files in the output dir after plotting are returned as artifacts."""
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        gerber_dir = tmp_path / "gerbers"
+        gerber_dir.mkdir()
+
+        # Pre-create fake "gerber" files that the mock plot controller would write
+        (gerber_dir / "board-F_Cu.gtl").write_bytes(b"gerber data")
+        (gerber_dir / "board-Edge_Cuts.gko").write_bytes(b"gerber data")
+        (gerber_dir / "board.drl").write_bytes(b"drill data")
+
+        pcb = MagicMock()
+        pcb.UNDEFINED_LAYER = -1
+        pcb.PLOT_FORMAT_GERBER = 1
+        pcb.FromMM = MagicMock(return_value=100)
+
+        board = MagicMock()
+        board.GetLayerID = MagicMock(return_value=0)
+        board.IsLayerEnabled = MagicMock(return_value=True)
+        board.GetDesignSettings.return_value.GetAuxOrigin.return_value = (0, 0)
+        pcb.PLOT_CONTROLLER = MagicMock(return_value=MagicMock())
+        pcb.EXCELLON_WRITER = MagicMock(return_value=MagicMock())
+
+        gen = PcbnewGerberGenerator(board=board)
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            return_value=(["F.Cu"], True, {}),
+        ):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **kw: (
+                    pcb if name == "pcbnew" else __import__(name, *a, **kw)
+                ),
+            ):
+                result = gen.generate(gerber_dir, fabricator="jlc")
+
+        assert result.skipped is False
+        assert len(result.artifacts) == 3
+        artifact_names = {p.name for p in result.artifacts}
+        assert "board-F_Cu.gtl" in artifact_names
+        assert "board.drl" in artifact_names
+
+    def test_returns_skipped_when_no_files_written(self, tmp_path: Path) -> None:
+        """An empty output directory yields skipped=True / no_artifacts."""
+        from jbom.plugin.gerber_generator import PcbnewGerberGenerator
+
+        gerber_dir = tmp_path / "gerbers"
+        gerber_dir.mkdir()  # empty — mock won't write any files
+
+        pcb = MagicMock()
+        pcb.UNDEFINED_LAYER = -1
+        pcb.PLOT_FORMAT_GERBER = 1
+        pcb.FromMM = MagicMock(return_value=100)
+
+        board = MagicMock()
+        board.GetLayerID = MagicMock(return_value=0)
+        board.IsLayerEnabled = MagicMock(return_value=True)
+        board.GetDesignSettings.return_value.GetAuxOrigin.return_value = (0, 0)
+        pcb.PLOT_CONTROLLER = MagicMock(return_value=MagicMock())
+        pcb.EXCELLON_WRITER = MagicMock(return_value=MagicMock())
+
+        gen = PcbnewGerberGenerator(board=board)
+        with patch(
+            "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
+            return_value=(["F.Cu"], True, {}),
+        ):
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *a, **kw: (
+                    pcb if name == "pcbnew" else __import__(name, *a, **kw)
+                ),
+            ):
+                result = gen.generate(gerber_dir, fabricator="jlc")
+
+        assert result.skipped is True
+        assert result.skip_reason == "no_artifacts"

--- a/tests/plugin/test_plugin_guard.py
+++ b/tests/plugin/test_plugin_guard.py
@@ -1,0 +1,134 @@
+"""Guard-behaviour tests for ``jbom.plugin``.
+
+These tests verify that:
+
+1. ``import jbom.plugin`` succeeds in a CLI/test environment (no ``pcbnew``
+   present) and is completely inert — no ActionPlugin is registered and no
+   KiCad-specific imports are triggered.
+
+2. The core ``jbom`` package remains importable independently of KiCad.
+
+3. The plugin's inner modules (``plugin.py``, ``dialog.py``) are **not**
+   imported when running outside KiCad; they are only loaded by the guard
+   branch that checks for ``pcbnew`` in ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_pcbnew_absent() -> None:
+    """Guard: fail fast if the test environment somehow has pcbnew loaded."""
+    assert "pcbnew" not in sys.modules, (
+        "pcbnew is loaded in sys.modules — tests must run outside KiCad. "
+        "The guard tests would be meaningless in this environment."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard importability
+# ---------------------------------------------------------------------------
+
+
+class TestPluginGuard:
+    """The plugin package is importable without KiCad installed."""
+
+    def test_jbom_plugin_importable_without_pcbnew(self) -> None:
+        """``import jbom.plugin`` must succeed in a non-KiCad environment."""
+        _ensure_pcbnew_absent()
+        # Fresh import — may already be cached from a prior test run.
+        import jbom.plugin  # noqa: F401 — side-effect import; success is the assertion
+
+    def test_jbom_plugin_does_not_pull_in_pcbnew(self) -> None:
+        """Importing jbom.plugin must not add pcbnew to sys.modules."""
+        _ensure_pcbnew_absent()
+        import jbom.plugin  # noqa: F401
+
+        assert (
+            "pcbnew" not in sys.modules
+        ), "jbom.plugin caused pcbnew to be imported — the guard is broken."
+
+    def test_jbom_plugin_inner_modules_not_imported_outside_kicad(self) -> None:
+        """plugin.py and dialog.py must remain unimported outside KiCad."""
+        _ensure_pcbnew_absent()
+        import jbom.plugin  # noqa: F401
+
+        # These modules import pcbnew / wx at the top level and must only be
+        # loaded by the guarded branch inside KiCad.
+        assert "jbom.plugin.plugin" not in sys.modules, (
+            "jbom.plugin.plugin was imported outside KiCad — "
+            "the import guard is not working."
+        )
+        assert "jbom.plugin.dialog" not in sys.modules, (
+            "jbom.plugin.dialog was imported outside KiCad — "
+            "the import guard is not working."
+        )
+
+    def test_jbom_plugin_is_standalone_flag_true_outside_kicad(self) -> None:
+        """The ``_is_standalone`` sentinel must be True in test environments."""
+        _ensure_pcbnew_absent()
+        import jbom.plugin as _mod
+
+        assert (
+            _mod._is_standalone is True
+        ), "_is_standalone should be True when pcbnew is absent."
+
+
+# ---------------------------------------------------------------------------
+# CLI independence
+# ---------------------------------------------------------------------------
+
+
+class TestCLIIndependenceFromKiCad:
+    """Core jbom package is importable without KiCad or the plugin."""
+
+    def test_jbom_importable(self) -> None:
+        """``import jbom`` must work without KiCad installed."""
+        _ensure_pcbnew_absent()
+        import jbom
+
+        assert jbom.__version__, "jbom.__version__ must be non-empty"
+
+    def test_fabrication_workflow_importable(self) -> None:
+        """``FabricationWorkflow`` must be importable from jbom.application."""
+        from jbom.application.fabrication_orchestration import (
+            FabricationRequest,
+            FabricationWorkflow,
+        )
+
+        assert FabricationWorkflow is not None
+        assert FabricationRequest is not None
+
+    def test_job_contracts_importable(self) -> None:
+        """Job contracts must be importable without KiCad."""
+        from jbom.application.jobs.contracts import JobOutcome
+
+        assert JobOutcome.SUCCEEDED.value == "succeeded"
+
+
+# ---------------------------------------------------------------------------
+# options.py independent importability
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsModuleImportable:
+    """options.py is importable without pcbnew or wx."""
+
+    def test_options_importable_without_kicad(self) -> None:
+        """``from jbom.plugin.options import PluginOptions`` must not raise."""
+        _ensure_pcbnew_absent()
+        from jbom.plugin.options import (
+            PluginOptions,
+            load_options,
+            save_options,
+        )  # noqa: F401
+
+        assert PluginOptions is not None
+        assert load_options is not None
+        assert save_options is not None

--- a/tests/plugin/test_plugin_options.py
+++ b/tests/plugin/test_plugin_options.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``jbom.plugin.options``.
+
+Covers:
+- ``PluginOptions`` default values and field types
+- ``PluginOptions.to_dict()`` / ``PluginOptions.from_dict()`` round-trip
+- ``from_dict`` robustness: extra keys, empty fabricator fallback
+- ``_find_git_root()`` with real and fake directories
+- ``_options_file()`` path resolution (git root vs. home fallback)
+- ``load_options()`` / ``save_options()`` filesystem round-trip
+- ``load_options()`` graceful degradation on malformed JSON
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from jbom.plugin.options import (
+    PluginOptions,
+    _find_git_root,
+    _options_file,
+    load_options,
+    save_options,
+)
+
+
+# ---------------------------------------------------------------------------
+# PluginOptions dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPluginOptionsDefaults:
+    def test_default_fabricator_is_jlc(self) -> None:
+        opts = PluginOptions()
+        assert opts.fabricator == "jlc"
+
+    def test_default_inventory_path_is_empty(self) -> None:
+        opts = PluginOptions()
+        assert opts.inventory_path == ""
+
+    def test_custom_values_are_stored(self) -> None:
+        opts = PluginOptions(fabricator="pcbway", inventory_path="/tmp/inv.csv")
+        assert opts.fabricator == "pcbway"
+        assert opts.inventory_path == "/tmp/inv.csv"
+
+
+class TestPluginOptionsSerialization:
+    def test_to_dict_contains_expected_keys(self) -> None:
+        opts = PluginOptions(fabricator="seeed", inventory_path="/a/b.csv")
+        d = opts.to_dict()
+        assert d == {"fabricator": "seeed", "inventory_path": "/a/b.csv"}
+
+    def test_round_trip_via_dict(self) -> None:
+        original = PluginOptions(fabricator="jlc", inventory_path="/inv/parts.csv")
+        restored = PluginOptions.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_from_dict_ignores_extra_keys(self) -> None:
+        data = {
+            "fabricator": "pcbway",
+            "inventory_path": "",
+            "unknown_future_field": 42,
+        }
+        opts = PluginOptions.from_dict(data)
+        assert opts.fabricator == "pcbway"
+        assert opts.inventory_path == ""
+
+    def test_from_dict_empty_fabricator_falls_back_to_jlc(self) -> None:
+        data = {"fabricator": "", "inventory_path": ""}
+        opts = PluginOptions.from_dict(data)
+        assert opts.fabricator == "jlc"
+
+    def test_from_dict_whitespace_fabricator_falls_back_to_jlc(self) -> None:
+        data = {"fabricator": "   ", "inventory_path": ""}
+        opts = PluginOptions.from_dict(data)
+        assert opts.fabricator == "jlc"
+
+    def test_from_dict_missing_keys_use_defaults(self) -> None:
+        opts = PluginOptions.from_dict({})
+        assert opts.fabricator == "jlc"
+        assert opts.inventory_path == ""
+
+    def test_round_trip_through_json(self) -> None:
+        original = PluginOptions(fabricator="generic", inventory_path="/x/y.xlsx")
+        json_str = json.dumps(original.to_dict())
+        restored = PluginOptions.from_dict(json.loads(json_str))
+        assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# _find_git_root
+# ---------------------------------------------------------------------------
+
+
+class TestFindGitRoot:
+    def test_returns_path_inside_real_repo(self, tmp_path: Path) -> None:
+        """jBOM is a real git repo; running from any subdir should find root."""
+        # Use the test file's own directory — guaranteed to be in a git repo.
+        result = _find_git_root(Path(__file__).parent)
+        assert result is not None
+        assert result.is_dir()
+        assert (result / ".git").exists()
+
+    def test_returns_none_outside_any_repo(self, tmp_path: Path) -> None:
+        """A freshly created temp dir is not a git repo."""
+        result = _find_git_root(tmp_path)
+        assert result is None
+
+    def test_returns_none_when_git_not_available(self, tmp_path: Path) -> None:
+        """Handles the case where the ``git`` binary cannot be found."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _find_git_root(tmp_path)
+        assert result is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        """Handles timeout gracefully."""
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 5)):
+            result = _find_git_root(tmp_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _options_file
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsFile:
+    def test_returns_path_under_git_root_when_in_repo(self, tmp_path: Path) -> None:
+        """When inside a git repo, options file lives at $git_root/.jbom/."""
+        fake_root = tmp_path / "myrepo"
+        fake_root.mkdir()
+        with patch("jbom.plugin.options._find_git_root", return_value=fake_root):
+            path = _options_file(fake_root / "myboard.kicad_pcb")
+        assert path == fake_root / ".jbom" / "jbom-options.json"
+
+    def test_returns_path_under_home_when_no_git_root(self, tmp_path: Path) -> None:
+        """When outside a git repo, options file falls back to ~/.jbom/."""
+        with patch("jbom.plugin.options._find_git_root", return_value=None):
+            path = _options_file(tmp_path / "board.kicad_pcb")
+        assert path == Path.home() / ".jbom" / "jbom-options.json"
+
+    def test_accepts_directory_as_project_path(self, tmp_path: Path) -> None:
+        """A directory path (not a file) should resolve without error."""
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            path = _options_file(project_dir)
+        assert path == tmp_path / ".jbom" / "jbom-options.json"
+
+
+# ---------------------------------------------------------------------------
+# load_options / save_options round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSaveRoundTrip:
+    def test_save_creates_file(self, tmp_path: Path) -> None:
+        opts = PluginOptions(fabricator="jlc", inventory_path="/inv/parts.csv")
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            save_options(opts, tmp_path)
+        expected = tmp_path / ".jbom" / "jbom-options.json"
+        assert expected.is_file()
+
+    def test_save_creates_parent_dir(self, tmp_path: Path) -> None:
+        opts = PluginOptions()
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            save_options(opts, tmp_path)
+        assert (tmp_path / ".jbom").is_dir()
+
+    def test_load_after_save_restores_values(self, tmp_path: Path) -> None:
+        opts = PluginOptions(fabricator="pcbway", inventory_path="/x/y.csv")
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            save_options(opts, tmp_path)
+            loaded = load_options(tmp_path)
+        assert loaded == opts
+
+    def test_load_returns_defaults_when_file_absent(self, tmp_path: Path) -> None:
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            loaded = load_options(tmp_path / "nofile.kicad_pcb")
+        assert loaded == PluginOptions()
+
+    def test_load_returns_defaults_on_malformed_json(self, tmp_path: Path) -> None:
+        jbom_dir = tmp_path / ".jbom"
+        jbom_dir.mkdir()
+        (jbom_dir / "jbom-options.json").write_text("NOT VALID JSON", encoding="utf-8")
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            loaded = load_options(tmp_path)
+        assert loaded == PluginOptions()
+
+    def test_load_returns_defaults_on_empty_file(self, tmp_path: Path) -> None:
+        jbom_dir = tmp_path / ".jbom"
+        jbom_dir.mkdir()
+        (jbom_dir / "jbom-options.json").write_text("", encoding="utf-8")
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            loaded = load_options(tmp_path)
+        assert loaded == PluginOptions()
+
+    def test_saved_json_is_human_readable(self, tmp_path: Path) -> None:
+        """Verify the persisted file is indented JSON, not a compact blob."""
+        opts = PluginOptions(fabricator="jlc", inventory_path="")
+        with patch("jbom.plugin.options._find_git_root", return_value=tmp_path):
+            save_options(opts, tmp_path)
+            path = _options_file(tmp_path)
+        content = path.read_text(encoding="utf-8")
+        # Must be valid JSON
+        parsed = json.loads(content)
+        assert parsed["fabricator"] == "jlc"
+        # Must be pretty-printed (indented)
+        assert "\n" in content, "Expected indented JSON but got compact output"

--- a/tests/plugin/test_plugin_options.py
+++ b/tests/plugin/test_plugin_options.py
@@ -50,7 +50,11 @@ class TestPluginOptionsSerialization:
     def test_to_dict_contains_expected_keys(self) -> None:
         opts = PluginOptions(fabricator="seeed", inventory_path="/a/b.csv")
         d = opts.to_dict()
-        assert d == {"fabricator": "seeed", "inventory_path": "/a/b.csv"}
+        assert d == {
+            "fabricator": "seeed",
+            "inventory_path": "/a/b.csv",
+            "archive_name_template": "${TITLE}_${REVISION}",
+        }
 
     def test_round_trip_via_dict(self) -> None:
         original = PluginOptions(fabricator="jlc", inventory_path="/inv/parts.csv")

--- a/tests/services/test_fabrication_step_callback.py
+++ b/tests/services/test_fabrication_step_callback.py
@@ -1,0 +1,141 @@
+"""Tests for the ``step_callback`` parameter added to ``FabricationWorkflow.run()``.
+
+Verifies that:
+- Passing ``step_callback=None`` (default) does not change existing behaviour.
+- A callback receives the correct (step, status) pairs in the right order.
+- Skipped steps do not fire callbacks.
+- Callback exceptions do not silently swallow errors.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from jbom.application.fabrication_orchestration import (
+    FabricationRequest,
+    FabricationWorkflow,
+)
+
+
+def _all_skipped_request() -> FabricationRequest:
+    return FabricationRequest(
+        input_path=".",
+        skip_bom=True,
+        skip_pos=True,
+        skip_gerbers=True,
+    )
+
+
+class TestStepCallbackDefault:
+    """step_callback=None (default) does not change existing behaviour."""
+
+    def test_no_callback_all_skipped(self) -> None:
+        request = _all_skipped_request()
+        result = FabricationWorkflow().run(request)  # no step_callback kwarg
+        assert result.artifacts == ()
+
+    def test_explicit_none_callback_all_skipped(self) -> None:
+        request = _all_skipped_request()
+        result = FabricationWorkflow().run(request, step_callback=None)
+        assert result.artifacts == ()
+
+
+class TestStepCallbackInvocations:
+    """Callback receives the expected (step, status) pairs."""
+
+    def test_bom_step_fires_start_and_done(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        bom_mock = SimpleNamespace(
+            diagnostics=(),
+            generation=None,
+        )
+        request = FabricationRequest(
+            input_path=".",
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.BOMWorkflow"
+        ) as mock_bom_cls:
+            mock_bom_cls.return_value.run.return_value = bom_mock
+            FabricationWorkflow().run(
+                request, step_callback=lambda step, status: calls.append((step, status))
+            )
+
+        assert ("bom", "start") in calls
+        assert ("bom", "done") in calls
+
+    def test_callback_order_is_start_before_done(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        bom_mock = SimpleNamespace(diagnostics=(), generation=None)
+        request = FabricationRequest(
+            input_path=".",
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.BOMWorkflow"
+        ) as mock_bom_cls:
+            mock_bom_cls.return_value.run.return_value = bom_mock
+            FabricationWorkflow().run(
+                request, step_callback=lambda s, st: calls.append((s, st))
+            )
+
+        bom_calls = [(s, st) for s, st in calls if s == "bom"]
+        assert bom_calls == [("bom", "start"), ("bom", "done")]
+
+    def test_skipped_bom_does_not_fire_callback(self) -> None:
+        calls: list[tuple[str, str]] = []
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        FabricationWorkflow().run(
+            request, step_callback=lambda s, st: calls.append((s, st))
+        )
+        assert all(s != "bom" for s, _ in calls)
+
+    def test_skipped_gerbers_does_not_fire_callback(self) -> None:
+        calls: list[tuple[str, str]] = []
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+        )
+        FabricationWorkflow().run(
+            request, step_callback=lambda s, st: calls.append((s, st))
+        )
+        assert all(s != "gerbers" for s, _ in calls)
+
+    def test_all_skipped_no_callback_calls(self) -> None:
+        calls: list[tuple[str, str]] = []
+        FabricationWorkflow().run(
+            _all_skipped_request(),
+            step_callback=lambda s, st: calls.append((s, st)),
+        )
+        assert calls == []
+
+    def test_pos_step_fires_when_not_skipped(self) -> None:
+        calls: list[tuple[str, str]] = []
+        pos_mock = SimpleNamespace(diagnostics=(), generation=None)
+        request = FabricationRequest(
+            input_path=".",
+            skip_bom=True,
+            skip_gerbers=True,
+        )
+        with patch(
+            "jbom.application.fabrication_orchestration.POSWorkflow"
+        ) as mock_pos_cls:
+            mock_pos_cls.return_value.run.return_value = pos_mock
+            FabricationWorkflow().run(
+                request, step_callback=lambda s, st: calls.append((s, st))
+            )
+
+        assert ("pos", "start") in calls
+        assert ("pos", "done") in calls

--- a/tests/test_project_discovery.py
+++ b/tests/test_project_discovery.py
@@ -42,21 +42,29 @@ class TestProjectDiscovery(unittest.TestCase):
 
         self.assertEqual(found, project_file)
 
-    def test_multiple_projects_raises_exception(self):
-        """Test that multiple project files raise an exception."""
-        (self.tmpdir / "project1.kicad_pro").write_text(
-            "(kicad_pro (version 20211014))"
-        )
-        (self.tmpdir / "project2.kicad_pro").write_text(
-            "(kicad_pro (version 20211014))"
-        )
+    def test_multiple_projects_prefers_directory_name_match(self):
+        """When multiple .kicad_pro files exist, prefer the one matching the dir name."""
+        dir_name = self.tmpdir.name
+        # One file matches the directory name; the other does not.
+        canonical = self.tmpdir / f"{dir_name}.kicad_pro"
+        canonical.write_text("(kicad_pro (version 20211014))")
+        other = self.tmpdir / "other_project.kicad_pro"
+        other.write_text("(kicad_pro (version 20211014))")
 
         discovery = ProjectDiscovery()
+        found = discovery.find_project_file(self.tmpdir)
 
-        with self.assertRaises(ValueError) as cm:
-            discovery.find_project_file(self.tmpdir)
+        self.assertEqual(found, canonical)
 
-        self.assertIn("Multiple project files found", str(cm.exception))
+    def test_multiple_projects_no_name_match_returns_first_alphabetically(self):
+        """When multiple .kicad_pro files exist and none matches the dir, return first."""
+        (self.tmpdir / "alpha.kicad_pro").write_text("(kicad_pro (version 20211014))")
+        (self.tmpdir / "beta.kicad_pro").write_text("(kicad_pro (version 20211014))")
+
+        discovery = ProjectDiscovery()
+        found = discovery.find_project_file(self.tmpdir)
+
+        self.assertEqual(found.name, "alpha.kicad_pro")
 
     def test_discover_project_files_returns_all(self):
         """Test discovering all project files at once."""

--- a/tests/unit/test_text_variable_expander.py
+++ b/tests/unit/test_text_variable_expander.py
@@ -1,0 +1,145 @@
+"""Unit tests for jbom.services.text_variable_expander."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+from jbom.common.types import TitleBlockMetadata
+from jbom.services.text_variable_expander import expand_text_variables
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TODAY_ISO = date.today().isoformat()
+
+
+def _meta(
+    title: str = "",
+    revision: str = "",
+    date_str: str = "",
+    company: str = "",
+) -> TitleBlockMetadata:
+    return TitleBlockMetadata(
+        title=title, revision=revision, date=date_str, company=company
+    )
+
+
+# ---------------------------------------------------------------------------
+# Standard title block variables
+# ---------------------------------------------------------------------------
+
+
+class TestKnownVariables:
+    def test_title_substituted(self) -> None:
+        result = expand_text_variables("${TITLE}", _meta(title="MyBoard"))
+        assert result == "MyBoard"
+
+    def test_revision_substituted(self) -> None:
+        result = expand_text_variables("${REVISION}", _meta(revision="1.0"))
+        assert result == "1.0"
+
+    def test_title_and_revision(self) -> None:
+        result = expand_text_variables(
+            "${TITLE}_${REVISION}", _meta(title="MyBoard", revision="2.0")
+        )
+        assert result == "MyBoard_2.0"
+
+    def test_company_substituted(self) -> None:
+        result = expand_text_variables("${COMPANY}", _meta(company="Acme"))
+        assert result == "Acme"
+
+    def test_date_from_title_block(self) -> None:
+        result = expand_text_variables("${DATE}", _meta(date_str="2026-01-15"))
+        assert result == "2026-01-15"
+
+    def test_issue_date_alias(self) -> None:
+        result = expand_text_variables("${ISSUE_DATE}", _meta(date_str="2026-01-15"))
+        assert result == "2026-01-15"
+
+    def test_current_date_is_today(self) -> None:
+        result = expand_text_variables("${CURRENT_DATE}", _meta())
+        assert result == _TODAY_ISO
+
+    def test_date_falls_back_to_today_when_empty(self) -> None:
+        result = expand_text_variables("${DATE}", _meta(date_str=""))
+        assert result == _TODAY_ISO
+
+    def test_issue_date_falls_back_to_today_when_empty(self) -> None:
+        result = expand_text_variables("${ISSUE_DATE}", _meta(date_str=""))
+        assert result == _TODAY_ISO
+
+    def test_multiple_vars_in_complex_template(self) -> None:
+        meta = _meta(title="cpNode", revision="1.0", company="SPCoast")
+        result = expand_text_variables("${COMPANY}/${TITLE}_${REVISION}", meta)
+        assert result == "SPCoast/cpNode_1.0"
+
+
+# ---------------------------------------------------------------------------
+# Empty context (no title block data set)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyContext:
+    def test_empty_title_produces_empty_string(self) -> None:
+        result = expand_text_variables("${TITLE}", _meta())
+        assert result == ""
+
+    def test_empty_revision_produces_empty_string(self) -> None:
+        result = expand_text_variables("${REVISION}", _meta())
+        assert result == ""
+
+    def test_template_with_empty_fields_leaves_only_literal(self) -> None:
+        result = expand_text_variables("prefix_${REVISION}", _meta())
+        assert result == "prefix_"
+
+
+# ---------------------------------------------------------------------------
+# Unknown variables are preserved
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownVariables:
+    def test_unknown_var_left_intact(self) -> None:
+        result = expand_text_variables("${UNKNOWN}", _meta())
+        assert result == "${UNKNOWN}"
+
+    def test_known_and_unknown_mixed(self) -> None:
+        result = expand_text_variables("${UNKNOWN}_${TITLE}", _meta(title="Board"))
+        assert result == "${UNKNOWN}_Board"
+
+    def test_custom_project_var_preserved(self) -> None:
+        """Custom project-level vars (e.g. ${PROJECT_VERSION}) pass through."""
+        result = expand_text_variables(
+            "${PROJECT_VERSION}_${REVISION}", _meta(revision="2")
+        )
+        assert result == "${PROJECT_VERSION}_2"
+
+
+# ---------------------------------------------------------------------------
+# Empty and trivial templates
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_template(self) -> None:
+        result = expand_text_variables("", _meta(title="X"))
+        assert result == ""
+
+    def test_no_variables(self) -> None:
+        result = expand_text_variables("static_name", _meta(title="X"))
+        assert result == "static_name"
+
+    def test_dollar_without_braces_left_intact(self) -> None:
+        result = expand_text_variables("$TITLE", _meta(title="X"))
+        assert result == "$TITLE"
+
+    def test_partial_brace_left_intact(self) -> None:
+        result = expand_text_variables("${TITLE", _meta(title="X"))
+        assert result == "${TITLE"
+
+    def test_current_date_format(self) -> None:
+        result = expand_text_variables("${CURRENT_DATE}", _meta())
+        assert re.match(r"^\d{4}-\d{2}-\d{2}$", result)


### PR DESCRIPTION
## Summary
Fixes all three blockers from issue #227 that prevented the KiCad plugin from producing a complete fabrication package. Also closes #256 (toolbar button only works once per KiCad session).

## Blockers resolved

### Blocker 1 — Gerbers now generated via pcbnew (not kicad-cli)
- New `src/jbom/plugin/gerber_generator.py`: `PcbnewGerberGenerator` using `pcbnew.PLOT_CONTROLLER` + `EXCELLON_WRITER`, ported from Fabrication-Toolkit `process.py`.
- Reads fabricator config `gerbers.layers` stanza; resolves layer IDs via `board.GetLayerID()`; skips `UNDEFINED_LAYER` with a diagnostic.
- Lazy-imports `pcbnew` inside `generate()` so the module is importable without KiCad.
- `skip_gerbers=True` removed from `dialog.py`.

### Blocker 2 / #256 — Toolbar button works on every click (root cause identified)
Root cause: `JBOMFabricationPlugin().register()` in `__init__.py` created a temporary Python wrapper with zero retained references. KiCad's ActionPlugin SWIG binding stores only a C++ pointer without incrementing Python's refcount. CPython's reference counting GC'd the wrapper between the first and second clicks. KiCad found a dead Python object and silently suppressed subsequent `Run()` calls.

Fix: store the instance at module level before calling `register()`:
```python
_plugin_instance = JBOMFabricationPlugin()
_plugin_instance.register()
```

Confirmed by scripting console lifecycle trace: `Run() #1` then `Run() #2` on successive clicks. Mirrors Fabrication-Toolkit's confirmed-working pattern exactly.

Additionally: `JBOMFabricationDialog` switched to `wx.Dialog + Show()` (modeless) with `parent=None` so `Run()` returns immediately. `pcbnew.Refresh()` called before every `Destroy()` to keep the PCB canvas in sync and ensure the KiCad toolbar `UpdateUI` handler fires.

### Blocker 3 — Gerber zip in production/ AND in backup
`_worker()` now orchestrates directly (A2): `BOMWorkflow` → `BOMWriter`, `POSWorkflow` → `POSWriter`, `PcbnewGerberGenerator` → `GerberPackager`, then `BackupService` once with all three artifacts.  `FabricationWorkflow` is not used from the plugin — eliminates the double-backup problem and the CLI subprocess hang.

### Bonus fixes
- Finder opens in debug mode: Close button in the diagnostics panel now calls `_open_folder` before `Destroy()`.

## Files changed
- `src/jbom/plugin/__init__.py` — retain plugin instance at module level
- `src/jbom/plugin/gerber_generator.py` (NEW) — `PcbnewGerberGenerator`
- `src/jbom/plugin/dialog.py` (rewritten) — `wx.Dialog`, A2 orchestration
- `src/jbom/plugin/plugin.py` — `Show()`, no parent, no unused imports
- `tests/plugin/test_pcbnew_gerber_generator.py` (NEW, 13 tests)

## Testing
1253 tests pass. New tests cover: importability without pcbnew, `_load_gerber_policy` (JLC config + fallback), `UNDEFINED_LAYER` skip, disabled-layer skip, plot_error path, artifact collection, no_artifacts path.

## Production output (acceptance criteria met)
```
production/
  jbom.csv                              ← BOM (fabricator-ready)
  cpl.csv                               ← CPL/placement
  {title}_{revision}.zip                ← Gerber archive
  backups/
    {title}_{revision}_{timestamp}.zip  ← snapshot of all three artifacts
```

Closes #227
Closes #256

---
Co-Authored-By: Oz <oz-agent@warp.dev>