### PR TITLE
test: functional tests for POS rotation corrections and fab range folding (#249)

### DIFF
--- a/features/pos/rotation_corrections.feature
+++ b/features/pos/rotation_corrections.feature
@@ -1,0 +1,58 @@
+Feature: POS Rotation Corrections (DB-driven, Part 1 of 2)
+  As a manufacturing engineer
+  I want footprint DB rotation corrections applied when requested
+  So that I can correct KiCad orientations for fabricators that expect different reel orientations
+
+  Background:
+    Given the generic fabricator is selected
+
+  Scenario: Without --apply-corrections, raw KiCad rotations are unchanged
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint   |
+      | U1        | 10| 5 | 0        | TOP  | SOT-23_3    |
+      | R1        | 15| 8 | 90       | TOP  | R_0805_2012 |
+    When I run jbom command "pos -o -"
+    Then the command should succeed
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | U1         | 0        |
+      | R1         | 90       |
+
+  Scenario: With --apply-corrections, DB rotation deltas are applied
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint   |
+      | U1        | 10| 5 | 0        | TOP  | SOT-23_3    |
+      | R1        | 15| 8 | 90       | TOP  | R_0805_2012 |
+    When I run jbom command "pos --apply-corrections -o -"
+    Then the command should succeed
+    # SOT-23_3 matches '^SOT-23' in transformations.csv -> +180 deg delta
+    # R_0805_2012 has no matching rule -> delta is 0 (output format changes to float)
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | U1         | 180.0    |
+      | R1         | 90.0     |
+
+  Scenario: With --apply-corrections --verbose, per-component diagnostics are emitted
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint |
+      | U1        | 10| 5 | 0        | TOP  | SOT-23_3  |
+    When I run jbom command "pos --apply-corrections --verbose -o -"
+    Then the command should succeed
+    And the output should contain "Corrected U1"
+
+  Scenario: Multiple footprint families each receive their own DB correction
+    Given a PCB that contains:
+      | Reference | X  | Y  | Rotation | Side | Footprint        |
+      | C1        | 10 | 5  | 0        | TOP  | CP_Elec_5x5      |
+      | U1        | 20 | 10 | 0        | TOP  | SOIC-8_3.9x4.9mm |
+      | R1        | 30 | 15 | 0        | TOP  | R_0805_2012      |
+    When I run jbom command "pos --apply-corrections -o -"
+    Then the command should succeed
+    # CP_Elec_5x5 -> '^CP_Elec_' -> +180 deg
+    # SOIC-8_3.9x4.9mm -> '^SOIC-8_' -> +270 deg
+    # R_0805_2012 -> no rule -> 0 deg delta (only format changes to float)
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | C1         | 180.0    |
+      | U1         | 270.0    |
+      | R1         | 0.0      |

--- a/features/pos/rotation_orientation.feature
+++ b/features/pos/rotation_orientation.feature
@@ -25,3 +25,37 @@ Feature: POS Rotation and Orientation
     When I run jbom command "pos -o console"
     Then the command should succeed
     And the output should contain "R1"
+
+  Scenario: JLC fabricator folds out-of-range rotation into [0, 360)
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint   |
+      | R1        | 10| 5 | -90      | TOP  | R_0805_2012 |
+    When I run jbom command "pos --jlc -o -"
+    Then the command should succeed
+    # JLC cpl_rotation_range: [0, 360] -> (-90 - 0) % 360 + 0 = 270
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | R1         | 270.0    |
+
+  Scenario: Generic fabricator preserves raw negative rotation unchanged
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint   |
+      | R1        | 10| 5 | -90      | TOP  | R_0805_2012 |
+    When I run jbom command "pos -o -"
+    Then the command should succeed
+    # Generic has no cpl_rotation_range -> rotation_raw passed through as-is
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | R1         | -90      |
+
+  Scenario: DB corrections and JLC range folding both apply in sequence
+    Given a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint          |
+      | U1        | 10| 5 | 0        | TOP  | SOIC127P798X216-8N |
+    When I run jbom command "pos --apply-corrections --jlc -o -"
+    Then the command should succeed
+    # Part 1 (DB): SOIC127P798X216-8N -> '^SOIC127P798X216-8N' -> -90 deg delta -> 0 + (-90) = -90
+    # Part 2 (JLC fold): (-90 - 0) % 360 + 0 = 270
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | U1         | 270.0    |


### PR DESCRIPTION
## Summary

Adds behave functional tests covering the two-part rotation correction system introduced in #249 (DB corrections, PR #261) and the data-driven fabricator output range (PR #262).

### New: `features/pos/rotation_corrections.feature` (4 scenarios)

Covers **Part 1 — opt-in DB corrections** (`--apply-corrections`):
- Without flag: raw KiCad rotation strings pass through unchanged
- With flag: DB deltas applied (SOT-23 +180°, no-rule footprint formats as float)
- With `--verbose`: per-component "Corrected U1" diagnostics emitted to stderr
- Multi-family: CP_Elec (+180°), SOIC-8 (+270°), R_0805 (no delta) all in one run

### Extended: `features/pos/rotation_orientation.feature` (+3 scenarios)

Covers **Part 2 — always-on fabricator output range folding**:
- JLC `cpl_rotation_range: [0, 360]` folds −90° → 270.0
- Generic (no range config) preserves raw −90 string unchanged
- Combined: SOIC127P798X216-8N at 0° → DB −90° delta → JLC fold → 270.0

All 240 behave scenarios and 1315 unit tests pass.

---
_Conversation: https://app.warp.dev/conversation/d0c10e1a-9dd9-485e-bb8e-869af9a8cade_
_Roadmap: https://app.warp.dev/drive/notebook/XrvCApVqIKbm3ZRJnt5OnV_

Co-Authored-By: Oz <oz-agent@warp.dev>