### PR TITLE
refactor(pos): replace rotation_convention string with data-driven cpl_rotation_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # CHANGELOG
 
 
+## v6.56.0 (2026-05-10)
+
+### Features
+
+* feat(pos): rotation/offset correction service harvested from FT (#249)
+
+- Add src/jbom/config/transformations.csv (43 rules from Fabrication-Toolkit,
+  MIT license, with attribution header; duplicates deduplicated)
+- Add RotationCorrectionService: first-match regex semantics matching FT,
+  apply_rotation(normalize=) for fabricator-specific angle conventions,
+  apply_offset() for centroid deltas, config search-path override support
+- Add apply_corrections: bool = False to POSRequest, FabricationRequest,
+  --apply-corrections CLI flag to jbom pos
+- Wire normalize_rotation: true into jlc.fab.yaml; FabricatorConfig carries
+  the field; POSWorkflow reads it and passes normalize flag to corrections
+- Enable Apply placement corrections checkbox in plugin dialog (was grayed)
+- 42 new tests: Tier 1 unit, Tier 2 pipeline integration, Tier 3 fabricator
+  config, Tier 4 FT parity contract against Core-ESP32-Devkit (73/73 match)
+- pyproject.toml: add config/*.csv to package-data
+
+Closes #249
+
+Co-Authored-By: Oz <oz-agent@warp.dev> ([`64ae811`](https://github.com/plocher/jBOM/commit/64ae8117f4c8e7d5025f8af3a6103677c0f0309e))
+
+
 ## v6.55.2 (2026-05-10)
 
 ### Refactoring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jbom"
-version = "6.55.2"
+version = "6.56.0"
 description = "Intelligent KiCad Bill of Materials generator with inventory matching"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/jbom/__init__.py
+++ b/src/jbom/__init__.py
@@ -1,3 +1,3 @@
 """jBOM - KiCad Bill of Materials and Placement File Generator."""
 
-__version__ = "6.55.2"
+__version__ = "6.56.0"

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -355,27 +355,78 @@ def _entry_has_dnp_marker(entry: dict[str, Any]) -> bool:
     return False
 
 
+def apply_fab_rotation_range(
+    pos_data: list[dict[str, Any]],
+    fab_config: FabricatorConfig | None,
+) -> list[dict[str, Any]]:
+    """Fold CPL rotation angles into the fabricator's required output range (Part 2 of 2).
+
+    Applies the ``cpl_rotation_range: [lo, hi]`` setting from the fabricator's
+    ``.fab.yaml``.  This step is independent of the component DB-correction
+    rules and fires for **every** CPL row regardless of whether
+    ``--apply-corrections`` is set.
+
+    The fold formula is::
+
+        output = ((angle - lo) % (hi - lo)) + lo
+
+    Examples:
+      * ``[0, 360]`` (JLCPCB): ``-90\u00b0 \u2192 270\u00b0``, ``270\u00b0 stays 270\u00b0``
+      * ``[-180, 180]`` (hypothetical): ``270\u00b0 \u2192 -90\u00b0``, ``-90\u00b0 stays -90\u00b0``
+
+    When ``fab_config`` is ``None`` or ``cpl_rotation_range`` is unset, the
+    pos_data list is returned unchanged.
+
+    Args:
+        pos_data: List of POS row dictionaries (may be corrected or raw).
+        fab_config: Loaded :class:`~jbom.config.fabricators.FabricatorConfig`,
+            or ``None`` when the fabricator is unknown.
+
+    Returns:
+        New list with ``rotation`` fields folded into the declared range and
+        ``rotation_raw`` cleared so the field resolver uses the updated float.
+    """
+    if fab_config is None or fab_config.cpl_rotation_range is None:
+        return pos_data
+
+    lo, hi = fab_config.cpl_rotation_range
+    span = hi - lo  # always 360.0 (validated at parse time)
+
+    result: list[dict[str, Any]] = []
+    for row in pos_data:
+        angle = float(row.get("rotation", 0.0) or 0.0)
+        folded = ((angle - lo) % span) + lo
+        if folded == angle:
+            result.append(row)
+        else:
+            new_row = dict(row)
+            new_row["rotation"] = folded
+            new_row.pop("rotation_raw", None)
+            result.append(new_row)
+    return result
+
+
 def apply_rotation_corrections(
     pos_data: list[dict[str, Any]],
     *,
     verbose: bool = False,
-    convention: str | None = None,
 ) -> tuple[list[dict[str, Any]], list[Diagnostic]]:
-    """Apply footprint rotation/offset corrections to POS data rows.
+    """Apply footprint DB-correction deltas to POS data rows (Part 1 of 2).
 
     Loads the :class:`~jbom.services.rotation_correction_service.RotationCorrectionService`
-    from the configured search path and applies first-match corrections to
+    from the configured search path and applies first-match deltas to
     each component's ``rotation``, ``x_mm``, and ``y_mm`` fields.
     Raw coordinate tokens (``rotation_raw``, ``x_raw``, ``y_raw``) are cleared
     so the field resolver uses the corrected float values.
 
+    Fab-specific output-range folding is handled separately by
+    :func:`apply_fab_rotation_range`, which runs unconditionally via
+    :class:`POSWorkflow`.
+
     Args:
         pos_data: List of POS row dictionaries from :class:`POSGenerator`.
         verbose: When True, emit a per-component info diagnostic for each
-            corrected row.
-        convention: Named angle convention from the fabricator's
-            ``rotation_convention`` config key (e.g. ``"jlcpcb"``).  ``None``
-            preserves raw KiCad angles.
+            DB-rule hit.
 
     Returns:
         Tuple of (corrected_pos_data, diagnostics).
@@ -396,9 +447,7 @@ def apply_rotation_corrections(
     for row in pos_data:
         footprint = str(row.get("footprint", ""))
         rotation = float(row.get("rotation", 0.0) or 0.0)
-        new_rotation = service.apply_rotation(
-            footprint, rotation, convention=convention
-        )
+        new_rotation = service.apply_rotation(footprint, rotation)
         delta_x, delta_y = service.apply_offset(footprint)
         has_db_rule = service.has_correction(footprint)
 
@@ -603,16 +652,8 @@ class POSWorkflow:
         pos_data = POSGenerator(placement_options).generate_pos_data(board)
 
         if request.apply_corrections:
-            _convention: str | None = None
-            try:
-                from jbom.config.fabricators import load_fabricator
-
-                _fab_cfg = load_fabricator(request.fabricator)
-                _convention = _fab_cfg.rotation_convention
-            except Exception:
-                pass
             pos_data, correction_diagnostics = apply_rotation_corrections(
-                pos_data, verbose=request.verbose, convention=_convention
+                pos_data, verbose=request.verbose
             )
             diagnostics.extend(correction_diagnostics)
 
@@ -660,6 +701,18 @@ class POSWorkflow:
         pos_data = enrich_pos_with_merge_namespaces(pos_data, merge_result)
         pos_data = apply_pos_dnp_filter(pos_data, include_dnp=request.include_dnp)
 
+        # Part 2: fold CPL rotations into the fab's required output range,
+        # unconditionally — fires even without --apply-corrections.
+        # Fab config resolved below; use a best-effort load here.
+        _fab_config_for_range: FabricatorConfig | None = None
+        try:
+            from jbom.config.fabricators import load_fabricator as _lf
+
+            _fab_config_for_range = _lf(request.fabricator)
+        except Exception:
+            pass
+        pos_data = apply_fab_rotation_range(pos_data, _fab_config_for_range)
+
         available_pos_fields = get_available_pos_fields(
             schematic_components=schematic_components,
             pcb_components=list(board.footprints),
@@ -706,6 +759,7 @@ __all__ = [
     "POSRequest",
     "POSResult",
     "POSWorkflow",
+    "apply_fab_rotation_range",
     "apply_pos_dnp_filter",
     "apply_rotation_corrections",
     "enrich_pos_with_merge_namespaces",

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -102,7 +102,7 @@ class FabricatorConfig:
     name: str
     pos_columns: Dict[str, str]  # Header -> internal field mapping
     pos_additive_default_fields: Optional[List[str]] = None
-    rotation_convention: Optional[str] = None  # Fabricator-specific angle convention
+    cpl_rotation_range: Optional[tuple] = None  # (lo, hi) — fold CPL angles to [lo, hi)
 
     # Phase 1 schema: ordered supplier profile IDs.
     # Position encodes priority (first entry is most preferred).
@@ -216,17 +216,26 @@ class FabricatorConfig:
 
         tier_overrides = _parse_tier_overrides(data.get("tier_overrides") or [])
         tier_rules = _derive_tier_rules(tier_overrides=tier_overrides)
-        rotation_convention_raw = data.get("rotation_convention")
-        rotation_convention: Optional[str] = (
-            str(rotation_convention_raw).strip() if rotation_convention_raw else None
-        )
+        cpl_rotation_range: Optional[tuple] = None
+        raw_range = data.get("cpl_rotation_range")
+        if raw_range is not None:
+            if (
+                not isinstance(raw_range, (list, tuple))
+                or len(raw_range) != 2
+                or raw_range[1] - raw_range[0] != 360
+            ):
+                raise ValueError(
+                    f"Fabricator '{pid}' cpl_rotation_range must be a two-element "
+                    f"list spanning exactly 360° — e.g. [0, 360] or [-180, 180]"
+                )
+            cpl_rotation_range = (float(raw_range[0]), float(raw_range[1]))
 
         return FabricatorConfig(
             id=pid,
             name=name,
             pos_columns=pos_columns,
             pos_additive_default_fields=pos_additive_default_fields,
-            rotation_convention=rotation_convention,
+            cpl_rotation_range=cpl_rotation_range,
             suppliers=suppliers,
             field_synonyms=field_synonyms,
             tier_rules=tier_rules,

--- a/src/jbom/config/fabricators/jlc.fab.yaml
+++ b/src/jbom/config/fabricators/jlc.fab.yaml
@@ -8,8 +8,11 @@ pcb_manufacturing:
 pcb_assembly:
   website: "https://jlcpcb.com/help/article/bill-of-materials-for-pcb-assembly"
 
-# JLCPCB requires CPL rotations in [0°, 360°) — negative KiCad angles are not accepted.
-rotation_convention: jlcpcb
+# CPL rotation output range for JLCPCB's assembler.
+# KiCad stores angles as arbitrary floats (CCW positive).
+# [0, 360] maps the 360° cycle to [0°, 360°): -90° → 270°, 270° stays 270°.
+# Formula: output = ((angle - lo) % 360) + lo  where lo=0.
+cpl_rotation_range: [0, 360]
 
 # Ordered supplier profile IDs (position encodes priority).
 # First entry is the fabricator's own catalog.

--- a/tests/unit/test_rotation_correction_service.py
+++ b/tests/unit/test_rotation_correction_service.py
@@ -10,8 +10,9 @@ Tier 2 — Pipeline integration (synthetic pos_data rows):
     apply_rotation_corrections() wires the service into pos_data dicts;
     verifies rotation_raw clearing, offset application, diagnostic output.
 
-Tier 3 — Fabricator config (rotation_convention field):
-    jlc.fab.yaml sets rotation_convention: jlcpcb; generic/pcbway default None.
+Tier 3 — Fabricator config (cpl_rotation_range field):
+    jlc.fab.yaml sets cpl_rotation_range: [0, 360]; generic/pcbway have None.
+    apply_fab_rotation_range() folds angles into the declared window.
 
 Tier 4 — FT parity contract (real PCB + fresh FT golden file, contract marker):
     Core-ESP32-Devkit project: jBOM+corrections must match the FT-generated
@@ -29,7 +30,10 @@ from typing import Any
 import pytest
 
 from jbom.services.rotation_correction_service import RotationCorrectionService
-from jbom.application.pos_workflow import apply_rotation_corrections
+from jbom.application.pos_workflow import (
+    apply_fab_rotation_range,
+    apply_rotation_corrections,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -184,60 +188,23 @@ class TestRotationArithmetic:
         # KiCad 0° + delta -90° = -90° (no normalization)
         assert svc.apply_rotation("SPCoast:SOIC127P798X216-8N", 0.0) == -90.0
 
-    def test_no_convention_preserves_negative_kicad_angle(self) -> None:
-        """Without a convention, raw KiCad negative angles pass through."""
+    def test_apply_rotation_returns_raw_no_range_folding(self) -> None:
+        """apply_rotation always returns the raw delta-adjusted value; no range folding."""
         svc = _service_from_csv_text(
             '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",180,0,0\n'
         )
-        result = svc.apply_rotation("Resistor_SMD:R_0805", -90.0, convention=None)
+        # No rule match — raw KiCad -90° passes through unchanged
+        result = svc.apply_rotation("Resistor_SMD:R_0805", -90.0)
         assert result == -90.0
 
-    def test_jlcpcb_convention_converts_negative_angle_to_positive(self) -> None:
-        """convention='jlcpcb' folds negative angles into [0, 360)."""
-        svc = _service_from_csv_text(
-            '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",180,0,0\n'
-        )
-        # No rule match, rotation = -90; with jlcpcb: -90 % 360 = 270
-        result = svc.apply_rotation("Resistor_SMD:R_0805", -90.0, convention="jlcpcb")
-        assert result == 270.0
-
-    def test_jlcpcb_convention_wraps_rotation_above_360(self) -> None:
+    def test_delta_applied_returns_raw_even_when_out_of_0_360(self) -> None:
+        """A 450° result is returned as-is; range folding is done by apply_fab_rotation_range."""
         svc = _service_from_csv_text(
             '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",270,0,0\n'
         )
-        # KiCad 180° + delta 270° = 450°; jlcpcb convention → 90°
-        result = svc.apply_rotation(
-            "Package_TO_SOT_SMD:SOT-23", 180.0, convention="jlcpcb"
-        )
-        assert result == pytest.approx(90.0)
-
-    def test_jlcpcb_convention_does_not_change_already_valid_rotation(self) -> None:
-        svc = _service_from_csv_text(
-            '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",90,0,0\n'
-        )
-        # KiCad 90° + delta 90° = 180°; 180 in [0, 360) → stays 180
-        result = svc.apply_rotation(
-            "Package_TO_SOT_SMD:SOT-23", 90.0, convention="jlcpcb"
-        )
-        assert result == pytest.approx(180.0)
-
-    def test_zero_rotation_no_match_jlcpcb_stays_zero(self) -> None:
-        svc = _service_from_csv_text(
-            '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",180,0,0\n'
-        )
-        assert (
-            svc.apply_rotation("Resistor_SMD:R_0805", 0.0, convention="jlcpcb") == 0.0
-        )
-
-    def test_unknown_convention_falls_through_to_raw(self) -> None:
-        """Unrecognised convention strings preserve raw KiCad angles."""
-        svc = _service_from_csv_text(
-            '"Regex To Match","Rotation","Delta X","Delta Y"\n' '"^SOT-23",180,0,0\n'
-        )
-        result = svc.apply_rotation(
-            "Resistor_SMD:R_0805", -90.0, convention="future_fab"
-        )
-        assert result == -90.0
+        # KiCad 180° + delta 270° = 450° — no folding in apply_rotation
+        result = svc.apply_rotation("Package_TO_SOT_SMD:SOT-23", 180.0)
+        assert result == pytest.approx(450.0)
 
 
 class TestOffsets:
@@ -321,17 +288,11 @@ class TestApplyRotationCorrectionsPipeline:
         corrected, _ = apply_rotation_corrections(rows)
         assert "rotation_raw" not in corrected[0]
 
-    def test_no_convention_preserves_negative_angle(self) -> None:
-        """Without a convention, -90° for an unmatched footprint stays -90°."""
+    def test_corrections_preserve_negative_angle_without_range(self) -> None:
+        """apply_rotation_corrections does NOT fold angles; raw -90° stays -90°."""
         rows = [_pos_row("R1", "Resistor_SMD:R_0805_2012Metric", -90.0)]
-        corrected, _ = apply_rotation_corrections(rows, convention=None)
+        corrected, _ = apply_rotation_corrections(rows)
         assert corrected[0]["rotation"] == pytest.approx(-90.0)
-
-    def test_jlcpcb_convention_converts_negative_angle(self) -> None:
-        """With convention='jlcpcb', -90° for an unmatched footprint becomes 270°."""
-        rows = [_pos_row("R1", "Resistor_SMD:R_0805_2012Metric", -90.0)]
-        corrected, _ = apply_rotation_corrections(rows, convention="jlcpcb")
-        assert corrected[0]["rotation"] == pytest.approx(270.0)
 
     def test_nonzero_offset_updates_x_y(self) -> None:
         """When a DB rule has non-zero X/Y deltas, x_mm and y_mm are adjusted."""
@@ -401,36 +362,145 @@ class TestApplyRotationCorrectionsPipeline:
 
 
 # ---------------------------------------------------------------------------
-# Tier 3 — Fabricator config rotation_convention
+# Tier 3 — Fabricator config cpl_rotation_range + apply_fab_rotation_range
 # ---------------------------------------------------------------------------
 
 
-class TestFabricatorRotationConvention:
-    def test_jlc_has_jlcpcb_rotation_convention(self) -> None:
+class TestFabricatorCplRotationRange:
+    def test_jlc_has_0_360_range(self) -> None:
         from jbom.config.fabricators import load_fabricator
 
         jlc = load_fabricator("jlc")
-        assert jlc.rotation_convention == "jlcpcb"
+        assert jlc.cpl_rotation_range == (0.0, 360.0)
 
-    def test_generic_has_no_rotation_convention(self) -> None:
+    def test_generic_has_no_rotation_range(self) -> None:
         from jbom.config.fabricators import load_fabricator
 
         generic = load_fabricator("generic")
-        assert generic.rotation_convention is None
+        assert generic.cpl_rotation_range is None
 
-    def test_pcbway_has_no_rotation_convention(self) -> None:
-        """PCBWay does not specify a rotation convention."""
+    def test_pcbway_has_no_rotation_range(self) -> None:
         from jbom.config.fabricators import load_fabricator
 
         pcbway = load_fabricator("pcbway")
-        assert pcbway.rotation_convention is None
+        assert pcbway.cpl_rotation_range is None
 
-    def test_rotation_convention_defaults_none_when_absent(self) -> None:
-        """Fabricators without rotation_convention key default to None."""
+    def test_cpl_rotation_range_defaults_none(self) -> None:
         from jbom.config.fabricators import FabricatorConfig
 
-        default = FabricatorConfig.__dataclass_fields__["rotation_convention"].default
+        default = FabricatorConfig.__dataclass_fields__["cpl_rotation_range"].default
         assert default is None
+
+    def test_invalid_range_not_360_span_raises(self) -> None:
+        from jbom.config.fabricators import FabricatorConfig
+
+        with pytest.raises(ValueError, match="spanning exactly 360"):
+            FabricatorConfig.from_yaml_dict(
+                {
+                    "id": "test",
+                    "pos_columns": {"Designator": "reference"},
+                    "suppliers": ["lcsc"],
+                    "field_synonyms": {
+                        "fab_pn": {"display_name": "P", "synonyms": []},
+                        "supplier_pn": {"display_name": "S", "synonyms": []},
+                        "mpn": {"display_name": "M", "synonyms": []},
+                    },
+                    "cpl_rotation_range": [0, 180],  # only 180° span — invalid
+                },
+                default_id="test",
+            )
+
+
+class TestApplyFabRotationRange:
+    """Tests for the data-driven range-folding function (Part 2)."""
+
+    def _make_fab(self, lo: float, hi: float):
+        """Build a minimal FabricatorConfig with the given cpl_rotation_range."""
+        from jbom.config.fabricators import FabricatorConfig
+
+        cfg = FabricatorConfig(
+            id="test",
+            name="Test",
+            pos_columns={"Designator": "reference"},
+            cpl_rotation_range=(lo, hi),
+            suppliers=[],
+        )
+        return cfg
+
+    def test_none_fab_config_returns_unchanged(self) -> None:
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", -90.0)]
+        result = apply_fab_rotation_range(rows, None)
+        assert result[0]["rotation"] == pytest.approx(-90.0)
+
+    def test_fab_without_range_returns_unchanged(self) -> None:
+        from jbom.config.fabricators import FabricatorConfig
+
+        cfg = FabricatorConfig(
+            id="generic", name="Generic", pos_columns={"D": "r"}, suppliers=[]
+        )
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", -90.0)]
+        result = apply_fab_rotation_range(rows, cfg)
+        assert result[0]["rotation"] == pytest.approx(-90.0)
+
+    def test_0_360_folds_negative_to_positive(self) -> None:
+        """[0, 360]: -90° → 270°  (JLCPCB use case)."""
+        fab = self._make_fab(0, 360)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", -90.0)]
+        result = apply_fab_rotation_range(rows, fab)
+        assert result[0]["rotation"] == pytest.approx(270.0)
+
+    def test_0_360_preserves_already_valid_positive(self) -> None:
+        fab = self._make_fab(0, 360)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", 270.0)]
+        result = apply_fab_rotation_range(rows, fab)
+        assert result[0]["rotation"] == pytest.approx(270.0)
+
+    def test_0_360_folds_above_360(self) -> None:
+        """[0, 360]: 450° → 90°."""
+        fab = self._make_fab(0, 360)
+        rows = [_pos_row("U1", "Package_SO:SOIC-8", 450.0)]
+        result = apply_fab_rotation_range(rows, fab)
+        assert result[0]["rotation"] == pytest.approx(90.0)
+
+    def test_neg180_pos180_folds_positive_to_negative(self) -> None:
+        """[-180, 180]: 270° → -90°  (hypothetical alternative convention)."""
+        fab = self._make_fab(-180, 180)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", 270.0)]
+        result = apply_fab_rotation_range(rows, fab)
+        assert result[0]["rotation"] == pytest.approx(-90.0)
+
+    def test_neg180_pos180_preserves_already_valid_negative(self) -> None:
+        fab = self._make_fab(-180, 180)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", -90.0)]
+        result = apply_fab_rotation_range(rows, fab)
+        assert result[0]["rotation"] == pytest.approx(-90.0)
+
+    def test_rotation_raw_cleared_when_angle_changes(self) -> None:
+        fab = self._make_fab(0, 360)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", -90.0, rotation_raw="-90")]
+        result = apply_fab_rotation_range(rows, fab)
+        assert "rotation_raw" not in result[0]
+
+    def test_rotation_raw_preserved_when_angle_unchanged(self) -> None:
+        """If the angle is already in range, no copy is made and rotation_raw kept."""
+        fab = self._make_fab(0, 360)
+        rows = [_pos_row("R1", "Resistor_SMD:R_0805", 90.0, rotation_raw="90")]
+        result = apply_fab_rotation_range(rows, fab)
+        # 90° is already in [0, 360) — same row object, raw preserved
+        assert "rotation_raw" in result[0]
+
+    def test_multiple_rows_all_folded(self) -> None:
+        fab = self._make_fab(0, 360)
+        rows = [
+            _pos_row("R1", "Resistor_SMD:R_0805", -90.0),
+            _pos_row("R2", "Resistor_SMD:R_0805", 0.0),
+            _pos_row("R3", "Resistor_SMD:R_0805", 180.0),
+            _pos_row("R4", "Resistor_SMD:R_0805", 270.0),
+        ]
+        result = apply_fab_rotation_range(rows, fab)
+        assert [r["rotation"] for r in result] == pytest.approx(
+            [270.0, 0.0, 180.0, 270.0]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -482,9 +552,13 @@ class TestFTParity:
             if ft_rot is None:
                 skipped += 1
                 continue
-            corrected = svc.apply_rotation(
-                r["footprint"], r["rotation"], convention="jlcpcb"
-            )
+            corrected = svc.apply_rotation(r["footprint"], r["rotation"])
+            # Apply JLCPCB range folding (Part 2) separately
+            from jbom.config.fabricators import load_fabricator as _lf
+
+            _jlc = _lf("jlc")
+            folded_rows = apply_fab_rotation_range([{"rotation": corrected}], _jlc)
+            corrected = folded_rows[0]["rotation"]
             if abs(corrected - ft_rot) >= 0.1:
                 mismatches.append(
                     f"{ref}: kicad={r['rotation']:.1f}° → jbom={corrected:.1f}°"


### PR DESCRIPTION
## Problem

The `rotation_convention: jlcpcb` string introduced in #261 was two problems in one:
1. Magic string dispatch — the behaviour lived in Python code, not in the YAML data
2. Wrong abstraction — Part 1 (footprint DB corrections) and Part 2 (fab output representation) were conflated inside `apply_rotation()`

## Solution

**Part 1 (DB corrections)** and **Part 2 (output representation)** are now cleanly separated:

```
pos_data = POSGenerator(...)           # raw KiCad rotations
pos_data = apply_corrections(...)      # Part 1: opt-in, CSV-driven
pos_data = apply_fab_rotation_range(…) # Part 2: always-on, YAML-driven
```

**Data, not code.** The output range is expressed directly in the fab YAML:

```yaml
# jlc.fab.yaml — self-documenting
# Formula: output = ((angle - lo) % span) + lo
cpl_rotation_range: [0, 360]   # [0°, 360°): -90° → 270°

# hypothetical alternative
cpl_rotation_range: [-180, 180]  # (-180°, 180°]: 270° → -90°
```

Python becomes a generic two-line formula with no string dispatch. Adding a new fabricator convention is pure YAML.

**Validated at parse time:** non-360° spans raise `ValueError`.

## Changes

- `FabricatorConfig`: `rotation_convention: str | None` → `cpl_rotation_range: tuple[float, float] | None`
- `jlc.fab.yaml`: `rotation_convention: jlcpcb` → `cpl_rotation_range: [0, 360]` with inline formula comment
- `RotationCorrectionService.apply_rotation()`: removed `convention` param; returns raw delta-adjusted value only
- `pos_workflow.py`: new `apply_fab_rotation_range(pos_data, fab_config)` function, called unconditionally after corrections+DNP; `apply_rotation_corrections()` no longer has a `convention` param
- 15 new tests covering `[0,360]`, `[-180,180]`, raw preservation, `rotation_raw` clearing, and YAML validation guard

Conversation: https://app.warp.dev/conversation/d0c10e1a-9dd9-485e-bb8e-869af9a8cade