### PR TITLE
diag(plugin): dirty-flag trace + root cause investigation (#255)

### DIFF
--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -68,6 +68,18 @@ try:
 except ImportError:  # pragma: no cover
     _jbom_version = "unknown"
 
+
+def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
+    """Diagnostic trace — REMOVE before production."""
+    modified = ""
+    if board is not None:
+        try:
+            modified = f"  IsModified={board.IsModified()}"
+        except Exception as exc:
+            modified = f"  IsModified=ERR({exc})"
+    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
+
+
 # Steps in display order — matches storyboard progress panel.
 _STEPS: list[str] = ["bom", "pos", "gerbers", "backup"]
 _STEP_LABELS: dict[str, str] = {
@@ -453,7 +465,26 @@ class JBOMFabricationDialog(wx.Dialog):
         # Optional zone fill — smart: skips if zones are already current,
         # auto-saves the board file when fill actually ran.
         if self._cb_fill_zones.GetValue():
+            try:
+                import pcbnew as _pcb  # noqa: PLC0415
+
+                _trace("_on_generate: before _fill_zones()", _pcb.GetBoard())
+            except Exception:
+                pass
             self._fill_zones()
+            try:
+                import pcbnew as _pcb  # noqa: PLC0415
+
+                _trace("_on_generate: after _fill_zones()", _pcb.GetBoard())
+            except Exception:
+                pass
+        else:
+            try:
+                import pcbnew as _pcb  # noqa: PLC0415
+
+                _trace("_on_generate: fill zones checkbox OFF", _pcb.GetBoard())
+            except Exception:
+                pass
 
         # Swap to progress panel
         self._cancel_requested.clear()
@@ -472,6 +503,7 @@ class JBOMFabricationDialog(wx.Dialog):
                 import pcbnew  # noqa: PLC0415
 
                 board = pcbnew.GetBoard()
+                _trace("_worker: thread start", board)
 
                 project_dir = Path(pcb_path).parent if pcb_path else Path(".")
                 production_dir = project_dir / "production"
@@ -486,6 +518,7 @@ class JBOMFabricationDialog(wx.Dialog):
                 # ----------------------------------------------------------
                 # Step 1: BOM
                 # ----------------------------------------------------------
+                _trace("_worker: before BOM step", board)
                 _step("bom", "start")
                 if not cancelled():
                     try:
@@ -511,10 +544,12 @@ class JBOMFabricationDialog(wx.Dialog):
                     except Exception as exc:
                         diagnostics.append(f"BOM generation failed: {exc}")
                 _step("bom", "done")
+                _trace("_worker: after BOM step", board)
 
                 # ----------------------------------------------------------
                 # Step 2: POS
                 # ----------------------------------------------------------
+                _trace("_worker: before POS step", board)
                 _step("pos", "start")
                 if not cancelled():
                     try:
@@ -538,10 +573,12 @@ class JBOMFabricationDialog(wx.Dialog):
                     except Exception as exc:
                         diagnostics.append(f"POS generation failed: {exc}")
                 _step("pos", "done")
+                _trace("_worker: after POS step", board)
 
                 # ----------------------------------------------------------
                 # Step 3: Gerbers (pcbnew PLOT_CONTROLLER — no kicad-cli)
                 # ----------------------------------------------------------
+                _trace("_worker: before Gerbers step", board)
                 _step("gerbers", "start")
                 if not cancelled():
                     try:
@@ -570,10 +607,12 @@ class JBOMFabricationDialog(wx.Dialog):
                     except Exception as exc:
                         diagnostics.append(f"Gerber generation failed: {exc}")
                 _step("gerbers", "done")
+                _trace("_worker: after Gerbers step", board)
 
                 # ----------------------------------------------------------
                 # Step 4: Backup (all three artifacts in one archive)
                 # ----------------------------------------------------------
+                _trace("_worker: before Backup step", board)
                 _step("backup", "start")
                 if do_backup and not cancelled() and artifact_paths:
                     try:
@@ -588,6 +627,7 @@ class JBOMFabricationDialog(wx.Dialog):
                     except Exception as exc:
                         diagnostics.append(f"Backup creation failed: {exc}")
                 _step("backup", "done")
+                _trace("_worker: after Backup step / pipeline complete", board)
 
                 # Build a lightweight result carrier for _on_complete.
                 result = types.SimpleNamespace(

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -69,6 +69,9 @@ except ImportError:  # pragma: no cover
     _jbom_version = "unknown"
 
 
+_TRACE_LOG = "/tmp/jbom_trace.log"
+
+
 def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
     """Diagnostic trace — REMOVE before production."""
     modified = ""
@@ -77,7 +80,13 @@ def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
             modified = f"  IsModified={board.IsModified()}"
         except Exception as exc:
             modified = f"  IsModified=ERR({exc})"
-    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
+    msg = f"[jBOM-TRACE] {label}{modified}"
+    print(msg, flush=True)
+    try:
+        with open(_TRACE_LOG, "a") as _f:
+            _f.write(msg + "\n")
+    except Exception:
+        pass
 
 
 # Steps in display order — matches storyboard progress panel.
@@ -133,6 +142,22 @@ class JBOMFabricationDialog(wx.Dialog):
         self._options: PluginOptions = (
             load_options(Path(pcb_path)) if pcb_path else PluginOptions()
         )
+
+        # Pre-read title block metadata from disk (no SWIG) so that
+        # _on_archive_template_changed can expand templates without calling
+        # board.GetProject() / board.GetTitleBlock(), which dirty the board
+        # in KiCad 10 even on read-only access.
+        self._pcb_title_meta: object | None = None  # TitleBlockMetadata | None
+        if pcb_path:
+            try:
+                from jbom.services.project_metadata import create_metadata
+
+                _pcb_file = Path(pcb_path)
+                _proj_file = _pcb_file.parent / f"{_pcb_file.parent.name}.kicad_pro"
+                _md = create_metadata(_proj_file, pcb_file=_pcb_file)
+                self._pcb_title_meta = _md.pcb_metadata
+            except Exception:
+                pass
 
         # Build UI
         outer = wx.BoxSizer(wx.VERTICAL)
@@ -379,48 +404,35 @@ class JBOMFabricationDialog(wx.Dialog):
 
         Called on every keystroke in the Archive text field.  Updates
         ``self._archive_name`` so that Generate uses the new expansion.
-        Uses the same two-step expansion as plugin.py._expand_archive_template:
-        1. pcbnew.ExpandTextVars for project-level variables
-        2. jBOM TextVariableExpander for standard title block variables
+
+        Uses file-based title block metadata cached at dialog init time
+        (``self._pcb_title_meta``) so that pcbnew SWIG calls are completely
+        avoided here.  ``board.GetProject()`` / ``board.GetTitleBlock()``
+        dirty the board in KiCad 10 even on read-only access; calling them
+        from an EVT_TEXT handler that fires in the event loop after
+        ``dlg.Show()`` was the root cause of the spurious dirty flag on
+        plugin invocation (issue #255).
         """
         if self._archive_preview is None:
             return
+        import re
+
         new_template = self._archive_tpl.GetValue()
         try:
-            import re
+            from jbom.services.text_variable_expander import expand_text_variables
 
-            import pcbnew  # noqa: PLC0415 — safe inside KiCad
-
-            board = pcbnew.GetBoard()
-
-            # Step 1: pcbnew.ExpandTextVars handles custom project vars.
-            try:
-                project = board.GetProject()
-                expanded = pcbnew.ExpandTextVars(new_template, project)
-            except Exception:
-                expanded = new_template
-
-            # Step 2: jBOM expander handles standard title block vars
-            # (${TITLE}, ${REVISION}, ${DATE}, ${COMPANY}, ${CURRENT_DATE}).
-            try:
-                from jbom.common.types import TitleBlockMetadata
-                from jbom.services.text_variable_expander import expand_text_variables
-
-                tb = board.GetTitleBlock()
-                meta = TitleBlockMetadata(
-                    title=(tb.GetTitle() or "").strip(),
-                    revision=(tb.GetRevision() or "").strip(),
-                    date=(tb.GetDate() or "").strip(),
-                    company=(tb.GetCompany() or "").strip(),
-                )
-                expanded = expand_text_variables(expanded, meta)
-            except Exception:
-                pass
-
-            cleaned = re.sub(r"[^\w.-]", "_", expanded).strip("_")
-            self._archive_name = cleaned or new_template
+            meta = self._pcb_title_meta  # pre-read in __init__, no SWIG
+            if meta is not None:
+                expanded = expand_text_variables(new_template, meta)
+                cleaned = re.sub(r"[^\w.-]", "_", expanded).strip("_")
+                self._archive_name = cleaned or new_template
+                self._archive_preview.SetLabel(self._archive_name)
+                return
         except Exception:
-            self._archive_name = new_template
+            pass
+
+        # Fallback: show template unexpanded
+        self._archive_name = new_template
         self._archive_preview.SetLabel(self._archive_name)
 
     def _on_browse_inventory(self, _evt: wx.CommandEvent) -> None:

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -16,6 +16,9 @@ import sys
 import pcbnew  # noqa: F401 — only imported inside KiCad, safe here
 
 
+_TRACE_LOG = "/tmp/jbom_trace.log"
+
+
 def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
     """Diagnostic trace — REMOVE before production."""
     modified = ""
@@ -24,7 +27,13 @@ def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
             modified = f"  IsModified={board.IsModified()}"
         except Exception as exc:
             modified = f"  IsModified=ERR({exc})"
-    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
+    msg = f"[jBOM-TRACE] {label}{modified}"
+    print(msg, flush=True)
+    try:
+        with open(_TRACE_LOG, "a") as _f:
+            _f.write(msg + "\n")
+    except Exception:
+        pass
 
 
 class JBOMFabricationPlugin(pcbnew.ActionPlugin):
@@ -74,12 +83,18 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         template = options.archive_name_template if options else "${TITLE}_${REVISION}"
         _trace("_run_impl() after load_options", board)
 
-        # Expand the template using pcbnew's own variable expander so that
-        # custom project-level variables (defined in .kicad_pro) are honoured
-        # in addition to the standard title block variables.
-        _trace("_run_impl() before _expand_archive_template", board)
-        archive_name = self._expand_archive_template(board, template)
-        _trace(f"_run_impl() after _expand_archive_template → '{archive_name}'", board)
+        # Expand the template using FILE-BASED reads only.
+        # The old _expand_archive_template(board, ...) called board.GetProject() and
+        # board.GetTitleBlock() via SWIG, which KiCad 10 registers as a modification
+        # and sets the board dirty flag even though no data was changed.
+        # _expand_archive_template_from_file() reads the same data directly from the
+        # .kicad_pcb file, bypassing the SWIG binding entirely.
+        _trace("_run_impl() before _expand_archive_template_from_file", board)
+        archive_name = self._expand_archive_template_from_file(pcb_path, template)
+        _trace(
+            f"_run_impl() after _expand_archive_template_from_file → '{archive_name}'",
+            board,
+        )
 
         from .dialog import JBOMFabricationDialog
 
@@ -89,16 +104,25 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         _trace("_run_impl() after dlg.Show() (returns immediately — modeless)", board)
 
     @staticmethod
-    def _expand_archive_template(board: object, template: str) -> str:
-        """Expand the archive name template for the given board.
+    def _expand_archive_template_from_file(pcb_path: str, template: str) -> str:
+        """Expand the archive name template using file-based reads only.
+
+        Reads title block metadata from the ``.kicad_pcb`` file directly via
+        jBOM's ``DefaultKiCadReaderService``, completely bypassing the pcbnew
+        SWIG bindings.  This prevents ``board.GetProject()`` /
+        ``board.GetTitleBlock()`` SWIG reads from setting the board's modified
+        flag as a side-effect.
 
         Priority:
-        1. ``pcbnew.ExpandTextVars(template, project)`` — resolves all KiCad
-           text variables including custom project-level variables.
-        2. jBOM :func:`~jbom.services.text_variable_expander.expand_text_variables`
-           — fallback resolving the standard title block subset.
-        3. PCB filename stem — used when both produce an empty result.
-        4. ``"(unknown)"`` — last resort.
+        1. jBOM :func:`~jbom.services.text_variable_expander.expand_text_variables`
+           on PCB title block read from disk.
+        2. PCB filename stem — when template expansion yields nothing.
+        3. ``"(unknown)"`` — last resort.
+
+        Note: Custom project-level variables (defined in ``.kicad_pro`` and
+        resolved by ``pcbnew.ExpandTextVars``) are NOT supported by this path.
+        Standard title block tokens (``${TITLE}``, ``${REVISION}``, ``${DATE}``,
+        ``${COMPANY}``, ``${CURRENT_DATE}``) are supported.
         """
         import re
         from pathlib import Path
@@ -108,40 +132,24 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
             return re.sub(r"[^\w.-]", "_", s).strip("_")
 
         try:
-            # Attempt pcbnew.ExpandTextVars first for full variable support.
-            _trace("  _expand: before GetProject", board)
-            project = board.GetProject()  # type: ignore[union-attr]
-            _trace("  _expand: after GetProject", board)
-            expanded = pcbnew.ExpandTextVars(template, project)
-            _trace("  _expand: after ExpandTextVars", board)
-        except Exception:
-            expanded = template
-
-        # Fallback: apply jBOM's own expander for the title block subset.
-        try:
-            from jbom.common.types import TitleBlockMetadata
+            from jbom.services.project_metadata import create_metadata
             from jbom.services.text_variable_expander import expand_text_variables
 
-            _trace("  _expand: before GetTitleBlock", board)
-            tb = board.GetTitleBlock()  # type: ignore[union-attr]
-            _trace("  _expand: after GetTitleBlock", board)
-            meta = TitleBlockMetadata(
-                title=(tb.GetTitle() or "").strip(),
-                revision=(tb.GetRevision() or "").strip(),
-                date=(tb.GetDate() or "").strip(),
-                company=(tb.GetCompany() or "").strip(),
-            )
-            expanded = expand_text_variables(expanded, meta)
+            pcb_file = Path(pcb_path)
+            # Look for the .kicad_pro in the same directory, named after the dir.
+            project_file = pcb_file.parent / f"{pcb_file.parent.name}.kicad_pro"
+            metadata = create_metadata(project_file, pcb_file=pcb_file)
+            meta = metadata.pcb_metadata  # TitleBlockMetadata | None
+            if meta is not None:
+                expanded = expand_text_variables(template, meta)
+                cleaned = _normalise(expanded)
+                if cleaned:
+                    return cleaned
         except Exception:
             pass
 
-        cleaned = _normalise(expanded)
-        if cleaned:
-            return cleaned
-
-        # Final fallback: PCB filename stem.
+        # Fallback: PCB filename stem.
         try:
-            pcb_path: str = board.GetFileName()  # type: ignore[union-attr]
             if pcb_path:
                 stem = _normalise(Path(pcb_path).stem)
                 if stem:

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -11,8 +11,20 @@ progress view) is implemented in Session B.
 """
 
 from __future__ import annotations
+import sys
 
 import pcbnew  # noqa: F401 — only imported inside KiCad, safe here
+
+
+def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
+    """Diagnostic trace — REMOVE before production."""
+    modified = ""
+    if board is not None:
+        try:
+            modified = f"  IsModified={board.IsModified()}"
+        except Exception as exc:
+            modified = f"  IsModified=ERR({exc})"
+    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
 
 
 class JBOMFabricationPlugin(pcbnew.ActionPlugin):
@@ -38,9 +50,11 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
     def Run(self) -> None:  # noqa: N802 — KiCad API name
         """Open the jBOM Fabrication dialog."""
         try:
+            _board = pcbnew.GetBoard()
+            _trace("Run() entry", _board)
             self._run_impl()
+            _trace("Run() exit (dialog shown)", _board)
         except Exception:  # pragma: no cover
-            import sys
             import traceback
 
             traceback.print_exc(file=sys.stderr)
@@ -49,6 +63,7 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
         """Implementation body of Run(); separated for exception tracing."""
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
+        _trace("_run_impl() after GetBoard/GetFileName", board)
 
         # Load persisted options to get the archive name template.
         from pathlib import Path
@@ -57,16 +72,21 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
         options = load_options(Path(pcb_path)) if pcb_path else None
         template = options.archive_name_template if options else "${TITLE}_${REVISION}"
+        _trace("_run_impl() after load_options", board)
 
         # Expand the template using pcbnew's own variable expander so that
         # custom project-level variables (defined in .kicad_pro) are honoured
         # in addition to the standard title block variables.
+        _trace("_run_impl() before _expand_archive_template", board)
         archive_name = self._expand_archive_template(board, template)
+        _trace(f"_run_impl() after _expand_archive_template → '{archive_name}'", board)
 
         from .dialog import JBOMFabricationDialog
 
         dlg = JBOMFabricationDialog(pcb_path=pcb_path, archive_name=archive_name)
+        _trace("_run_impl() before dlg.Show()", board)
         dlg.Show()
+        _trace("_run_impl() after dlg.Show() (returns immediately — modeless)", board)
 
     @staticmethod
     def _expand_archive_template(board: object, template: str) -> str:
@@ -89,8 +109,11 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
         try:
             # Attempt pcbnew.ExpandTextVars first for full variable support.
+            _trace("  _expand: before GetProject", board)
             project = board.GetProject()  # type: ignore[union-attr]
+            _trace("  _expand: after GetProject", board)
             expanded = pcbnew.ExpandTextVars(template, project)
+            _trace("  _expand: after ExpandTextVars", board)
         except Exception:
             expanded = template
 
@@ -99,7 +122,9 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
             from jbom.common.types import TitleBlockMetadata
             from jbom.services.text_variable_expander import expand_text_variables
 
+            _trace("  _expand: before GetTitleBlock", board)
             tb = board.GetTitleBlock()  # type: ignore[union-attr]
+            _trace("  _expand: after GetTitleBlock", board)
             meta = TitleBlockMetadata(
                 title=(tb.GetTitle() or "").strip(),
                 revision=(tb.GetRevision() or "").strip(),

--- a/src/jbom/plugin/zone_filler.py
+++ b/src/jbom/plugin/zone_filler.py
@@ -13,6 +13,17 @@ from __future__ import annotations
 __all__ = ["fill_zones_if_needed"]
 
 
+def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
+    """Diagnostic trace — REMOVE before production."""
+    modified = ""
+    if board is not None:
+        try:
+            modified = f"  IsModified={board.IsModified()}"
+        except Exception as exc:
+            modified = f"  IsModified=ERR({exc})"
+    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
+
+
 def fill_zones_if_needed(pcb_path: str) -> bool:
     """Fill board zones only if actually needed; auto-save when fill runs.
 
@@ -42,9 +53,21 @@ def fill_zones_if_needed(pcb_path: str) -> bool:
 
         board = pcbnew.GetBoard()
         if not board:
+            _trace("fill_zones_if_needed: no board")
             return False
 
+        _trace("fill_zones_if_needed: entry", board)
         zones = list(board.Zones())
+        _trace(f"fill_zones_if_needed: {len(zones)} zone(s) found", board)
+
+        # Check each zone for stale/unfilled status
+        for i, z in enumerate(zones):
+            try:
+                is_f = z.IsFilled()
+                need_r = z.GetNeedRefill() if hasattr(z, "GetNeedRefill") else "N/A"
+                _trace(f"  zone[{i}]: IsFilled={is_f}  GetNeedRefill={need_r}", board)
+            except Exception as exc:
+                _trace(f"  zone[{i}]: ERR({exc})", board)
 
         # Skip fill if all zones are already filled and not stale.
         # GetNeedRefill() was added in KiCad 7; guard for older builds.
@@ -53,24 +76,40 @@ def fill_zones_if_needed(pcb_path: str) -> bool:
             for z in zones
         )
         if already_current:
+            _trace("fill_zones_if_needed: all zones current — skipping Fill()", board)
             return False  # No-op: board state untouched
 
         # Zones need filling — fill then immediately save.
+        _trace("fill_zones_if_needed: calling ZONE_FILLER.Fill()", board)
         pcbnew.ZONE_FILLER(board).Fill(board.Zones())
+        _trace("fill_zones_if_needed: after ZONE_FILLER.Fill()", board)
 
         # Auto-save: keep source file in sync with filled state used for
         # Gerbers and backup.  Try pcbnew.SaveBoard() first (standard
         # KiCad 7+ API), fall back to board.Save() for older builds.
         if pcb_path:
             try:
+                _trace(f"fill_zones_if_needed: calling SaveBoard('{pcb_path}')", board)
                 pcbnew.SaveBoard(pcb_path, board)
-            except Exception:  # pragma: no cover
+                _trace("fill_zones_if_needed: after SaveBoard()", board)
+            except Exception as exc:  # pragma: no cover
+                _trace(
+                    f"fill_zones_if_needed: SaveBoard failed ({exc}), trying board.Save()",
+                    board,
+                )
                 try:
                     board.Save(pcb_path)
-                except Exception:  # pragma: no cover
-                    pass  # Non-fatal: Gerbers still use filled in-memory board
+                    _trace("fill_zones_if_needed: after board.Save()", board)
+                except Exception as exc2:  # pragma: no cover
+                    _trace(
+                        f"fill_zones_if_needed: board.Save() also failed ({exc2})",
+                        board,
+                    )
+        else:
+            _trace("fill_zones_if_needed: no pcb_path — skipping save", board)
 
         return True
 
-    except Exception:  # pragma: no cover
+    except Exception as exc:  # pragma: no cover
+        _trace(f"fill_zones_if_needed: EXCEPTION {exc}")
         return False  # Non-fatal; caller proceeds with generation

--- a/src/jbom/plugin/zone_filler.py
+++ b/src/jbom/plugin/zone_filler.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 __all__ = ["fill_zones_if_needed"]
 
 
+_TRACE_LOG = "/tmp/jbom_trace.log"
+
+
 def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
     """Diagnostic trace — REMOVE before production."""
     modified = ""
@@ -21,7 +24,13 @@ def _trace(label: str, board: object | None = None) -> None:  # pragma: no cover
             modified = f"  IsModified={board.IsModified()}"
         except Exception as exc:
             modified = f"  IsModified=ERR({exc})"
-    print(f"[jBOM-TRACE] {label}{modified}", flush=True)
+    msg = f"[jBOM-TRACE] {label}{modified}"
+    print(msg, flush=True)
+    try:
+        with open(_TRACE_LOG, "a") as _f:
+            _f.write(msg + "\n")
+    except Exception:
+        pass
 
 
 def fill_zones_if_needed(pcb_path: str) -> bool:


### PR DESCRIPTION
DO NOT MERGE — investigation branch only. Production fixes shipped in PR #258.

## Purpose

This branch instruments the full plugin lifecycle with `[jBOM-TRACE]` `print()` + `/tmp/jbom_trace.log` file output to confirm the exact source of the board dirty flag described in issue #255.

## Findings

**Dialog open**: `Run()` exits with `IsModified=False` through all SWIG reads. NOT caused by jBOM code.

**Generate →** `*`: `PLOT_CONTROLLER.SetOutputDirectory()` and related setters modify persisted board plot settings, setting the dirty flag. `pcbnew.SaveBoard()` from a background thread writes the file but does NOT reach the KiCad C++ editor frame dirty-state tracker — the `*`/save-dialog behavior cannot be cleared from plugin Python code.

**Confirmed**: Interactive HTML BOM plugin does not dirty the board (it never calls `SetOutputDirectory()`). FT has the same dirty-on-generate behavior as jBOM.

## Production fixes (shipped in #258, not this branch)
- File-based archive template expansion (no SWIG reads)
- Cached title block metadata in dialog `__init__`
- Plot output directory restored after Gerbers
- `pcbnew.SaveBoard()` after Gerbers (board file stays in sync)

Closing as superseded by #258.

Co-Authored-By: Oz <oz-agent@warp.dev>