### PR TITLE
feat(fab): #243 DesignatorsWriter service + --designators flag

### DIFF
--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -105,6 +105,8 @@ class FabricationRequest:
             the workflow derive it from ``ProjectMetadata``.
         apply_corrections: When ``True`` apply footprint rotation/offset
             corrections (from ``transformations.csv``) to the CPL output.
+        generate_designators: When ``True`` write ``production/designators.csv``
+            listing all PCB reference designators in ``REF:COUNT`` format.
     """
 
     input_path: str
@@ -124,6 +126,7 @@ class FabricationRequest:
     debug: bool = False
     archive_stem: str = ""
     apply_corrections: bool = False
+    generate_designators: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -163,6 +166,9 @@ class FabricationRequest:
         object.__setattr__(self, "debug", bool(self.debug))
         object.__setattr__(self, "archive_stem", str(self.archive_stem or "").strip())
         object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
+        object.__setattr__(
+            self, "generate_designators", bool(self.generate_designators)
+        )
 
 
 @dataclass(frozen=True)
@@ -378,6 +384,25 @@ class FabricationWorkflow:
                     )
 
         # ------------------------------------------------------------------
+        # Step 2.5: Designators CSV (gated on request flag; skipped in dry_run)
+        # ------------------------------------------------------------------
+        if (
+            request.generate_designators
+            and not request.dry_run
+            and production_dir is not None
+        ):
+            des_path, des_diagnostics = self._run_designators(request, production_dir)
+            diagnostics.extend(des_diagnostics)
+            if des_path is not None:
+                artifacts.append(
+                    FabricationArtifact(
+                        artifact_type="designators",
+                        path=des_path,
+                        media_type="text/plain",
+                    )
+                )
+
+        # ------------------------------------------------------------------
         # Step 3: Gerbers (skipped in dry_run mode)
         # ------------------------------------------------------------------
         if not request.skip_gerbers:
@@ -481,6 +506,46 @@ class FabricationWorkflow:
             return result, diagnostics
         except Exception as exc:
             diagnostics.append(Diagnostic("error", f"POS generation failed: {exc}"))
+            return None, diagnostics
+
+    def _run_designators(
+        self,
+        request: FabricationRequest,
+        production_dir: Path,
+    ) -> tuple[Path | None, list[Diagnostic]]:
+        """Read PCB footprints and write production/designators.csv.
+
+        Returns:
+            ``(designators_path, diagnostics)`` where path is None on failure.
+        """
+        diagnostics: list[Diagnostic] = []
+        try:
+            from jbom.services.designators_writer import DesignatorsWriter
+            from jbom.services.pcb_reader import DefaultKiCadReaderService
+
+            pcb_file, _project_dir, resolve_diags = self._resolve_pcb_and_project_dir(
+                request
+            )
+            diagnostics.extend(resolve_diags)
+            if pcb_file is None or not pcb_file.exists():
+                diagnostics.append(
+                    Diagnostic("warning", "designators.csv skipped: PCB file not found")
+                )
+                return None, diagnostics
+
+            board = DefaultKiCadReaderService().read_pcb_file(pcb_file)
+            references = [fp.reference for fp in board.footprints]
+            result = DesignatorsWriter.write(
+                references,
+                production_dir / "designators.csv",
+                force=True,
+            )
+            diagnostics.extend(result.diagnostics)
+            return result.path, diagnostics
+        except Exception as exc:
+            diagnostics.append(
+                Diagnostic("error", f"Designators generation failed: {exc}")
+            )
             return None, diagnostics
 
     def _run_gerbers(

--- a/src/jbom/cli/fabrication.py
+++ b/src/jbom/cli/fabrication.py
@@ -105,6 +105,18 @@ def register_command(subparsers) -> None:  # type: ignore[type-arg]
         help="Inventory CSV to enhance BOM (repeatable)",
     )
 
+    # Designators opt-in
+    parser.add_argument(
+        "--designators",
+        action="store_true",
+        default=False,
+        help=(
+            "Generate designators.csv listing all PCB reference designators "
+            "(REF:COUNT format).  Default is set by the fabricator config "
+            "(generic: off)."
+        ),
+    )
+
     # POS options (forwarded to POS orchestration)
     parser.add_argument(
         "--smd-only",
@@ -207,6 +219,20 @@ def _build_fab_job_request(args) -> JobRequest:  # type: ignore[type-arg]
     )
 
 
+def _resolve_generate_designators(args) -> bool:  # type: ignore[type-arg]
+    """Return effective generate_designators flag: CLI arg or fabricator config default."""
+    if bool(getattr(args, "designators", False)):
+        return True
+    # Fall back to fabricator config default
+    try:
+        from jbom.config.fabricators import load_fabricator
+
+        fab_config = load_fabricator(resolve_fabricator_from_args(args))
+        return fab_config.generate_designators
+    except Exception:
+        return False
+
+
 def _execute_fab_command(args) -> int:  # type: ignore[type-arg]
     """Build FabricationRequest, run FabricationWorkflow, and report outputs."""
     try:
@@ -224,6 +250,7 @@ def _execute_fab_command(args) -> int:  # type: ignore[type-arg]
             pos_layer=str(args.layer or ""),
             pos_origin=str(args.origin or "board"),
             debug=bool(args.debug),
+            generate_designators=_resolve_generate_designators(args),
         )
 
         result = FabricationWorkflow().run(request)

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -103,6 +103,7 @@ class FabricatorConfig:
     pos_columns: Dict[str, str]  # Header -> internal field mapping
     pos_additive_default_fields: Optional[List[str]] = None
     cpl_rotation_range: Optional[tuple] = None  # (lo, hi) — fold CPL angles to [lo, hi)
+    generate_designators: bool = False  # When True, fab run produces designators.csv
 
     # Phase 1 schema: ordered supplier profile IDs.
     # Position encodes priority (first entry is most preferred).
@@ -230,12 +231,15 @@ class FabricatorConfig:
                 )
             cpl_rotation_range = (float(raw_range[0]), float(raw_range[1]))
 
+        generate_designators = bool(data.get("generate_designators", False))
+
         return FabricatorConfig(
             id=pid,
             name=name,
             pos_columns=pos_columns,
             pos_additive_default_fields=pos_additive_default_fields,
             cpl_rotation_range=cpl_rotation_range,
+            generate_designators=generate_designators,
             suppliers=suppliers,
             field_synonyms=field_synonyms,
             tier_rules=tier_rules,

--- a/src/jbom/config/fabricators/generic.fab.yaml
+++ b/src/jbom/config/fabricators/generic.fab.yaml
@@ -46,6 +46,10 @@ pos_columns:
   "Rotation": "rotation"
   "Package": "package"
 
+# Whether jbom fab / plugin should generate designators.csv by default.
+# Set to true in a custom fab YAML to enable for all runs with that fabricator.
+generate_designators: false
+
 # Baseline field set used when users append fields via +syntax (for example,
 # --fields +Value) so additive behavior stays profile-driven and predictable.
 pos_additive_default_fields:

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -265,6 +265,21 @@ class JBOMFabricationDialog(wx.Dialog):
             "in ~/.jbom/ or <project>/.jbom/."
         )
 
+        # Default from fabricator config (generic: False; fab.yaml can set True)
+        _des_default = False
+        try:
+            from jbom.config.fabricators import load_fabricator as _lf
+
+            _des_default = _lf(self._options.fabricator).generate_designators
+        except Exception:
+            pass
+        self._cb_designators = _cb("Generate designators.csv", _des_default)
+        self._cb_designators.SetToolTip(
+            "Write production/designators.csv listing all PCB reference "
+            "designators in REF:COUNT format.  Default is set by the "
+            "fabricator config (generic: off)."
+        )
+
         self._cb_debug = _cb("Keep intermediate files (debug)", False)
 
         for cb in (
@@ -274,6 +289,7 @@ class JBOMFabricationDialog(wx.Dialog):
             self._cb_backup,
             self._cb_open_folder,
             self._cb_corrections,
+            self._cb_designators,
             self._cb_debug,
         ):
             check_sizer.Add(cb, flag=wx.LEFT | wx.BOTTOM, border=4)
@@ -550,6 +566,26 @@ class JBOMFabricationDialog(wx.Dialog):
                             _Diag("error", f"POS generation failed: {exc}")
                         )
                 _step("pos", "done")
+
+                # ----------------------------------------------------------
+                # Step 2.5: Designators CSV (optional, gated by checkbox)
+                # ----------------------------------------------------------
+                if self._cb_designators.GetValue() and not cancelled():
+                    try:
+                        from jbom.services.designators_writer import (
+                            DesignatorsWriter,
+                        )
+
+                        refs = [fp.GetReference() for fp in board.GetFootprints()]
+                        DesignatorsWriter.write(
+                            refs,
+                            production_dir / "designators.csv",
+                            force=True,
+                        )
+                    except Exception as exc:
+                        diagnostics.append(
+                            _Diag("error", f"Designators generation failed: {exc}")
+                        )
 
                 # ----------------------------------------------------------
                 # Step 3: Gerbers (pcbnew PLOT_CONTROLLER — no kicad-cli)

--- a/src/jbom/services/designators_writer.py
+++ b/src/jbom/services/designators_writer.py
@@ -1,0 +1,147 @@
+"""Designators CSV generation service.
+
+Produces ``designators.csv`` — one ``REFERENCE:COUNT`` line per unique
+reference designator, sorted in natural (human) order.  This file is
+consumed by downstream assembly tooling such as Fabrication-Toolkit.
+
+Format example::
+
+    C1:1
+    C2:1
+    R1:1
+    U1:1
+
+COUNT is the number of times the reference appears in the input list.
+For correctly-annotated KiCad designs each designator is unique and the
+count will always be ``1``, but the service handles duplicates
+gracefully rather than raising an error.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from jbom.common.reference_sort import natural_reference_sort_key
+from jbom.common.types import Diagnostic
+
+
+@dataclass(frozen=True)
+class DesignatorsResult:
+    """Result produced by :class:`DesignatorsWriter`.
+
+    Attributes:
+        path: Path to the written ``designators.csv``, or ``None`` when
+            the write was skipped (e.g. no references, or dry run).
+        designator_count: Number of unique reference designators written.
+        diagnostics: Ordered diagnostic messages from the write operation.
+    """
+
+    path: Path | None
+    designator_count: int
+    diagnostics: tuple[Diagnostic, ...]
+
+    def __post_init__(self) -> None:
+        if self.path is not None:
+            object.__setattr__(self, "path", Path(self.path))
+        object.__setattr__(self, "designator_count", int(self.designator_count))
+        object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
+
+
+class DesignatorsWriter:
+    """Writes ``designators.csv`` from an iterable of reference designators.
+
+    Typical usage::
+
+        result = DesignatorsWriter.write(
+            references=["R1", "C1", "U1", "R2"],
+            output_path=production_dir / "designators.csv",
+            force=True,
+        )
+    """
+
+    @staticmethod
+    def write(
+        references: Iterable[str],
+        output_path: Path,
+        *,
+        force: bool = False,
+    ) -> DesignatorsResult:
+        """Write ``designators.csv`` to *output_path*.
+
+        Args:
+            references: Iterable of reference designator strings.  May
+                contain duplicates; occurrences are counted per designator.
+                Empty or blank strings are silently skipped.
+            output_path: Destination file path.
+            force: When ``True`` overwrite an existing file.  When
+                ``False`` and the file already exists, a warning diagnostic
+                is returned and no file is written.
+
+        Returns:
+            :class:`DesignatorsResult` with the written path, count, and
+            any diagnostics.
+        """
+        output_path = Path(output_path)
+        diagnostics: list[Diagnostic] = []
+
+        # Normalise and count
+        counts: Counter[str] = Counter()
+        for ref in references:
+            ref = str(ref or "").strip()
+            if ref:
+                counts[ref] += 1
+
+        if not counts:
+            diagnostics.append(
+                Diagnostic(
+                    "info", "designators.csv skipped: no reference designators found"
+                )
+            )
+            return DesignatorsResult(
+                path=None,
+                designator_count=0,
+                diagnostics=tuple(diagnostics),
+            )
+
+        if output_path.exists() and not force:
+            diagnostics.append(
+                Diagnostic(
+                    "warning",
+                    f"designators.csv not written: '{output_path}' already exists "
+                    "(use force=True to overwrite)",
+                )
+            )
+            return DesignatorsResult(
+                path=None,
+                designator_count=len(counts),
+                diagnostics=tuple(diagnostics),
+            )
+
+        # Sort naturally and write
+        sorted_refs = sorted(counts.keys(), key=natural_reference_sort_key)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8", newline="\n") as fh:
+            for ref in sorted_refs:
+                fh.write(f"{ref}:{counts[ref]}\n")
+
+        diagnostics.append(
+            Diagnostic(
+                "info",
+                f"designators.csv written: {len(counts)} designator"
+                f"{'s' if len(counts) != 1 else ''} → {output_path.name}",
+            )
+        )
+        return DesignatorsResult(
+            path=output_path,
+            designator_count=len(counts),
+            diagnostics=tuple(diagnostics),
+        )
+
+
+__all__ = [
+    "DesignatorsResult",
+    "DesignatorsWriter",
+]

--- a/tests/unit/test_designators_writer.py
+++ b/tests/unit/test_designators_writer.py
@@ -1,0 +1,340 @@
+"""Unit tests for DesignatorsWriter service and related integration points."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jbom.services.designators_writer import DesignatorsResult, DesignatorsWriter
+
+
+# ---------------------------------------------------------------------------
+# DesignatorsWriter.write — core behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_write_basic_sorted(tmp_path: Path) -> None:
+    """Designators are sorted naturally and written as REF:COUNT."""
+    out = tmp_path / "designators.csv"
+    result = DesignatorsWriter.write(["R2", "C1", "U1", "R1"], out, force=True)
+
+    assert result.path == out
+    assert result.designator_count == 4
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines == ["C1:1", "R1:1", "R2:1", "U1:1"]
+
+
+def test_write_natural_sort_order(tmp_path: Path) -> None:
+    """R10 sorts after R9, not after R1."""
+    out = tmp_path / "designators.csv"
+    DesignatorsWriter.write(["R10", "R2", "R1", "R9"], out, force=True)
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines == ["R1:1", "R2:1", "R9:1", "R10:1"]
+
+
+def test_write_duplicate_references_counted(tmp_path: Path) -> None:
+    """Duplicate references produce count > 1."""
+    out = tmp_path / "designators.csv"
+    result = DesignatorsWriter.write(["R1", "R1", "C1"], out, force=True)
+    assert result.designator_count == 2
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert "R1:2" in lines
+    assert "C1:1" in lines
+
+
+def test_write_empty_input_returns_none_path(tmp_path: Path) -> None:
+    """Empty input produces no file and returns path=None."""
+    out = tmp_path / "designators.csv"
+    result = DesignatorsWriter.write([], out, force=True)
+
+    assert result.path is None
+    assert result.designator_count == 0
+    assert not out.exists()
+    assert any("skipped" in d.message for d in result.diagnostics)
+
+
+def test_write_blank_references_skipped(tmp_path: Path) -> None:
+    """Blank and whitespace-only references are ignored."""
+    out = tmp_path / "designators.csv"
+    result = DesignatorsWriter.write(["R1", "", "  ", "C1"], out, force=True)
+    assert result.designator_count == 2
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines == ["C1:1", "R1:1"]
+
+
+def test_write_no_force_existing_file_not_overwritten(tmp_path: Path) -> None:
+    """Without force=True, an existing file is not overwritten."""
+    out = tmp_path / "designators.csv"
+    out.write_text("old content", encoding="utf-8")
+    result = DesignatorsWriter.write(["R1"], out, force=False)
+
+    assert result.path is None
+    assert result.designator_count == 1
+    assert out.read_text(encoding="utf-8") == "old content"
+    assert any("already exists" in d.message for d in result.diagnostics)
+
+
+def test_write_force_overwrites_existing_file(tmp_path: Path) -> None:
+    """force=True overwrites an existing file."""
+    out = tmp_path / "designators.csv"
+    out.write_text("old content", encoding="utf-8")
+    result = DesignatorsWriter.write(["R1"], out, force=True)
+
+    assert result.path == out
+    assert out.read_text(encoding="utf-8").strip() == "R1:1"
+
+
+def test_write_creates_parent_directories(tmp_path: Path) -> None:
+    """write() creates parent directories if they do not exist."""
+    out = tmp_path / "deep" / "nested" / "designators.csv"
+    result = DesignatorsWriter.write(["C1"], out, force=True)
+
+    assert result.path == out
+    assert out.exists()
+
+
+def test_write_utf8_no_bom(tmp_path: Path) -> None:
+    """Output file is plain UTF-8, no BOM."""
+    out = tmp_path / "designators.csv"
+    DesignatorsWriter.write(["R1"], out, force=True)
+    raw = out.read_bytes()
+    assert not raw.startswith(b"\xef\xbb\xbf"), "File must not have a UTF-8 BOM"
+
+
+def test_write_unix_line_endings(tmp_path: Path) -> None:
+    """Lines are terminated with LF only (\\n), not CRLF."""
+    out = tmp_path / "designators.csv"
+    DesignatorsWriter.write(["R1", "C1"], out, force=True)
+    raw = out.read_bytes()
+    assert b"\r\n" not in raw
+
+
+def test_result_success_diagnostic(tmp_path: Path) -> None:
+    """Successful write emits an info diagnostic with the count."""
+    out = tmp_path / "designators.csv"
+    result = DesignatorsWriter.write(["R1", "R2"], out, force=True)
+    infos = [d.message for d in result.diagnostics if d.severity == "info"]
+    assert any("2 designators" in msg for msg in infos)
+
+
+# ---------------------------------------------------------------------------
+# DesignatorsResult dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_designators_result_immutable(tmp_path: Path) -> None:
+    """DesignatorsResult is frozen — attributes cannot be reassigned."""
+    result = DesignatorsResult(
+        path=tmp_path / "d.csv",
+        designator_count=3,
+        diagnostics=(),
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        result.designator_count = 99  # type: ignore[misc]
+
+
+def test_designators_result_path_coerced_to_path(tmp_path: Path) -> None:
+    """path is coerced to Path even when given as a string."""
+    result = DesignatorsResult(
+        path=str(tmp_path / "d.csv"),  # type: ignore[arg-type]
+        designator_count=1,
+        diagnostics=(),
+    )
+    assert isinstance(result.path, Path)
+
+
+# ---------------------------------------------------------------------------
+# FabricatorConfig — generate_designators field
+# ---------------------------------------------------------------------------
+
+
+def test_fabricator_config_default_is_false() -> None:
+    """generate_designators defaults to False when not set in YAML."""
+    from jbom.config.fabricators import load_fabricator
+
+    cfg = load_fabricator("generic")
+    assert cfg.generate_designators is False
+
+
+def test_fabricator_config_parse_true(tmp_path: Path) -> None:
+    """generate_designators: true is parsed correctly from YAML."""
+    import yaml
+    from jbom.config.fabricators import FabricatorConfig
+
+    # Patch a minimal fab YAML with generate_designators: true
+    yaml_content = """
+name: "TestFab"
+id: "testfab"
+generate_designators: true
+suppliers:
+  - generic
+pos_columns:
+  "Designator": "reference"
+  "Mid X": "x"
+  "Mid Y": "y"
+  "Layer": "side"
+  "Rotation": "rotation"
+  "Package": "package"
+field_synonyms:
+  fab_pn:
+    display_name: "Part #"
+    synonyms: []
+  supplier_pn:
+    display_name: "SPN"
+    synonyms: []
+  mpn:
+    display_name: "MPN"
+    synonyms: []
+"""
+    data = yaml.safe_load(yaml_content)
+    cfg = FabricatorConfig.from_yaml_dict(data, default_id="testfab")
+    assert cfg.generate_designators is True
+
+
+def test_fabricator_config_parse_false_explicit(tmp_path: Path) -> None:
+    """generate_designators: false is parsed correctly from YAML."""
+    import yaml
+    from jbom.config.fabricators import FabricatorConfig
+
+    yaml_content = """
+name: "TestFab"
+id: "testfab"
+generate_designators: false
+suppliers:
+  - generic
+pos_columns:
+  "Designator": "reference"
+  "Mid X": "x"
+  "Mid Y": "y"
+  "Layer": "side"
+  "Rotation": "rotation"
+  "Package": "package"
+field_synonyms:
+  fab_pn:
+    display_name: "Part #"
+    synonyms: []
+  supplier_pn:
+    display_name: "SPN"
+    synonyms: []
+  mpn:
+    display_name: "MPN"
+    synonyms: []
+"""
+    data = yaml.safe_load(yaml_content)
+    cfg = FabricatorConfig.from_yaml_dict(data, default_id="testfab")
+    assert cfg.generate_designators is False
+
+
+# ---------------------------------------------------------------------------
+# FabricationRequest — generate_designators field
+# ---------------------------------------------------------------------------
+
+
+def test_fabrication_request_defaults_false(tmp_path: Path) -> None:
+    """generate_designators defaults to False in FabricationRequest."""
+    from jbom.application.fabrication_orchestration import FabricationRequest
+
+    req = FabricationRequest(input_path=str(tmp_path))
+    assert req.generate_designators is False
+
+
+def test_fabrication_request_truthy_coercion(tmp_path: Path) -> None:
+    """generate_designators is coerced to bool."""
+    from jbom.application.fabrication_orchestration import FabricationRequest
+
+    req = FabricationRequest(input_path=str(tmp_path), generate_designators=1)  # type: ignore[arg-type]
+    assert req.generate_designators is True
+
+
+# ---------------------------------------------------------------------------
+# FabricationWorkflow integration — designators artifact produced
+# ---------------------------------------------------------------------------
+
+
+def test_fabrication_workflow_generates_designators_when_requested(
+    tmp_path: Path,
+) -> None:
+    """When generate_designators=True, workflow writes designators.csv artifact."""
+    import textwrap
+    from jbom.application.fabrication_orchestration import (
+        FabricationRequest,
+        FabricationWorkflow,
+    )
+
+    # Minimal KiCad project fixture
+    proj_name = "proj"
+    (tmp_path / f"{proj_name}.kicad_pro").write_text(
+        "(kicad_project (version 1))\n", encoding="utf-8"
+    )
+    (tmp_path / f"{proj_name}.kicad_sch").write_text(
+        "(kicad_sch (version 20211123) (generator eeschema))\n", encoding="utf-8"
+    )
+    pcb_content = textwrap.dedent(
+        """\
+        (kicad_pcb (version 20211014) (generator pcbnew)
+          (footprint "R_0805_2012" (at 10 5 0) (layer "F.Cu")
+            (property "Reference" "R1")
+            (attr smd)
+          )
+          (footprint "C_0603_1608" (at 15 8 0) (layer "F.Cu")
+            (property "Reference" "C1")
+            (attr smd)
+          )
+        )
+    """
+    )
+    (tmp_path / f"{proj_name}.kicad_pcb").write_text(pcb_content, encoding="utf-8")
+
+    req = FabricationRequest(
+        input_path=str(tmp_path),
+        skip_bom=True,
+        skip_pos=True,
+        skip_gerbers=True,
+        skip_backup=True,
+        generate_designators=True,
+    )
+    result = FabricationWorkflow().run(req)
+
+    des_artifacts = [a for a in result.artifacts if a.artifact_type == "designators"]
+    assert des_artifacts, "Expected a 'designators' artifact in the result"
+    des_path = des_artifacts[0].path
+    assert des_path is not None and des_path.exists()
+    content = des_path.read_text(encoding="utf-8")
+    assert "C1:1" in content
+    assert "R1:1" in content
+
+
+def test_fabrication_workflow_skips_designators_when_not_requested(
+    tmp_path: Path,
+) -> None:
+    """When generate_designators=False (default), no designators artifact is produced."""
+    from jbom.application.fabrication_orchestration import (
+        FabricationRequest,
+        FabricationWorkflow,
+    )
+
+    proj_name = "proj"
+    (tmp_path / f"{proj_name}.kicad_pro").write_text(
+        "(kicad_project (version 1))\n", encoding="utf-8"
+    )
+    (tmp_path / f"{proj_name}.kicad_sch").write_text(
+        "(kicad_sch (version 20211123) (generator eeschema))\n", encoding="utf-8"
+    )
+    (tmp_path / f"{proj_name}.kicad_pcb").write_text(
+        "(kicad_pcb (version 20211014) (generator pcbnew))\n", encoding="utf-8"
+    )
+
+    req = FabricationRequest(
+        input_path=str(tmp_path),
+        skip_bom=True,
+        skip_pos=True,
+        skip_gerbers=True,
+        skip_backup=True,
+        generate_designators=False,
+    )
+    result = FabricationWorkflow().run(req)
+
+    des_artifacts = [a for a in result.artifacts if a.artifact_type == "designators"]
+    assert not des_artifacts
+    assert not (tmp_path / "production" / "designators.csv").exists()


### PR DESCRIPTION
## Summary

Implements issue #243: `designators.csv` generation as a jBOM service wired into the fabrication workflow, CLI, and plugin dialog.

## What's added

### `DesignatorsWriter` service (new)
Writes `REF:COUNT` lines in natural sort order (R1, R2, …, R10 — not lexicographic). Handles duplicates, blank references, force-overwrite, parent-dir creation. Plain UTF-8, LF line endings, no BOM.

### `FabricatorConfig.generate_designators: bool`
Optional YAML key (absent → `False`). Set `generate_designators: true` in a `.fab.yaml` to make that fabricator's default ON. Generic stays OFF.

### `FabricationWorkflow` — Step 2.5
Runs after POS, before Gerbers. Reads all PCB footprint references via `DefaultKiCadReaderService`, delegates to `DesignatorsWriter`, registers a `designators` artifact (consistent with how gerbers are handled — no dedicated result field).

### `jbom fab --designators` flag
`--designators` forces generation on; when absent, the effective default is read from the selected fabricator config.

### Plugin dialog checkbox
"Generate designators.csv" checkbox, default value from the currently-selected fabricator config. `_worker` uses `board.GetFootprints()` (in-memory, no file re-read).

## Tests
20 new unit tests: service correctness (sort, dedup, empty, force, BOM/CRLF), `DesignatorsResult` contract, YAML parse round-trip, `FabricationRequest` field, workflow integration (generates artifact / skips correctly).

**1335 / 1335 unit tests passing.**

---
_Conversation: https://app.warp.dev/conversation/d0c10e1a-9dd9-485e-bb8e-869af9a8cade_
_Plan: https://app.warp.dev/drive/notebook/ji2FAL4g1ymgNzcY8peKMS_
_Roadmap: https://app.warp.dev/drive/notebook/XrvCApVqIKbm3ZRJnt5OnV_

Co-Authored-By: Oz <oz-agent@warp.dev>