### PR TITLE
refactor(diagnostics): typed Diagnostic(severity, message) across all result contracts (#245)

### DIFF
--- a/src/jbom/application/bom_workflow.py
+++ b/src/jbom/application/bom_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
+from jbom.common.types import Diagnostic
 from jbom.common.field_parser import (
     check_fabricator_field_completeness,
     parse_fields_argument,
@@ -137,7 +138,7 @@ class BOMResult:
     """Result contract emitted by BOM application orchestration."""
 
     mode: BOMMode
-    diagnostics: tuple[str, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
     field_listing: BOMFieldListingPayload | None = None
     generation: BOMGenerationPayload | None = None
 
@@ -223,7 +224,7 @@ class BOMWorkflow:
     def _generate(self, request: BOMRequest) -> BOMResult:
         """Run BOM generation sequencing independent from CLI adapter concerns."""
 
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         options = GeneratorOptions(verbose=request.verbose) if request.verbose else None
         resolver = ProjectFileResolver(
             prefer_pcb=False,
@@ -234,17 +235,27 @@ class BOMWorkflow:
 
         if not resolved_input.is_schematic:
             diagnostics.append(
-                "Note: BOM generation requires a schematic file. "
-                f"Found {resolved_input.resolved_path.suffix} file, trying to find matching schematic."
+                Diagnostic(
+                    "info",
+                    "Note: BOM generation requires a schematic file. "
+                    f"Found {resolved_input.resolved_path.suffix} file, trying to find matching schematic.",
+                )
             )
             resolved_input = resolver.resolve_for_wrong_file_type(
                 resolved_input,
                 "schematic",
             )
             diagnostics.append(
-                f"found matching schematic {resolved_input.resolved_path.name}"
+                Diagnostic(
+                    "info",
+                    f"found matching schematic {resolved_input.resolved_path.name}",
+                )
             )
-            diagnostics.append(f"Using schematic: {resolved_input.resolved_path.name}")
+            diagnostics.append(
+                Diagnostic(
+                    "info", f"Using schematic: {resolved_input.resolved_path.name}"
+                )
+            )
 
         if not resolved_input.project_context:
             raise ValueError("No project context available")
@@ -261,14 +272,18 @@ class BOMWorkflow:
         schematic_files = list(hierarchical_files)
         if request.verbose and len(hierarchical_files) > 1:
             diagnostics.append(
-                "Processing hierarchical design with "
-                f"{len(hierarchical_files)} schematic files"
+                Diagnostic(
+                    "info",
+                    f"Processing hierarchical design with {len(hierarchical_files)} schematic files",
+                )
             )
 
         components = []
         for schematic_file in hierarchical_files:
             if request.verbose:
-                diagnostics.append(f"Loading components from {schematic_file.name}")
+                diagnostics.append(
+                    Diagnostic("info", f"Loading components from {schematic_file.name}")
+                )
             file_components = reader.load_components(schematic_file)
             components.extend(file_components)
 
@@ -289,7 +304,9 @@ class BOMWorkflow:
             fabricator_presets,
         )
         if request.verbose:
-            diagnostics.append(f"Selected fields: {', '.join(selected_fields)}")
+            diagnostics.append(
+                Diagnostic("info", f"Selected fields: {', '.join(selected_fields)}")
+            )
 
         if request.fields_argument:
             warning = check_fabricator_field_completeness(
@@ -298,7 +315,7 @@ class BOMWorkflow:
                 fabricator_presets,
             )
             if warning:
-                diagnostics.append(warning)
+                diagnostics.append(Diagnostic("warning", warning))
 
         filters = dict(request.filter_config)
         bom_data = generator.generate_bom_data(components, project_name, filters)
@@ -309,15 +326,20 @@ class BOMWorkflow:
         if request.inventory_files:
             if request.verbose:
                 diagnostics.append(
-                    f"Enhancing BOM with {len(request.inventory_files)} inventory file(s)"
+                    Diagnostic(
+                        "info",
+                        f"Enhancing BOM with {len(request.inventory_files)} inventory file(s)",
+                    )
                 )
             inventory_file = Path(request.inventory_files[0])
             if not inventory_file.exists():
                 raise ValueError(f"Inventory file not found: {inventory_file}")
             if len(request.inventory_files) > 1 and request.verbose:
                 diagnostics.append(
-                    "Note: Using primary inventory file "
-                    f"{inventory_file}, multi-file enhancement coming soon"
+                    Diagnostic(
+                        "info",
+                        f"Note: Using primary inventory file {inventory_file}, multi-file enhancement coming soon",
+                    )
                 )
 
         include_inventory_dnp = not filters.get("exclude_dnp", True)
@@ -368,10 +390,10 @@ def run_component_merge(
     schematic_files: list[Path],
     pcb_file: Optional[Path],
     verbose: bool,
-) -> tuple[ComponentMergeResult | None, tuple[str, ...]]:
+) -> tuple[ComponentMergeResult | None, tuple[Diagnostic, ...]]:
     """Best-effort collector/merge execution for canonical namespace enrichment."""
 
-    diagnostics: list[str] = []
+    diagnostics: list[Diagnostic] = []
     try:
         pcb_components = []
         if pcb_file is not None and pcb_file.exists():
@@ -389,15 +411,21 @@ def run_component_merge(
 
         if verbose:
             diagnostics.append(
-                "Merge model active: "
-                f"{project_graph.reference_count} references, "
-                f"{len(merge_result.mismatches)} mismatch record(s)"
+                Diagnostic(
+                    "info",
+                    "Merge model active: "
+                    f"{project_graph.reference_count} references, "
+                    f"{len(merge_result.mismatches)} mismatch record(s)",
+                )
             )
         return merge_result, tuple(diagnostics)
     except Exception as exc:
         if verbose:
             diagnostics.append(
-                f"Warning: merge model execution skipped due to error: {exc}"
+                Diagnostic(
+                    "warning",
+                    f"Warning: merge model execution skipped due to error: {exc}",
+                )
             )
         return None, tuple(diagnostics)
 
@@ -539,10 +567,10 @@ def _load_pcb_smd_lookup(
     pcb_file: Optional[Path],
     *,
     verbose: bool = False,
-) -> tuple[dict[str, bool], tuple[str, ...]]:
+) -> tuple[dict[str, bool], tuple[Diagnostic, ...]]:
     """Return reference->is_smd lookup from a KiCad PCB file plus diagnostics."""
 
-    diagnostics: list[str] = []
+    diagnostics: list[Diagnostic] = []
     if pcb_file is None or not pcb_file.exists():
         return {}, tuple(diagnostics)
 
@@ -551,7 +579,10 @@ def _load_pcb_smd_lookup(
     except Exception as exc:
         if verbose:
             diagnostics.append(
-                f"Warning: Could not read PCB mount metadata from {pcb_file}: {exc}"
+                Diagnostic(
+                    "warning",
+                    f"Warning: Could not read PCB mount metadata from {pcb_file}: {exc}",
+                )
             )
         return {}, tuple(diagnostics)
 
@@ -591,7 +622,7 @@ def enrich_bom_smd_from_project_pcb(
     pcb_file: Optional[Path],
     *,
     verbose: bool = False,
-) -> tuple[BOMData, tuple[str, ...]]:
+) -> tuple[BOMData, tuple[Diagnostic, ...]]:
     """Populate missing BOM `smd` attributes from PCB mount metadata."""
 
     smd_by_reference, diagnostics = _load_pcb_smd_lookup(pcb_file, verbose=verbose)

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -42,6 +42,7 @@ from jbom.application.pos_workflow import (
     POSResult,
     POSWorkflow,
 )
+from jbom.common.types import Diagnostic
 from jbom.services.gerber_service import GerberExporter, GerberRequest, GerberResult
 
 __all__ = [
@@ -209,7 +210,7 @@ class FabricationResult:
     """
 
     artifacts: tuple[FabricationArtifact, ...]
-    diagnostics: tuple[str, ...]
+    diagnostics: tuple[Diagnostic, ...]
     bom_result: BOMResult | None = None
     pos_result: POSResult | None = None
     gerber_result: GerberResult | None = None
@@ -268,7 +269,7 @@ class FabricationWorkflow:
             :class:`FabricationResult` aggregating BOM, POS, and Gerber outputs,
             with all files written to the production/ directory when appropriate.
         """
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         artifacts: list[FabricationArtifact] = []
         bom_result: BOMResult | None = None
         pos_result: POSResult | None = None
@@ -287,7 +288,9 @@ class FabricationWorkflow:
             try:
                 production_dir.mkdir(parents=True, exist_ok=True)
             except OSError as exc:
-                diagnostics.append(f"Failed to create production directory: {exc}")
+                diagnostics.append(
+                    Diagnostic("error", f"Failed to create production directory: {exc}")
+                )
                 return FabricationResult(
                     artifacts=tuple(artifacts),
                     diagnostics=tuple(diagnostics),
@@ -318,7 +321,9 @@ class FabricationWorkflow:
 
                         BOMWriter.write(bom_result.generation, bom_path, force=True)
                     except Exception as exc:
-                        diagnostics.append(f"BOM write failed: {exc}")
+                        diagnostics.append(
+                            Diagnostic("error", f"BOM write failed: {exc}")
+                        )
                         bom_path = None
                 else:
                     bom_path = bom_result.generation.default_output_path
@@ -352,7 +357,9 @@ class FabricationWorkflow:
 
                         POSWriter.write(pos_result.generation, pos_path, force=True)
                     except Exception as exc:
-                        diagnostics.append(f"POS write failed: {exc}")
+                        diagnostics.append(
+                            Diagnostic("error", f"POS write failed: {exc}")
+                        )
                         pos_path = None
                 else:
                     pos_path = pos_result.generation.default_output_path
@@ -374,7 +381,9 @@ class FabricationWorkflow:
                 step_callback("gerbers", "start")
             if request.dry_run:
                 diagnostics.append(
-                    "Dry run: Gerber generation skipped (no files written)."
+                    Diagnostic(
+                        "info", "Dry run: Gerber generation skipped (no files written)."
+                    )
                 )
             else:
                 (
@@ -431,9 +440,9 @@ class FabricationWorkflow:
 
     def _run_bom(
         self, request: FabricationRequest
-    ) -> tuple[BOMResult | None, list[str]]:
+    ) -> tuple[BOMResult | None, list[Diagnostic]]:
         """Run BOM orchestration and return result + diagnostics."""
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         try:
             bom_request = BOMRequest(
                 input_path=request.input_path,
@@ -445,14 +454,14 @@ class FabricationWorkflow:
             diagnostics.extend(result.diagnostics)
             return result, diagnostics
         except Exception as exc:
-            diagnostics.append(f"BOM generation failed: {exc}")
+            diagnostics.append(Diagnostic("error", f"BOM generation failed: {exc}"))
             return None, diagnostics
 
     def _run_pos(
         self, request: FabricationRequest
-    ) -> tuple[POSResult | None, list[str]]:
+    ) -> tuple[POSResult | None, list[Diagnostic]]:
         """Run POS orchestration and return result + diagnostics."""
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         try:
             pos_request = POSRequest(
                 input_path=request.input_path,
@@ -466,14 +475,14 @@ class FabricationWorkflow:
             diagnostics.extend(result.diagnostics)
             return result, diagnostics
         except Exception as exc:
-            diagnostics.append(f"POS generation failed: {exc}")
+            diagnostics.append(Diagnostic("error", f"POS generation failed: {exc}"))
             return None, diagnostics
 
     def _run_gerbers(
         self, request: FabricationRequest
-    ) -> tuple[GerberResult | None, list[str]]:
+    ) -> tuple[GerberResult | None, list[Diagnostic]]:
         """Resolve PCB file and run GerberExporter."""
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
 
         pcb_file, project_dir, resolve_diags = self._resolve_pcb_and_project_dir(
             request
@@ -482,8 +491,11 @@ class FabricationWorkflow:
 
         if pcb_file is None:
             diagnostics.append(
-                "Gerber generation skipped: PCB file could not be resolved "
-                "from the given input path."
+                Diagnostic(
+                    "warning",
+                    "Gerber generation skipped: PCB file could not be resolved "
+                    "from the given input path.",
+                )
             )
             return None, diagnostics
 
@@ -497,18 +509,20 @@ class FabricationWorkflow:
             result = GerberExporter().generate(gerber_request)
             return result, diagnostics
         except Exception as exc:
-            diagnostics.append(f"Gerber generation failed unexpectedly: {exc}")
+            diagnostics.append(
+                Diagnostic("error", f"Gerber generation failed unexpectedly: {exc}")
+            )
             return None, diagnostics
 
     def _resolve_pcb_and_project_dir(
         self, request: FabricationRequest
-    ) -> tuple[Path | None, Path | None, list[str]]:
+    ) -> tuple[Path | None, Path | None, list[Diagnostic]]:
         """Resolve PCB file path and project directory from input_path.
 
         Returns:
             ``(pcb_file, project_directory, diagnostics)``
         """
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         try:
             from jbom.services.project_file_resolver import ProjectFileResolver
 
@@ -525,7 +539,9 @@ class FabricationWorkflow:
             return pcb_file, project_dir, diagnostics
         except Exception as exc:
             if request.verbose:
-                diagnostics.append(f"Note: could not resolve PCB file: {exc}")
+                diagnostics.append(
+                    Diagnostic("info", f"Note: could not resolve PCB file: {exc}")
+                )
             return None, None, diagnostics
 
     def _resolve_archive_stem(
@@ -582,7 +598,7 @@ class FabricationWorkflow:
         self,
         request: FabricationRequest,
         production_dir: Path | None,
-    ) -> tuple[list[FabricationArtifact], GerberResult | None, list[str]]:
+    ) -> tuple[list[FabricationArtifact], GerberResult | None, list[Diagnostic]]:
         """Generate Gerbers to temp dir, package to production/, return artifacts.
 
         Returns:
@@ -591,11 +607,15 @@ class FabricationWorkflow:
             gerber_result carries the raw GerberExporter result for diagnostics.
         """
         artifacts: list[FabricationArtifact] = []
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         gerber_result: GerberResult | None = None
 
         if production_dir is None:
-            diagnostics.append("Production dir not available for gerber packaging.")
+            diagnostics.append(
+                Diagnostic(
+                    "warning", "Production dir not available for gerber packaging."
+                )
+            )
             return artifacts, gerber_result, diagnostics
 
         # Generate gerbers to a temporary directory
@@ -619,7 +639,10 @@ class FabricationWorkflow:
 
                 if gerber_result is None or gerber_result.skipped:
                     diagnostics.append(
-                        "Gerber generation skipped or failed; no artifacts to package."
+                        Diagnostic(
+                            "warning",
+                            "Gerber generation skipped or failed; no artifacts to package.",
+                        )
                     )
                     return artifacts, gerber_result, diagnostics
 
@@ -647,10 +670,14 @@ class FabricationWorkflow:
                         )
                     )
                 except Exception as exc:
-                    diagnostics.append(f"Gerber packaging failed: {exc}")
+                    diagnostics.append(
+                        Diagnostic("error", f"Gerber packaging failed: {exc}")
+                    )
 
         except Exception as exc:
-            diagnostics.append(f"Gerber generation or packaging failed: {exc}")
+            diagnostics.append(
+                Diagnostic("error", f"Gerber generation or packaging failed: {exc}")
+            )
 
         return artifacts, gerber_result, diagnostics
 
@@ -659,14 +686,14 @@ class FabricationWorkflow:
         request: FabricationRequest,
         artifact_paths: list[Path],
         production_dir: Path,
-    ) -> tuple[Path | None, list[str]]:
+    ) -> tuple[Path | None, list[Diagnostic]]:
         """Create a dated backup archive of all production artifacts.
 
         Returns:
             ``(backup_archive_path, diagnostics)`` where backup_archive_path
             is None if backup creation failed.
         """
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
 
         try:
             from jbom.services.backup_service import BackupService
@@ -692,7 +719,7 @@ class FabricationWorkflow:
             return backup_archive, diagnostics
 
         except Exception as exc:
-            diagnostics.append(f"Backup creation failed: {exc}")
+            diagnostics.append(Diagnostic("error", f"Backup creation failed: {exc}"))
             return None, diagnostics
 
     def _resolve_gerber_output_dir(

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Mapping
 
+from jbom.common.types import Diagnostic
 from jbom.common.field_parser import parse_fields_argument
 from jbom.common.fields import field_to_header
 from jbom.common.options import GeneratorOptions, PlacementOptions
@@ -140,7 +141,7 @@ class POSResult:
     """Result contract emitted by POS application orchestration."""
 
     mode: POSMode
-    diagnostics: tuple[str, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
     field_listing: POSFieldListingPayload | None = None
     generation: POSGenerationPayload | None = None
 
@@ -171,9 +172,9 @@ def run_pos_component_merge(
     schematic_files: list[Path],
     pcb_file: Path | None,
     verbose: bool,
-) -> tuple[ComponentMergeResult | None, tuple[str, ...]]:
+) -> tuple[ComponentMergeResult | None, tuple[Diagnostic, ...]]:
     """Best-effort collector/merge execution for POS namespace enrichment."""
-    diagnostics: list[str] = []
+    diagnostics: list[Diagnostic] = []
 
     try:
         collector = ProjectComponentCollector()
@@ -187,15 +188,21 @@ def run_pos_component_merge(
         merge_result = merge_service.merge(project_graph)
         if verbose:
             diagnostics.append(
-                "Merge model active: "
-                f"{project_graph.reference_count} references, "
-                f"{len(merge_result.mismatches)} mismatch record(s)"
+                Diagnostic(
+                    "info",
+                    "Merge model active: "
+                    f"{project_graph.reference_count} references, "
+                    f"{len(merge_result.mismatches)} mismatch record(s)",
+                )
             )
         return merge_result, tuple(diagnostics)
     except Exception as exc:
         if verbose:
             diagnostics.append(
-                f"Warning: merge model execution skipped due to error: {exc}"
+                Diagnostic(
+                    "warning",
+                    f"Warning: merge model execution skipped due to error: {exc}",
+                )
             )
         return None, tuple(diagnostics)
 
@@ -445,7 +452,7 @@ class POSWorkflow:
         request: POSRequest,
     ) -> POSResult:
         """Execute POS orchestration and return adapter-ready output payloads."""
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
 
         gen_options = (
             GeneratorOptions(verbose=request.verbose) if request.verbose else None
@@ -459,14 +466,21 @@ class POSWorkflow:
 
         if not resolved_input.is_pcb:
             diagnostics.append(
-                "Note: POS generation requires a PCB file. "
-                f"Found {resolved_input.resolved_path.suffix} file, trying to find matching PCB."
+                Diagnostic(
+                    "info",
+                    "Note: POS generation requires a PCB file. "
+                    f"Found {resolved_input.resolved_path.suffix} file, trying to find matching PCB.",
+                )
             )
             resolved_input = resolver.resolve_for_wrong_file_type(resolved_input, "pcb")
             diagnostics.append(
-                f"found matching PCB {resolved_input.resolved_path.name}"
+                Diagnostic(
+                    "info", f"found matching PCB {resolved_input.resolved_path.name}"
+                )
             )
-            diagnostics.append(f"Using PCB: {resolved_input.resolved_path.name}")
+            diagnostics.append(
+                Diagnostic("info", f"Using PCB: {resolved_input.resolved_path.name}")
+            )
 
         pcb_file = resolved_input.resolved_path
         if not resolved_input.project_context:
@@ -481,7 +495,7 @@ class POSWorkflow:
         try:
             hier_files = list(project_context.get_hierarchical_schematic_files())
             if hier_files and len(hier_files) > 1:
-                diagnostics.append("Processing hierarchical design")
+                diagnostics.append(Diagnostic("info", "Processing hierarchical design"))
         except Exception:
             pass
 
@@ -491,7 +505,9 @@ class POSWorkflow:
             layer_filter=request.layer or None,
         )
         if request.verbose and request.include_dnp:
-            diagnostics.append("Including DNP components in POS output")
+            diagnostics.append(
+                Diagnostic("info", "Including DNP components in POS output")
+            )
 
         board = DefaultKiCadReaderService().read_pcb_file(pcb_file)
         pos_data = POSGenerator(placement_options).generate_pos_data(board)
@@ -507,8 +523,10 @@ class POSWorkflow:
         except Exception as exc:
             if request.verbose:
                 diagnostics.append(
-                    "Warning: could not load schematic files for merge enrichment: "
-                    f"{exc}"
+                    Diagnostic(
+                        "warning",
+                        f"Warning: could not load schematic files for merge enrichment: {exc}",
+                    )
                 )
 
         schematic_components: list[Any] = []
@@ -522,8 +540,10 @@ class POSWorkflow:
                 except Exception as exc:
                     if request.verbose:
                         diagnostics.append(
-                            "Warning: skipping schematic source for merge enrichment "
-                            f"({schematic_file}): {exc}"
+                            Diagnostic(
+                                "warning",
+                                f"Warning: skipping schematic source for merge enrichment ({schematic_file}): {exc}",
+                            )
                         )
         merge_result, merge_diagnostics = run_pos_component_merge(
             schematic_components=schematic_components,

--- a/src/jbom/cli/fabrication.py
+++ b/src/jbom/cli/fabrication.py
@@ -227,8 +227,10 @@ def _execute_fab_command(args) -> int:  # type: ignore[type-arg]
         )
 
         result = FabricationWorkflow().run(request)
-        for diag in result.diagnostics:
-            print(diag, file=sys.stderr)
+        for d in result.diagnostics:
+            if d.severity == "info" and not bool(getattr(args, "verbose", False)):
+                continue
+            print(d.message, file=sys.stderr)
         if result.production_dir is not None:
             print(f"Production directory: {result.production_dir}")
         if result.backup_archive is not None:

--- a/src/jbom/cli/gerbers.py
+++ b/src/jbom/cli/gerbers.py
@@ -182,8 +182,10 @@ def _execute_gerbers_command(args) -> int:  # type: ignore[type-arg]
 
 def _render_gerber_result(result: GerberResult, *, verbose: bool) -> int:
     """Print GerberResult diagnostics and artifact paths; return exit code."""
-    for diagnostic in result.diagnostics:
-        print(diagnostic, file=sys.stderr)
+    for d in result.diagnostics:
+        if d.severity == "info" and not verbose:
+            continue
+        print(d.message, file=sys.stderr)
 
     if result.skipped:
         print(

--- a/src/jbom/common/types.py
+++ b/src/jbom/common/types.py
@@ -1,8 +1,37 @@
 """Data classes for jBOM components and inventory items."""
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Dict, Literal, Optional
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A typed diagnostic message emitted by jBOM services and workflows.
+
+    Carrying severity on every diagnostic enables adapters to filter or
+    render messages without parsing message text:
+
+    * ``"info"``    — informational note; CLI adapters gate on ``--verbose``.
+    * ``"warning"`` — potential issue; always displayed.
+    * ``"error"``   — generation step failed; always displayed.
+
+    Attributes:
+        severity: Severity level token.
+        message:  Human-readable diagnostic text.
+    """
+
+    severity: Literal["info", "warning", "error"]
+    message: str
+
+    def __post_init__(self) -> None:
+        if self.severity not in ("info", "warning", "error"):
+            raise ValueError(
+                f"Diagnostic severity must be 'info', 'warning', or 'error'; "
+                f"got {self.severity!r}"
+            )
+        object.__setattr__(self, "message", str(self.message))
+
 
 # Default priority value
 DEFAULT_PRIORITY = 99
@@ -95,6 +124,7 @@ class InventoryItem:
 __all__ = [
     "DEFAULT_PRIORITY",
     "Component",
+    "Diagnostic",
     "InventoryItem",
     "TitleBlockMetadata",
 ]

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -477,7 +477,9 @@ class JBOMFabricationDialog(wx.Dialog):
                 production_dir = project_dir / "production"
                 production_dir.mkdir(parents=True, exist_ok=True)
 
-                diagnostics: list[str] = []
+                from jbom.common.types import Diagnostic as _Diag  # noqa: PLC0415
+
+                diagnostics: list[_Diag] = []
                 artifact_paths: list[Path] = []
 
                 def cancelled() -> bool:
@@ -509,7 +511,9 @@ class JBOMFabricationDialog(wx.Dialog):
                             BOMWriter.write(bom_result.generation, bom_path, force=True)
                             artifact_paths.append(bom_path)
                     except Exception as exc:
-                        diagnostics.append(f"BOM generation failed: {exc}")
+                        diagnostics.append(
+                            _Diag("error", f"BOM generation failed: {exc}")
+                        )
                 _step("bom", "done")
 
                 # ----------------------------------------------------------
@@ -536,7 +540,9 @@ class JBOMFabricationDialog(wx.Dialog):
                             POSWriter.write(pos_result.generation, pos_path, force=True)
                             artifact_paths.append(pos_path)
                     except Exception as exc:
-                        diagnostics.append(f"POS generation failed: {exc}")
+                        diagnostics.append(
+                            _Diag("error", f"POS generation failed: {exc}")
+                        )
                 _step("pos", "done")
 
                 # ----------------------------------------------------------
@@ -568,7 +574,9 @@ class JBOMFabricationDialog(wx.Dialog):
                                 )
                                 artifact_paths.append(gerber_zip)
                     except Exception as exc:
-                        diagnostics.append(f"Gerber generation failed: {exc}")
+                        diagnostics.append(
+                            _Diag("error", f"Gerber generation failed: {exc}")
+                        )
                 _step("gerbers", "done")
 
                 # Auto-save after Gerbers: PLOT_CONTROLLER.SetOutputDirectory()
@@ -604,7 +612,9 @@ class JBOMFabricationDialog(wx.Dialog):
                             archive_stem,
                         )
                     except Exception as exc:
-                        diagnostics.append(f"Backup creation failed: {exc}")
+                        diagnostics.append(
+                            _Diag("error", f"Backup creation failed: {exc}")
+                        )
                 _step("backup", "done")
 
                 # Build a lightweight result carrier for _on_complete.
@@ -682,7 +692,15 @@ class JBOMFabricationDialog(wx.Dialog):
         if stay_open:
             # Show diagnostics and switch Cancel → Close.
             if diagnostics:
-                self._diag_text.SetValue("\n".join(str(d) for d in diagnostics))
+                # Render with severity prefix for warnings/errors; info shown plain.
+                lines = []
+                for d in diagnostics:
+                    prefix = {"warning": "⚠ ", "error": "✗ "}.get(
+                        getattr(d, "severity", ""), ""
+                    )
+                    msg = getattr(d, "message", str(d))
+                    lines.append(f"{prefix}{msg}")
+                self._diag_text.SetValue("\n".join(lines))
                 self._diag_text.Show()
                 self.GetSizer().Layout()
                 self.GetSizer().Fit(self)

--- a/src/jbom/plugin/gerber_generator.py
+++ b/src/jbom/plugin/gerber_generator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from jbom.common.types import Diagnostic
 from jbom.services.gerber_service import GerberResult
 
 __all__ = ["PcbnewGerberGenerator"]
@@ -89,7 +90,7 @@ class PcbnewGerberGenerator:
         """
         import pcbnew  # noqa: PLC0415 — only executed inside KiCad
 
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         artifacts_before_drill: list[Path] = []
 
         output_dir = Path(output_dir)
@@ -98,7 +99,11 @@ class PcbnewGerberGenerator:
         except OSError as exc:
             return GerberResult(
                 artifacts=(),
-                diagnostics=(f"Could not create Gerber output directory: {exc}",),
+                diagnostics=(
+                    Diagnostic(
+                        "error", f"Could not create Gerber output directory: {exc}"
+                    ),
+                ),
                 skipped=True,
                 skip_reason="output_dir_error",
             )
@@ -156,7 +161,10 @@ class PcbnewGerberGenerator:
 
                     if layer_id == undefined_layer:
                         diagnostics.append(
-                            f"Gerber: layer {layer_name!r} not present on this board — skipped."
+                            Diagnostic(
+                                "info",
+                                f"Gerber: layer {layer_name!r} not present on this board — skipped.",
+                            )
                         )
                         continue
 
@@ -183,7 +191,7 @@ class PcbnewGerberGenerator:
                     pass
 
         except Exception as exc:
-            diagnostics.append(f"Gerber plotting failed: {exc}")
+            diagnostics.append(Diagnostic("error", f"Gerber plotting failed: {exc}"))
             return GerberResult(
                 artifacts=(),
                 diagnostics=tuple(diagnostics),
@@ -218,7 +226,10 @@ class PcbnewGerberGenerator:
 
         except Exception as exc:
             diagnostics.append(
-                f"Drill file generation failed (Gerbers were written): {exc}"
+                Diagnostic(
+                    "error",
+                    f"Drill file generation failed (Gerbers were written): {exc}",
+                )
             )
             # Gerbers succeeded — return them even if drills failed.
             if artifacts_before_drill:
@@ -258,7 +269,7 @@ class PcbnewGerberGenerator:
     def _load_gerber_policy(
         self,
         fabricator: str,
-        diagnostics: list[str],
+        diagnostics: list[Diagnostic],
     ) -> tuple[list[str], bool, dict[str, Any]]:
         """Return ``(layers, protel_extensions, drill_config)`` from fabricator config.
 
@@ -289,7 +300,10 @@ class PcbnewGerberGenerator:
             return layers, protel, drill_cfg
         except Exception as exc:
             diagnostics.append(
-                f"Could not load Gerber policy for fabricator {fabricator!r} ({exc}); "
-                "using default layer set."
+                Diagnostic(
+                    "warning",
+                    f"Could not load Gerber policy for fabricator {fabricator!r} ({exc}); "
+                    "using default layer set.",
+                )
             )
             return list(_DEFAULT_LAYERS), True, {}

--- a/src/jbom/services/gerber_service.py
+++ b/src/jbom/services/gerber_service.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from jbom.common.kicad_runtime import is_running_inside_kicad
+from jbom.common.types import Diagnostic
 
 __all__ = [
     "GerberExporter",
@@ -202,7 +203,7 @@ class GerberResult:
     Attributes:
         artifacts: Paths of all files written to ``output_directory``.
             Empty when ``skipped`` is ``True``.
-        diagnostics: Human-readable messages emitted during generation.
+        diagnostics: Typed diagnostic messages emitted during generation.
             Always present; may be empty on clean success.
         skipped: ``True`` when generation could not proceed (e.g. missing
             ``kicad-cli``, missing PCB file, or plugin-mode stub).
@@ -212,7 +213,7 @@ class GerberResult:
     """
 
     artifacts: tuple[Path, ...]
-    diagnostics: tuple[str, ...]
+    diagnostics: tuple[Diagnostic, ...]
     skipped: bool = False
     skip_reason: str = ""
 
@@ -255,10 +256,13 @@ class GerberExporter:
         return GerberResult(
             artifacts=(),
             diagnostics=(
-                "Gerber generation via the pcbnew Python API is not yet implemented "
-                "(tracked in issue #227). "
-                "To generate Gerbers, run `jbom gerbers` from the command line "
-                "where kicad-cli is available.",
+                Diagnostic(
+                    "warning",
+                    "Gerber generation via the pcbnew Python API is not yet implemented "
+                    "(tracked in issue #227). "
+                    "To generate Gerbers, run `jbom gerbers` from the command line "
+                    "where kicad-cli is available.",
+                ),
             ),
             skipped=True,
             skip_reason="pcbnew_api_not_implemented",
@@ -270,7 +274,7 @@ class GerberExporter:
         if kicad_cli is None:
             return GerberResult(
                 artifacts=(),
-                diagnostics=(_kicad_cli_not_found_message(),),
+                diagnostics=(Diagnostic("error", _kicad_cli_not_found_message()),),
                 skipped=True,
                 skip_reason="kicad_cli_not_found",
             )
@@ -279,8 +283,10 @@ class GerberExporter:
             return GerberResult(
                 artifacts=(),
                 diagnostics=(
-                    f"PCB file not found: {request.pcb_file}. "
-                    "Gerber generation skipped.",
+                    Diagnostic(
+                        "error",
+                        f"PCB file not found: {request.pcb_file}. Gerber generation skipped.",
+                    ),
                 ),
                 skipped=True,
                 skip_reason="pcb_file_not_found",
@@ -288,7 +294,7 @@ class GerberExporter:
 
         request.output_directory.mkdir(parents=True, exist_ok=True)
 
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         artifacts: list[Path] = []
 
         # --- Gerbers ---
@@ -307,7 +313,7 @@ class GerberExporter:
         gerber_args.append(str(request.pcb_file))
         err = self._run_kicad_cli(kicad_cli, args=gerber_args, step="gerbers")
         if err:
-            diagnostics.append(err)
+            diagnostics.append(Diagnostic("error", err))
             return GerberResult(
                 artifacts=(),
                 diagnostics=tuple(diagnostics),
@@ -336,7 +342,7 @@ class GerberExporter:
             drill_args.append(str(request.pcb_file))
             err = self._run_kicad_cli(kicad_cli, args=drill_args, step="drill")
             if err:
-                diagnostics.append(err)
+                diagnostics.append(Diagnostic("error", err))
             else:
                 after = set(request.output_directory.iterdir())
                 artifacts.extend(sorted(after - before))
@@ -358,7 +364,7 @@ class GerberExporter:
                 step="netlist",
             )
             if err:
-                diagnostics.append(err)
+                diagnostics.append(Diagnostic("error", err))
             else:
                 after = set(request.output_directory.iterdir())
                 artifacts.extend(sorted(after - before))

--- a/tests/plugin/test_pcbnew_gerber_generator.py
+++ b/tests/plugin/test_pcbnew_gerber_generator.py
@@ -68,8 +68,10 @@ class TestLoadGerberPolicy:
         return PcbnewGerberGenerator(board=MagicMock())
 
     def test_returns_default_layers_when_fabricator_not_found(self) -> None:
+        from jbom.common.types import Diagnostic
+
         gen = self._make_generator()
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         with patch(
             "jbom.plugin.gerber_generator.PcbnewGerberGenerator._load_gerber_policy",
             wraps=gen._load_gerber_policy,
@@ -87,11 +89,13 @@ class TestLoadGerberPolicy:
         assert "Edge.Cuts" in layers
         assert protel is True
         assert drill_cfg == {}
-        assert any("nonexistent" in d for d in diagnostics)
+        assert any("nonexistent" in d.message for d in diagnostics)
 
     def test_returns_fabricator_config_layers_for_jlc(self) -> None:
+        from jbom.common.types import Diagnostic
+
         gen = self._make_generator()
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
         layers, protel, drill_cfg = gen._load_gerber_policy("jlc", diagnostics)
 
         # jlc.fab.yaml specifies 9 standard layers
@@ -103,10 +107,11 @@ class TestLoadGerberPolicy:
         assert diagnostics == []
 
     def test_returns_default_layers_when_gerbers_stanza_empty(self) -> None:
+        from jbom.common.types import Diagnostic
         from jbom.plugin.gerber_generator import _DEFAULT_LAYERS
 
         gen = self._make_generator()
-        diagnostics: list[str] = []
+        diagnostics: list[Diagnostic] = []
 
         fake_config = MagicMock()
         fake_config.gerbers = {}  # empty stanza
@@ -242,7 +247,7 @@ class TestGenerateLayerIteration:
         assert set_layer_calls[0] == call(0)
 
         # Diagnostic must mention the skipped layer
-        assert any("B.Cu" in d for d in result.diagnostics)
+        assert any("B.Cu" in d.message for d in result.diagnostics)
 
     def test_disabled_layer_is_silently_skipped(self, tmp_path: Path) -> None:
         """An explicitly disabled layer is skipped without a diagnostic."""
@@ -256,7 +261,7 @@ class TestGenerateLayerIteration:
         assert len(set_layer_calls) == 1
         assert set_layer_calls[0] == call(0)
         # No diagnostic for disabled layers
-        assert not any("B.Cu" in d for d in result.diagnostics)
+        assert not any("B.Cu" in d.message for d in result.diagnostics)
 
     def test_plot_controller_closed_after_loop(self, tmp_path: Path) -> None:
         """ClosePlot() is called regardless of how many layers were plotted."""
@@ -287,7 +292,7 @@ class TestGenerateLayerIteration:
 
         assert result.skipped is True
         assert result.skip_reason == "plot_error"
-        assert any("plotting" in d.lower() for d in result.diagnostics)
+        assert any("plotting" in d.message.lower() for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_bom_workflow.py
+++ b/tests/services/test_bom_workflow.py
@@ -151,4 +151,7 @@ def test_generation_orchestration_handles_cross_resolution_and_returns_payload(
         "/tmp/project-dir/project.bom.csv"
     )
     assert result.generation.selected_fields == ("reference", "quantity")
-    assert "found matching schematic project.kicad_sch" in result.diagnostics
+    assert any(
+        "found matching schematic project.kicad_sch" in d.message
+        for d in result.diagnostics
+    )

--- a/tests/services/test_fabrication_orchestration.py
+++ b/tests/services/test_fabrication_orchestration.py
@@ -156,7 +156,7 @@ class TestFabricationWorkflowDryRun:
             mock_gerber.assert_not_called()
 
         assert result.gerber_result is None
-        assert any("Dry run" in d for d in result.diagnostics)
+        assert any("Dry run" in d.message for d in result.diagnostics)
 
     def test_dry_run_still_processes_bom(self) -> None:
         """dry_run=True should NOT block BOM generation (only Gerbers)."""
@@ -255,7 +255,7 @@ class TestFabricationWorkflowSubServiceFailure:
             result = FabricationWorkflow().run(request)
 
         assert result.bom_result is None
-        assert any("BOM generation failed" in d for d in result.diagnostics)
+        assert any("BOM generation failed" in d.message for d in result.diagnostics)
 
     def test_pos_failure_captured_as_diagnostic(self) -> None:
         request = FabricationRequest(
@@ -270,7 +270,7 @@ class TestFabricationWorkflowSubServiceFailure:
             result = FabricationWorkflow().run(request)
 
         assert result.pos_result is None
-        assert any("POS generation failed" in d for d in result.diagnostics)
+        assert any("POS generation failed" in d.message for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gerber_service.py
+++ b/tests/unit/test_gerber_service.py
@@ -360,7 +360,7 @@ class TestGerberExporterNoKicadCli:
 
         assert result.skipped is True
         assert result.skip_reason == "kicad_cli_not_found"
-        assert any("kicad-cli" in d for d in result.diagnostics)
+        assert any("kicad-cli" in d.message for d in result.diagnostics)
         assert result.artifacts == ()
 
 
@@ -384,7 +384,7 @@ class TestGerberExporterMissingPcb:
 
         assert result.skipped is True
         assert result.skip_reason == "pcb_file_not_found"
-        assert any("PCB file not found" in d for d in result.diagnostics)
+        assert any("PCB file not found" in d.message for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +408,7 @@ class TestGerberExporterPluginMode:
 
         assert result.skipped is True
         assert result.skip_reason == "pcbnew_api_not_implemented"
-        assert any("not yet implemented" in d for d in result.diagnostics)
+        assert any("not yet implemented" in d.message for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +442,7 @@ class TestGerberExporterCliFailure:
 
         assert result.skipped is True
         assert result.skip_reason == "gerber_export_failed"
-        assert any("failed" in d for d in result.diagnostics)
+        assert any("failed" in d.message for d in result.diagnostics)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gerbers_cli.py
+++ b/tests/unit/test_gerbers_cli.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from jbom.cli.gerbers import _render_gerber_result
 from jbom.cli.main import create_parser
+from jbom.common.types import Diagnostic
 from jbom.services.gerber_service import GerberResult
 
 
@@ -65,7 +66,7 @@ class TestRenderGerberResult:
     def test_skipped_result_returns_exit_1(self, capsys) -> None:
         result = GerberResult(
             artifacts=(),
-            diagnostics=("kicad-cli not found",),
+            diagnostics=(Diagnostic("error", "kicad-cli not found"),),
             skipped=True,
             skip_reason="kicad_cli_not_found",
         )


### PR DESCRIPTION
Closes #245

## Summary

Adds `Diagnostic(severity, message)` to `jbom.common.types` and migrates all four result contracts and their callsites from `tuple[str, ...]` to `tuple[Diagnostic, ...]`.

## `Diagnostic` type

```python
@dataclass(frozen=True)
class Diagnostic:
    severity: Literal["info", "warning", "error"]
    message: str
```

- `"info"` — informational note; CLI adapters gate on `--verbose`
- `"warning"` — potential issue; always displayed
- `"error"` — generation step failed; always displayed

## Files changed

**New type**: `jbom/common/types.py`

**Result contracts**: `BOMResult`, `POSResult`, `GerberResult`, `FabricationResult` → `tuple[Diagnostic, ...]`

**Callsite updates** (all `diagnostics.append(msg)` → `diagnostics.append(Diagnostic(severity, msg))`):
- `bom_workflow.py`, `pos_workflow.py` — info/warning classification
- `gerber_service.py`, `gerber_generator.py` — error/warning/info
- `fabrication_orchestration.py` — all 24+ callsites

**CLI adapters**:
- `gerbers.py`, `fabrication.py` — INFO gated on `--verbose`; WARNING/ERROR always printed to stderr

**Plugin dialog**:
- `_worker()` local list updated; `_on_complete()` renders ⚠/✗ severity prefixes

**Tests**: 5 files updated (`d` → `d.message` in assertions)

1266/1266 tests pass.

Co-Authored-By: Oz <oz-agent@warp.dev>