### PR TITLE
test(gerbers): functional tests for jbom gerbers and jbom fab via mock kicad-cli

### DIFF
--- a/features/fixtures/mock_kicad_cli/kicad-cli
+++ b/features/fixtures/mock_kicad_cli/kicad-cli
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""mock-kicad-cli — generates structurally valid Gerber/drill stub files.
+
+Used by jBOM BDD feature tests to exercise the full pipeline
+(argument construction → artifact collection → packaging → backup)
+without requiring a real KiCad installation.
+
+Design:
+  - Layer file list is driven by the --layers argument jBOM passes, not
+    hardcoded.  This validates the contract between jBOM's GerberExporter
+    and kicad-cli's argument interface.
+  - File content uses real Gerber X2 attribute headers so downstream tools
+    and test assertions can inspect them meaningfully.  TF.GenerationSoftware
+    encodes the fabricator; TF.FileFunction encodes the layer.
+  - Edge.Cuts → .gm1  (KiCad 10 actual output, not .gko)
+
+Supported interface (mirrors real kicad-cli):
+  mock-kicad-cli pcb export gerbers --output DIR [--layers L1,L2,...] \
+                 [--no-protel-ext] PCB_FILE
+  mock-kicad-cli pcb export drill   --output DIR \
+                 [--excellon-separate-th] PCB_FILE
+"""
+from __future__ import annotations
+
+import datetime
+import pathlib
+import sys
+
+# Protel extension mapping — KiCad 10 defaults
+PROTEL_EXT: dict[str, str] = {
+    "F.Cu": "gtl",
+    "B.Cu": "gbl",
+    "In1.Cu": "g2",
+    "In2.Cu": "g3",
+    "In3.Cu": "g3",
+    "F.Mask": "gts",
+    "B.Mask": "gbs",
+    "F.Paste": "gtp",
+    "B.Paste": "gbp",
+    "F.Silkscreen": "gto",
+    "B.Silkscreen": "gbo",
+    "Edge.Cuts": "gm1",  # KiCad 10 — NOT .gko
+    "Dwgs.User": "gbr",
+    "Cmts.User": "gbr",
+}
+
+# Gerber X2 TF.FileFunction values per layer
+FILE_FUNCTION: dict[str, str] = {
+    "F.Cu": "Copper,L1,Top",
+    "B.Cu": "Copper,L2,Bot",
+    "In1.Cu": "Copper,L3,Inr",
+    "In2.Cu": "Copper,L4,Inr",
+    "In3.Cu": "Copper,L5,Inr",
+    "F.Mask": "Soldermask,Top",
+    "B.Mask": "Soldermask,Bot",
+    "F.Paste": "SolderPaste,Top",
+    "B.Paste": "SolderPaste,Bot",
+    "F.Silkscreen": "Legend,Top",
+    "B.Silkscreen": "Legend,Bot",
+    "Edge.Cuts": "Profile,NP",
+}
+
+# Default layers when --layers is omitted (kicad-cli exports all active layers)
+DEFAULT_LAYERS: list[str] = ["F.Cu", "B.Cu", "Edge.Cuts"]
+
+
+def _arg(args: list[str], flag: str) -> str | None:
+    """Return the value after flag in args, or None."""
+    try:
+        return args[args.index(flag) + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def _gerber_content(layer: str, stem: str, fabricator: str, now: str) -> str:
+    """Return a minimal but structurally valid Gerber X2 file body."""
+    fn = FILE_FUNCTION.get(layer, f"Other,{layer}")
+    return (
+        f"G04 #@! TF.GenerationSoftware,jBOM-test,mock-kicad-cli,{fabricator}*\n"
+        f"G04 #@! TF.CreationDate,{now}*\n"
+        f"G04 #@! TF.ProjectId,{stem},mock,0.0*\n"
+        f"G04 #@! TF.SameCoordinates,Original*\n"
+        f"G04 #@! TF.FileFunction,{fn}*\n"
+        f"G04 #@! TF.FilePolarity,Positive*\n"
+        f"%FSLAX46Y46*%\n"
+        f"G04 Gerber Fmt 4.6, Leading zero omitted, Abs format (unit mm)*\n"
+        f"G04 Created by mock-kicad-cli for jBOM testing*\n"
+        f"%MOMM*%\n"
+        f"%LPD*%\n"
+        f"G01*\n"
+        f"M02*\n"
+    )
+
+
+def _drill_content(stem: str, fabricator: str) -> str:
+    """Return a minimal Excellon drill file body."""
+    return (
+        f"; mock-kicad-cli drill stem={stem} fabricator={fabricator}\n"
+        f"M48\n"
+        f"METRIC,LZ\n"
+        f"%\n"
+        f"G90\n"
+        f"G05\n"
+        f"M30\n"
+    )
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    is_gerbers = "gerbers" in args
+    is_drill = "drill" in args
+
+    # --output DIR
+    out_str = _arg(args, "--output")
+    out = pathlib.Path(out_str) if out_str else pathlib.Path(".")
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Derive board stem from last positional (PCB file path)
+    positional = [a for a in args if not a.startswith("-")]
+    pcb_path = (
+        pathlib.Path(positional[-1]) if positional else pathlib.Path("board.kicad_pcb")
+    )
+    stem = pcb_path.stem
+
+    # Fabricator passed via --fabricator (jBOM adds this in some paths)
+    fabricator = _arg(args, "--fabricator") or "generic"
+
+    now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+
+    if is_gerbers:
+        # Layer list: use --layers if provided, else fall back to defaults
+        layers_str = _arg(args, "--layers")
+        layers = (
+            [layer.strip() for layer in layers_str.split(",") if layer.strip()]
+            if layers_str
+            else DEFAULT_LAYERS
+        )
+        protel = "--no-protel-ext" not in args
+
+        for layer in layers:
+            ext = PROTEL_EXT.get(layer, "gbr") if protel else "gbr"
+            safe = layer.replace(".", "_")
+            path = out / f"{stem}-{safe}.{ext}"
+            path.write_text(
+                _gerber_content(layer, stem, fabricator, now), encoding="utf-8"
+            )
+
+    elif is_drill:
+        split = "--excellon-separate-th" in args
+        content = _drill_content(stem, fabricator)
+        if split:
+            (out / f"{stem}-PTH.drl").write_text(content, encoding="utf-8")
+            (out / f"{stem}-NPTH.drl").write_text(content, encoding="utf-8")
+        else:
+            (out / f"{stem}.drl").write_text(content, encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/features/gerbers/core.feature
+++ b/features/gerbers/core.feature
@@ -1,0 +1,63 @@
+Feature: jbom gerbers — standalone Gerber/drill generation
+  As a PCB engineer
+  I want to generate Gerber and drill files from a KiCad project
+  So that I can submit fabrication files to a PCB manufacturer
+
+  Background:
+    Given a PCB that contains:
+      | Reference | X  | Y  | Rotation | Side | Footprint   |
+      | R1        | 10 | 10 | 0        | TOP  | R_0805_2012 |
+    And a schematic that contains:
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+    And mock kicad-cli is available
+
+  Scenario: Standard 9-layer gerbers produced with correct Protel extensions
+    When I run jbom command "gerbers ."
+    Then the command should succeed
+    # 9 layers from generic/JLC config + 2 drill files (split PTH/NPTH)
+    And the gerbers output directory should contain 11 gerber files
+    And a gerber file for layer "F.Cu" should exist
+    And a gerber file for layer "B.Cu" should exist
+    And a gerber file for layer "Edge.Cuts" should exist
+    And the gerber file for layer "F.Cu" should use extension ".gtl"
+    And the gerber file for layer "B.Cu" should use extension ".gbl"
+    # Edge.Cuts uses .gm1 in KiCad 10 — NOT .gko
+    And the gerber file for layer "Edge.Cuts" should use extension ".gm1"
+    And the gerber file for layer "F.Mask" should use extension ".gts"
+    And the gerber file for layer "B.Mask" should use extension ".gbs"
+    And a drill file should exist in the gerbers output directory
+
+  Scenario: Gerber files contain valid X2 attribute headers
+    When I run jbom command "gerbers ."
+    Then the command should succeed
+    # Mock writes structurally valid Gerber X2 headers — verify key attributes
+    And the gerber file for layer "F.Cu" should contain "TF.GenerationSoftware"
+    And the gerber file for layer "F.Cu" should contain "TF.FileFunction"
+    And the gerber file for layer "F.Cu" should contain "TF.FilePolarity,Positive"
+    And the gerber file for layer "F.Cu" should contain "%FSLAX46Y46*%"
+    And the gerber file for layer "F.Cu" should contain "%MOMM*%"
+    And the gerber file for layer "Edge.Cuts" should contain "TF.FileFunction,Profile,NP"
+
+  Scenario: Each copper layer carries the correct Copper FileFunction attribute
+    When I run jbom command "gerbers ."
+    Then the command should succeed
+    And the gerber file for layer "F.Cu" should contain "TF.FileFunction,Copper,L1,Top"
+    And the gerber file for layer "B.Cu" should contain "TF.FileFunction,Copper,L2,Bot"
+    And the gerber file for layer "F.Mask" should contain "TF.FileFunction,Soldermask,Top"
+    And the gerber file for layer "B.Mask" should contain "TF.FileFunction,Soldermask,Bot"
+    And the gerber file for layer "F.Silkscreen" should contain "TF.FileFunction,Legend,Top"
+
+  Scenario: Output directory reported in command output
+    When I run jbom command "gerbers ."
+    Then the command should succeed
+    And the output should contain "Written:"
+
+  Scenario: dry-run reports prerequisites without generating files
+    When I run jbom command "gerbers . --dry-run"
+    # dry-run always exits 0 when kicad-cli is found (mock is on PATH)
+    # It prints the resolved PCB path and output directory without writing files
+    Then the command should succeed
+    And the output should contain "Dry run: PCB file"
+    And the output should contain "Dry run: Output dir"
+    And "gerbers" should not exist in the sandbox

--- a/features/gerbers/fabrication.feature
+++ b/features/gerbers/fabrication.feature
@@ -1,0 +1,78 @@
+Feature: jbom fab — complete fabrication pipeline (BOM + CPL + Gerbers + Backup)
+  As a manufacturing engineer
+  I want to generate all fabrication artifacts in one command
+  So that I can upload a complete package to a PCB manufacturer
+
+  # jbom fab orchestrates BOM → POS → Gerbers → Backup in sequence.
+  # The acceptance criteria from issue #227:
+  #
+  #   production/
+  #     jbom.csv                              ← BOM (fabricator-ready)
+  #     cpl.csv                               ← CPL/placement
+  #     {title}_{revision}.zip                ← Gerber archive
+  #     backups/
+  #       {title}_{revision}_{timestamp}.zip  ← snapshot of all three artifacts
+
+  Background:
+    Given a PCB that contains:
+      | Reference | X  | Y  | Rotation | Side | Footprint   |
+      | R1        | 10 | 10 | 0        | TOP  | R_0805_2012 |
+    And a schematic that contains:
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+    And mock kicad-cli is available
+
+  Scenario: fab produces the complete production/ directory structure
+    When I run jbom command "fab ."
+    Then the command should succeed
+    And the production directory should exist
+    And the production artifact "jbom.csv" should exist
+    And the production artifact "cpl.csv" should exist
+    And a gerber zip matching "*.zip" should exist in production/
+    And a backup zip should exist under "production/backups/"
+
+  Scenario: fab output reports production directory path
+    When I run jbom command "fab ."
+    Then the command should succeed
+    And the output should contain "Production directory:"
+
+  Scenario: fab gerber zip contains files for key copper and profile layers
+    When I run jbom command "fab ."
+    Then the command should succeed
+    # jbom fab passes no --layers flag so mock uses DEFAULT_LAYERS (F.Cu, B.Cu, Edge.Cuts)
+    And the gerber zip should contain a file for layer "F.Cu"
+    And the gerber zip should contain a file for layer "B.Cu"
+    And the gerber zip should contain a file for layer "Edge.Cuts"
+
+  Scenario: backup contains all three production artifacts
+    # BOM + CPL + gerber zip = 3 entries in the backup archive
+    When I run jbom command "fab ."
+    Then the command should succeed
+    And the backup zip should contain 3 files
+
+  Scenario: --skip-gerbers produces BOM and CPL but no gerber zip
+    When I run jbom command "fab . --skip-gerbers"
+    Then the command should succeed
+    And the production directory should exist
+    And the production artifact "jbom.csv" should exist
+    And the production artifact "cpl.csv" should exist
+    And no file matching "*.zip" should exist in production/
+
+  Scenario: --skip-gerbers backup contains only BOM and CPL
+    # Without gerbers, only 2 artifacts are in the backup
+    When I run jbom command "fab . --skip-gerbers"
+    Then the command should succeed
+    And the backup zip should contain 2 files
+
+  Scenario: --skip-bom skips BOM generation but still creates CPL and gerbers
+    When I run jbom command "fab . --skip-bom"
+    Then the command should succeed
+    And the production directory should exist
+    And "production/jbom.csv" should not exist in the sandbox
+    And the production artifact "cpl.csv" should exist
+    And a gerber zip matching "*.zip" should exist in production/
+
+  Scenario: --dry-run does not write any production files
+    When I run jbom command "fab . --dry-run"
+    Then the command should succeed
+    And "production" should not exist in the sandbox

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -140,6 +140,9 @@ def step_run_command(context, command):
     env["JBOM_QUIET"] = "1"
     if getattr(context, "trace", False):
         env["JBOM_BEHAVE_TRACE"] = "1"
+    # Apply mock tool overrides (e.g. PATH prefix for mock kicad-cli).
+    # Set by 'Given mock kicad-cli is available' and similar steps.
+    env.update(getattr(context, "mock_env", {}))
 
     try:
         result = subprocess.run(

--- a/features/steps/gerbers_steps.py
+++ b/features/steps/gerbers_steps.py
@@ -1,0 +1,357 @@
+"""Step definitions for features/gerbers/ BDD scenarios.
+
+Covers:
+- mock kicad-cli PATH injection
+- jbom gerbers output assertions (file count, layer names, extensions, content)
+- jbom fab production/ directory structure assertions
+- zip archive content assertions (gerber zip + backup zip)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import zipfile
+from pathlib import Path
+
+from behave import given, then
+from common_diagnostic_utils import assert_with_diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Given: mock kicad-cli injection
+# ---------------------------------------------------------------------------
+
+
+@given("mock kicad-cli is available")
+def step_mock_kicad_cli_available(context) -> None:
+    """Install the mock kicad-cli fixture and prepend its directory to PATH.
+
+    Copies ``features/fixtures/mock_kicad_cli/kicad-cli`` into the scenario
+    sandbox, makes it executable, then records a PATH override in
+    ``context.mock_env`` so that ``step_run_command`` passes it to every
+    subsequent subprocess.  The mock is found before any real kicad-cli on the
+    host system.
+
+    The mock generates structurally valid Gerber X2 stub files whose layer list
+    is driven by the ``--layers`` argument jBOM constructs from the fabricator
+    config — not hardcoded here.
+    """
+    fixture_src = (
+        Path(context.repo_root)
+        / "features"
+        / "fixtures"
+        / "mock_kicad_cli"
+        / "kicad-cli"
+    )
+    assert fixture_src.exists(), f"mock kicad-cli fixture not found: {fixture_src}"
+
+    mock_bin = Path(context.sandbox_root) / "mock_bin"
+    mock_bin.mkdir(exist_ok=True)
+
+    dst = mock_bin / "kicad-cli"
+    shutil.copy2(fixture_src, dst)
+    # Ensure executable bit is set (copytree may not preserve it on all OSes)
+    dst.chmod(dst.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Prepend mock_bin to PATH so GerberExporter._find_kicad_cli() finds it first.
+    # env.update() in step_run_command applies this to every subsequent subprocess.
+    existing_path = os.environ.get("PATH", "")
+    context.mock_env = {"PATH": f"{mock_bin}:{existing_path}"}
+
+
+# ---------------------------------------------------------------------------
+# Then: file existence helpers (sandbox-root-relative)
+# ---------------------------------------------------------------------------
+
+
+@then('"{rel_path}" should exist in the sandbox')
+def step_rel_path_exists(context, rel_path: str) -> None:
+    """Assert a path relative to the sandbox root exists (file or directory)."""
+    target = Path(context.sandbox_root) / rel_path
+    assert_with_diagnostics(
+        target.exists(),
+        f"Expected path does not exist: {rel_path}",
+        context,
+        expected=f"exists: {rel_path}",
+        actual=f"not found: {target}",
+    )
+
+
+@then('"{rel_path}" should not exist in the sandbox')
+def step_rel_path_not_exists(context, rel_path: str) -> None:
+    """Assert a path relative to the sandbox root does NOT exist."""
+    target = Path(context.sandbox_root) / rel_path
+    assert_with_diagnostics(
+        not target.exists(),
+        f"Path should not exist but does: {rel_path}",
+        context,
+        expected=f"absent: {rel_path}",
+        actual=f"found: {target}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then: gerber output directory assertions
+# ---------------------------------------------------------------------------
+
+
+@then("the gerbers output directory should contain {count:d} gerber files")
+def step_gerbers_dir_file_count(context, count: int) -> None:
+    """Assert the gerbers/ subdirectory contains exactly *count* Gerber files.
+
+    Counts only files — not drill maps (.gbr map files are counted separately).
+    """
+    gerbers_dir = Path(context.sandbox_root) / "gerbers"
+    assert_with_diagnostics(
+        gerbers_dir.is_dir(),
+        "gerbers/ output directory does not exist",
+        context,
+        expected="gerbers/ directory exists",
+        actual=f"not found: {gerbers_dir}",
+    )
+    # Count all files (Gerber + drill); the count the scenario specifies
+    # should match the total produced by the mock for the chosen fabricator.
+    files = [f for f in gerbers_dir.iterdir() if f.is_file()]
+    assert_with_diagnostics(
+        len(files) == count,
+        f"Expected {count} file(s) in gerbers/, found {len(files)}",
+        context,
+        expected=f"{count} files",
+        actual=f"{len(files)} files: {[f.name for f in sorted(files)]}",
+    )
+
+
+@then('a gerber file for layer "{layer}" should exist')
+def step_gerber_file_for_layer_exists(context, layer: str) -> None:
+    """Assert that a Gerber file whose name contains the layer name exists.
+
+    Layer names use KiCad dot notation (e.g. ``F.Cu``); the file will have
+    underscores (``project-F_Cu.gtl``).  The check matches on the safe name
+    (dots replaced with underscores) anywhere in the output directory.
+    """
+    gerbers_dir = Path(context.sandbox_root) / "gerbers"
+    safe = layer.replace(".", "_")
+    matches = list(gerbers_dir.glob(f"*-{safe}.*")) if gerbers_dir.is_dir() else []
+    assert_with_diagnostics(
+        len(matches) > 0,
+        f"No gerber file found for layer '{layer}' (looking for *-{safe}.*)",
+        context,
+        expected=f"file matching *-{safe}.*",
+        actual=(
+            f"files present: {[f.name for f in sorted(gerbers_dir.iterdir())]}"
+            if gerbers_dir.is_dir()
+            else "directory absent"
+        ),
+    )
+
+
+@then('the gerber file for layer "{layer}" should use extension ".{ext}"')
+def step_gerber_extension(context, layer: str, ext: str) -> None:
+    """Assert the Gerber file for *layer* carries the expected Protel extension."""
+    gerbers_dir = Path(context.sandbox_root) / "gerbers"
+    safe = layer.replace(".", "_")
+    matches = list(gerbers_dir.glob(f"*-{safe}.*")) if gerbers_dir.is_dir() else []
+    assert_with_diagnostics(
+        len(matches) > 0,
+        f"No gerber file found for layer '{layer}'",
+        context,
+        expected=f"*-{safe}.{ext}",
+        actual="no file found",
+    )
+    actual_ext = matches[0].suffix.lstrip(".")
+    assert_with_diagnostics(
+        actual_ext == ext,
+        f"Layer '{layer}' file has wrong extension: expected .{ext}, got .{actual_ext}",
+        context,
+        expected=f".{ext}",
+        actual=f".{actual_ext} ({matches[0].name})",
+    )
+
+
+@then('the gerber file for layer "{layer}" should contain "{text}"')
+def step_gerber_content(context, layer: str, text: str) -> None:
+    """Assert the Gerber stub for *layer* contains *text* (e.g. a TF attribute)."""
+    gerbers_dir = Path(context.sandbox_root) / "gerbers"
+    safe = layer.replace(".", "_")
+    matches = list(gerbers_dir.glob(f"*-{safe}.*")) if gerbers_dir.is_dir() else []
+    assert len(matches) > 0, f"No gerber file found for layer '{layer}'"
+    content = matches[0].read_text(encoding="utf-8")
+    assert_with_diagnostics(
+        text in content,
+        f"Text '{text}' not found in gerber file for layer '{layer}'",
+        context,
+        expected=text,
+        actual=content[:400],
+    )
+
+
+@then("a drill file should exist in the gerbers output directory")
+def step_drill_file_exists(context) -> None:
+    """Assert at least one .drl drill file exists in gerbers/."""
+    gerbers_dir = Path(context.sandbox_root) / "gerbers"
+    drills = list(gerbers_dir.glob("*.drl")) if gerbers_dir.is_dir() else []
+    assert_with_diagnostics(
+        len(drills) > 0,
+        "No .drl file found in gerbers/ directory",
+        context,
+        expected="at least one .drl file",
+        actual=f"files: {[f.name for f in sorted(gerbers_dir.iterdir())] if gerbers_dir.is_dir() else 'directory absent'}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then: production/ directory structure (jbom fab)
+# ---------------------------------------------------------------------------
+
+
+@then("the production directory should exist")
+def step_production_dir_exists(context) -> None:
+    prod = Path(context.sandbox_root) / "production"
+    assert_with_diagnostics(
+        prod.is_dir(),
+        "production/ directory not found",
+        context,
+        expected="production/ exists",
+        actual=f"contents of sandbox: {[p.name for p in sorted(Path(context.sandbox_root).iterdir())]}",
+    )
+
+
+@then('the production artifact "{filename}" should exist')
+def step_production_artifact_exists(context, filename: str) -> None:
+    """Assert a named file exists directly inside production/."""
+    target = Path(context.sandbox_root) / "production" / filename
+    assert_with_diagnostics(
+        target.exists(),
+        f"Production artifact '{filename}' not found",
+        context,
+        expected=f"production/{filename}",
+        actual=_list_production(context),
+    )
+
+
+@then('no file matching "{glob_pattern}" should exist in production/')
+def step_no_production_match(context, glob_pattern: str) -> None:
+    """Assert no file matching *glob_pattern* exists in production/."""
+    prod = Path(context.sandbox_root) / "production"
+    matches = list(prod.glob(glob_pattern)) if prod.is_dir() else []
+    assert_with_diagnostics(
+        len(matches) == 0,
+        f"Unexpected file(s) matching '{glob_pattern}' found in production/",
+        context,
+        expected="no matches",
+        actual=f"found: {[m.name for m in matches]}",
+    )
+
+
+@then('a gerber zip matching "{glob_pattern}" should exist in production/')
+def step_gerber_zip_exists(context, glob_pattern: str) -> None:
+    """Assert a zip file matching *glob_pattern* exists in production/."""
+    prod = Path(context.sandbox_root) / "production"
+    matches = list(prod.glob(glob_pattern)) if prod.is_dir() else []
+    assert_with_diagnostics(
+        len(matches) > 0,
+        f"No file matching '{glob_pattern}' found in production/",
+        context,
+        expected=f"at least one match for '{glob_pattern}'",
+        actual=_list_production(context),
+    )
+
+
+@then('a backup zip should exist under "production/backups/"')
+def step_backup_zip_exists(context) -> None:
+    """Assert at least one .zip exists in production/backups/."""
+    backups = Path(context.sandbox_root) / "production" / "backups"
+    zips = list(backups.glob("*.zip")) if backups.is_dir() else []
+    assert_with_diagnostics(
+        len(zips) > 0,
+        "No backup zip found in production/backups/",
+        context,
+        expected="at least one .zip in production/backups/",
+        actual=_list_production(context),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Then: zip content assertions
+# ---------------------------------------------------------------------------
+
+
+@then("the gerber zip should contain {count:d} files")
+def step_gerber_zip_entry_count(context, count: int) -> None:
+    """Assert the gerber zip in production/ has exactly *count* entries."""
+    zips = list((Path(context.sandbox_root) / "production").glob("*.zip"))
+    # Exclude backup zips (they live under backups/)
+    zips = [z for z in zips if z.parent.name == "production"]
+    assert (
+        len(zips) == 1
+    ), f"Expected exactly one gerber zip, found: {[z.name for z in zips]}"
+    with zipfile.ZipFile(zips[0]) as zf:
+        names = zf.namelist()
+    assert_with_diagnostics(
+        len(names) == count,
+        f"Gerber zip should contain {count} file(s), found {len(names)}",
+        context,
+        expected=f"{count} entries",
+        actual=f"{len(names)} entries: {sorted(names)}",
+    )
+
+
+@then('the gerber zip should contain a file for layer "{layer}"')
+def step_gerber_zip_has_layer(context, layer: str) -> None:
+    """Assert the gerber zip contains a file whose name includes the layer."""
+    zips = [
+        z
+        for z in (Path(context.sandbox_root) / "production").glob("*.zip")
+        if z.parent.name == "production"
+    ]
+    assert len(zips) >= 1, "No gerber zip found in production/"
+    safe = layer.replace(".", "_")
+    with zipfile.ZipFile(zips[0]) as zf:
+        names = zf.namelist()
+    matches = [n for n in names if f"-{safe}." in n or f"_{safe}." in n]
+    assert_with_diagnostics(
+        len(matches) > 0,
+        f"Gerber zip contains no file for layer '{layer}'",
+        context,
+        expected=f"entry containing '{safe}'",
+        actual=f"zip entries: {sorted(names)}",
+    )
+
+
+@then("the backup zip should contain {count:d} files")
+def step_backup_zip_entry_count(context, count: int) -> None:
+    """Assert the backup zip has exactly *count* entries."""
+    backups = Path(context.sandbox_root) / "production" / "backups"
+    zips = list(backups.glob("*.zip")) if backups.is_dir() else []
+    assert len(zips) >= 1, "No backup zip found in production/backups/"
+    with zipfile.ZipFile(zips[0]) as zf:
+        names = zf.namelist()
+    assert_with_diagnostics(
+        len(names) == count,
+        f"Backup zip should contain {count} file(s), found {len(names)}",
+        context,
+        expected=f"{count} entries",
+        actual=f"{len(names)} entries: {sorted(names)}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_production(context) -> str:
+    """Return a diagnostic string listing production/ contents (recursive)."""
+    prod = Path(context.sandbox_root) / "production"
+    if not prod.is_dir():
+        return "production/ directory absent"
+    lines = []
+    for p in sorted(prod.rglob("*")):
+        lines.append(str(p.relative_to(context.sandbox_root)))
+    return (
+        "production/ contents:\n  " + "\n  ".join(lines)
+        if lines
+        else "production/ is empty"
+    )


### PR DESCRIPTION
## Summary
Adds BDD feature tests for `jbom gerbers` and `jbom fab` using a mock `kicad-cli` fixture, closing the gap left by PR #253 which landed without `features/gerbers/` functional tests.

Closes #264.

## Mock kicad-cli design
`features/fixtures/mock_kicad_cli/kicad-cli` is a Python script that:
- **Layer list driven by `--layers` arg jBOM passes** — not hardcoded. Tests the contract between jBOM's `GerberExporter` and kicad-cli's argument interface.
- **Structurally valid Gerber X2 headers** — mirrors real KiCad output for debuggability and zip-edge-case safety:
```
G04 #@! TF.GenerationSoftware,jBOM-test,mock-kicad-cli,generic*
G04 #@! TF.FileFunction,Copper,L1,Top*
%FSLAX46Y46*%  /  %MOMM*%  /  M02*
```
- **`Edge.Cuts` → `.gm1`** — KiCad 10 actual output (not `.gko`)
- Handles `pcb export gerbers` and `pcb export drill` subcommands
- Handles `--no-protel-ext` and `--excellon-separate-th` flags

## PATH injection mechanism
- `env.update(getattr(context, 'mock_env', {}))` added to `step_run_command` in `common_steps.py`
- `Given mock kicad-cli is available` copies fixture to sandbox `mock_bin/`, makes executable, prepends to PATH via `context.mock_env`
- No-op when `context.mock_env` is absent: all existing tests unaffected

## Files changed
- `features/fixtures/mock_kicad_cli/kicad-cli` (NEW, executable)
- `features/steps/gerbers_steps.py` (NEW — Given/Then step definitions)
- `features/steps/common_steps.py` (PATCH — mock_env support)
- `features/gerbers/core.feature` (NEW — 5 scenarios)
- `features/gerbers/fabrication.feature` (NEW — 8 scenarios)

## Scenarios covered
**core.feature** (jbom gerbers):
- 9-layer output + 2 drill files (11 total) with correct Protel extensions
- Gerber X2 attribute headers (TF.GenerationSoftware, TF.FileFunction, etc.)
- Correct TF.FileFunction per layer (Copper, Soldermask, Legend, Profile)
- Written: reported in output
- `--dry-run` reports prerequisites without generating files

**fabrication.feature** (jbom fab):
- Complete `production/` structure: jbom.csv + cpl.csv + *.zip + backups/*.zip
- Production directory path reported in output
- Gerber zip contains F.Cu / B.Cu / Edge.Cuts layer files
- Backup contains **3 files** (BOM + CPL + gerber zip)
- `--skip-gerbers`: BOM+CPL only, no zip, backup contains **2 files**
- `--skip-bom`: CPL+gerbers only, no jbom.csv
- `--dry-run`: no production/ directory written

## Testing
13 BDD scenarios pass. 1315 pytest tests pass.

---
Co-Authored-By: Oz <oz-agent@warp.dev>