### PR TITLE
feat(plugin): Tranche 1 — skip_backup (#254), smart zone fill + auto-save (#255)

### DIFF
--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -91,6 +91,8 @@ class FabricationRequest:
         smd_only: Forward SMD-only filter to POS generation.
         pos_layer: Forward layer filter (``"TOP"`` / ``"BOTTOM"``) to POS.
         pos_origin: Forward origin reference (``"board"`` / ``"aux"``) to POS.
+        skip_backup: When ``True`` skip backup archive creation even when
+            artifacts are present.  Defaults to ``False`` (backup is created).
         debug: When ``True`` preserve intermediate gerber directory after
             packaging for inspection.
         archive_stem: Pre-expanded archive base name (e.g. ``"MyBoard_1.0"``)
@@ -115,6 +117,7 @@ class FabricationRequest:
     smd_only: bool = False
     pos_layer: str = ""
     pos_origin: str = "board"
+    skip_backup: bool = False
     debug: bool = False
     archive_stem: str = ""
 
@@ -152,6 +155,7 @@ class FabricationRequest:
             "pos_origin",
             _normalize_text(self.pos_origin or "board", field_name="pos_origin"),
         )
+        object.__setattr__(self, "skip_backup", bool(self.skip_backup))
         object.__setattr__(self, "debug", bool(self.debug))
         object.__setattr__(self, "archive_stem", str(self.archive_stem or "").strip())
 
@@ -384,9 +388,14 @@ class FabricationWorkflow:
                 step_callback("gerbers", "done")
 
         # ------------------------------------------------------------------
-        # Step 4: Backup (if any files were written)
+        # Step 4: Backup (if any files were written and not skipped by caller)
         # ------------------------------------------------------------------
-        if not request.dry_run and production_dir is not None and artifacts:
+        if (
+            not request.skip_backup
+            and not request.dry_run
+            and production_dir is not None
+            and artifacts
+        ):
             artifact_paths = [a.path for a in artifacts if a.path is not None]
             if artifact_paths:
                 if step_callback:

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -229,7 +229,14 @@ class JBOMFabricationDialog(wx.Dialog):
         self._cb_smd_only = _cb("SMD only (placement)", False)
         self._cb_exclude_dnp = _cb("Exclude DNP components")
         self._cb_fill_zones = _cb("Fill all zones before Gerbers")
+        self._cb_fill_zones.SetToolTip(
+            "Fill all zones before Gerbers. Skipped automatically if zones are "
+            "already current; saves the board file automatically if fill was needed."
+        )
         self._cb_backup = _cb("Create backup archive")
+        self._cb_backup.SetToolTip(
+            "Archive BOM, CPL, and Gerbers into a dated backup zip after generation."
+        )
         self._cb_open_folder = _cb("Open production folder when done")
 
         # Grayed placeholder — pending issue #249
@@ -422,6 +429,7 @@ class JBOMFabricationDialog(wx.Dialog):
         fab_id = self._selected_fabricator_id()
         inventory_path = self._inv_text.GetValue().strip()
         smd_only = self._cb_smd_only.GetValue()
+        do_backup = self._cb_backup.GetValue()
         open_folder = self._cb_open_folder.GetValue()
         debug_mode = self._cb_debug.GetValue()
         archive_stem = self._archive_name
@@ -442,7 +450,8 @@ class JBOMFabricationDialog(wx.Dialog):
             except OSError:
                 pass  # Non-fatal; proceed with generation
 
-        # Optional zone fill (in-memory, updates live KiCad view)
+        # Optional zone fill — smart: skips if zones are already current,
+        # auto-saves the board file when fill actually ran.
         if self._cb_fill_zones.GetValue():
             self._fill_zones()
 
@@ -566,7 +575,7 @@ class JBOMFabricationDialog(wx.Dialog):
                 # Step 4: Backup (all three artifacts in one archive)
                 # ----------------------------------------------------------
                 _step("backup", "start")
-                if not cancelled() and artifact_paths:
+                if do_backup and not cancelled() and artifact_paths:
                     try:
                         from jbom.services.backup_service import BackupService
 
@@ -593,26 +602,20 @@ class JBOMFabricationDialog(wx.Dialog):
         thread = threading.Thread(target=_worker, daemon=True)
         thread.start()
 
-    def _fill_zones(self) -> None:
-        """Fill board zones using the pcbnew API (in-memory only).
+    def _fill_zones(self) -> bool:
+        """Fill board zones only if actually needed; auto-save when fill runs.
 
-        Note: pcbnew.Refresh() is intentionally omitted here.  Calling it
-        marks the board as modified in KiCad's undo history, which would
-        prompt the user to save even if they only invoked the plugin and
-        cancelled.  The zone fill is reflected in the exported Gerbers;
-        the live editor view updates automatically when the board reloads.
+        Delegates to :func:`~jbom.plugin.zone_filler.fill_zones_if_needed`
+        which is extracted into a wx-free module for testability.  See that
+        function's docstring for full semantics.
+
+        Returns:
+            ``True`` if ``ZONE_FILLER.Fill()`` was called (zones were stale).
+            ``False`` if fill was skipped (zones already current).
         """
-        try:
-            import pcbnew  # noqa: PLC0415
+        from jbom.plugin.zone_filler import fill_zones_if_needed  # noqa: PLC0415
 
-            board = pcbnew.GetBoard()
-            if board:
-                filler = pcbnew.ZONE_FILLER(board)
-                filler.Fill(board.Zones())
-                # Do NOT call pcbnew.Refresh() — it sets the board's
-                # modified flag and causes an unsaved-changes prompt.
-        except Exception:  # pragma: no cover
-            pass  # Non-fatal; proceed with generation
+        return fill_zones_if_needed(self._pcb_path)
 
     # ------------------------------------------------------------------
     # Event handlers — progress panel

--- a/src/jbom/plugin/zone_filler.py
+++ b/src/jbom/plugin/zone_filler.py
@@ -1,0 +1,76 @@
+"""Zone fill utility for the KiCad plugin.
+
+Extracted from :mod:`jbom.plugin.dialog` for testability.  This module does
+**not** import ``wx`` — ``pcbnew`` is lazy-imported inside
+:func:`fill_zones_if_needed` so the module is safe to import in CLI/test
+environments.
+
+Only called from within KiCad's embedded Python interpreter at runtime.
+"""
+
+from __future__ import annotations
+
+__all__ = ["fill_zones_if_needed"]
+
+
+def fill_zones_if_needed(pcb_path: str) -> bool:
+    """Fill board zones only if actually needed; auto-save when fill runs.
+
+    Checks whether all zones are already filled and not stale before calling
+    ``ZONE_FILLER.Fill()``.  If zones are already current the fill is skipped
+    entirely — the board state is untouched and no dirty flag is set.
+
+    If zones genuinely need filling, ``Fill()`` is called and the board file
+    is saved to disk immediately so that the source file, generated Gerbers,
+    and backup archive are all produced from the same consistent state.
+
+    KiCad owns the dirty flag entirely; this function never reads or writes
+    ``board.IsModified()``.
+
+    Args:
+        pcb_path: Filesystem path of the active PCB file, or empty string.
+            When non-empty, ``pcbnew.SaveBoard()`` is called after fill so
+            the disk file matches the in-memory filled state.
+
+    Returns:
+        ``True`` if ``ZONE_FILLER.Fill()`` was called (zones were stale).
+        ``False`` if fill was skipped (zones already current) or if the board
+        could not be obtained.
+    """
+    try:
+        import pcbnew  # noqa: PLC0415 — only executed inside KiCad
+
+        board = pcbnew.GetBoard()
+        if not board:
+            return False
+
+        zones = list(board.Zones())
+
+        # Skip fill if all zones are already filled and not stale.
+        # GetNeedRefill() was added in KiCad 7; guard for older builds.
+        already_current = not zones or all(
+            z.IsFilled() and (not hasattr(z, "GetNeedRefill") or not z.GetNeedRefill())
+            for z in zones
+        )
+        if already_current:
+            return False  # No-op: board state untouched
+
+        # Zones need filling — fill then immediately save.
+        pcbnew.ZONE_FILLER(board).Fill(board.Zones())
+
+        # Auto-save: keep source file in sync with filled state used for
+        # Gerbers and backup.  Try pcbnew.SaveBoard() first (standard
+        # KiCad 7+ API), fall back to board.Save() for older builds.
+        if pcb_path:
+            try:
+                pcbnew.SaveBoard(pcb_path, board)
+            except Exception:  # pragma: no cover
+                try:
+                    board.Save(pcb_path)
+                except Exception:  # pragma: no cover
+                    pass  # Non-fatal: Gerbers still use filled in-memory board
+
+        return True
+
+    except Exception:  # pragma: no cover
+        return False  # Non-fatal; caller proceeds with generation

--- a/tests/plugin/test_tranche1.py
+++ b/tests/plugin/test_tranche1.py
@@ -1,0 +1,208 @@
+"""Unit tests for Tranche 1 plugin improvements (issues #254 and #255).
+
+#254 — FabricationRequest.skip_backup field and FabricationWorkflow gate:
+- skip_backup defaults to False
+- skip_backup=True prevents BackupService from being called
+- __post_init__ coerces value to bool
+
+#255 — _fill_zones() no-op detection:
+- returns False and skips ZONE_FILLER.Fill() when all zones are already filled
+- returns True when fill was genuinely needed (zones not all filled)
+- returns False gracefully when board has no zones
+- GetNeedRefill() is used when present; absent attribute is tolerated
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# #254 — FabricationRequest.skip_backup
+# ---------------------------------------------------------------------------
+
+
+class TestFabricationRequestSkipBackup:
+    """FabricationRequest carries skip_backup with correct defaults/coercion."""
+
+    def test_skip_backup_defaults_to_false(self) -> None:
+        from jbom.application.fabrication_orchestration import FabricationRequest
+
+        req = FabricationRequest(input_path="/fake/board.kicad_pcb")
+        assert req.skip_backup is False
+
+    def test_skip_backup_true_is_stored(self) -> None:
+        from jbom.application.fabrication_orchestration import FabricationRequest
+
+        req = FabricationRequest(input_path="/fake/board.kicad_pcb", skip_backup=True)
+        assert req.skip_backup is True
+
+    def test_skip_backup_is_coerced_to_bool(self) -> None:
+        from jbom.application.fabrication_orchestration import FabricationRequest
+
+        req = FabricationRequest(
+            input_path="/fake/board.kicad_pcb", skip_backup=1  # type: ignore[arg-type]
+        )
+        assert req.skip_backup is True
+        assert type(req.skip_backup) is bool
+
+
+class TestFabricationWorkflowSkipBackup:
+    """FabricationWorkflow skips BackupService when skip_backup=True."""
+
+    def _make_request(self, tmp_path: Path, *, skip_backup: bool) -> object:
+        from jbom.application.fabrication_orchestration import FabricationRequest
+
+        # Point input_path at the tmp dir so the workflow can resolve a project dir.
+        return FabricationRequest(
+            input_path=str(tmp_path),
+            skip_bom=True,
+            skip_pos=True,
+            skip_gerbers=True,
+            skip_backup=skip_backup,
+        )
+
+    def test_backup_skipped_when_skip_backup_true(self, tmp_path: Path) -> None:
+        from jbom.application.fabrication_orchestration import FabricationWorkflow
+
+        request = self._make_request(tmp_path, skip_backup=True)
+
+        with patch(
+            "jbom.application.fabrication_orchestration.FabricationWorkflow"
+            "._create_backup"
+        ) as mock_backup:
+            FabricationWorkflow().run(request)  # type: ignore[arg-type]
+            mock_backup.assert_not_called()
+
+    def test_backup_called_when_skip_backup_false(self, tmp_path: Path) -> None:
+        """When skip_backup=False, _create_backup is reached (may still no-op due to
+        empty artifact list, but it is not pre-empted by the flag)."""
+        from jbom.application.fabrication_orchestration import FabricationWorkflow
+
+        request = self._make_request(tmp_path, skip_backup=False)
+
+        # With all steps skipped, artifact list will be empty and backup gate
+        # (artifacts truthy) will prevent _create_backup from being called anyway.
+        # We verify skip_backup=False does NOT block the gate; the artifact list
+        # gate handles the rest.
+        with patch(
+            "jbom.application.fabrication_orchestration.FabricationWorkflow"
+            "._create_backup"
+        ) as mock_backup:
+            FabricationWorkflow().run(request)  # type: ignore[arg-type]
+            # No artifacts → backup gate blocks even with skip_backup=False.
+            mock_backup.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #255 — fill_zones_if_needed() no-op detection (tested via sys.modules patching)
+# ---------------------------------------------------------------------------
+# Tests import jbom.plugin.zone_filler directly — no wx dependency.
+
+
+def _make_mock_zone(*, is_filled: bool, need_refill: bool = False) -> MagicMock:
+    """Return a mock ZONE object with configurable IsFilled/GetNeedRefill."""
+    zone = MagicMock()
+    zone.IsFilled.return_value = is_filled
+    zone.GetNeedRefill.return_value = need_refill
+    return zone
+
+
+def _make_mock_board(zones: list[MagicMock]) -> MagicMock:
+    board = MagicMock()
+    board.Zones.return_value = zones
+    return board
+
+
+class TestFillZonesNoOp:
+    """fill_zones_if_needed() skips ZONE_FILLER when zones are already current."""
+
+    def _run_fill_zones(
+        self,
+        zones: list[MagicMock],
+        pcb_path: str = "",
+    ) -> tuple[bool, MagicMock]:
+        """Run fill_zones_if_needed() with pcbnew injected via sys.modules."""
+        import sys
+
+        mock_board = _make_mock_board(zones)
+        mock_pcbnew = MagicMock()
+        mock_pcbnew.GetBoard.return_value = mock_board
+        mock_pcbnew.ZONE_FILLER.return_value = MagicMock()
+        mock_pcbnew.SaveBoard = MagicMock()
+
+        with patch.dict(sys.modules, {"pcbnew": mock_pcbnew}):
+            # Reload is not needed; the lazy import inside fill_zones_if_needed
+            # will use sys.modules['pcbnew'] at call time.
+            from jbom.plugin.zone_filler import fill_zones_if_needed
+
+            result = fill_zones_if_needed(pcb_path)
+
+        return result, mock_pcbnew
+
+    def test_no_zones_returns_false_without_filling(self) -> None:
+        """A board with no zones is a no-op — fill is skipped, returns False."""
+        result, mock_pcbnew = self._run_fill_zones(zones=[])
+        assert result is False
+        mock_pcbnew.ZONE_FILLER.assert_not_called()
+
+    def test_all_zones_filled_and_current_returns_false(self) -> None:
+        """All zones IsFilled=True, GetNeedRefill=False → skip, return False."""
+        zones = [
+            _make_mock_zone(is_filled=True, need_refill=False),
+            _make_mock_zone(is_filled=True, need_refill=False),
+        ]
+        result, mock_pcbnew = self._run_fill_zones(zones)
+        assert result is False
+        mock_pcbnew.ZONE_FILLER.assert_not_called()
+
+    def test_unfilled_zone_triggers_fill(self) -> None:
+        """At least one zone IsFilled=False → ZONE_FILLER.Fill() is called."""
+        zones = [
+            _make_mock_zone(is_filled=True, need_refill=False),
+            _make_mock_zone(is_filled=False, need_refill=False),
+        ]
+        result, mock_pcbnew = self._run_fill_zones(zones)
+        assert result is True
+        mock_pcbnew.ZONE_FILLER.assert_called_once()
+        mock_pcbnew.ZONE_FILLER.return_value.Fill.assert_called_once()
+
+    def test_stale_zone_triggers_fill(self) -> None:
+        """Zone IsFilled=True but GetNeedRefill=True → fill is still run."""
+        zones = [_make_mock_zone(is_filled=True, need_refill=True)]
+        result, mock_pcbnew = self._run_fill_zones(zones)
+        assert result is True
+        mock_pcbnew.ZONE_FILLER.assert_called_once()
+
+    def test_zone_without_get_need_refill_attribute_is_tolerated(self) -> None:
+        """Zones without GetNeedRefill (pre-KiCad-7) don't crash; IsFilled governs."""
+        zone = MagicMock(spec=["IsFilled"])  # no GetNeedRefill
+        zone.IsFilled.return_value = True
+        # hasattr(zone, "GetNeedRefill") → False; treated as not-stale.
+        result, mock_pcbnew = self._run_fill_zones([zone])
+        assert result is False
+        mock_pcbnew.ZONE_FILLER.assert_not_called()
+
+    def test_fill_auto_saves_when_pcb_path_set(self, tmp_path: Path) -> None:
+        """When fill runs, pcbnew.SaveBoard() is called with the pcb_path."""
+        pcb_file = str(tmp_path / "board.kicad_pcb")
+        zones = [_make_mock_zone(is_filled=False)]
+        result, mock_pcbnew = self._run_fill_zones(zones, pcb_path=pcb_file)
+        assert result is True
+        mock_pcbnew.SaveBoard.assert_called_once_with(pcb_file, mock_pcbnew.GetBoard())
+
+    def test_fill_does_not_save_when_no_pcb_path(self) -> None:
+        """When pcb_path is empty, SaveBoard is NOT called even if fill ran."""
+        zones = [_make_mock_zone(is_filled=False)]
+        result, mock_pcbnew = self._run_fill_zones(zones, pcb_path="")
+        assert result is True
+        mock_pcbnew.SaveBoard.assert_not_called()
+
+    def test_no_op_does_not_save(self, tmp_path: Path) -> None:
+        """When fill is a no-op, SaveBoard is NOT called."""
+        pcb_file = str(tmp_path / "board.kicad_pcb")
+        zones = [_make_mock_zone(is_filled=True, need_refill=False)]
+        result, mock_pcbnew = self._run_fill_zones(zones, pcb_path=pcb_file)
+        assert result is False
+        mock_pcbnew.SaveBoard.assert_not_called()


### PR DESCRIPTION
Closes #254
Closes #255

## Summary

Two plugin polish issues completing the #227 MVP story.

### #254 — Wire "Create backup" checkbox to FabricationRequest

`FabricationRequest` now carries `skip_backup: bool = False`. The CLI workflow gates `BackupService` on `not request.skip_backup`. The plugin dialog captures `do_backup = self._cb_backup.GetValue()` on the main thread before `_worker()` starts and gates the backup step accordingly. Checkbox was already present in the dialog; this wires it to actual behavior.

### #255 — Smart zone fill with no-op detection and auto-save

Previous `_fill_zones()` always called `ZONE_FILLER.Fill()` even when zones were already current, setting KiCads dirty flag unnecessarily.

New behavior (extracted to `jbom.plugin.zone_filler.fill_zones_if_needed()`, a wx-free module for testability):

- **Skip entirely** when all zones satisfy `IsFilled() and not GetNeedRefill()` — board state untouched, no dirty flag set
- **Fill + auto-save** when zones are genuinely stale: `ZONE_FILLER.Fill()` runs, then `pcbnew.SaveBoard()` writes the board file so source, Gerbers, and backup are all produced from the same consistent state
- KiCad owns the dirty flag entirely — this code never reads/writes `IsModified()`
- `GetNeedRefill()` guarded with `hasattr` for pre-KiCad-7 compatibility; falls back to `board.Save()` if `SaveBoard()` is unavailable

### Also: Close #244

`netlist.ipc` generation is not a fab deliverable — closed with rationale comment.

## Testing

13 new unit tests in `tests/plugin/test_tranche1.py`:
- `FabricationRequest.skip_backup` default, storage, bool coercion
- `FabricationWorkflow` backup gate with `skip_backup=True`
- `fill_zones_if_needed()`: no zones, all filled, one unfilled, stale zone, missing `GetNeedRefill`, auto-save on fill, no save on no-op, no save when `pcb_path` empty

Full suite: 1266/1266 passed.

---
Conversation: https://app.warp.dev/conversation/d0c10e1a-9dd9-485e-bb8e-869af9a8cade
Roadmap: https://app.warp.dev/drive/notebook/XrvCApVqIKbm3ZRJnt5OnV

Co-Authored-By: Oz <oz-agent@warp.dev>