### PR TITLE
design(config): ADR 0008 — unified *.jbom.yaml configuration schema (#250, #251)

### DIFF
--- a/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
+++ b/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
@@ -95,7 +95,50 @@ named configs; the `generic` profile is the implicit fallback when no flag
 is given. CI tests that probe edge cases use explicit flags; tests of generic
 behavior rely on the implied `generic` profile.
 
-## Design Decisions
+## Options Considered
+
+### Option 1 — Status quo: four separate file types (rejected)
+Continue with `*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml`, `*.yaml`
+(presets). Low migration cost. Does not address any of the user stories;
+partial-override and cross-stanza composition remain impossible.
+
+### Option 2 — Unified format, dimension flags for stanza selection (rejected)
+Introduce `--fabricator NAME`, `--defaults NAME`, `--supplier NAME` as
+explicit dimension-selecting CLI flags. Each flag extracts only its named
+stanza from the loaded file. Conflicting stanzas from multiple loaded files
+are resolved by flag precedence.
+
+Rejected because: the combinatorics are complex (a 3-file × 3-stanza matrix
+with non-obvious precedence rules); the cross-cutting use case (org tolerance
+floor) requires an additional flag every time; the `common.jbom.yaml` mechanism
+(D5) addresses the same use cases with zero new flags.
+
+### Option 3 — Unified format, no multi-stanza files (rejected)
+Allow `.jbom.yaml` suffix but require each file to contain exactly one stanza.
+Renames `jlc.fab.yaml` to `jlc.jbom.yaml` with `fab:` stanza, etc. Eliminates
+stanza ambiguity.
+
+Rejected because: it does not address Story D (single composite profile per
+fabricator) and does not simplify anything over the current 4-type system
+except the naming convention.
+
+### Option 4 — Unified format, command-scoped stanza selection (accepted — this ADR)
+Described in Decision Details below (D1–D8).
+
+## Decision
+
+Adopt the unified `*.jbom.yaml` schema as described in D1–D8.
+
+Key properties of the accepted design:
+- One file suffix, one inheritance model, one search path, one merge engine.
+- Command provides stanza scope; no dimension-specific CLI flags in v1.
+- `common.jbom.yaml` per search-path level provides composable ambient defaults.
+- `policy.jbom.yaml` per search-path level provides mandate enforcement (deferred).
+- `extends:` + deep-merge + list-replace + `null`-delete enables partial override.
+- `generic.jbom.yaml` consolidates all current generic config files.
+- Legacy file types and prefixes retired atomically with the new loader — no shim.
+
+### Decision Details
 
 ### D1. Unified `*.jbom.yaml` file format
 
@@ -346,49 +389,6 @@ removed as part of this feature branch — not deferred to a follow-on.
 
 `pyproject.toml` `[tool.hatch.build.targets.wheel] include` patterns are
 updated to `*.jbom.yaml` in the same commit.
-
-## Options Considered
-
-### Option 1 — Status quo: four separate file types (rejected)
-Continue with `*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml`, `*.yaml`
-(presets). Low migration cost. Does not address any of the user stories;
-partial-override and cross-stanza composition remain impossible.
-
-### Option 2 — Unified format, dimension flags for stanza selection (rejected)
-Introduce `--fabricator NAME`, `--defaults NAME`, `--supplier NAME` as
-explicit dimension-selecting CLI flags. Each flag extracts only its named
-stanza from the loaded file. Conflicting stanzas from multiple loaded files
-are resolved by flag precedence.
-
-Rejected because: the combinatorics are complex (a 3-file × 3-stanza matrix
-with non-obvious precedence rules); the cross-cutting use case (org tolerance
-floor) requires an additional flag every time; the `common.jbom.yaml` mechanism
-(D5) addresses the same use cases with zero new flags.
-
-### Option 3 — Unified format, no multi-stanza files (rejected)
-Allow `.jbom.yaml` suffix but require each file to contain exactly one stanza.
-Renames `jlc.fab.yaml` to `jlc.jbom.yaml` with `fab:` stanza, etc. Eliminates
-stanza ambiguity.
-
-Rejected because: it does not address Story D (single composite profile per
-fabricator) and does not simplify anything over the current 4-type system
-except the naming convention.
-
-### Option 4 — Unified format, command-scoped stanza selection (accepted — this ADR)
-Described in D1–D8 above.
-
-## Decision
-
-Adopt the unified `*.jbom.yaml` schema as described in D1–D8.
-
-Key properties of the accepted design:
-- One file suffix, one inheritance model, one search path, one merge engine.
-- Command provides stanza scope; no dimension-specific CLI flags in v1.
-- `common.jbom.yaml` per search-path level provides composable ambient defaults.
-- `policy.jbom.yaml` per search-path level provides mandate enforcement (deferred).
-- `extends:` + deep-merge + list-replace + `null`-delete enables partial override.
-- `generic.jbom.yaml` consolidates all current generic config files.
-- Legacy file types and prefixes retired atomically with the new loader — no shim.
 
 ## Consequences
 

--- a/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
+++ b/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
@@ -1,0 +1,459 @@
+# ADR 0008: Unified jBOM Configuration Schema
+Date: 2026-05-11
+Status: Proposed
+Related: #250, #251, ADR 0007
+
+## Context
+
+jBOM currently has four separate configuration file types living in four separate
+subdirectories under `src/jbom/config/`:
+
+| Type | Directory | File pattern | Python loader |
+|---|---|---|---|
+| Fabricator | `fabricators/` | `<name>.fab.yaml` | `config/fabricators.py` |
+| Supplier | `suppliers/` | `<name>.supplier.yaml` | `config/suppliers.py` |
+| Defaults | `defaults/` | `<name>.defaults.yaml` | `config/defaults.py` |
+| Presets | `presets/` | *(no type suffix)* | *(no dedicated loader)* |
+
+Each type has its own loader, its own schema, and its own inheritance semantics.
+`defaults.py` implements `extends:` deep-merge (working well). `fabricators.py`
+documents a `based_on:` key but does not implement it. `suppliers.py` has no
+inheritance at all. `presets/common.yaml` has no suffix convention and no loader.
+
+The fragmentation creates real user friction:
+- A user customizing JLCPCB output must maintain three files (`jlc.fab.yaml`,
+  `lcsc.supplier.yaml`, `generic.defaults.yaml`) to express a single coherent profile.
+- Inheritance is only available for `*.defaults.yaml`; fabricator and supplier
+  overrides require full-file copies.
+- Extending with org-wide or project-specific settings has no consistent mechanism.
+- The `profile_search.py` unified search path is good but is called three times
+  with three different suffixes, producing three separate resolution chains.
+- There is no way to express "this value is mandatory and cannot be overridden
+  by a lower-priority config."
+
+Issue #250 identifies the naming inconsistency. Issue #251 calls for a unified
+schema. This ADR records the design decision for both.
+
+## Decision Drivers
+
+- **Simplicity for the common case.** `jbom bom --jlc` should work with one
+  config file that expresses everything JLC-specific.
+- **Partial override without full-file copy.** A user who wants to change one
+  column in JLC's BOM format should not have to copy and maintain the entire
+  `jlc.fab.yaml`.
+- **Org/team standards that compose with any fabricator.** Tolerance floors,
+  mandatory columns, and search defaults must be expressible at an org level
+  and apply regardless of which fabricator flag the user chooses.
+- **Consistent semantics.** One inheritance model, one merge strategy, one
+  search path mechanism — not one per config type.
+- **Command-scoped consumption.** Each `jbom <cmd>` knows which stanzas it
+  needs; config files may contain multiple stanzas but each command only
+  consumes what is relevant.
+- **No external migration burden.** Nothing has shipped externally; backward
+  compatibility with existing user `.jbom/` files is desirable but not blocking.
+- **Buildable in phases.** The design must not require a big-bang rewrite;
+  the legacy file types can coexist as a deprecation shim during migration.
+
+## User Stories
+
+These are the concrete scenarios that drove the design. Each one is validated
+against the decision below.
+
+**Story A — Project 4-layer override**
+A board has inner copper layers. The user wants JLC's full profile plus
+`gerbers.layers` overridden with the 4-layer set. Copying and maintaining the
+full `jlc.jbom.yaml` to change one list is unacceptable.
+
+**Story B — Org-wide tolerance standard**
+An org mandates 0.1% resistors. Every project under `$JBOM_PROFILE_PATH`
+inherits that floor regardless of which fabricator flag the user chooses.
+No per-project configuration should be required.
+
+**Story C — Personal extra column**
+A developer always wants an `IPN` column in their BOMs. Their `~/.jbom/`
+config adds the column without duplicating the rest of the fabricator profile.
+
+**Story D — Single-file fabricator profile**
+One `jlc.jbom.yaml` expresses the JLC column format, LCSC as the preferred
+supplier, and JLC-appropriate parametric search defaults — without maintaining
+three separate files.
+
+**Story E — Corporate fork of JLC**
+`acme-jlc.jbom.yaml` extends `jlc`, overriding only the delta fields. New
+hires get the team's format automatically by running `jbom bom --acme-jlc`
+from the checked-in repo root.
+
+**Story F — Column deletion**
+A team's JLC profile should be `jlc` minus the `Surface Mount` column plus
+an `IPN` column. Without a deletion mechanism, the user must copy and maintain
+the full `bom_columns` dict.
+
+**Story G — CI / headless determinism**
+`jbom bom --jlc` in CI must produce identical output regardless of the
+developer's `~/.jbom/` contents. Explicit flags (`--jlc`) select specific
+named configs; the `generic` profile is the implicit fallback when no flag
+is given. CI tests that probe edge cases use explicit flags; tests of generic
+behavior rely on the implied `generic` profile.
+
+## Design Decisions
+
+### D1. Unified `*.jbom.yaml` file format
+
+All configuration files use the `.jbom.yaml` suffix. A file may contain one
+or more top-level stanzas:
+
+```yaml
+fab:        # Fabricator output format (bom columns, pos columns, gerbers, etc.)
+supplier:   # Supplier API connection (URL, auth, rate limits, search providers)
+defaults:   # General jBOM-wide defaults (electrical defaults, search config,
+            # enrichment attributes, component ID policy, field precedence)
+presets:    # Named field-set collections (global, shared across contexts)
+```
+
+A file that contains only a `fab:` stanza is a pure fabricator profile. A file
+that contains all four stanzas is a complete composite profile. Either is valid.
+
+The `defaults:` stanza is the general cross-cutting stanza for settings that
+are not tied to any specific fabricator or supplier — electrical attribute
+defaults, parametric search configuration, enrichment classification, and
+component ID field policies.
+
+### D2. Command-scoped stanza consumption
+
+Each `jbom <cmd>` consumes only the stanzas relevant to its function:
+
+| Command | Stanzas consumed |
+|---|---|
+| `bom` | `fab:`, `defaults:` |
+| `pos` | `fab:` |
+| `fab` | `fab:`, `defaults:` |
+| `gerbers` | `fab:` (gerbers section) |
+| `search` | `supplier:`, `defaults:` |
+| `annotate` | `defaults:` |
+
+A unified file loaded for `jbom bom --jlc` will have its `supplier:` stanza
+loaded but not consumed. The stanza is inert for that command; it does not
+produce errors or warnings.
+
+### D3. One CLI flag per named profile — no dimension qualifiers in v1
+
+The CLI accepts `--<configname>` where `<configname>` is derived from the
+profile's `id` field (same auto-generation as today). A single flag loads
+the entire named `.jbom.yaml` file; the command determines which stanzas
+it uses.
+
+```
+jbom bom --jlc          # loads jlc.jbom.yaml; bom command uses fab: stanza
+jbom search --lcsc      # loads lcsc.jbom.yaml; search command uses supplier: stanza
+jbom bom                # no flag → generic.jbom.yaml (same as today's --generic)
+```
+
+Dimension-specific flags (`--fabricator`, `--defaults`, `--supplier`) are not
+introduced in v1. The `common.jbom.yaml` ambient mechanism (D5) addresses the
+cross-cutting composition use case without needing explicit dimension flags.
+
+Flag auto-generation per command: a command only exposes `--<id>` for profiles
+whose `.jbom.yaml` contains at least one stanza that command consumes. `jbom bom`
+does not expose `--lcsc` if `lcsc.jbom.yaml` has only a `supplier:` stanza.
+
+### D4. Explicit `extends:` inheritance with consistent merge semantics
+
+Inheritance is always explicit via the top-level `extends:` key, which names
+a profile to inherit from:
+
+```yaml
+# acme-jlc.jbom.yaml
+extends: jlc
+
+fab:
+  bom_columns:
+    "IPN": "internal_ipn"    # additive: adds this column
+    "Surface Mount": null    # deletion: removes inherited column
+```
+
+Merge semantics (applied recursively per stanza, consistent with `defaults.py`):
+
+- **Dicts**: deep-merged. Child keys override parent keys; omitted parent keys
+  are inherited unchanged.
+- **Lists**: child replaces parent entirely. To inherit a list you must include
+  it explicitly. There is no list-append syntax in v1.
+- **Scalars**: child replaces parent.
+- **`null` value**: deletes the key from the merged result. This is the deletion
+  mechanism for Story F.
+
+`extends:` applies at the file level: the entire parent file is loaded and
+merged before the child's stanzas are applied. Circular `extends:` chains are
+an error.
+
+### D5. `common.jbom.yaml` — ambient defaults at each search path level
+
+A file named `common.jbom.yaml` found at any search path level is automatically
+deep-merged as ambient defaults at that level. It is not a named profile and
+cannot be selected with `--common`.
+
+The effective config resolution for `jbom bom --jlc` (named profile) is:
+
+```
+policy.jbom.yaml         (all levels, mandates — applied post-resolution; see D6)
+─────────────────────────────────────────────────────────
+jlc.jbom.yaml            (first found in search path — named selection)
+─────────────────────────────────────────────────────────
+common.jbom.yaml         (cwd/.jbom/   — if present)
+common.jbom.yaml         (repo/.jbom/  — if present)
+common.jbom.yaml         ($JBOM_PROFILE_PATH — if present)
+common.jbom.yaml         (~/.jbom/     — if present)
+common.jbom.yaml         (system dir   — if present)
+```
+
+The effective config resolution for `jbom bom` (no flag) is:
+
+```
+policy.jbom.yaml         (all levels, mandates — applied post-resolution; see D6)
+─────────────────────────────────────────────────────────
+generic.jbom.yaml        (first found in search path — implicit fallback)
+─────────────────────────────────────────────────────────
+common.jbom.yaml         (cwd/.jbom/   — if present)
+common.jbom.yaml         (repo/.jbom/  — if present)
+common.jbom.yaml         ($JBOM_PROFILE_PATH — if present)
+common.jbom.yaml         (~/.jbom/     — if present)
+common.jbom.yaml         (system dir   — if present)
+─────────────────────────────────────────────────────────
+generic.jbom.yaml        (built-in package — floor, always present)
+```
+
+Note that in the no-flag case `generic.jbom.yaml` is searched like any other named
+profile (first match in search path wins), so a `generic.jbom.yaml` in `$REPO_ROOT/.jbom/`
+overrides the built-in generic for that repo's no-flag invocations.
+
+All `common.jbom.yaml` files are deep-merged in search-path priority order
+(cwd highest, built-in lowest). The named profile (`jlc.jbom.yaml`) is then
+applied on top of the merged common base.
+
+`common.jbom.yaml` files in the search path are cumulative; named profile files
+use first-match-wins (same as today's `profile_search.py` behavior for named
+configs). This means a `jlc.jbom.yaml` in `cwd/.jbom/` fully replaces the
+built-in `jlc.jbom.yaml` unless `extends:` is used.
+
+The existing `presets/common.yaml` content migrates into a `presets:` stanza
+in `generic.jbom.yaml` (or into a built-in `common.jbom.yaml`).
+
+This mechanism addresses Stories B and C without any new CLI flags: org-wide
+tolerance floors go in `$JBOM_PROFILE_PATH/common.jbom.yaml`; they activate
+for every command, regardless of which named profile is selected.
+
+### D6. `policy.jbom.yaml` — mandatory overrides (v1: reserved, enforcement deferred)
+
+A file named `policy.jbom.yaml` found at any search path level declares
+mandatory values. Policy is applied **after** the full user-config resolution
+(common chain + named selection + extends chain) and enforces values downward
+from the level at which the policy file was found.
+
+A `policy.jbom.yaml` at `$JBOM_PROFILE_PATH` overrides anything in `~/.jbom/`
+or `cwd/.jbom/`. A `policy.jbom.yaml` at `~/.jbom/` overrides only `cwd/.jbom/`.
+
+This is the mechanism for Story B's "1% tolerance floor that a user's personal
+config cannot override."
+
+The `!final` YAML tag is reserved for per-value mandate marking at the point
+of declaration (analogous to CSS `!important`). YAML's `!` introduces a type
+tag, so this requires a custom tag registered as `!final`:
+
+```yaml
+# $JBOM_PROFILE_PATH/policy.jbom.yaml
+defaults:
+  domain_defaults:
+    resistor:
+      tolerance: !final "1%"
+```
+
+**v1 scope**: The `policy.jbom.yaml` filename is reserved and must not be used
+for other purposes. The enforcement mechanism (post-resolution overlay and
+`!final` tag processing) is deferred to a follow-on issue. v1 loads and ignores
+`policy.jbom.yaml` with a logged warning so users who place such a file in the
+search path are informed the feature is not yet active.
+
+### D7. `generic.jbom.yaml` — fallback for the no-flag case only
+
+The built-in `generic.jbom.yaml` consolidates the content of all current
+built-in generic config files:
+- `config/fabricators/generic.fab.yaml` → `fab:` stanza
+- `config/defaults/generic.defaults.yaml` → `defaults:` stanza
+- `config/suppliers/generic.supplier.yaml` → `supplier:` stanza
+- `config/presets/common.yaml` → `presets:` stanza
+
+`generic.jbom.yaml` is loaded **only** in the no-flag case (`jbom bom` with
+no named profile). Selecting a named profile (`jbom bom --jlc`) disengages
+implicit generic inheritance entirely: you get exactly what the named profile
+defines, plus any `extends:` chain it declares explicitly, plus the
+`common.jbom.yaml` ambient layer.
+
+If a named profile wants generic content, it must say so explicitly:
+```yaml
+# jlc.jbom.yaml
+extends: generic   # explicit — not implied
+```
+
+This preserves the principle of least astonishment: specifying a named
+profile is a declaration of intent; silently mixing in generic defaults
+would violate that.
+
+The built-in `generic.jbom.yaml` is intentionally minimal — it provides
+a reproducible, testable foundation rather than production-quality defaults.
+Orgs that want a customized "no-flag" default across a repository can place
+a `generic.jbom.yaml` in `$REPO_ROOT/.jbom/`. This file is found by
+`profile_search.py` at the repo-root level and becomes the effective floor
+for any `jbom` invocation in that repo that specifies no named profile —
+without affecting `--jlc` or any other named profile unless those profiles
+explicitly `extends: generic`.
+
+### D8. Migration path and backward compatibility
+
+Existing `*.fab.yaml`, `*.supplier.yaml`, and `*.defaults.yaml` files are
+supported as a **deprecation shim** during migration. The new unified loader
+detects the legacy suffix and delegates to the existing per-type loaders with
+a deprecation log warning. The shim will be removed in a future major version.
+
+Built-in config files migrate from the legacy format to `.jbom.yaml` as part
+of this feature branch. The four subdirectories (`fabricators/`, `suppliers/`,
+`defaults/`, `presets/`) are retained during the shim period and removed when
+the shim is removed.
+
+`pyproject.toml` `[tool.hatch.build.targets.wheel] include` patterns must be
+updated to include `*.jbom.yaml` alongside the legacy patterns, and later to
+remove the legacy patterns when the subdirectories are retired.
+
+## Options Considered
+
+### Option 1 — Status quo: four separate file types (rejected)
+Continue with `*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml`, `*.yaml`
+(presets). Low migration cost. Does not address any of the user stories;
+partial-override and cross-stanza composition remain impossible.
+
+### Option 2 — Unified format, dimension flags for stanza selection (rejected)
+Introduce `--fabricator NAME`, `--defaults NAME`, `--supplier NAME` as
+explicit dimension-selecting CLI flags. Each flag extracts only its named
+stanza from the loaded file. Conflicting stanzas from multiple loaded files
+are resolved by flag precedence.
+
+Rejected because: the combinatorics are complex (a 3-file × 3-stanza matrix
+with non-obvious precedence rules); the cross-cutting use case (org tolerance
+floor) requires an additional flag every time; the `common.jbom.yaml` mechanism
+(D5) addresses the same use cases with zero new flags.
+
+### Option 3 — Unified format, no multi-stanza files (rejected)
+Allow `.jbom.yaml` suffix but require each file to contain exactly one stanza.
+Renames `jlc.fab.yaml` to `jlc.jbom.yaml` with `fab:` stanza, etc. Eliminates
+stanza ambiguity.
+
+Rejected because: it does not address Story D (single composite profile per
+fabricator) and does not simplify anything over the current 4-type system
+except the naming convention.
+
+### Option 4 — Unified format, command-scoped stanza selection (accepted — this ADR)
+Described in D1–D8 above.
+
+## Decision
+
+Adopt the unified `*.jbom.yaml` schema as described in D1–D8.
+
+Key properties of the accepted design:
+- One file suffix, one inheritance model, one search path, one merge engine.
+- Command provides stanza scope; no dimension-specific CLI flags in v1.
+- `common.jbom.yaml` per search-path level provides composable ambient defaults.
+- `policy.jbom.yaml` per search-path level provides mandate enforcement (deferred).
+- `extends:` + deep-merge + list-replace + `null`-delete enables partial override.
+- `generic.jbom.yaml` consolidates all current generic config files.
+- Legacy file types supported via deprecation shim during migration.
+
+## Consequences
+
+### Positive
+- Stories A–G are all addressable within this design.
+- Config system complexity drops: one loader, one merge engine, one search path call.
+- Org-level standards (`$JBOM_PROFILE_PATH/common.jbom.yaml`) activate for every
+  command with no per-project or per-user configuration.
+- `defaults.py`'s existing `_deep_merge` and `extends:` machinery is reused and
+  extended rather than replaced.
+- The file naming convention is now unambiguous and self-documenting.
+- Flag generation per command is now driven by stanza presence, not file suffix.
+
+### Negative / Tradeoffs
+- Migration work: all built-in config files must be converted to `.jbom.yaml`.
+- `pyproject.toml` package-data declarations must be updated (affects PCM
+  archive build per ADR 0007).
+- The deprecation shim period means two code paths for config loading during
+  the transition.
+- `common.jbom.yaml` files are merged cumulatively (not first-match-wins), which
+  is a different behavior from named profile files. This asymmetry must be
+  clearly documented.
+- List-replace semantics (not list-append) means Story A's 4-layer override
+  requires specifying all 9 layers, not just the 2 new ones. Acceptable for v1;
+  a `_append:` list modifier could be added later.
+
+### Risks and Mitigations
+- **Risk**: Circular `extends:` chains produce infinite loops.
+  **Mitigation**: track seen profile names during resolution; raise `ValueError`
+  on the second visit to the same name.
+- **Risk**: `null`-delete semantics surprise users who set a value to `null`
+  intending "no value" rather than "delete inherited value."
+  **Mitigation**: document prominently; consider a `_unset:` explicit keyword
+  in a future revision.
+- **Risk**: `policy.jbom.yaml` reserved name collision with existing user files.
+  **Mitigation**: Log a deprecation warning if found during the shim period
+  with instructions to rename.
+
+## Deferred Items
+
+The following are explicitly out of scope for the initial implementation but
+are recorded here to prevent loss:
+
+1. **`policy.jbom.yaml` enforcement** — the file is reserved; enforcement logic
+   (post-resolution overlay, per-level downward scope) is a follow-on issue.
+2. **`!final` tag processing** — reserved tag name; parser registration and
+   merge-engine enforcement are deferred with policy enforcement.
+3. **Dimension flags (`--fabricator`, `--defaults`, `--supplier`)** — may be
+   introduced in v2 as power-user escape hatches once the common/policy
+   mechanism is validated in practice.
+4. **List-append modifier (`_append:`)** — would allow additive layer overrides
+   for lists (e.g., Story A with only the new layers, not the full list).
+5. **`jbom config show --jlc`** — diagnostic command to print the fully-resolved
+   effective config (Story K). Requires the merge engine to be serializable
+   back to YAML.
+
+## Implementation Phases
+
+**Phase 1 (this feature branch, issues #250 + #251)**
+- Land this ADR.
+- Implement the unified loader in `src/jbom/config/unified.py`:
+  - `load_unified(name, cwd)` → resolves the full stack (common chain + named
+    profile + extends chain) and returns a raw merged dict.
+  - Stanza extractors: `fab_config_from_unified(dict)`, `supplier_config_from_unified(dict)`,
+    `defaults_config_from_unified(dict)`.
+  - Dispatch to existing `FabricatorConfig.from_yaml_dict`, `SupplierConfig.from_yaml_dict`,
+    `DefaultsConfig.from_yaml_dict` with the extracted stanza dict.
+- Extend `profile_search.py` to recognize `*.jbom.yaml` alongside legacy suffixes.
+- Migrate all built-in config files to `.jbom.yaml` format; consolidate into
+  `generic.jbom.yaml`.
+- Wire the new loader into `fabricators.py:load_fabricator`, `suppliers.py:load_supplier`,
+  `defaults.py:load_defaults` as the primary path (legacy suffix as shim).
+- Update `docs/README.configuration.md` to document the new convention (#250
+  acceptance criteria).
+- Unit tests for: `_deep_merge`, `null`-delete, `extends:` chain resolution,
+  circular-extends detection, `common.jbom.yaml` cumulative merge.
+- Functional tests for Stories A–E (Stories F, G already covered by existing
+  CI design).
+
+**Phase 2 (future issue)**
+- `policy.jbom.yaml` enforcement + `!final` tag.
+- `jbom config show` diagnostic command.
+- Remove legacy file suffix shim after one release cycle.
+- Retire `fabricators/`, `suppliers/`, `defaults/`, `presets/` subdirectories.
+
+## References
+- Issue #250: naming convention normalization
+- Issue #251: unified schema design (this ADR records the outcome of that design work)
+- `src/jbom/config/profile_search.py`: existing search path implementation
+- `src/jbom/config/defaults.py`: existing `extends:` deep-merge (reused in Phase 1)
+- `src/jbom/config/fabricators.py`: `FabricatorConfig.from_yaml_dict` (reused)
+- `src/jbom/config/suppliers.py`: `SupplierConfig.from_yaml_dict` (reused)
+- ADR 0007: PCM packaging — `pyproject.toml` package-data changes affect PCM archive build

--- a/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
+++ b/docs/dev/architecture/adr/0008-unified-jbom-config-schema.md
@@ -49,10 +49,10 @@ schema. This ADR records the design decision for both.
 - **Command-scoped consumption.** Each `jbom <cmd>` knows which stanzas it
   needs; config files may contain multiple stanzas but each command only
   consumes what is relevant.
-- **No external migration burden.** Nothing has shipped externally; backward
-  compatibility with existing user `.jbom/` files is desirable but not blocking.
-- **Buildable in phases.** The design must not require a big-bang rewrite;
-  the legacy file types can coexist as a deprecation shim during migration.
+- **Clean break.** Nothing has shipped externally; legacy file types and
+  prefixes are retired atomically with no shim and no major-version requirement.
+- **Atomic delivery.** The loader, built-in file migration, and legacy file
+  removal land in a single feature branch — no intermediate broken state.
 
 ## User Stories
 
@@ -144,17 +144,43 @@ it uses.
 
 ```
 jbom bom --jlc          # loads jlc.jbom.yaml; bom command uses fab: stanza
-jbom search --lcsc      # loads lcsc.jbom.yaml; search command uses supplier: stanza
+jbom search --lcsc      # loads jlc.jbom.yaml; search command uses supplier: stanza
 jbom bom                # no flag → generic.jbom.yaml (same as today's --generic)
 ```
+
+**Per-stanza `id:` override**: a file-level `id:` is the default for all
+stanzas, but each stanza may declare its own `id:` to control which CLI flag
+reaches it for that command type:
+
+```yaml
+# jlc.jbom.yaml
+id: jlc          # file-level default
+
+fab:             # inherits id: jlc  →  jbom bom --jlc resolves here
+  ...
+
+supplier:
+  id: lcsc       # overrides for this stanza  →  jbom search --lcsc resolves here
+  ...
+```
+
+Both `--jlc` and `--lcsc` resolve to the same file; each command consumes
+its own stanza. The file is named for its primary purpose (the fabricator);
+the supplier stanza self-identifies as `lcsc` because that is the supplier
+name users naturally think in.
+
+For fabricators without a tightly coupled supplier (e.g. PCBWay), the
+`supplier:` stanza may be absent. `jbom search --pcbway` searches using the
+ordered `fab.suppliers:` list from the PCBWay config, falling back to the
+ambient supplier config from the `common.jbom.yaml` chain.
 
 Dimension-specific flags (`--fabricator`, `--defaults`, `--supplier`) are not
 introduced in v1. The `common.jbom.yaml` ambient mechanism (D5) addresses the
 cross-cutting composition use case without needing explicit dimension flags.
 
 Flag auto-generation per command: a command only exposes `--<id>` for profiles
-whose `.jbom.yaml` contains at least one stanza that command consumes. `jbom bom`
-does not expose `--lcsc` if `lcsc.jbom.yaml` has only a `supplier:` stanza.
+whose `.jbom.yaml` contains at least one stanza that command consumes, using
+the effective `id:` for that stanza.
 
 ### D4. Explicit `extends:` inheritance with consistent merge semantics
 
@@ -306,21 +332,20 @@ for any `jbom` invocation in that repo that specifies no named profile —
 without affecting `--jlc` or any other named profile unless those profiles
 explicitly `extends: generic`.
 
-### D8. Migration path and backward compatibility
+### D8. Migration — atomic, no shim
 
-Existing `*.fab.yaml`, `*.supplier.yaml`, and `*.defaults.yaml` files are
-supported as a **deprecation shim** during migration. The new unified loader
-detects the legacy suffix and delegates to the existing per-type loaders with
-a deprecation log warning. The shim will be removed in a future major version.
+Nothing has shipped externally. The legacy file types (`*.fab.yaml`,
+`*.supplier.yaml`, `*.defaults.yaml`) and the legacy field prefix notation
+(`c:`, `p:`, `i:`, `k:`) are retired in the same commit set that introduces
+the new loader. There is no intermediate state with the old files and the new
+loader coexisting, and no deprecation shim.
 
-Built-in config files migrate from the legacy format to `.jbom.yaml` as part
-of this feature branch. The four subdirectories (`fabricators/`, `suppliers/`,
-`defaults/`, `presets/`) are retained during the shim period and removed when
-the shim is removed.
+Built-in config files are converted to `.jbom.yaml` format and the legacy
+subdirectories (`fabricators/`, `suppliers/`, `defaults/`, `presets/`) are
+removed as part of this feature branch — not deferred to a follow-on.
 
-`pyproject.toml` `[tool.hatch.build.targets.wheel] include` patterns must be
-updated to include `*.jbom.yaml` alongside the legacy patterns, and later to
-remove the legacy patterns when the subdirectories are retired.
+`pyproject.toml` `[tool.hatch.build.targets.wheel] include` patterns are
+updated to `*.jbom.yaml` in the same commit.
 
 ## Options Considered
 
@@ -363,7 +388,7 @@ Key properties of the accepted design:
 - `policy.jbom.yaml` per search-path level provides mandate enforcement (deferred).
 - `extends:` + deep-merge + list-replace + `null`-delete enables partial override.
 - `generic.jbom.yaml` consolidates all current generic config files.
-- Legacy file types supported via deprecation shim during migration.
+- Legacy file types and prefixes retired atomically with the new loader — no shim.
 
 ## Consequences
 
@@ -381,8 +406,8 @@ Key properties of the accepted design:
 - Migration work: all built-in config files must be converted to `.jbom.yaml`.
 - `pyproject.toml` package-data declarations must be updated (affects PCM
   archive build per ADR 0007).
-- The deprecation shim period means two code paths for config loading during
-  the transition.
+- The atomic migration (no shim) means the entire built-in config file set
+  must be converted in one branch — no cherry-picking partial migrations.
 - `common.jbom.yaml` files are merged cumulatively (not first-match-wins), which
   is a different behavior from named profile files. This asymmetry must be
   clearly documented.
@@ -399,8 +424,8 @@ Key properties of the accepted design:
   **Mitigation**: document prominently; consider a `_unset:` explicit keyword
   in a future revision.
 - **Risk**: `policy.jbom.yaml` reserved name collision with existing user files.
-  **Mitigation**: Log a deprecation warning if found during the shim period
-  with instructions to rename.
+  **Mitigation**: The loader rejects `policy.jbom.yaml` as a selectable named
+  profile and logs an error if a user attempts to load it with `--policy`.
 
 ## Deferred Items
 
@@ -419,35 +444,43 @@ are recorded here to prevent loss:
 5. **`jbom config show --jlc`** — diagnostic command to print the fully-resolved
    effective config (Story K). Requires the merge engine to be serializable
    back to YAML.
+6. **`defaults.inventory` path** — the `defaults:` stanza could declare a default
+   inventory file path (or list of paths), enabling a `$REPO_ROOT/.jbom/common.jbom.yaml`
+   to specify a corporate or project-family inventory without requiring a
+   `--inventory` CLI flag on every invocation. Follows the same search-path layering
+   as all other `defaults:` content. Deferred to a follow-on issue.
+7. **`import X as Y`** — stanza-level renaming for aliasing an imported profile
+   under a local name. Deferred until concrete use cases emerge.
 
 ## Implementation Phases
 
-**Phase 1 (this feature branch, issues #250 + #251)**
-- Land this ADR.
+**Phase 1 (this feature branch, issues #250 + #251) — atomic delivery**
+- Land this ADR and ADR 0009.
 - Implement the unified loader in `src/jbom/config/unified.py`:
   - `load_unified(name, cwd)` → resolves the full stack (common chain + named
-    profile + extends chain) and returns a raw merged dict.
+    profile + extends chain + per-stanza id resolution) and returns a raw merged dict.
   - Stanza extractors: `fab_config_from_unified(dict)`, `supplier_config_from_unified(dict)`,
     `defaults_config_from_unified(dict)`.
-  - Dispatch to existing `FabricatorConfig.from_yaml_dict`, `SupplierConfig.from_yaml_dict`,
+  - Dispatch to `FabricatorConfig.from_yaml_dict`, `SupplierConfig.from_yaml_dict`,
     `DefaultsConfig.from_yaml_dict` with the extracted stanza dict.
-- Extend `profile_search.py` to recognize `*.jbom.yaml` alongside legacy suffixes.
-- Migrate all built-in config files to `.jbom.yaml` format; consolidate into
-  `generic.jbom.yaml`.
-- Wire the new loader into `fabricators.py:load_fabricator`, `suppliers.py:load_supplier`,
-  `defaults.py:load_defaults` as the primary path (legacy suffix as shim).
+- Update `profile_search.py` to recognize `*.jbom.yaml` only; remove legacy suffix handling.
+- Migrate all built-in config files to `.jbom.yaml` format (including
+  `generic.jbom.yaml` consolidation). Remove legacy subdirectories
+  (`fabricators/`, `suppliers/`, `defaults/`, `presets/`) and legacy files in the same commit.
+- Update `pyproject.toml` package-data for `*.jbom.yaml`; remove legacy patterns.
+- Wire the new loader into `fabricators.py`, `suppliers.py`, `defaults.py` as
+  the sole loading path (no legacy shim).
 - Update `docs/README.configuration.md` to document the new convention (#250
   acceptance criteria).
 - Unit tests for: `_deep_merge`, `null`-delete, `extends:` chain resolution,
-  circular-extends detection, `common.jbom.yaml` cumulative merge.
+  circular-extends detection, `common.jbom.yaml` cumulative merge, per-stanza id.
 - Functional tests for Stories A–E (Stories F, G already covered by existing
   CI design).
 
 **Phase 2 (future issue)**
 - `policy.jbom.yaml` enforcement + `!final` tag.
 - `jbom config show` diagnostic command.
-- Remove legacy file suffix shim after one release cycle.
-- Retire `fabricators/`, `suppliers/`, `defaults/`, `presets/` subdirectories.
+- `defaults.inventory` path configuration.
 
 ## References
 - Issue #250: naming convention normalization

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -159,10 +159,10 @@ Three namespaces are defined:
 | `inv:` | Inventory | Fields from matched inventory CSV rows (replaces `i:`) |
 
 Bare names without a namespace prefix are either jBOM-computed fields (a small
-set: `quantity`, `fabricator_part_number`, `smd`) or convenience aliases
-(`value`, `reference`, `footprint`, etc.) that resolve to the appropriate source
-namespace via the active `field_precedence_policy` in `defaults:`. The full
-taxonomy is described in D4.
+set: `quantity`, `fabricator_part_number`, `smd`) or unqualified source-data
+names (`value`, `reference`, `footprint`, etc.) that resolve to the originating
+source namespace, disambiguated by `field_precedence_policy` when the same name
+exists in multiple sources. The full taxonomy is described in D4.
 
 `k:` is not a namespace — it is replaced by the expression mechanism in D2.
 The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are retired;
@@ -176,7 +176,7 @@ one of two forms. `:` means exactly one thing throughout: namespace separator.
 **A plain field reference** — resolved directly:
 ```yaml
 bom_columns:
-  "Designator": "reference"        # convenience alias (resolves via field_precedence_policy)
+  "Designator": "reference"        # unqualified source-data name (sch:Reference)
   "Package":    "inv:package"      # inventory namespace
   "Footprint":  "pcb:footprint"    # PCB namespace
 ```
@@ -202,10 +202,10 @@ bom_columns:
    Resolve each to its string value and bind as `namespace_field` in the local
    variable namespace.
 
-2. Convenience alias names referenced in the expression are resolved via the
-   active `field_precedence_policy` and bound by name in the local namespace
-   (e.g., `value` → whichever source namespace the policy designates as
-   authoritative for `value`).
+2. Unqualified source-data names referenced in the expression are resolved via
+   the active `field_precedence_policy` when ambiguous across sources, and
+   bound by name in the local namespace (e.g., `value` → `sch:Value` when
+   schematic-biased policy is active and `inv:Value` is not present).
 
 3. Replace `namespace:field` tokens in the expression string with their
    `namespace_field` variable names. The result is a valid Python expression.
@@ -284,17 +284,27 @@ not passed through from any source:
 
 These are the only fields registered in `src/jbom/config/fields.py`. The earlier
 draft of this ADR incorrectly listed source fields (`reference`, `value`, etc.)
-as "canonical jBOM-computed fields" — they are source fields, accessed via
-namespace prefix or convenience alias (Category 3).
+as "canonical jBOM-computed fields" — they are source fields (Category 3).
 
 `__resolved_fabricator_part_number__` is retired; replaced by `fabricator_part_number`.
 
-**Category 3: Convenience aliases — config-defined bare names**
+The `jbom:` prefix is provisionally reserved for this category:
+`jbom:quantity`, `jbom:fabricator_part_number`, `jbom:smd`. The bare form
+(`quantity`) remains valid as a shorthand. The explicit `jbom:` form is
+useful when an inventory CSV column is also named `quantity` — `jbom:quantity`
+unambiguously selects the computed grouping count, not the inventory column.
+
+**Category 3: Unqualified field names — source-data names, policy-disambiguated**
 
 Bare names without a namespace prefix (`value`, `footprint`, `reference`) are
-convenience aliases. They resolve to the appropriate source namespace field
-according to the `field_precedence_policy` defined in the active `defaults:`
-stanza:
+not invented aliases — they are real attribute names that exist in the source
+data. KiCad schematic symbols have a `Value` property; PCB placement has a
+`Footprint` attribute; inventory CSVs use column headers like `Package`. When a
+bare name uniquely identifies one source it resolves there directly. The
+`field_precedence_policy` is invoked only when the same name exists in multiple
+sources simultaneously (e.g., both `sch:Value` and `inv:Value` are present):
+
+The policy lives in `common.jbom.yaml`, applied at each search-path level:
 
 ```yaml
 # common.jbom.yaml (ambient — applied at every search-path level)
@@ -409,9 +419,18 @@ available to all configs at that level and below.
 
 jBOM validates transform names at config load time. When a user-defined name
 matches a built-in from the shipped `common.jbom.yaml`, the user's definition
-shadows the built-in (intentional override is supported) and jBOM logs a
-`NOTICE`-level message so accidental shadows are detectable. Two user-defined
-transforms with the same name in the same file are a load-time error.
+shadows the built-in (intentional override is supported) and jBOM emits a
+`Diagnostic(severity=NOTICE, ...)` through the existing result contract
+diagnostic infrastructure (the same typed `Diagnostic` system used throughout
+jBOM since #245) so accidental shadows surface through normal diagnostic
+reporting. Two user-defined transforms with the same name in the same file are
+a load-time `Diagnostic(severity=ERROR)` that aborts config loading.
+
+The `jbom fields` command (Deferred Item 3) and the `jbom config show` command
+(ADR 0008, Deferred Item 5) belong to a planned diagnostic command group whose
+name and design are not yet specified. The NOTICE for transform shadowing, the
+loaded-transform listing, and the resolved-config display are all outputs of
+that command group.
 
 This allows `--fields` CLI arguments and config `bom_columns` values to
 reference org-defined transforms by name, enabling a team's `common.jbom.yaml`
@@ -445,8 +464,9 @@ Key properties:
   single-character prefixes. `:` means exactly one thing: namespace separator.
 - Source fields are runtime-discovered; only three jBOM-computed fields
   (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
-- Bare convenience alias names resolve via `field_precedence_policy` in
-  `defaults:` — config-owned, not hardcoded.
+- Unqualified source-data names (e.g., `value`, `reference`) resolve
+  unambiguously when unique; `field_precedence_policy` in `common.jbom.yaml`
+  disambiguates when the same name appears in multiple sources.
 - `namespace:field` tokens are syntactically invalid Python and are
   unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
 - Named transforms (including built-in ones in `common.jbom.yaml`) are

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -1,0 +1,368 @@
+# ADR 0009: Field Reference System and Value Expressions
+Date: 2026-05-11
+Status: Proposed
+Related: #250, #251, ADR 0008
+
+## Context
+
+ADR 0008 establishes the unified `*.jbom.yaml` container format. This ADR
+addresses the content within that container: the language used to reference
+fields and express field value transformations.
+
+The current system grew organically and has accumulated several compounding
+problems.
+
+### The `i:/p:/c:/k:` prefix system
+
+The field prefix notation (`i:package`, `p:k:footprint`, `c:tolerance`)
+originated in the `--fields` CLI argument parser and was copied into
+`bom_columns` config because both express the same concept. The config schema
+borrowed a CLI convention rather than defining its own.
+
+More critically, the notation conflates three orthogonal concepts in a single
+opaque string:
+
+```
+p  : k  : footprint
+│    │    └─ field name
+│    └─── transformation (strip KiCad library prefix)
+└──────── source namespace (PCB/placement data)
+```
+
+`k:` is not a namespace qualifier — it is a value transformation. The notation
+has no schema definition, no discoverable vocabulary, and no way for users to
+express new transformations without a jBOM release.
+
+### Magic sentinels
+
+`enrichment_bindings` in `generic.defaults.yaml` contains
+`"__resolved_fabricator_part_number__"` — a Python-internal implementation
+detail serialized as a YAML string with no meaning to a config author.
+
+### Triplicated `field_synonyms` structure
+
+The `field_synonyms` mapping appears in `fab:`, `defaults:`, and `supplier:`
+stanzas with structural drift between them, despite all three mapping to the
+same Python type (`FieldSynonym`). The YAML structure is not isomorphic to the
+data model.
+
+### CLI / config syntax divergence
+
+The `--fields` CLI argument and `bom_columns` config values express the same
+concept (field selection) but are parsed by separate code with diverging
+conventions. A user must learn two syntaxes that should be one.
+
+### The design lens
+
+A useful test for any proposed fix: *if this config were a Python expression
+constructing jBOM dataclass instances directly, what would it look like? Does
+the YAML schema reflect that clearly?* Any YAML key or value that requires
+explanation to translate to its Python equivalent is a schema design smell.
+
+## Decision Drivers
+
+- Field references must separate **source**, **name**, and **transformation**
+  into independently named, composable concepts.
+- Users must be able to express value transformations without a jBOM release.
+- The `--fields` CLI syntax and `bom_columns` config values must share one
+  canonical field reference language — defined in the config spec, consumed by
+  the CLI parser.
+- Transformation expressions must be safe (expressions only, no imports, no
+  side effects) and require no new parser infrastructure beyond Python's own
+  `ast` module.
+- The YAML schema should be isomorphic to the Python data model it serializes.
+- Backward compatibility with `i:`, `p:`, `c:`, `k:` notation is provided by
+  a deprecation shim shared with ADR 0008's migration period.
+
+## Design Decisions
+
+### D1. Source namespace vocabulary
+
+Field references from non-canonical sources carry an explicit namespace prefix.
+Three namespaces are defined:
+
+| Prefix | Source | Description |
+|---|---|---|
+| `sch:` | Schematic | Component properties from `.kicad_sch` (replaces `c:`) |
+| `pcb:` | PCB / placement | Component data from `.kicad_pcb` (replaces `p:`) |
+| `inv:` | Inventory | Fields from matched inventory CSV rows (replaces `i:`) |
+
+Canonical jBOM-computed fields (`reference`, `quantity`, `value`, `description`,
+`footprint`, `package`, `manufacturer`, `fabricator_part_number`, `smd`, `x`,
+`y`, `rotation`, `side`, etc.) carry **no namespace prefix**. They are resolved
+by jBOM from whichever source is authoritative and need no source qualifier from
+the config author.
+
+Migration shim: `c:` → `sch:`, `p:` → `pcb:`, `i:` → `inv:` are accepted with
+a deprecation log warning during the ADR 0008 shim period. `k:` is replaced by
+the expression mechanism (D2).
+
+### D2. Value expressions via `${token}` interpolation
+
+A `bom_columns` value (or any config value that accepts a field reference) may
+be either:
+
+**A plain field reference** — resolved directly:
+```yaml
+bom_columns:
+  "Designator": "reference"          # canonical computed field
+  "Package":    "inv:package"        # inventory namespace
+  "Footprint":  "pcb:footprint"      # PCB namespace
+```
+
+**A Python expression with `${field_ref}` interpolation** — evaluated to produce
+the output value:
+```yaml
+bom_columns:
+  # Strip KiCad library prefix from footprint (replaces "p:k:footprint")
+  "Footprint": "kicad_strip_library_prefix(${pcb:footprint})"
+
+  # Combine two fields
+  "Label":     "f'{${sch:reference}} ({${inv:manufacturer}})'"
+
+  # Arbitrary regex
+  "PN":        "re.sub(r'\\s+', '-', ${inv:manufacturer_part}).upper()"
+```
+
+**Expression evaluation contract:**
+
+1. All `${namespace:field}` and `${canonical_field}` tokens are extracted and
+   resolved to string values. Each is bound as a local variable in the
+   evaluation namespace (`:` replaced by `_` in the variable name, e.g.
+   `${pcb:footprint}` → `pcb_footprint`).
+
+2. The token references in the expression string are replaced with the
+   corresponding variable names.
+
+3. The resulting string is parsed with `ast.parse(expr, mode='eval')`. This
+   rejects statements, loop constructs, function definitions, and `import`
+   statements at the grammar level — before any evaluation.
+
+4. The compiled expression is evaluated in a restricted namespace containing:
+   - The resolved token variables
+   - `re` (Python's standard `re` module)
+   - The jBOM expression stdlib (see D3)
+   - No `__builtins__`
+
+5. The return value is coerced to `str`. Exceptions during evaluation surface as
+   a `FieldExpressionError` with the offending expression and token values in
+   the message.
+
+Expressions are detected by the presence of `${...}` in the value string.
+Values without `${...}` are treated as plain field references regardless of
+content.
+
+### D3. jBOM expression stdlib
+
+A small set of jBOM-curated helper functions is available in every expression
+evaluation namespace. These are regular Python functions (not magic syntax),
+documented, and versioned with jBOM. They provide convenience for common
+jBOM-specific transformations without requiring users to write raw regex.
+
+v1 stdlib:
+```
+kicad_strip_library_prefix(s)   → re.sub(r'^[^:]+:', '', s)
+    Removes the KiCad library nickname from a symbol or footprint name.
+    "Capacitors_SMD:C_0402" → "C_0402"
+```
+
+Users are not limited to the stdlib — `re.sub`, `str` methods, and other
+Python expression constructs work directly. The stdlib is an additive
+convenience layer, not a replacement vocabulary.
+
+New stdlib functions are added as part of jBOM releases. Users who need a
+transformation not in the stdlib can express it directly in the expression
+without waiting for a release.
+
+### D4. Canonical field name registry
+
+All valid canonical (no-namespace) field names are defined in a single
+authoritative registry in `src/jbom/config/fields.py`. Config values and CLI
+`--fields` arguments are validated against this registry. Unknown bare names
+produce a warning with the list of valid names.
+
+The registry replaces scattered string constants and serves as the definitive
+documentation of what computed fields jBOM produces.
+
+Initial registry (non-exhaustive — full list in `fields.py`):
+
+| Name | Description |
+|---|---|
+| `reference` | Component designator (R1, C2, U1) |
+| `quantity` | Grouped component count |
+| `value` | Component value |
+| `description` | Component description |
+| `footprint` | Resolved footprint name (normalized) |
+| `package` | Package size / footprint shorthand |
+| `manufacturer` | Manufacturer name |
+| `fabricator_part_number` | Resolved fabricator / supplier part number |
+| `smd` | Surface-mount flag (Y/N) |
+| `x`, `y` | Placement coordinates |
+| `rotation` | Placement rotation |
+| `side` | Board side (F / B) |
+
+`__resolved_fabricator_part_number__` is retired. Its role is expressed by the
+canonical field name `fabricator_part_number`.
+
+### D5. Unified `field_synonyms` structure
+
+The `field_synonyms` stanza structure is identical across `fab:`, `defaults:`,
+and `supplier:` stanzas. One canonical YAML structure, one Python type, one
+parser:
+
+```yaml
+field_synonyms:
+  <canonical_key>:
+    display_name: "<output header string>"
+    synonyms:
+      - "<accepted input variant>"
+      - "<accepted input variant>"
+```
+
+The per-stanza parsers (`_parse_field_synonyms` in `fabricators.py`,
+`_parse_field_synonym_configs` in `defaults.py`, and the supplier parser)
+are replaced by a single shared function in `src/jbom/config/field_synonyms.py`.
+
+### D6. CLI `--fields` alignment
+
+The `--fields` CLI argument accepts the same field reference syntax as
+`bom_columns`: plain canonical names, namespaced references (`inv:package`),
+and expression strings (`"re.sub(...)"`). The CLI parser delegates to the
+same `FieldRefResolver` used by the config loader.
+
+This makes the CLI and config syntaxes a single documented language rather than
+two diverging conventions.
+
+## Options Considered
+
+### Option 1 — Named transform vocabulary (rejected)
+Define a curated set of named transforms: `strip_kicad_library_prefix`,
+`normalize_value`, etc. Users select from this vocabulary in config.
+
+Rejected because: extending the vocabulary requires a jBOM release. It is
+"more magic" — just relocated from special characters to a developer-maintained
+list. The expression mechanism (D2) provides a strict superset of this
+capability at no additional security cost.
+
+### Option 2 — Jinja2 template engine (rejected)
+Use Jinja2's expression syntax (`{{ field | filter }}`) for field value
+transforms. Jinja2 provides a sandboxed eval environment and custom filter
+registration.
+
+Rejected because: Jinja2 solves document templating (with looping constructs,
+block inheritance, macros). That is more capability — and more cognitive
+surface area — than field value expression requires. The `${token}` +
+`ast.parse(mode='eval')` approach provides the needed expression power without
+the baggage, and without a new dependency.
+
+### Option 3 — Pipe model for chained transforms (deferred)
+`"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
+Unix-pipeline syntax chaining field read and named transforms.
+
+Not adopted as the primary mechanism; a pipeline model could be layered on top
+of the expression mechanism in a future ADR if use cases emerge. The expression
+mechanism (D2) handles multi-step transforms natively.
+
+### Option 4 — `${token}` + `ast.parse(mode='eval')` (accepted — this ADR)
+Described in D1–D6 above.
+
+## Decision
+
+Adopt the field reference system and value expression mechanism as described
+in D1–D6.
+
+Key properties:
+- Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
+  single-character prefixes.
+- Canonical computed fields carry no namespace prefix and are defined in a
+  single authoritative registry.
+- `${token}` interpolation + `ast.parse(mode='eval')` provides safe, user-
+  extensible field value transformation without requiring jBOM releases for
+  common string manipulation needs.
+- A small jBOM expression stdlib provides named convenience functions without
+  replacing the general expression mechanism.
+- `field_synonyms` is unified to one structure and one parser across all stanzas.
+- CLI `--fields` and config `bom_columns` share one field reference language.
+
+## Consequences
+
+### Positive
+- `p:k:footprint` becomes `kicad_strip_library_prefix(${pcb:footprint})` —
+  self-documenting, no magic characters, extensible to any regex the user needs.
+- Users can combine fields, apply regex, and format output values without waiting
+  for jBOM releases.
+- `__resolved_fabricator_part_number__` is gone; `fabricator_part_number` is in
+  the canonical registry with a clear definition.
+- `field_synonyms` triplication eliminated; one parser to test and maintain.
+- CLI and config field references are one language; documentation collapses to
+  one section.
+
+### Negative / Tradeoffs
+- Expressions in config are harder to read for non-developers than simple field
+  references. Plain field references remain the common case; expressions are
+  opt-in for transformation needs.
+- The `ast.parse` + restricted-eval path adds complexity to the field resolver.
+  This complexity is bounded and testable (expression rejection, namespace
+  restriction, error surfacing).
+- The jBOM expression stdlib must be documented, versioned, and not broken
+  across jBOM releases (same API stability bar as the rest of the config API).
+
+### Risks and Mitigations
+- **Risk**: A future Python version changes `ast.parse` expression grammar or
+  `compile/eval` semantics.
+  **Mitigation**: expression evaluation is isolated in `FieldExpressionEvaluator`;
+  one class to update if Python internals shift.
+- **Risk**: Users write expressions that are technically valid but produce empty
+  strings or exceptions at runtime due to missing field values.
+  **Mitigation**: `FieldExpressionError` surfaces expression + context at the
+  point of failure; a future `jbom config show` command (ADR 0008, Deferred 5)
+  would allow pre-flight validation.
+- **Risk**: Namespace renames (`c:` → `sch:`) break existing user `.jbom/` files.
+  **Mitigation**: the legacy prefix shim (shared with ADR 0008 migration) accepts
+  and translates old prefixes with a deprecation warning.
+
+## Deferred Items
+
+1. **Value type contracts** — percentage strings (`"5%"`), voltage strings
+   (`"10V"`), wattage strings (`"63mW"`) have no schema-level type contract or
+   normalization rule. These are out of scope here; a follow-on ADR or
+   enhancement tracks them.
+2. **Category token vocabulary** — canonical casing and normalization rules for
+   component category tokens (`RES`, `res`, `resistor`) are out of scope here.
+3. **Pipe-chained transforms** — reserved for future consideration once
+   expression usage patterns are observed in practice.
+4. **User-registerable stdlib extensions** — allowing `common.jbom.yaml` to
+   register named helper functions into the expression stdlib. Deferred until
+   concrete use cases emerge beyond what raw `re` expressions cover.
+
+## Implementation Phases
+
+**Phase 1 (this feature branch, alongside ADR 0008 Phase 1)**
+- `src/jbom/config/fields.py` — canonical field name registry as a typed enum
+  or frozenset; source namespace constants.
+- `src/jbom/config/field_ref.py` — `FieldRef` dataclass (namespace, name,
+  expression); `FieldRefResolver.resolve(ref, context)` → value.
+- `src/jbom/config/field_expr.py` — `FieldExpressionEvaluator`:
+  - `${token}` extraction and local variable binding
+  - `ast.parse(mode='eval')` + restricted eval
+  - jBOM expression stdlib registration
+- `src/jbom/config/field_synonyms.py` — single shared `parse_field_synonyms()`
+  replacing the three divergent parsers.
+- Update `fabricators.py`, `defaults.py`, `suppliers.py` to use shared parser.
+- Update `bom_workflow.py` / CLI `--fields` parser to use `FieldRefResolver`.
+- Deprecation shim: accept `c:`, `p:`, `i:`, `k:` with warnings.
+- Unit tests: namespace resolution, expression evaluation, statement rejection,
+  `kicad_strip_library_prefix`, error surfacing, legacy prefix shim.
+
+**Phase 2 (alongside ADR 0008 Phase 1b — built-in file migration)**
+- Migrate built-in config files: `"p:k:footprint"` → expression form.
+- Retire `__resolved_fabricator_part_number__` sentinel from defaults YAML.
+- Migrate `field_synonyms` structures in all built-in files to unified form.
+
+## References
+- ADR 0008: unified `*.jbom.yaml` container format
+- `src/jbom/config/fabricators.py`: `_parse_field_synonyms` (to be replaced)
+- `src/jbom/config/defaults.py`: `_parse_field_synonym_configs` (to be replaced)
+- `src/jbom/config/suppliers.py`: supplier field_synonyms parser (to be replaced)
+- `src/jbom/common/fields.py`: existing field handling (context for registry work)
+- Python `ast` module — expression-mode parsing and safe eval pattern

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -74,7 +74,72 @@ explanation to translate to its Python equivalent is a schema design smell.
 - The old `i:`, `p:`, `c:`, `k:` notation is retired with no shim. Nothing
   has shipped externally; a clean break requires no major version bump.
 
-## Design Decisions
+## Options Considered
+
+### Option 1 — Named transform vocabulary (rejected)
+Define a curated set of named transforms: `strip_kicad_library_prefix`,
+`normalize_value`, etc. Users select from this vocabulary in config.
+
+Rejected because: extending the vocabulary requires a jBOM release. It is
+"more magic" — just relocated from special characters to a developer-maintained
+list. The expression mechanism (D2) provides a strict superset of this
+capability at no additional security cost.
+
+### Option 2 — Jinja2 template engine (rejected)
+Use Jinja2's expression syntax (`{{ field | filter }}`) for field value
+transforms. Jinja2 provides a sandboxed eval environment and custom filter
+registration.
+
+Rejected because: Jinja2 solves document templating (with looping constructs,
+block inheritance, macros). That is more capability — and more cognitive
+surface area — than field value expression requires. The `namespace:field`
+preprocessing + `ast.parse(mode='eval')` approach provides the needed expression
+power without the baggage, and without a new dependency.
+
+### Option 3 — Pipe model for chained transforms (deferred)
+`"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
+Unix-pipeline syntax chaining field read and named transforms.
+
+Not adopted as the primary mechanism; a pipeline model could be layered on top
+of the expression mechanism in a future ADR if use cases emerge. The expression
+mechanism (D2) handles multi-step transforms natively.
+
+### Option 3b — `transform:namespace:field` shorthand syntax (rejected)
+`"Footprint": "strip_lib_prefix:pcb:footprint"` — a compact positional syntax
+for applying a named transform to a single field reference.
+
+Rejected because: this overloads `:` with two meanings simultaneously —
+namespace separator AND "apply transform to field". `pcb:` is a namespace
+qualifier; is `strip_lib_prefix:` also a "transform qualifier"? The parser
+would need external knowledge (the namespace vocabulary) to disambiguate,
+reintroducing exactly the kind of implicit magic this ADR is designed to
+eliminate. Function call syntax `strip_lib_prefix(pcb:footprint)` is
+unambiguous, already covered by the expression mechanism, and reads as
+standard Python.
+
+### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted — this ADR)
+Described in Decision Details below (D1–D7).
+
+## Decision
+
+Adopt the field reference system and value expression mechanism as described
+in D1–D7.
+
+Key properties:
+- Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
+  single-character prefixes. `:` means exactly one thing: namespace separator.
+- Source fields are runtime-discovered; only three jBOM-computed fields
+  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
+- Bare convenience alias names resolve via `field_precedence_policy` in
+  `defaults:` — config-owned, not hardcoded.
+- `namespace:field` tokens are syntactically invalid Python and are
+  unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
+- Named transforms (including built-in ones in `common.jbom.yaml`) are
+  config-defined; expression eval provides only `re`. No Python stdlib.
+- `field_synonyms` is unified to one structure and one parser across all stanzas.
+- CLI `--fields` and config `bom_columns` share one field reference language.
+
+### Decision Details
 
 ### D1. Source namespace vocabulary
 
@@ -115,7 +180,7 @@ output value:
 ```yaml
 bom_columns:
   # Strip KiCad library prefix (replaces "p:k:footprint")
-  "Footprint": "kicad_strip_library_prefix(pcb:footprint)"
+  "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
 
   # Combine two fields
   "Label":     "f'{reference} ({inv:manufacturer})'"
@@ -154,8 +219,8 @@ identifiers and are bound directly in the eval namespace after alias resolution.
 
 5. Evaluate in a restricted namespace containing:
    - The resolved field variables
-   - `re` (Python's standard `re` module)
-   - The jBOM expression stdlib and user-defined transforms (see D3, D7)
+   - `re` (Python's standard `re` module, see D3)
+   - All compiled transforms from the active config chain (D3, D7)
    - No `__builtins__`
 
 6. The return value is coerced to `str`. Exceptions surface as a
@@ -165,24 +230,28 @@ identifiers and are bound directly in the eval namespace after alias resolution.
 i.e., it contains characters outside `(namespace:)?fieldname` (parentheses,
 quotes, operators, etc.). Plain field references are always tried first.
 
-### D3. jBOM expression stdlib
+### D3. Expression evaluation namespace
 
-A small set of jBOM-curated helper functions is available in every expression
-evaluation namespace. These are regular Python functions (not magic syntax),
-documented, and versioned with jBOM.
+The expression evaluator provides `re` (Python's standard regex module) in the
+evaluation namespace. No other Python modules or functions are pre-loaded.
 
-v1 stdlib:
+Named transforms — including those shipped with jBOM — are config-defined (D7),
+not Python-registered. This keeps the Python-side minimal and means even
+jBOM-provided transforms can be inspected, overridden, or extended in config
+without a jBOM release.
+
+The built-in `common.jbom.yaml` shipped with jBOM pre-defines common transforms:
+
+```yaml
+# src/jbom/config/common.jbom.yaml (built-in, shipped with jBOM)
+transforms:
+  strip_kicad_library_prefix:
+    expr: "re.sub(r'^[^:]+:', '', value)"
+    doc:  "Remove KiCad library nickname. 'Capacitors_SMD:C_0402' → 'C_0402'"
 ```
-kicad_strip_library_prefix(s)   → re.sub(r'^[^:]+:', '', s)
-    Removes the KiCad library nickname from a symbol or footprint name.
-    "Capacitors_SMD:C_0402" → "C_0402"
-```
 
-Users are not limited to the stdlib — `re.sub`, `str` methods, and other
-Python expression constructs work directly. The stdlib is an additive
-convenience layer, not a replacement vocabulary. Users who need a named
-transform not in the stdlib can define it in their own config (see D7)
-without waiting for a jBOM release.
+A user can override a built-in transform by defining the same name in their
+own `.jbom.yaml`.
 
 ### D4. Field categories — source, computed, and convenience aliases
 
@@ -305,89 +374,25 @@ transforms:
 fail early, not at BOM generation time.
 
 Each defined transform is compiled to a single-argument callable and added to
-the expression evaluation namespace alongside the jBOM stdlib (D3). From the
-evaluator's perspective, user-defined and jBOM-stdlib transforms are
-indistinguishable — they are the same kind of thing.
+the expression evaluation namespace alongside `re` (D3). From the evaluator's
+perspective, user-defined, org-defined, and built-in config transforms are
+indistinguishable — they are all config-defined.
 
 `transforms:` follows the same inheritance rules as all other config content:
 `extends:` chains propagate parent transforms to child profiles; a
 `common.jbom.yaml` at each search-path level contributes ambient transforms
 available to all configs at that level and below. Transform names must not
-collide with jBOM stdlib names (validated at load time with a warning).
+collide with built-in transform names from the shipped `common.jbom.yaml`
+(validated at load time with a warning).
 
 This allows `--fields` CLI arguments and config `bom_columns` values to
 reference org-defined transforms by name, enabling a team's `common.jbom.yaml`
 to publish a shared transform library without requiring a jBOM release.
 
-## Options Considered
-
-### Option 1 — Named transform vocabulary (rejected)
-Define a curated set of named transforms: `strip_kicad_library_prefix`,
-`normalize_value`, etc. Users select from this vocabulary in config.
-
-Rejected because: extending the vocabulary requires a jBOM release. It is
-"more magic" — just relocated from special characters to a developer-maintained
-list. The expression mechanism (D2) provides a strict superset of this
-capability at no additional security cost.
-
-### Option 2 — Jinja2 template engine (rejected)
-Use Jinja2's expression syntax (`{{ field | filter }}`) for field value
-transforms. Jinja2 provides a sandboxed eval environment and custom filter
-registration.
-
-Rejected because: Jinja2 solves document templating (with looping constructs,
-block inheritance, macros). That is more capability — and more cognitive
-surface area — than field value expression requires. The `namespace:field`
-preprocessing + `ast.parse(mode='eval')` approach provides the needed expression
-power without the baggage, and without a new dependency.
-
-### Option 3 — Pipe model for chained transforms (deferred)
-`"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
-Unix-pipeline syntax chaining field read and named transforms.
-
-Not adopted as the primary mechanism; a pipeline model could be layered on top
-of the expression mechanism in a future ADR if use cases emerge. The expression
-mechanism (D2) handles multi-step transforms natively.
-
-### Option 3b — `transform:namespace:field` shorthand syntax (rejected)
-`"Footprint": "strip_lib_prefix:pcb:footprint"` — a compact positional syntax
-for applying a named transform to a single field reference.
-
-Rejected because: this overloads `:` with two meanings simultaneously —
-namespace separator AND "apply transform to field". `pcb:` is a namespace
-qualifier; is `strip_lib_prefix:` also a "transform qualifier"? The parser
-would need external knowledge (the namespace vocabulary) to disambiguate,
-reintroducing exactly the kind of implicit magic this ADR is designed to
-eliminate. Function call syntax `strip_lib_prefix(pcb:footprint)` is
-unambiguous, already covered by the expression mechanism, and reads as
-standard Python.
-
-### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted — this ADR)
-Described in D1–D7 above.
-
-## Decision
-
-Adopt the field reference system and value expression mechanism as described
-in D1–D7.
-
-Key properties:
-- Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
-  single-character prefixes. `:` means exactly one thing: namespace separator.
-- Source fields are runtime-discovered; only three jBOM-computed fields
-  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
-- Bare convenience alias names resolve via `field_precedence_policy` in
-  `defaults:` — config-owned, not hardcoded.
-- `namespace:field` tokens are syntactically invalid Python and are
-  unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
-- A jBOM expression stdlib provides named convenience functions; users extend
-  it via the `transforms:` stanza in any `.jbom.yaml` without a jBOM release.
-- `field_synonyms` is unified to one structure and one parser across all stanzas.
-- CLI `--fields` and config `bom_columns` share one field reference language.
-
 ## Consequences
 
 ### Positive
-- `p:k:footprint` becomes `kicad_strip_library_prefix(pcb:footprint)` —
+- `p:k:footprint` becomes `strip_kicad_library_prefix(pcb:footprint)` —
   self-documenting, no magic characters, extensible to any regex the user needs.
 - Users can combine fields, apply regex, and format output values without waiting
   for jBOM releases.
@@ -406,8 +411,8 @@ Key properties:
 - The `ast.parse` + restricted-eval path adds complexity to the field resolver.
   This complexity is bounded and testable (expression rejection, namespace
   restriction, error surfacing).
-- The jBOM expression stdlib must be documented, versioned, and not broken
-  across jBOM releases (same API stability bar as the rest of the config API).
+- Built-in transforms in `common.jbom.yaml` must be documented, versioned, and
+  not broken across releases (same bar as any other shipped config content).
 - The `transforms:` stanza adds a new user-facing config concept that must be
   validated, documented, and handled by the merge engine (inherited via
   `extends:` and `common.jbom.yaml`).
@@ -452,16 +457,15 @@ Key properties:
 - `src/jbom/config/field_expr.py` — `FieldExpressionEvaluator`:
   - `namespace:field` token scanning and local variable binding
   - `ast.parse(mode='eval')` + restricted eval
-  - jBOM expression stdlib registration
   - `transforms:` stanza parsing: validate `expr` at load time, compile to
-    callable, add to eval namespace
+    callable, add to eval namespace alongside `re`
 - `src/jbom/config/field_synonyms.py` — single shared `parse_field_synonyms()`
   replacing the three divergent parsers.
 - Update `fabricators.py`, `defaults.py`, `suppliers.py` to use shared parser.
 - Update `bom_workflow.py` / CLI `--fields` parser to use `FieldRefResolver`.
 - Built-in config files using old prefixes are migrated in Phase 2; no shim.
 - Unit tests: namespace resolution, expression evaluation, statement rejection,
-  `kicad_strip_library_prefix`, error surfacing, transform compilation.
+  `strip_kicad_library_prefix`, error surfacing, transform compilation.
 
 **Phase 2 (alongside ADR 0008 Phase 1b — built-in file migration)**
 - Migrate built-in config files: `"p:k:footprint"` → expression form.

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -158,11 +158,11 @@ Three namespaces are defined:
 | `pcb:` | PCB / placement | Component data from `.kicad_pcb` (replaces `p:`) |
 | `inv:` | Inventory | Fields from matched inventory CSV rows (replaces `i:`) |
 
-Bare names without a namespace prefix are either jBOM-computed fields (a small
-set: `quantity`, `fabricator_part_number`, `smd`) or unqualified source-data
-names (`value`, `reference`, `footprint`, etc.) that resolve to the originating
-source namespace, disambiguated by `field_precedence_policy` when the same name
-exists in multiple sources. The full taxonomy is described in D4.
+jBOM-computed fields use the `jbom:` prefix (`jbom:quantity`,
+`jbom:fabricator_part_number`, `jbom:smd`). Unqualified source-data names
+(`value`, `reference`, `footprint`, etc.) resolve to their originating source
+namespace, disambiguated by `field_precedence_policy` when the same name exists
+in multiple sources. The full taxonomy is described in D4.
 
 `k:` is not a namespace — it is replaced by the expression mechanism in D2.
 The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are retired;
@@ -250,7 +250,7 @@ transforms:
 A user can override a built-in transform by defining the same name in their
 own `.jbom.yaml`.
 
-### D4. Field categories — source, computed, and convenience aliases
+### D4. Field categories — source, computed, and unqualified source-data names
 
 Fields accessible in `bom_columns` values, `--fields` arguments, and expressions
 fall into three distinct categories with different natures.
@@ -278,9 +278,9 @@ not passed through from any source:
 
 | Name | Computed by |
 |---|---|
-| `quantity` | Grouping logic (count of identical components) |
-| `fabricator_part_number` | Part number resolution from matched inventory item |
-| `smd` | Calculated from PCB placement type |
+| `jbom:quantity` | Grouping logic (count of identical components) |
+| `jbom:fabricator_part_number` | Part number resolution from matched inventory item |
+| `jbom:smd` | Calculated from PCB placement type |
 
 These are the only fields registered in `src/jbom/config/fields.py`. The earlier
 draft of this ADR incorrectly listed source fields (`reference`, `value`, etc.)
@@ -288,11 +288,11 @@ as "canonical jBOM-computed fields" — they are source fields (Category 3).
 
 `__resolved_fabricator_part_number__` is retired; replaced by `fabricator_part_number`.
 
-The `jbom:` prefix is provisionally reserved for this category:
-`jbom:quantity`, `jbom:fabricator_part_number`, `jbom:smd`. The bare form
-(`quantity`) remains valid as a shorthand. The explicit `jbom:` form is
-useful when an inventory CSV column is also named `quantity` — `jbom:quantity`
-unambiguously selects the computed grouping count, not the inventory column.
+jBOM-computed fields use the `jbom:` namespace: `jbom:quantity`,
+`jbom:fabricator_part_number`, `jbom:smd`. Consistent with the clean-break
+approach of this ADR, no bare shorthand is provided — `jbom:quantity` is the
+canonical form and unambiguously selects the computed grouping count even when
+an inventory CSV column is also named `quantity`.
 
 **Category 3: Unqualified field names — source-data names, policy-disambiguated**
 
@@ -384,11 +384,11 @@ transforms:
 fab:
   bom_columns:
     "Designator": "reference"
-    "Quantity": "quantity"
+    "Quantity": "jbom:quantity"
     "Value": "value"
     "Footprint": "strip_kicad_library_prefix_from_value(pcb:footprint)"
-    "LCSC": "fabricator_part_number"  # JLCPCB requires this column name in BOM
-    "Surface Mount": "smd"
+    "LCSC": "jbom:fabricator_part_number"  # JLCPCB requires this column name in BOM
+    "Surface Mount": "jbom:smd"
     "Comment": "description"
 ```
 
@@ -462,8 +462,8 @@ namespace vocabulary — reintroducing the implicit magic this design eliminates
 Key properties:
 - Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
   single-character prefixes. `:` means exactly one thing: namespace separator.
-- Source fields are runtime-discovered; only three jBOM-computed fields
-  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
+- Source fields are runtime-discovered; jBOM-computed fields use the `jbom:`
+  namespace (`jbom:quantity`, `jbom:fabricator_part_number`, `jbom:smd`).
 - Unqualified source-data names (e.g., `value`, `reference`) resolve
   unambiguously when unique; `field_precedence_policy` in `common.jbom.yaml`
   disambiguates when the same name appears in multiple sources.
@@ -564,8 +564,9 @@ Key properties:
 
 **Phase 1 (this feature branch, alongside ADR 0008 Phase 1)**
 - `src/jbom/config/fields.py` — jBOM-computed field registry (Category 2 only:
-  `quantity`, `fabricator_part_number`, `smd`); source namespace constants
-  (`SCH`, `PCB`, `INV`). Source field discovery is runtime, not pre-registered.
+  `jbom:quantity`, `jbom:fabricator_part_number`, `jbom:smd`); source namespace
+  constants (`SCH`, `PCB`, `INV`, `JBOM`). Source field discovery is runtime,
+  not pre-registered.
 - `src/jbom/config/field_ref.py` — `FieldRef` dataclass (namespace, name,
   expression); `FieldRefResolver.resolve(ref, context)` → value.
 - `src/jbom/config/field_expr.py` — `FieldExpressionEvaluator`:

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -71,8 +71,8 @@ explanation to translate to its Python equivalent is a schema design smell.
   side effects) and require no new parser infrastructure beyond Python's own
   `ast` module.
 - The YAML schema should be isomorphic to the Python data model it serializes.
-- Backward compatibility with `i:`, `p:`, `c:`, `k:` notation is provided by
-  a deprecation shim shared with ADR 0008's migration period.
+- The old `i:`, `p:`, `c:`, `k:` notation is retired with no shim. Nothing
+  has shipped externally; a clean break requires no major version bump.
 
 ## Design Decisions
 
@@ -93,9 +93,9 @@ Canonical jBOM-computed fields (`reference`, `quantity`, `value`, `description`,
 by jBOM from whichever source is authoritative and need no source qualifier from
 the config author.
 
-Migration shim: `c:` → `sch:`, `p:` → `pcb:`, `i:` → `inv:` are accepted with
-a deprecation log warning during the ADR 0008 shim period. `k:` is replaced by
-the expression mechanism (D2).
+`k:` is not a namespace — it is replaced by the expression mechanism in D2.
+The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are retired;
+no shim or deprecation warning is provided.
 
 ### D2. Value expressions — field references and Python expressions
 
@@ -376,9 +376,8 @@ Key properties:
   **Mitigation**: `FieldExpressionError` surfaces expression + context at the
   point of failure; a future `jbom config show` command (ADR 0008, Deferred 5)
   would allow pre-flight validation.
-- **Risk**: Namespace renames (`c:` → `sch:`) break existing user `.jbom/` files.
-  **Mitigation**: the legacy prefix shim (shared with ADR 0008 migration) accepts
-  and translates old prefixes with a deprecation warning.
+- **Non-risk**: The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are
+  not supported. No user files exist to break; nothing has shipped externally.
 
 ## Deferred Items
 
@@ -408,9 +407,9 @@ Key properties:
   replacing the three divergent parsers.
 - Update `fabricators.py`, `defaults.py`, `suppliers.py` to use shared parser.
 - Update `bom_workflow.py` / CLI `--fields` parser to use `FieldRefResolver`.
-- Deprecation shim: accept `c:`, `p:`, `i:`, `k:` with warnings.
+- Built-in config files using old prefixes are migrated in Phase 2; no shim.
 - Unit tests: namespace resolution, expression evaluation, statement rejection,
-  `kicad_strip_library_prefix`, error surfacing, legacy prefix shim.
+  `kicad_strip_library_prefix`, error surfacing, transform compilation.
 
 **Phase 2 (alongside ADR 0008 Phase 1b — built-in file migration)**
 - Migrate built-in config files: `"p:k:footprint"` → expression form.

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -96,13 +96,25 @@ surface area — than field value expression requires. The `namespace:field`
 preprocessing + `ast.parse(mode='eval')` approach provides the needed expression
 power without the baggage, and without a new dependency.
 
-### Option 3 — Pipe model for chained transforms (deferred)
-`"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
-Unix-pipeline syntax chaining field read and named transforms.
+### Option 2b — `${token}` interpolation in expression strings (rejected)
+Instead of preprocessing `word:word` tokens, require users to wrap field
+references in `${}` markers: `"re.sub(r'^[^:]+:', '', ${pcb:footprint})"`.
 
-Not adopted as the primary mechanism; a pipeline model could be layered on top
-of the expression mechanism in a future ADR if use cases emerge. The expression
-mechanism (D2) handles multi-step transforms natively.
+Rejected because: in Python expression context, `word:word` is already
+syntactically invalid — the `:` creates a syntax error outside subscript or
+dict literal positions. The preprocessor can unambiguously identify field
+references without any decoration. `${...}` solves a problem that doesn't exist
+and creates visual noise with no semantic value.
+
+### Option 3 — Pipe model for chained transforms (rejected)
+`"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
+Unix-pipeline syntax chaining a field read and named transforms.
+
+Rejected because: this is a solution in search of a problem. The expression
+mechanism already handles multi-step transforms natively using standard Python
+function call composition. A pipe DSL adds new syntax to learn for no capability
+gain. The expression `upper(strip_kicad_library_prefix(pcb:footprint))` is
+clearer and already works.
 
 ### Option 3b — `transform:namespace:field` shorthand syntax (rejected)
 `"Footprint": "strip_lib_prefix:pcb:footprint"` — a compact positional syntax
@@ -117,8 +129,36 @@ eliminate. Function call syntax `strip_lib_prefix(pcb:footprint)` is
 unambiguous, already covered by the expression mechanism, and reads as
 standard Python.
 
-### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted — this ADR)
-Described in Decision Details below (D1–D7).
+### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted)
+
+This option emerged from the successive rejections above:
+
+**From Option 1**: a fixed Python vocabulary requires jBOM releases to extend.
+The config that invents a transformation requirement should be able to express
+how to satisfy it — in the same file, without a release cycle.
+
+**From Option 2**: Jinja2 brings a full template engine when we need only a
+safe expression evaluator. No new dependency; Python's own `ast` module is
+the right tool.
+
+**From Option 2b**: `${token}` decoration is unnecessary. `word:word` in Python
+expression context is already a syntax error — the `:` makes the reference
+unambiguous without any additional markers.
+
+**From Option 3**: a pipe DSL adds syntax to learn for zero capability gain;
+standard Python function composition handles the same cases.
+
+**From Option 3b**: `:` must mean one thing. Using it as both namespace
+separator and transform-apply operator requires the parser to know the closed
+set of namespace names — reintroducing exactly the kind of implicit vocabulary
+this design avoids.
+
+The design that emerges: preprocess `namespace:field` tokens to local variable
+bindings (the syntax error is the signal), evaluate as a Python expression with
+`ast.parse(mode='eval')` in a namespace containing `re` and config-defined
+transforms, no Python stdlib. The same `.jbom.yaml` that creates a requirement
+(e.g., "strip the KiCad library prefix") also defines how to satisfy it (the
+transform expression in `transforms:`). See Decision Details below.
 
 ## Decision
 
@@ -192,11 +232,11 @@ bom_columns:
   "Footprint": "strip_lib_prefix(pcb:footprint)"
 ```
 
-**Why no `${}` decoration:** in Python expression context, `word:word`
-(namespace-qualified field references) is syntactically invalid Python. The
-preprocessor identifies and binds these unambiguously without additional
-decoration. Bare convenience alias names (Category 3 in D4) are valid Python
-identifiers and are bound directly in the eval namespace after alias resolution.
+**Why no `${}` decoration** (see Option 2b rejection): in Python expression
+context, `word:word` is already syntactically invalid — the preprocessor
+unambiguously identifies field references without any added markers. Bare
+convenience alias names (Category 3 in D4) are valid Python identifiers and
+are bound directly in the eval namespace after alias resolution.
 
 **Expression evaluation contract:**
 
@@ -392,8 +432,24 @@ to publish a shared transform library without requiring a jBOM release.
 ## Consequences
 
 ### Positive
-- `p:k:footprint` becomes `strip_kicad_library_prefix(pcb:footprint)` —
-  self-documenting, no magic characters, extensible to any regex the user needs.
+- The old `p:k:footprint` becomes transparent: the transform is defined in
+  `common.jbom.yaml` and used in `bom_columns`. Complete picture:
+
+  ```yaml
+  # src/jbom/config/common.jbom.yaml — definition (ships with jBOM)
+  transforms:
+    strip_kicad_library_prefix:
+      expr: "re.sub(r'^[^:]+:', '', value)"
+      doc:  "'Capacitors_SMD:C_0402' → 'C_0402'"
+
+  # jlc.jbom.yaml — usage
+  fab:
+    bom_columns:
+      "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
+  ```
+
+  Both sides live in config. The transform can be inspected, overridden, or
+  replaced without touching Python.
 - Users can combine fields, apply regex, and format output values without waiting
   for jBOM releases.
 - `__resolved_fabricator_part_number__` is gone; `fabricator_part_number` is a
@@ -407,7 +463,29 @@ to publish a shared transform library without requiring a jBOM release.
 ### Negative / Tradeoffs
 - Expressions in config are harder to read for non-developers than simple field
   references. Plain field references remain the common case; expressions are
-  opt-in for transformation needs.
+  opt-in for transformation needs. A realistic composite config using both:
+
+  ```yaml
+  # $REPO_ROOT/.jbom/acme-jlc.jbom.yaml — corporate JLC fork
+  extends: jlc
+
+  transforms:
+    normalize_value:
+      expr: "re.sub(r'\\s+', '', value).upper()"
+      doc:  "Normalize value strings: '10 K' → '10K'"
+
+  fab:
+    bom_columns:
+      "Surface Mount": null                                   # delete inherited
+      "Footprint":     "strip_kicad_library_prefix(pcb:footprint)"
+      "Value":         "normalize_value(sch:Value)"
+      "IPN":           "inv:IPN"                              # plain field ref
+      "Status":        "inv:PART_STATUS"                      # custom sch attribute
+  ```
+
+  The plain `"inv:IPN"` and `"inv:PART_STATUS"` lines are readable to any
+  engineer. The expression lines require understanding the transform mechanism.
+  The comment on `normalize_value` is the recommended mitigation.
 - The `ast.parse` + restricted-eval path adds complexity to the field resolver.
   This complexity is bounded and testable (expression rejection, namespace
   restriction, error surfacing).
@@ -422,29 +500,36 @@ to publish a shared transform library without requiring a jBOM release.
   `compile/eval` semantics.
   **Mitigation**: expression evaluation is isolated in `FieldExpressionEvaluator`;
   one class to update if Python internals shift.
-- **Risk**: Users write expressions that are technically valid but produce empty
-  strings or exceptions at runtime due to missing field values.
-  **Mitigation**: `FieldExpressionError` surfaces expression + context at the
-  point of failure; a future `jbom config show` command (ADR 0008, Deferred 5)
-  would allow pre-flight validation.
+- **Risk**: Users write expressions that produce wrong output silently (no
+  exception, just an unexpected value) due to wrong field reference or transform.
+  **Mitigation**: `FieldExpressionError` surfaces failures with expression +
+  field values. The `jbom fields` diagnostic command (Deferred 4) will show
+  which transforms are loaded and from which config file; a debug/verbose mode
+  should trace transform input → output at evaluation time.
 - **Non-risk**: The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are
   not supported. No user files exist to break; nothing has shipped externally.
 
 ## Deferred Items
 
-1. **Value type contracts** — percentage strings (`"5%"`), voltage strings
-   (`"10V"`), wattage strings (`"63mW"`) have no schema-level type contract or
-   normalization rule. These are out of scope here; a follow-on ADR or
-   enhancement tracks them.
-2. **Category token vocabulary** — canonical casing and normalization rules for
-   component category tokens (`RES`, `res`, `resistor`) are out of scope here.
-3. **Pipe-chained transforms** — reserved for future consideration once
-   expression usage patterns are observed in practice.
-4. **`jbom fields` diagnostic command** — prints the discovered source field
+1. **Value type contracts and normalize transforms** — Percentage strings
+   (`"5%"`), voltage strings (`"10V"`), and wattage strings (`"63mW"`) are
+   currently consumed opaquely by jBOM's heuristics engine. Whether these
+   normalizations can be expressed as config-defined transforms (making component
+   matching rules extensible without code changes) is worth exploring in a
+   follow-on design. If feasible, the heuristics engine would become a consumer
+   of config-defined normalizers rather than a holder of hardcoded string
+   patterns.
+2. **Category classification** — Component categories (`RES`, `CAP`, `IND`,
+   etc.) are data-driven: they emerge from the component's content (value,
+   footprint, symbol name), not from a fixed jBOM vocabulary. The heuristic
+   classifier that maps content to category tokens is partly hardcoded in Python.
+   Like value normalization (item 1), config-driven category classification would
+   be the consistent direction. Out of scope here; tracked separately.
+3. **`jbom fields` diagnostic command** — prints the discovered source field
    sets for the current project: `sch:*` attributes found in the schematic,
    `pcb:*` placement attributes, `inv:*` inventory column headers, and the
-   three jBOM-computed fields. Complements `jbom config show` (ADR 0008,
-   Deferred Item 5). Useful when authoring `bom_columns` expressions.
+   three jBOM-computed fields; also lists all loaded transforms and which config
+   file defined each. Complements `jbom config show` (ADR 0008, Deferred Item 5).
 
 ## Implementation Phases
 

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -87,11 +87,11 @@ Three namespaces are defined:
 | `pcb:` | PCB / placement | Component data from `.kicad_pcb` (replaces `p:`) |
 | `inv:` | Inventory | Fields from matched inventory CSV rows (replaces `i:`) |
 
-Canonical jBOM-computed fields (`reference`, `quantity`, `value`, `description`,
-`footprint`, `package`, `manufacturer`, `fabricator_part_number`, `smd`, `x`,
-`y`, `rotation`, `side`, etc.) carry **no namespace prefix**. They are resolved
-by jBOM from whichever source is authoritative and need no source qualifier from
-the config author.
+Bare names without a namespace prefix are either jBOM-computed fields (a small
+set: `quantity`, `fabricator_part_number`, `smd`) or convenience aliases
+(`value`, `reference`, `footprint`, etc.) that resolve to the appropriate source
+namespace via the active `field_precedence_policy` in `defaults:`. The full
+taxonomy is described in D4.
 
 `k:` is not a namespace — it is replaced by the expression mechanism in D2.
 The old single-character prefixes (`c:`, `p:`, `i:`, `k:`) are retired;
@@ -105,7 +105,7 @@ one of two forms. `:` means exactly one thing throughout: namespace separator.
 **A plain field reference** — resolved directly:
 ```yaml
 bom_columns:
-  "Designator": "reference"        # canonical computed field (no namespace)
+  "Designator": "reference"        # convenience alias (resolves via field_precedence_policy)
   "Package":    "inv:package"      # inventory namespace
   "Footprint":  "pcb:footprint"    # PCB namespace
 ```
@@ -130,8 +130,8 @@ bom_columns:
 **Why no `${}` decoration:** in Python expression context, `word:word`
 (namespace-qualified field references) is syntactically invalid Python. The
 preprocessor identifies and binds these unambiguously without additional
-decoration. Canonical field names are valid Python identifiers and are bound
-directly in the eval namespace.
+decoration. Bare convenience alias names (Category 3 in D4) are valid Python
+identifiers and are bound directly in the eval namespace after alias resolution.
 
 **Expression evaluation contract:**
 
@@ -140,8 +140,10 @@ directly in the eval namespace.
    Resolve each to its string value and bind as `namespace_field` in the local
    variable namespace.
 
-2. Canonical field names referenced in the expression are bound by name in the
-   local namespace (e.g., `reference` → the resolved reference value).
+2. Convenience alias names referenced in the expression are resolved via the
+   active `field_precedence_policy` and bound by name in the local namespace
+   (e.g., `value` → whichever source namespace the policy designates as
+   authoritative for `value`).
 
 3. Replace `namespace:field` tokens in the expression string with their
    `namespace_field` variable names. The result is a valid Python expression.
@@ -182,35 +184,75 @@ convenience layer, not a replacement vocabulary. Users who need a named
 transform not in the stdlib can define it in their own config (see D7)
 without waiting for a jBOM release.
 
-### D4. Canonical field name registry
+### D4. Field categories — source, computed, and convenience aliases
 
-All valid canonical (no-namespace) field names are defined in a single
-authoritative registry in `src/jbom/config/fields.py`. Config values and CLI
-`--fields` arguments are validated against this registry. Unknown bare names
-produce a warning with the list of valid names.
+Fields accessible in `bom_columns` values, `--fields` arguments, and expressions
+fall into three distinct categories with different natures.
 
-The registry replaces scattered string constants and serves as the definitive
-documentation of what computed fields jBOM produces.
+**Category 1: Source fields — not pre-registered; discovered at runtime**
 
-Initial registry (non-exhaustive — full list in `fields.py`):
+Source fields carry an explicit namespace prefix and their availability is
+determined by the actual data:
+- `sch:*` — whatever symbol properties the KiCad schematic contains
+  (`sch:Value`, `sch:Footprint`, `sch:Reference`, user-defined attributes such
+  as `sch:LCSC`, `sch:PART_STATUS`, ...)
+- `pcb:*` — placement attributes from the PCB file (`pcb:x`, `pcb:y`,
+  `pcb:rotation`, `pcb:side`)
+- `inv:*` — whatever column headers the matched inventory CSV provides
+  (`inv:IPN`, `inv:Supplier`, `inv:SPN`, `inv:MPN`, `inv:Package`, ...)
 
-| Name | Description |
+jBOM cannot enumerate these ahead of time. A user's schematic may have a
+custom `PART_STATUS` attribute; their inventory may use bespoke column names.
+These fields are discovered at evaluation time from the actual data sources.
+
+**Category 2: jBOM-computed fields — a small Python-registered set**
+
+A small set of field names are produced by jBOM's internal processing logic,
+not passed through from any source:
+
+| Name | Computed by |
 |---|---|
-| `reference` | Component designator (R1, C2, U1) |
-| `quantity` | Grouped component count |
-| `value` | Component value |
-| `description` | Component description |
-| `footprint` | Resolved footprint name (normalized) |
-| `package` | Package size / footprint shorthand |
-| `manufacturer` | Manufacturer name |
-| `fabricator_part_number` | Resolved fabricator / supplier part number |
-| `smd` | Surface-mount flag (Y/N) |
-| `x`, `y` | Placement coordinates |
-| `rotation` | Placement rotation |
-| `side` | Board side (F / B) |
+| `quantity` | Grouping logic (count of identical components) |
+| `fabricator_part_number` | Part number resolution from matched inventory item |
+| `smd` | Calculated from PCB placement type |
 
-`__resolved_fabricator_part_number__` is retired. Its role is expressed by the
-canonical field name `fabricator_part_number`.
+These are the only fields registered in `src/jbom/config/fields.py`. The earlier
+draft of this ADR incorrectly listed source fields (`reference`, `value`, etc.)
+as "canonical jBOM-computed fields" — they are source fields, accessed via
+namespace prefix or convenience alias (Category 3).
+
+`__resolved_fabricator_part_number__` is retired; replaced by `fabricator_part_number`.
+
+**Category 3: Convenience aliases — config-defined bare names**
+
+Bare names without a namespace prefix (`value`, `footprint`, `reference`) are
+convenience aliases. They resolve to the appropriate source namespace field
+according to the `field_precedence_policy` defined in the active `defaults:`
+stanza:
+
+```yaml
+# generic.defaults.yaml (existing)
+field_precedence_policy:
+  schematic_biased:
+    - value
+    - tolerance
+    - footprint
+    ...
+  pcb_biased:
+    - x
+    - y
+    - rotation
+    ...
+```
+
+This policy is the config-owned mechanism for convenience alias resolution —
+not a static Python registry. An org can override the policy in their
+`common.jbom.yaml` to change which source namespace a bare name resolves to,
+without changing any code.
+
+Note: the `field_precedence_policy` as currently defined in `generic.defaults.yaml`
+needs to be extended to fully cover the alias resolution role described here.
+That extension is part of the built-in file migration in Phase 1.
 
 ### D5. Unified `field_synonyms` structure
 
@@ -331,8 +373,10 @@ in D1–D7.
 Key properties:
 - Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
   single-character prefixes. `:` means exactly one thing: namespace separator.
-- Canonical computed fields carry no namespace prefix and are defined in a
-  single authoritative registry.
+- Source fields are runtime-discovered; only three jBOM-computed fields
+  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
+- Bare convenience alias names resolve via `field_precedence_policy` in
+  `defaults:` — config-owned, not hardcoded.
 - `namespace:field` tokens are syntactically invalid Python and are
   unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
 - A jBOM expression stdlib provides named convenience functions; users extend
@@ -347,8 +391,10 @@ Key properties:
   self-documenting, no magic characters, extensible to any regex the user needs.
 - Users can combine fields, apply regex, and format output values without waiting
   for jBOM releases.
-- `__resolved_fabricator_part_number__` is gone; `fabricator_part_number` is in
-  the canonical registry with a clear definition.
+- `__resolved_fabricator_part_number__` is gone; `fabricator_part_number` is a
+  jBOM-computed field with a clear definition.
+- Source field vocabulary (sch:/pcb:/inv:) is runtime-discovered, not a static
+  Python registry that diverges from reality.
 - `field_synonyms` triplication eliminated; one parser to test and maintain.
 - CLI and config field references are one language; documentation collapses to
   one section.
@@ -389,12 +435,18 @@ Key properties:
    component category tokens (`RES`, `res`, `resistor`) are out of scope here.
 3. **Pipe-chained transforms** — reserved for future consideration once
    expression usage patterns are observed in practice.
+4. **`jbom fields` diagnostic command** — prints the discovered source field
+   sets for the current project: `sch:*` attributes found in the schematic,
+   `pcb:*` placement attributes, `inv:*` inventory column headers, and the
+   three jBOM-computed fields. Complements `jbom config show` (ADR 0008,
+   Deferred Item 5). Useful when authoring `bom_columns` expressions.
 
 ## Implementation Phases
 
 **Phase 1 (this feature branch, alongside ADR 0008 Phase 1)**
-- `src/jbom/config/fields.py` — canonical field name registry as a typed enum
-  or frozenset; source namespace constants.
+- `src/jbom/config/fields.py` — jBOM-computed field registry (Category 2 only:
+  `quantity`, `fabricator_part_number`, `smd`); source namespace constants
+  (`SCH`, `PCB`, `INV`). Source field discovery is runtime, not pre-registered.
 - `src/jbom/config/field_ref.py` — `FieldRef` dataclass (namespace, name,
   expression); `FieldRefResolver.resolve(ref, context)` → value.
 - `src/jbom/config/field_expr.py` — `FieldExpressionEvaluator`:

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -117,7 +117,7 @@ gain. The expression `upper(strip_kicad_library_prefix(pcb:footprint))` is
 clearer and already works.
 
 ### Option 3b — `transform:namespace:field` shorthand syntax (rejected)
-`"Footprint": "strip_lib_prefix:pcb:footprint"` — a compact positional syntax
+`"Footprint": "strip_kicad_library_prefix:pcb:footprint"` — a compact positional syntax
 for applying a named transform to a single field reference.
 
 Rejected because: this overloads `:` with two meanings simultaneously —
@@ -131,39 +131,45 @@ standard Python.
 
 ### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted)
 
-This option emerged from the successive rejections above:
+A two-part system:
 
-**From Option 1**: a fixed Python vocabulary requires jBOM releases to extend.
-The config that invents a transformation requirement should be able to express
-how to satisfy it — in the same file, without a release cycle.
+1. **Field references** use an explicit `namespace:field` syntax (`pcb:footprint`,
+   `inv:IPN`). In Python expression context, `word:word` is already syntactically
+   invalid — the preprocessor exploits this as an unambiguous signal without
+   requiring any decoration (`${...}` is unnecessary).
 
-**From Option 2**: Jinja2 brings a full template engine when we need only a
-safe expression evaluator. No new dependency; Python's own `ast` module is
-the right tool.
+2. **Value expressions** are Python expressions evaluated with
+   `ast.parse(mode='eval')` in a restricted namespace: `re` plus all
+   config-defined transforms. No imports, no side effects.
 
-**From Option 2b**: `${token}` decoration is unnecessary. `word:word` in Python
-expression context is already a syntax error — the `:` makes the reference
-unambiguous without any additional markers.
+3. **Transforms** are single-argument functions defined in any `.jbom.yaml` via
+   a `transforms:` stanza. The same config that creates a transformation
+   requirement also defines how to satisfy it, with no jBOM release needed.
+   Built-in transforms ship in `common.jbom.yaml`.
 
-**From Option 3**: a pipe DSL adds syntax to learn for zero capability gain;
-standard Python function composition handles the same cases.
-
-**From Option 3b**: `:` must mean one thing. Using it as both namespace
-separator and transform-apply operator requires the parser to know the closed
-set of namespace names — reintroducing exactly the kind of implicit vocabulary
-this design avoids.
-
-The design that emerges: preprocess `namespace:field` tokens to local variable
-bindings (the syntax error is the signal), evaluate as a Python expression with
-`ast.parse(mode='eval')` in a namespace containing `re` and config-defined
-transforms, no Python stdlib. The same `.jbom.yaml` that creates a requirement
-(e.g., "strip the KiCad library prefix") also defines how to satisfy it (the
-transform expression in `transforms:`). See Decision Details below.
+See the Decision below for rationale; Decision Details (D1–D7) for specification.
 
 ## Decision
 
-Adopt the field reference system and value expression mechanism as described
-in D1–D7.
+**Option 4 is approved.** Rationale from the successive rejections:
+
+**From Option 1**: a fixed Python vocabulary requires jBOM releases to extend.
+The config that invents a transformation requirement should define how to satisfy
+it — in the same file, without a release cycle.
+
+**From Option 2**: Jinja2 is a document template engine. Python's `ast` module
+provides the right capability (expression evaluation) without the baggage.
+
+**From Option 2b**: `${...}` decoration is unnecessary. `word:word` in Python
+expression context is already a syntax error — the preprocessor exploits this
+as an unambiguous signal with no additional markers required.
+
+**From Option 3**: a pipe DSL adds syntax to learn with no capability gain;
+standard Python function call composition handles multi-step transforms.
+
+**From Option 3b**: `:` must mean one thing. Using it as both namespace
+separator and transform operator requires the parser to know the closed
+namespace vocabulary — reintroducing the implicit magic this design eliminates.
 
 Key properties:
 - Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
@@ -219,24 +225,15 @@ bom_columns:
 output value:
 ```yaml
 bom_columns:
-  # Strip KiCad library prefix (replaces "p:k:footprint")
+  # Strip KiCad library prefix (replaces "p:k:footprint"; transform from D3/D7)
   "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
 
-  # Combine two fields
+  # Combine two source fields
   "Label":     "f'{reference} ({inv:manufacturer})'"
 
-  # Arbitrary regex
+  # Arbitrary regex inline (no named transform needed)
   "PN":        "re.sub(r'\\s+', '-', inv:manufacturer_part).upper()"
-
-  # User-defined named transform (see D7)
-  "Footprint": "strip_lib_prefix(pcb:footprint)"
 ```
-
-**Why no `${}` decoration** (see Option 2b rejection): in Python expression
-context, `word:word` is already syntactically invalid — the preprocessor
-unambiguously identifies field references without any added markers. Bare
-convenience alias names (Category 3 in D4) are valid Python identifiers and
-are bound directly in the eval namespace after alias resolution.
 
 **Expression evaluation contract:**
 
@@ -395,23 +392,38 @@ two diverging conventions.
 ### D7. User-defined named transforms via `transforms:` stanza
 
 Any `.jbom.yaml` file may define named single-argument transform functions in a
-top-level `transforms:` stanza:
+top-level `transforms:` stanza. The built-in `strip_kicad_library_prefix` (see D3)
+ships this way. Org-level `common.jbom.yaml` files add to that set:
 
 ```yaml
-# common.jbom.yaml — team-wide named transforms
+# $REPO_ROOT/.jbom/common.jbom.yaml — org-wide transforms
 transforms:
-  strip_lib_prefix:
-    expr: "re.sub(r'^[^:]+:', '', value)"
-    doc:  "Remove KiCad library nickname prefix from symbol or footprint"
+  normalize_component_value:
+    expr: "re.sub(r'\\s+', '', value).upper()"
+    doc:  "Normalize component value strings: '10 K' → '10K', '100 nF' → '100NF'"
 
-  normalize_pn:
+  normalize_internal_part_number:
     expr: "value.replace(' ', '-').upper()"
-    doc:  "Normalize part number to hyphenated uppercase"
+    doc:  "Normalize internal part numbers for cross-referencing"
 ```
 
-`value` is the implicit single argument. `expr` is validated with
-`ast.parse(mode='eval')` at config load time — malformed transform expressions
-fail early, not at BOM generation time.
+Usage in a profile that `extends: jlc`:
+
+```yaml
+fab:
+  bom_columns:
+    "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
+    "Value":     "normalize_component_value(sch:Value)"
+    "IPN":       "inv:IPN"    # plain field ref — no transform needed
+```
+
+`value` is the implicit single argument in each `expr`. Naming convention:
+transform names should be descriptive verb phrases that make the action clear
+(`strip_kicad_library_prefix`, `normalize_component_value`); avoid generic names
+(`normalize`, `strip`) that obscure what is being transformed or why.
+
+`expr` is validated with `ast.parse(mode='eval')` at config load time —
+malformed transform expressions fail early, not at BOM generation time.
 
 Each defined transform is compiled to a single-argument callable and added to
 the expression evaluation namespace alongside `re` (D3). From the evaluator's
@@ -470,7 +482,7 @@ to publish a shared transform library without requiring a jBOM release.
   extends: jlc
 
   transforms:
-    normalize_value:
+    normalize_component_value:
       expr: "re.sub(r'\\s+', '', value).upper()"
       doc:  "Normalize value strings: '10 K' → '10K'"
 
@@ -478,14 +490,14 @@ to publish a shared transform library without requiring a jBOM release.
     bom_columns:
       "Surface Mount": null                                   # delete inherited
       "Footprint":     "strip_kicad_library_prefix(pcb:footprint)"
-      "Value":         "normalize_value(sch:Value)"
+      "Value":         "normalize_component_value(sch:Value)"
       "IPN":           "inv:IPN"                              # plain field ref
       "Status":        "inv:PART_STATUS"                      # custom sch attribute
   ```
 
   The plain `"inv:IPN"` and `"inv:PART_STATUS"` lines are readable to any
   engineer. The expression lines require understanding the transform mechanism.
-  The comment on `normalize_value` is the recommended mitigation.
+  The comment on `normalize_component_value` is the recommended mitigation.
 - The `ast.parse` + restricted-eval path adds complexity to the field resolver.
   This complexity is bounded and testable (expression rejection, namespace
   restriction, error surfacing).

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -97,67 +97,77 @@ Migration shim: `c:` → `sch:`, `p:` → `pcb:`, `i:` → `inv:` are accepted w
 a deprecation log warning during the ADR 0008 shim period. `k:` is replaced by
 the expression mechanism (D2).
 
-### D2. Value expressions via `${token}` interpolation
+### D2. Value expressions — field references and Python expressions
 
-A `bom_columns` value (or any config value that accepts a field reference) may
-be either:
+A `bom_columns` value (or any config value that accepts a field reference) is
+one of two forms. `:` means exactly one thing throughout: namespace separator.
 
 **A plain field reference** — resolved directly:
 ```yaml
 bom_columns:
-  "Designator": "reference"          # canonical computed field
-  "Package":    "inv:package"        # inventory namespace
-  "Footprint":  "pcb:footprint"      # PCB namespace
+  "Designator": "reference"        # canonical computed field (no namespace)
+  "Package":    "inv:package"      # inventory namespace
+  "Footprint":  "pcb:footprint"    # PCB namespace
 ```
 
-**A Python expression with `${field_ref}` interpolation** — evaluated to produce
-the output value:
+**A Python expression containing field references** — evaluated to produce the
+output value:
 ```yaml
 bom_columns:
-  # Strip KiCad library prefix from footprint (replaces "p:k:footprint")
-  "Footprint": "kicad_strip_library_prefix(${pcb:footprint})"
+  # Strip KiCad library prefix (replaces "p:k:footprint")
+  "Footprint": "kicad_strip_library_prefix(pcb:footprint)"
 
   # Combine two fields
-  "Label":     "f'{${sch:reference}} ({${inv:manufacturer}})'"
+  "Label":     "f'{reference} ({inv:manufacturer})'"
 
   # Arbitrary regex
-  "PN":        "re.sub(r'\\s+', '-', ${inv:manufacturer_part}).upper()"
+  "PN":        "re.sub(r'\\s+', '-', inv:manufacturer_part).upper()"
+
+  # User-defined named transform (see D7)
+  "Footprint": "strip_lib_prefix(pcb:footprint)"
 ```
+
+**Why no `${}` decoration:** in Python expression context, `word:word`
+(namespace-qualified field references) is syntactically invalid Python. The
+preprocessor identifies and binds these unambiguously without additional
+decoration. Canonical field names are valid Python identifiers and are bound
+directly in the eval namespace.
 
 **Expression evaluation contract:**
 
-1. All `${namespace:field}` and `${canonical_field}` tokens are extracted and
-   resolved to string values. Each is bound as a local variable in the
-   evaluation namespace (`:` replaced by `_` in the variable name, e.g.
-   `${pcb:footprint}` → `pcb_footprint`).
+1. Scan the expression string for `word:word` patterns. Each `namespace:field`
+   token is syntactically invalid Python and is unambiguously a field reference.
+   Resolve each to its string value and bind as `namespace_field` in the local
+   variable namespace.
 
-2. The token references in the expression string are replaced with the
-   corresponding variable names.
+2. Canonical field names referenced in the expression are bound by name in the
+   local namespace (e.g., `reference` → the resolved reference value).
 
-3. The resulting string is parsed with `ast.parse(expr, mode='eval')`. This
-   rejects statements, loop constructs, function definitions, and `import`
-   statements at the grammar level — before any evaluation.
+3. Replace `namespace:field` tokens in the expression string with their
+   `namespace_field` variable names. The result is a valid Python expression.
 
-4. The compiled expression is evaluated in a restricted namespace containing:
-   - The resolved token variables
+4. Parse with `ast.parse(expr, mode='eval')`. This rejects statements, loop
+   constructs, function definitions, and `import` statements at the grammar
+   level — before any evaluation.
+
+5. Evaluate in a restricted namespace containing:
+   - The resolved field variables
    - `re` (Python's standard `re` module)
-   - The jBOM expression stdlib (see D3)
+   - The jBOM expression stdlib and user-defined transforms (see D3, D7)
    - No `__builtins__`
 
-5. The return value is coerced to `str`. Exceptions during evaluation surface as
-   a `FieldExpressionError` with the offending expression and token values in
-   the message.
+6. The return value is coerced to `str`. Exceptions surface as a
+   `FieldExpressionError` with the offending expression and field values.
 
-Expressions are detected by the presence of `${...}` in the value string.
-Values without `${...}` are treated as plain field references regardless of
-content.
+**Detection:** a value is an expression if it is not a plain field reference —
+i.e., it contains characters outside `(namespace:)?fieldname` (parentheses,
+quotes, operators, etc.). Plain field references are always tried first.
 
 ### D3. jBOM expression stdlib
 
 A small set of jBOM-curated helper functions is available in every expression
 evaluation namespace. These are regular Python functions (not magic syntax),
-documented, and versioned with jBOM. They provide convenience for common
-jBOM-specific transformations without requiring users to write raw regex.
+documented, and versioned with jBOM.
 
 v1 stdlib:
 ```
@@ -168,11 +178,9 @@ kicad_strip_library_prefix(s)   → re.sub(r'^[^:]+:', '', s)
 
 Users are not limited to the stdlib — `re.sub`, `str` methods, and other
 Python expression constructs work directly. The stdlib is an additive
-convenience layer, not a replacement vocabulary.
-
-New stdlib functions are added as part of jBOM releases. Users who need a
-transformation not in the stdlib can express it directly in the expression
-without waiting for a release.
+convenience layer, not a replacement vocabulary. Users who need a named
+transform not in the stdlib can define it in their own config (see D7)
+without waiting for a jBOM release.
 
 ### D4. Canonical field name registry
 
@@ -233,6 +241,42 @@ same `FieldRefResolver` used by the config loader.
 This makes the CLI and config syntaxes a single documented language rather than
 two diverging conventions.
 
+### D7. User-defined named transforms via `transforms:` stanza
+
+Any `.jbom.yaml` file may define named single-argument transform functions in a
+top-level `transforms:` stanza:
+
+```yaml
+# common.jbom.yaml — team-wide named transforms
+transforms:
+  strip_lib_prefix:
+    expr: "re.sub(r'^[^:]+:', '', value)"
+    doc:  "Remove KiCad library nickname prefix from symbol or footprint"
+
+  normalize_pn:
+    expr: "value.replace(' ', '-').upper()"
+    doc:  "Normalize part number to hyphenated uppercase"
+```
+
+`value` is the implicit single argument. `expr` is validated with
+`ast.parse(mode='eval')` at config load time — malformed transform expressions
+fail early, not at BOM generation time.
+
+Each defined transform is compiled to a single-argument callable and added to
+the expression evaluation namespace alongside the jBOM stdlib (D3). From the
+evaluator's perspective, user-defined and jBOM-stdlib transforms are
+indistinguishable — they are the same kind of thing.
+
+`transforms:` follows the same inheritance rules as all other config content:
+`extends:` chains propagate parent transforms to child profiles; a
+`common.jbom.yaml` at each search-path level contributes ambient transforms
+available to all configs at that level and below. Transform names must not
+collide with jBOM stdlib names (validated at load time with a warning).
+
+This allows `--fields` CLI arguments and config `bom_columns` values to
+reference org-defined transforms by name, enabling a team's `common.jbom.yaml`
+to publish a shared transform library without requiring a jBOM release.
+
 ## Options Considered
 
 ### Option 1 — Named transform vocabulary (rejected)
@@ -251,9 +295,9 @@ registration.
 
 Rejected because: Jinja2 solves document templating (with looping constructs,
 block inheritance, macros). That is more capability — and more cognitive
-surface area — than field value expression requires. The `${token}` +
-`ast.parse(mode='eval')` approach provides the needed expression power without
-the baggage, and without a new dependency.
+surface area — than field value expression requires. The `namespace:field`
+preprocessing + `ast.parse(mode='eval')` approach provides the needed expression
+power without the baggage, and without a new dependency.
 
 ### Option 3 — Pipe model for chained transforms (deferred)
 `"Footprint": "pcb:footprint | strip_kicad_library_prefix | upper"` — a
@@ -263,31 +307,43 @@ Not adopted as the primary mechanism; a pipeline model could be layered on top
 of the expression mechanism in a future ADR if use cases emerge. The expression
 mechanism (D2) handles multi-step transforms natively.
 
-### Option 4 — `${token}` + `ast.parse(mode='eval')` (accepted — this ADR)
-Described in D1–D6 above.
+### Option 3b — `transform:namespace:field` shorthand syntax (rejected)
+`"Footprint": "strip_lib_prefix:pcb:footprint"` — a compact positional syntax
+for applying a named transform to a single field reference.
+
+Rejected because: this overloads `:` with two meanings simultaneously —
+namespace separator AND "apply transform to field". `pcb:` is a namespace
+qualifier; is `strip_lib_prefix:` also a "transform qualifier"? The parser
+would need external knowledge (the namespace vocabulary) to disambiguate,
+reintroducing exactly the kind of implicit magic this ADR is designed to
+eliminate. Function call syntax `strip_lib_prefix(pcb:footprint)` is
+unambiguous, already covered by the expression mechanism, and reads as
+standard Python.
+
+### Option 4 — `namespace:field` preprocessing + `ast.parse(mode='eval')` (accepted — this ADR)
+Described in D1–D7 above.
 
 ## Decision
 
 Adopt the field reference system and value expression mechanism as described
-in D1–D6.
+in D1–D7.
 
 Key properties:
 - Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
-  single-character prefixes.
+  single-character prefixes. `:` means exactly one thing: namespace separator.
 - Canonical computed fields carry no namespace prefix and are defined in a
   single authoritative registry.
-- `${token}` interpolation + `ast.parse(mode='eval')` provides safe, user-
-  extensible field value transformation without requiring jBOM releases for
-  common string manipulation needs.
-- A small jBOM expression stdlib provides named convenience functions without
-  replacing the general expression mechanism.
+- `namespace:field` tokens are syntactically invalid Python and are
+  unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
+- A jBOM expression stdlib provides named convenience functions; users extend
+  it via the `transforms:` stanza in any `.jbom.yaml` without a jBOM release.
 - `field_synonyms` is unified to one structure and one parser across all stanzas.
 - CLI `--fields` and config `bom_columns` share one field reference language.
 
 ## Consequences
 
 ### Positive
-- `p:k:footprint` becomes `kicad_strip_library_prefix(${pcb:footprint})` —
+- `p:k:footprint` becomes `kicad_strip_library_prefix(pcb:footprint)` —
   self-documenting, no magic characters, extensible to any regex the user needs.
 - Users can combine fields, apply regex, and format output values without waiting
   for jBOM releases.
@@ -306,6 +362,9 @@ Key properties:
   restriction, error surfacing).
 - The jBOM expression stdlib must be documented, versioned, and not broken
   across jBOM releases (same API stability bar as the rest of the config API).
+- The `transforms:` stanza adds a new user-facing config concept that must be
+  validated, documented, and handled by the merge engine (inherited via
+  `extends:` and `common.jbom.yaml`).
 
 ### Risks and Mitigations
 - **Risk**: A future Python version changes `ast.parse` expression grammar or
@@ -331,9 +390,6 @@ Key properties:
    component category tokens (`RES`, `res`, `resistor`) are out of scope here.
 3. **Pipe-chained transforms** — reserved for future consideration once
    expression usage patterns are observed in practice.
-4. **User-registerable stdlib extensions** — allowing `common.jbom.yaml` to
-   register named helper functions into the expression stdlib. Deferred until
-   concrete use cases emerge beyond what raw `re` expressions cover.
 
 ## Implementation Phases
 
@@ -343,9 +399,11 @@ Key properties:
 - `src/jbom/config/field_ref.py` — `FieldRef` dataclass (namespace, name,
   expression); `FieldRefResolver.resolve(ref, context)` → value.
 - `src/jbom/config/field_expr.py` — `FieldExpressionEvaluator`:
-  - `${token}` extraction and local variable binding
+  - `namespace:field` token scanning and local variable binding
   - `ast.parse(mode='eval')` + restricted eval
   - jBOM expression stdlib registration
+  - `transforms:` stanza parsing: validate `expr` at load time, compile to
+    callable, add to eval namespace
 - `src/jbom/config/field_synonyms.py` — single shared `parse_field_synonyms()`
   replacing the three divergent parsers.
 - Update `fabricators.py`, `defaults.py`, `suppliers.py` to use shared parser.

--- a/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
+++ b/docs/dev/architecture/adr/0009-field-reference-system-and-value-expressions.md
@@ -147,46 +147,6 @@ A two-part system:
    requirement also defines how to satisfy it, with no jBOM release needed.
    Built-in transforms ship in `common.jbom.yaml`.
 
-See the Decision below for rationale; Decision Details (D1–D7) for specification.
-
-## Decision
-
-**Option 4 is approved.** Rationale from the successive rejections:
-
-**From Option 1**: a fixed Python vocabulary requires jBOM releases to extend.
-The config that invents a transformation requirement should define how to satisfy
-it — in the same file, without a release cycle.
-
-**From Option 2**: Jinja2 is a document template engine. Python's `ast` module
-provides the right capability (expression evaluation) without the baggage.
-
-**From Option 2b**: `${...}` decoration is unnecessary. `word:word` in Python
-expression context is already a syntax error — the preprocessor exploits this
-as an unambiguous signal with no additional markers required.
-
-**From Option 3**: a pipe DSL adds syntax to learn with no capability gain;
-standard Python function call composition handles multi-step transforms.
-
-**From Option 3b**: `:` must mean one thing. Using it as both namespace
-separator and transform operator requires the parser to know the closed
-namespace vocabulary — reintroducing the implicit magic this design eliminates.
-
-Key properties:
-- Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
-  single-character prefixes. `:` means exactly one thing: namespace separator.
-- Source fields are runtime-discovered; only three jBOM-computed fields
-  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
-- Bare convenience alias names resolve via `field_precedence_policy` in
-  `defaults:` — config-owned, not hardcoded.
-- `namespace:field` tokens are syntactically invalid Python and are
-  unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
-- Named transforms (including built-in ones in `common.jbom.yaml`) are
-  config-defined; expression eval provides only `re`. No Python stdlib.
-- `field_synonyms` is unified to one structure and one parser across all stanzas.
-- CLI `--fields` and config `bom_columns` share one field reference language.
-
-### Decision Details
-
 ### D1. Source namespace vocabulary
 
 Field references from non-canonical sources carry an explicit namespace prefix.
@@ -226,7 +186,7 @@ output value:
 ```yaml
 bom_columns:
   # Strip KiCad library prefix (replaces "p:k:footprint"; transform from D3/D7)
-  "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
+  "Footprint": "strip_kicad_library_prefix_from_value(pcb:footprint)"
 
   # Combine two source fields
   "Label":     "f'{reference} ({inv:manufacturer})'"
@@ -282,7 +242,7 @@ The built-in `common.jbom.yaml` shipped with jBOM pre-defines common transforms:
 ```yaml
 # src/jbom/config/common.jbom.yaml (built-in, shipped with jBOM)
 transforms:
-  strip_kicad_library_prefix:
+  strip_kicad_library_prefix_from_value:
     expr: "re.sub(r'^[^:]+:', '', value)"
     doc:  "Remove KiCad library nickname. 'Capacitors_SMD:C_0402' → 'C_0402'"
 ```
@@ -337,7 +297,7 @@ according to the `field_precedence_policy` defined in the active `defaults:`
 stanza:
 
 ```yaml
-# generic.defaults.yaml (existing)
+# common.jbom.yaml (ambient — applied at every search-path level)
 field_precedence_policy:
   schematic_biased:
     - value
@@ -351,14 +311,13 @@ field_precedence_policy:
     ...
 ```
 
-This policy is the config-owned mechanism for convenience alias resolution —
-not a static Python registry. An org can override the policy in their
-`common.jbom.yaml` to change which source namespace a bare name resolves to,
-without changing any code.
+This policy lives in `common.jbom.yaml`, not `generic.jbom.yaml`, because it
+controls how bare field names resolve for every command regardless of which
+named profile is active — exactly what `common.jbom.yaml` is for. An org can
+override or extend the policy in their own `common.jbom.yaml`.
 
-Note: the `field_precedence_policy` as currently defined in `generic.defaults.yaml`
-needs to be extended to fully cover the alias resolution role described here.
-That extension is part of the built-in file migration in Phase 1.
+The `field_precedence_policy` content currently in `generic.defaults.yaml`
+migrates to `common.jbom.yaml` as part of the built-in file migration in Phase 1.
 
 ### D5. Unified `field_synonyms` structure
 
@@ -392,35 +351,48 @@ two diverging conventions.
 ### D7. User-defined named transforms via `transforms:` stanza
 
 Any `.jbom.yaml` file may define named single-argument transform functions in a
-top-level `transforms:` stanza. The built-in `strip_kicad_library_prefix` (see D3)
-ships this way. Org-level `common.jbom.yaml` files add to that set:
+top-level `transforms:` stanza. The built-in `strip_kicad_library_prefix_from_value`
+ships this way in `common.jbom.yaml` (see D3). Org-level and project-level
+`common.jbom.yaml` files extend the transform set at their respective search-path
+levels.
+
+`common.jbom.yaml` files are automatically deep-merged as ambient defaults at
+each search-path level — they are not named profiles. All `common.jbom.yaml`
+files in the search path are cumulative (every level contributes); named profile
+files use first-match-wins. The `policy.jbom.yaml` mandate mechanism (ADR 0008
+D6) can enforce transforms that lower-level configs cannot remove. See ADR 0008
+D5–D6 for the full `common.jbom.yaml` mechanics.
 
 ```yaml
-# $REPO_ROOT/.jbom/common.jbom.yaml — org-wide transforms
+  # src/jbom/config/common.jbom.yaml — definition (ships with jBOM)
 transforms:
-  normalize_component_value:
-    expr: "re.sub(r'\\s+', '', value).upper()"
-    doc:  "Normalize component value strings: '10 K' → '10K', '100 nF' → '100NF'"
+  strip_kicad_library_prefix_from_value:
+    expr: "re.sub(r'^[^:]+:', '', value)"
+    doc:  "'Capacitors_SMD:C_0402' → 'C_0402'"
 
-  normalize_internal_part_number:
-    expr: "value.replace(' ', '-').upper()"
-    doc:  "Normalize internal part numbers for cross-referencing"
-```
-
-Usage in a profile that `extends: jlc`:
-
-```yaml
+  # jlc.jbom.yaml — usage
 fab:
   bom_columns:
-    "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
-    "Value":     "normalize_component_value(sch:Value)"
-    "IPN":       "inv:IPN"    # plain field ref — no transform needed
+    "Designator": "reference"
+    "Quantity": "quantity"
+    "Value": "value"
+    "Footprint": "strip_kicad_library_prefix_from_value(pcb:footprint)"
+    "LCSC": "fabricator_part_number"  # JLCPCB requires this column name in BOM
+    "Surface Mount": "smd"
+    "Comment": "description"
 ```
 
 `value` is the implicit single argument in each `expr`. Naming convention:
-transform names should be descriptive verb phrases that make the action clear
-(`strip_kicad_library_prefix`, `normalize_component_value`); avoid generic names
-(`normalize`, `strip`) that obscure what is being transformed or why.
+the noun `value` must appear in the transform name — it maps directly to the
+`value` parameter used in the `expr`. This makes the connection explicit to
+anyone reading a config file without looking up the transform definition:
+
+- `strip_kicad_library_prefix_from_value` → `re.sub(r'^[^:]+:', '', value)`
+- `normalize_component_value` → `re.sub(r'\\s+', '', value).upper()`
+
+Avoid generic names (`normalize`, `strip`) that omit what is being transformed.
+Avoid names without the `value` noun: the reader needs to know the function
+operates on a single string argument named `value`.
 
 `expr` is validated with `ast.parse(mode='eval')` at config load time —
 malformed transform expressions fail early, not at BOM generation time.
@@ -433,35 +405,60 @@ indistinguishable — they are all config-defined.
 `transforms:` follows the same inheritance rules as all other config content:
 `extends:` chains propagate parent transforms to child profiles; a
 `common.jbom.yaml` at each search-path level contributes ambient transforms
-available to all configs at that level and below. Transform names must not
-collide with built-in transform names from the shipped `common.jbom.yaml`
-(validated at load time with a warning).
+available to all configs at that level and below.
+
+jBOM validates transform names at config load time. When a user-defined name
+matches a built-in from the shipped `common.jbom.yaml`, the user's definition
+shadows the built-in (intentional override is supported) and jBOM logs a
+`NOTICE`-level message so accidental shadows are detectable. Two user-defined
+transforms with the same name in the same file are a load-time error.
 
 This allows `--fields` CLI arguments and config `bom_columns` values to
 reference org-defined transforms by name, enabling a team's `common.jbom.yaml`
 to publish a shared transform library without requiring a jBOM release.
 
+
+## Decision
+
+**Option 4 is approved.** Rationale from the successive rejections:
+
+**From Option 1**: a fixed Python vocabulary requires jBOM releases to extend.
+The config that invents a transformation requirement should define how to satisfy
+it — in the same file, without a release cycle.
+
+**From Option 2**: Jinja2 is a document template engine. Python's `ast` module
+provides the right capability (expression evaluation) without the baggage.
+
+**From Option 2b**: `${...}` decoration is unnecessary. `word:word` in Python
+expression context is already a syntax error — the preprocessor exploits this
+as an unambiguous signal with no additional markers required.
+
+**From Option 3**: a pipe DSL adds syntax to learn with no capability gain;
+standard Python function call composition handles multi-step transforms.
+
+**From Option 3b**: `:` must mean one thing. Using it as both namespace
+separator and transform operator requires the parser to know the closed
+namespace vocabulary — reintroducing the implicit magic this design eliminates.
+
+Key properties:
+- Three explicit source namespaces (`sch:`, `pcb:`, `inv:`) replace opaque
+  single-character prefixes. `:` means exactly one thing: namespace separator.
+- Source fields are runtime-discovered; only three jBOM-computed fields
+  (`quantity`, `fabricator_part_number`, `smd`) are Python-registered.
+- Bare convenience alias names resolve via `field_precedence_policy` in
+  `defaults:` — config-owned, not hardcoded.
+- `namespace:field` tokens are syntactically invalid Python and are
+  unambiguously preprocessed before `ast.parse(mode='eval')`. No `${}` decoration.
+- Named transforms (including built-in ones in `common.jbom.yaml`) are
+  config-defined; expression eval provides only `re`. No Python stdlib.
+- `field_synonyms` is unified to one structure and one parser across all stanzas.
+- CLI `--fields` and config `bom_columns` share one field reference language.
+
 ## Consequences
 
 ### Positive
-- The old `p:k:footprint` becomes transparent: the transform is defined in
-  `common.jbom.yaml` and used in `bom_columns`. Complete picture:
-
-  ```yaml
-  # src/jbom/config/common.jbom.yaml — definition (ships with jBOM)
-  transforms:
-    strip_kicad_library_prefix:
-      expr: "re.sub(r'^[^:]+:', '', value)"
-      doc:  "'Capacitors_SMD:C_0402' → 'C_0402'"
-
-  # jlc.jbom.yaml — usage
-  fab:
-    bom_columns:
-      "Footprint": "strip_kicad_library_prefix(pcb:footprint)"
-  ```
-
-  Both sides live in config. The transform can be inspected, overridden, or
-  replaced without touching Python.
+- The old `p:k:footprint` is no longer magic; it is completely visible in the config files.
+  The transform can be inspected, overridden, or replaced without touching Python.
 - Users can combine fields, apply regex, and format output values without waiting
   for jBOM releases.
 - `__resolved_fabricator_part_number__` is gone; `fabricator_part_number` is a
@@ -489,7 +486,7 @@ to publish a shared transform library without requiring a jBOM release.
   fab:
     bom_columns:
       "Surface Mount": null                                   # delete inherited
-      "Footprint":     "strip_kicad_library_prefix(pcb:footprint)"
+      "Footprint":     "strip_kicad_library_prefix_from_value(pcb:footprint)"
       "Value":         "normalize_component_value(sch:Value)"
       "IPN":           "inv:IPN"                              # plain field ref
       "Status":        "inv:PART_STATUS"                      # custom sch attribute
@@ -562,7 +559,8 @@ to publish a shared transform library without requiring a jBOM release.
 - Update `bom_workflow.py` / CLI `--fields` parser to use `FieldRefResolver`.
 - Built-in config files using old prefixes are migrated in Phase 2; no shim.
 - Unit tests: namespace resolution, expression evaluation, statement rejection,
-  `strip_kicad_library_prefix`, error surfacing, transform compilation.
+  `strip_kicad_library_prefix_from_value`, error surfacing, transform name
+  shadowing (NOTICE logged), duplicate-name error.
 
 **Phase 2 (alongside ADR 0008 Phase 1b — built-in file migration)**
 - Migrate built-in config files: `"p:k:footprint"` → expression form.

--- a/docs/dev/architecture/adr/0010-pydantic-config-schema-binding.md
+++ b/docs/dev/architecture/adr/0010-pydantic-config-schema-binding.md
@@ -155,21 +155,18 @@ def validate_rotation_range(cls, v):
 
 The constraint is now visible in the class definition, not buried in a method.
 
-#### D4. `Field(alias=...)` for transitional legacy key renames
+#### D4. `Field(alias=...)` is not permitted in merged code
 
-When a YAML key cannot be renamed immediately (e.g., `tier_overrides` was the
-YAML key and Python used `tier_rules`), `Field(alias=...)` makes the discrepancy
-explicit and temporary:
+Nothing has shipped externally. There is no compatibility constraint that
+justifies carrying a name mismatch past the migration commit. The alias
+mechanism is scaffolding only: it may appear as an intermediate state during
+a rename commit but must be removed in the same commit that renames the
+Python attribute. A `Field(alias=...)` present at PR review time is a
+merge blocker.
 
-```python
-# Transitional only — must have a cleanup issue filed
-tier_overrides: List[TierOverride] = Field(
-    default=[],
-    alias="tier_overrides",   # legacy YAML key; Python attr must be renamed next
-)
-```
-
-No silent divergence. No "read Python to understand YAML" mystery.
+The correct resolution for any name mismatch is: rename the Python attribute
+to match the YAML key and update all consuming callsites. The schema audit
+identified the full set of such mismatches; it is a bounded list.
 
 #### D5. `model_json_schema()` as the authoritative schema
 
@@ -247,18 +244,34 @@ This ADR directly resolves the following smells from `config-schema-audit.md`:
 
 **Phase 1 (this feature branch, alongside ADR 0008/0009 Phase 1)**
 
-- Add `pydantic>=2.0` to `pyproject.toml` dependencies and PCM vendoring list.
-- Migrate `FabricatorConfig` → Pydantic `BaseModel`:
-  - Rename `tier_rules` attr to `tier_overrides` (or keep computed as D2)
-  - Move validation from `from_yaml_dict()` to `@field_validator` / `@model_validator`
-  - Add `model_config = ConfigDict(extra="ignore")`
-- Migrate `SupplierConfig` → Pydantic `BaseModel`
-- Migrate `DefaultsConfig` → Pydantic `BaseModel`
-- Migrate supporting types: `FieldSynonym`, `TierCondition`, `TierRule`,
-  `SearchProviderConfig`, `InventorySchemaConfig`, `EnrichmentCategoryConfig`
-- Introduce `TierOperator` enum (replaces undocumented string DSL)
-- Update all call sites: `from_yaml_dict()` → `model_validate()`
-- Unit tests: verify `model_json_schema()` output is stable (schema regression test)
+This is a source code refactoring, not merely a config file migration. The
+Pydantic migration touches three layers:
+
+1. **The config models** (`fabricators.py`, `suppliers.py`, `defaults.py`):
+   - Add `pydantic>=2.0` to `pyproject.toml` dependencies and PCM vendoring list.
+   - Replace `@dataclass` with `BaseModel` for `FabricatorConfig`, `SupplierConfig`,
+     `DefaultsConfig` and all supporting types (`FieldSynonym`, `TierCondition`,
+     `TierRule`, `SearchProviderConfig`, `InventorySchemaConfig`,
+     `EnrichmentCategoryConfig`).
+   - Add `model_config = ConfigDict(extra="ignore")` to each model.
+   - Move all validation from `from_yaml_dict()` to `@field_validator` /
+     `@model_validator`. Introduce `TierOperator` enum (replaces undocumented
+     string DSL).
+   - Replace `from_yaml_dict()` call sites with `model_validate()`.
+
+2. **Python attribute renames** (wherever audit-identified YAML/Python
+   mismatches exist): rename the Python attribute to match the YAML key, then
+   update every consuming callsite across the entire codebase. The schema audit
+   identified the full set; it is a bounded list. `Field(alias=...)` must not
+   appear in any merged commit.
+
+3. **Consuming code** (`bom_workflow.py`, `pos_workflow.py`, `cli/*.py`,
+   `services/*.py`, any code that reads a config attribute by name): update
+   attribute references wherever a rename occurred in layer 2. This is
+   mechanical (`git grep` + rename) but must be complete before the branch lands.
+
+- Unit tests: verify `model_json_schema()` output is stable (schema regression
+  test); verify all renamed attributes are reachable through the Pydantic model.
 
 **Phase 2 (alongside ADR 0008/0009 Phase 1b)**
 - Update `docs/README.configuration.md` with generated schema reference.

--- a/docs/dev/architecture/adr/0010-pydantic-config-schema-binding.md
+++ b/docs/dev/architecture/adr/0010-pydantic-config-schema-binding.md
@@ -1,0 +1,275 @@
+# ADR 0010: Pydantic BaseModel as Config Schema Binding Mechanism
+Date: 2026-05-11
+Status: Proposed
+Related: ADR 0008, ADR 0009, docs/dev/architecture/config-schema-audit.md
+
+## Context
+
+ADR 0009 established the design lens criterion:
+
+> *Every YAML key should correspond to a named Python attribute; any key whose
+> meaning requires reading Python to understand is a schema design smell.*
+
+The current config loading system violates this principle systematically. All
+three loaders (`fabricators.py`, `suppliers.py`, `defaults.py`) hand-write
+`from_yaml_dict()` methods that extract YAML keys as raw string literals:
+
+```python
+pid = data.get("id", default_id)
+tier_overrides = data.get("tier_overrides")   # YAML key
+# ...
+return FabricatorConfig(
+    tier_rules=_derive_tier_rules(tier_overrides),  # Python attr: different name
+```
+
+The schema audit (`config-schema-audit.md`) found 15 smells in the current
+vocabulary, including `tier_overrides` (YAML) → `tier_rules` (Python) as a
+representative example of the name-divergence anti-pattern. The root cause is
+that there is **no formal binding mechanism** between YAML keys and Python
+types — the correspondence is maintained by convention and reading code.
+
+The question crystallized during design review: *how are config data models
+tagged as "exported for use in config files", and how is that relationship
+enforced?*
+
+## Decision Drivers
+
+- The Python class definition should BE the schema — not a separate spec that
+  can drift from the implementation.
+- Every field visible in a `.jbom.yaml` file should correspond to a named
+  Python attribute with no translation layer.
+- Computed/derived Python attributes that do NOT correspond to YAML keys must
+  be structurally distinguished from YAML-facing fields, not just by convention.
+- The schema should be machine-readable without running jBOM — for IDE
+  completion, validation tooling, and documentation generation.
+- `from_yaml_dict()` methods (130+ lines in `fabricators.py` alone) should not
+  exist; parsing should be derived from the type definition.
+
+## Options Considered
+
+### Option 1 — Naming convention + generic reflection-based loader (rejected)
+
+Enforce that all Python attribute names match YAML keys by convention. Write a
+single generic `from_yaml_dict()` base that iterates `dataclasses.fields()` and
+calls `data.get(field.name)`. The contract is enforced at runtime (mismatches
+produce silently missing data; tests catch this).
+
+Rejected because: convention is not enforcement. The discrepancy between
+`tier_overrides` and `tier_rules` existed as a named convention violation for
+years without being caught. A structural mechanism is needed, not a better
+convention.
+
+### Option 2 — Dataclass field metadata annotations (rejected)
+
+Add `field(metadata={"yaml_key": "tier_overrides"})` to allow Python attribute
+names to differ from YAML keys while maintaining an explicit mapping.
+
+Rejected because: this perpetuates the dual-naming problem in annotated form.
+The audit (S11, `enrichment_bindings` → Python attribute names) shows exactly
+the kind of confusion this produces. Allowing divergence — even explicitly —
+means config authors must still learn both names.
+
+### Option 3 — Pydantic v2 `BaseModel` (accepted — this ADR)
+
+Replace all config `@dataclass` classes with Pydantic `BaseModel`. The model
+field name IS the YAML key by definition. `model_validate(yaml_dict)` replaces
+all `from_yaml_dict()` methods. See Decision Details below.
+
+## Decision
+
+**Adopt Pydantic v2 `BaseModel` for all config schema classes.**
+
+The formal answer to "how are data models tagged for export": **they are Pydantic
+fields**. That is the complete, unambiguous tag. `@computed_field` is the only
+way to have a Python attribute that is NOT a YAML key. There is no other
+distinction to maintain.
+
+Key properties:
+- Python field name = YAML key name. No exceptions, no aliases except for
+  explicitly temporary legacy transitions (see Decision Details).
+- `@computed_field` for derived values — structurally excluded from YAML parsing.
+- `model_validate(yaml_dict)` replaces every `from_yaml_dict()` method.
+- `model_json_schema()` provides machine-readable schema for free — directly
+  feeds the planned `jbom config --schema` command.
+- `model_fields_set` tracks which fields were explicitly provided vs. defaulted
+  — useful for diagnostic output (which config level set which value).
+
+### Decision Details
+
+#### D1. Python field name = YAML key name
+
+```python
+class FabricatorConfig(BaseModel):
+    id: str
+    name: str
+    bom_columns: Dict[str, str] = {}
+    # Renamed from Python 'tier_rules' to match YAML 'tier_overrides'
+    tier_overrides: List[TierOverride] = []
+    cpl_rotation_range: Optional[Tuple[float, float]] = None
+    generate_designators: bool = False
+```
+
+No `data.get("tier_overrides")` string literal anywhere. The field name IS the
+contract.
+
+#### D2. `@computed_field` for non-YAML Python attributes
+
+Any Python attribute that should NOT appear in the YAML is explicitly declared
+as a computed field. The design lens violation becomes structurally impossible:
+
+```python
+class FabricatorConfig(BaseModel):
+    tier_overrides: List[TierOverride] = []
+
+    @computed_field
+    @cached_property
+    def tier_rules(self) -> List[TierRule]:
+        """Derived from tier_overrides at construction time. Not a YAML key."""
+        return _derive_tier_rules(self.tier_overrides)
+```
+
+`@computed_field` is self-documenting: this is NOT in the YAML. No comment
+needed to explain the discrepancy.
+
+#### D3. `model_validate()` replaces `from_yaml_dict()`
+
+```python
+# Before
+config = FabricatorConfig.from_yaml_dict(data, default_id=fid)
+
+# After
+config = FabricatorConfig.model_validate(data)
+```
+
+Custom validation logic that currently lives in `from_yaml_dict()` migrates to
+`@field_validator` and `@model_validator`:
+
+```python
+@field_validator("cpl_rotation_range")
+@classmethod
+def validate_rotation_range(cls, v):
+    if v is not None and v[1] - v[0] != 360:
+        raise ValueError("cpl_rotation_range must span exactly 360°")
+    return v
+```
+
+The constraint is now visible in the class definition, not buried in a method.
+
+#### D4. `Field(alias=...)` for transitional legacy key renames
+
+When a YAML key cannot be renamed immediately (e.g., `tier_overrides` was the
+YAML key and Python used `tier_rules`), `Field(alias=...)` makes the discrepancy
+explicit and temporary:
+
+```python
+# Transitional only — must have a cleanup issue filed
+tier_overrides: List[TierOverride] = Field(
+    default=[],
+    alias="tier_overrides",   # legacy YAML key; Python attr must be renamed next
+)
+```
+
+No silent divergence. No "read Python to understand YAML" mystery.
+
+#### D5. `model_json_schema()` as the authoritative schema
+
+```python
+import json
+print(json.dumps(FabricatorConfig.model_json_schema(), indent=2))
+```
+
+This output feeds:
+- IDE completion for `.jbom.yaml` files (JSON Schema → VS Code yaml extension)
+- The planned `jbom config --schema` command (ADR 0008 Deferred 5)
+- Config documentation generation
+
+The schema is not a separate file to maintain — it is generated from the model.
+
+## Consequences
+
+### Positive
+- The design lens criterion is structurally enforced, not merely stated.
+- Adding a new YAML config key requires only adding a Python field — no
+  separate string literal, no `from_yaml_dict()` edit, no hand-written
+  validation unless the validation is complex.
+- `@computed_field` makes the YAML-vs-computed distinction explicit in the
+  code at the point of definition.
+- `model_json_schema()` is free — enables IDE support, `jbom config --schema`,
+  documentation generation.
+- All `from_yaml_dict()` methods (130+ lines in fabricators.py alone) collapse
+  to `model_validate()` plus field validators.
+- `model_fields_set` provides diagnostic visibility into which config level
+  contributed each value.
+- Schema audit smells S11 (`enrichment_bindings` → Python attr names) and all
+  `tier_overrides`-style mismatches are structurally eliminated.
+
+### Negative / Tradeoffs
+- Pydantic v2 becomes a required runtime dependency. Currently jBOM requires
+  only `sexpdata` and `PyYAML`. Adding Pydantic adds ~3 MB; it is pure Python
+  with optional Rust acceleration (pydantic-core) and widely available on PyPI.
+- Migration of the three loader files is mechanical but non-trivial — each
+  `@dataclass` becomes a `BaseModel`, each `from_yaml_dict()` is replaced with
+  validators. Estimated scope: `fabricators.py`, `suppliers.py`, `defaults.py`
+  plus their tests.
+- `@computed_field` requires `cached_property` for fields that are expensive
+  to compute or that reference other fields. This is idiomatic Pydantic v2 but
+  requires understanding the model lifecycle.
+
+### Risks and Mitigations
+- **Risk**: Pydantic v2 breaks compatibility with KiCad's bundled Python
+  (relevant for PCM plugin packaging per ADR 0007).
+  **Mitigation**: Pydantic v2 supports Python 3.8+; KiCad 8/9 ships Python
+  3.11+. Pydantic is pure Python (pydantic-core is optional but provides
+  significant speedup). It can be vendored into the PCM archive alongside
+  `sexpdata` and `PyYAML` per the ADR 0007 vendoring strategy.
+- **Risk**: Pydantic's `model_validate()` behavior for extra/unknown fields.
+  **Mitigation**: Set `model_config = ConfigDict(extra="ignore")` on all
+  config models. Unknown YAML keys are silently ignored — same behavior as the
+  current `data.get()` approach. A debug/verbose mode can warn on unknown keys.
+- **Risk**: `@computed_field` order-of-operations issues during validation.
+  **Mitigation**: Use `@model_validator(mode='after')` for fields that depend
+  on other fields being validated first. This is standard Pydantic v2 practice.
+
+## Schema Audit Smells Resolved
+
+This ADR directly resolves the following smells from `config-schema-audit.md`:
+
+| Smell | Resolution |
+|---|---|
+| `tier_overrides` (YAML) ≠ `tier_rules` (Python) | Python attr renamed to match YAML key |
+| `from_yaml_dict()` string literals | Replaced by field names |
+| `cpl_rotation_range` constraint undocumented | Moves to `@field_validator` |
+| `tier_overrides.conditions.operator` undocumented DSL | Moves to `TierOperator` enum with Pydantic validation |
+| `enrichment_bindings` references Python attr names (S11) | Replaced with field reference language in Phase 1b |
+| Any future YAML key that diverges from Python attr name | Structurally impossible without `Field(alias=...)` |
+
+## Implementation Phases
+
+**Phase 1 (this feature branch, alongside ADR 0008/0009 Phase 1)**
+
+- Add `pydantic>=2.0` to `pyproject.toml` dependencies and PCM vendoring list.
+- Migrate `FabricatorConfig` → Pydantic `BaseModel`:
+  - Rename `tier_rules` attr to `tier_overrides` (or keep computed as D2)
+  - Move validation from `from_yaml_dict()` to `@field_validator` / `@model_validator`
+  - Add `model_config = ConfigDict(extra="ignore")`
+- Migrate `SupplierConfig` → Pydantic `BaseModel`
+- Migrate `DefaultsConfig` → Pydantic `BaseModel`
+- Migrate supporting types: `FieldSynonym`, `TierCondition`, `TierRule`,
+  `SearchProviderConfig`, `InventorySchemaConfig`, `EnrichmentCategoryConfig`
+- Introduce `TierOperator` enum (replaces undocumented string DSL)
+- Update all call sites: `from_yaml_dict()` → `model_validate()`
+- Unit tests: verify `model_json_schema()` output is stable (schema regression test)
+
+**Phase 2 (alongside ADR 0008/0009 Phase 1b)**
+- Update `docs/README.configuration.md` with generated schema reference.
+- Wire `model_json_schema()` output to a `jbom config --schema` command stub.
+
+## References
+- ADR 0008: unified `*.jbom.yaml` container format
+- ADR 0009: field reference system (design lens criterion)
+- `docs/dev/architecture/config-schema-audit.md`: schema vocabulary audit
+- `src/jbom/config/fabricators.py`: primary migration target
+- `src/jbom/config/suppliers.py`: migration target
+- `src/jbom/config/defaults.py`: migration target
+- Pydantic v2 documentation: https://docs.pydantic.dev/latest/
+- `pyproject.toml`: dependency declarations + PCM vendoring

--- a/docs/dev/architecture/config-schema-audit.md
+++ b/docs/dev/architecture/config-schema-audit.md
@@ -1,0 +1,353 @@
+# Config Schema Vocabulary Audit
+Generated: 2026-05-11
+Branch: feat/config-unified-schema
+Status: Working document — feeds step 2.5 (design analysis) before Phase 1 implementation
+
+## Purpose
+
+Mechanical extraction of every YAML key name parsed by the three config loaders
+(`fabricators.py`, `suppliers.py`, `defaults.py`) and present in the current
+built-in YAML files. Basis for identifying schema smells before the Phase 1
+built-in file migration.
+
+The design lens criterion from ADR 0009: *every YAML key should correspond to
+a named Python attribute; any key whose meaning requires reading Python to
+understand is a smell.*
+
+---
+
+## Complete Key Inventory
+
+### File-level (meta-directives, apply before stanzas are processed)
+
+| Key | Type | Defined in | Notes |
+|---|---|---|---|
+| `extends:` | string | ADR 0008 D4 | Loads named parent; deep-merge before this file's content |
+| `id:` | string | ADR 0008 D3 | Default CLI flag name for all stanzas in this file |
+
+### `fab:` stanza
+
+**Identity / metadata**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `id:` | `FabricatorConfig.id` | string | Stanza-level override of file `id:` |
+| `name:` | `FabricatorConfig.name` | string | Human-readable display name |
+| `description:` | `FabricatorConfig.description` | string | |
+| `website:` | `FabricatorConfig.website` | string | |
+| `dynamic_name:` | *(no Python attr — parsed ad-hoc in jbom.py legacy)* | bool | Signals "use manufacturer field as name" for Generic fab |
+| `name_source:` | *(same)* | string | Which field to use when `dynamic_name` is true |
+
+**Output format**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `bom_columns:` | `FabricatorConfig.bom_columns` | dict: header → field_ref | Output column header maps to field reference |
+| `pos_columns:` | `FabricatorConfig.pos_columns` | dict: header → field_ref | Same for placement/CPL output |
+| `pos_additive_default_fields:` | `FabricatorConfig.pos_additive_default_fields` | list of field_ref | Fields included when user says `--fields +foo` |
+| `cpl_rotation_range:` | `FabricatorConfig.cpl_rotation_range` | [lo, hi] | Folds CPL angles into this 360° window; magic constraint: hi−lo==360 |
+| `generate_designators:` | `FabricatorConfig.generate_designators` | bool | Whether `fab` run produces designators.csv |
+| `gerbers:` | `FabricatorConfig.gerbers` | nested dict | See gerbers sub-keys below |
+
+**Gerbers sub-keys**
+
+| Key path | Type | Notes |
+|---|---|---|
+| `gerbers.layers:` | list of KiCad layer name strings | KiCad layer naming vocabulary; no connection to field reference system |
+| `gerbers.naming.protel_extensions:` | bool | Whether to use Protel-style file extensions |
+| `gerbers.drill.split_plated_holes:` | bool | |
+| `gerbers.drill.map_format:` | string (`"gerber"`) | Undocumented vocabulary |
+
+**Supplier / part number policy**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `suppliers:` | `FabricatorConfig.suppliers` | list of supplier ID strings | Ordered; position = priority |
+| `part_number:` | `FabricatorConfig.part_number` | dict | Only key used: `header:` (the output BOM column header for the part number) |
+| `field_synonyms:` | `FabricatorConfig.field_synonyms` | dict: canonical → {display_name, synonyms} | Three canonical keys: `fab_pn`, `supplier_pn`, `mpn` |
+| `tier_overrides:` | `FabricatorConfig.tier_rules` | list of {conditions: [{field, operator, value?}]} | Mini DSL; operator values: `exists`, `truthy`, `not_empty`, `equals` |
+
+**Presets / CLI**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `presets:` | `FabricatorConfig.presets` | dict: name → {description, fields: [field_ref]} | **COLLISION** with top-level `presets:` stanza |
+| `cli_aliases:` | `FabricatorConfig.cli_aliases` | dict: {flags: [str], presets: [str]} | Auto-generates `--<id>` flag and `+<id>` preset |
+
+**Manufacturing info (informational, not used in output logic)**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `pcb_manufacturing:` | `FabricatorConfig.pcb_manufacturing` | dict: {website, kicad_dru, gerbers} | Website + DRC file URL; unvalidated |
+| `pcb_assembly:` | `FabricatorConfig.pcb_assembly` | dict: {website} | |
+
+---
+
+### `supplier:` stanza
+
+**Identity / metadata**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `id:` | `SupplierConfig.id` | string | |
+| `name:` | `SupplierConfig.name` | string | |
+| `description:` | `SupplierConfig.description` | string | |
+| `website:` | `SupplierConfig.website` | string | |
+
+**Part number / URL**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `part_number:` | `SupplierConfig.part_number_pattern/example` | dict: {pattern, example} | **DIFFERENT STRUCTURE** from `fab.part_number` |
+| `url_template:` | `SupplierConfig.url_template` | string with `{pn}` placeholder | |
+| `search_url_template:` | `SupplierConfig.search_url_template` | string with `{query}` placeholder | |
+
+**Field synonyms**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `field_synonyms:` | `SupplierConfig.field_synonyms` | dict: canonical → {display_name, synonyms} | Only `supplier_pn` in practice; **SAME STRUCTURE** as `fab.field_synonyms` but different scope |
+
+**Search configuration**
+
+| Key path | Python attr | Type | Notes |
+|---|---|---|---|
+| `search:` | (multiple attrs) | nested dict | **DIFFERENT STRUCTURE** from `defaults.search:` |
+| `search.cache.ttl_hours:` | `SupplierConfig.search_cache_ttl_hours` | float | |
+| `search.api.timeout_seconds:` | `SupplierConfig.search_timeout_seconds` | float | |
+| `search.api.max_retries:` | `SupplierConfig.search_max_retries` | int | |
+| `search.api.retry_delay_seconds:` | `SupplierConfig.search_retry_delay_seconds` | float | |
+| `search.providers:` | `SupplierConfig.search_providers` | list of {type, ...extra} | `type` values: `mouser_api`, `jlcpcb_api`, `null_api` — hardcoded registry; `extra` is completely untyped |
+| `search.fields:` | `SupplierConfig.search_fields` | list of strings | Output display fields for search results; **NOT field references** (ADR 0009 sense) — names like `supplier_part_number`, `price`, `stock_quantity` are ungrounded |
+| `search.type_query_keywords:` | `SupplierConfig.search_type_query_keywords` | dict: category_token → keyword_str | Category tokens (RES, CAP...) map to search query keywords |
+
+---
+
+### `defaults:` stanza
+
+**Component electrical defaults**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `domain_defaults:` | `DefaultsConfig.domain_defaults` | dict: category → {attribute: value} | e.g., `resistor.tolerance: "5%"` |
+| `package_power:` | `DefaultsConfig.package_power` | dict: package_size → wattage_str | e.g., `"0402": "63mW"` — value strings untyped |
+| `package_voltage:` | `DefaultsConfig.package_voltage` | dict: package_size → voltage_str | Same — value strings untyped |
+
+**Parametric search**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `parametric_query_fields:` | `DefaultsConfig.parametric_query_fields` | dict: category → [field_names] | Field names are bare strings; not grounded in ADR 0009 field reference system |
+| `category_route_rules:` | `DefaultsConfig.category_route_rules` | dict: category → {first_sort, second_sort_*} | **JLCPCB/LCSC internal catalog taxonomy strings** embedded in generic defaults |
+| `search_excluded_categories:` | `DefaultsConfig.search_excluded_categories` | frozenset of category token strings | |
+
+**Field synonym definitions**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `field_synonyms:` | `DefaultsConfig.field_synonyms` | dict: canonical → {display_name, synonyms} | General field names; **SAME KEY** third occurrence |
+
+**Inventory schema contract**
+
+| Key path | Python attr | Type | Notes |
+|---|---|---|---|
+| `inventory_schema:` | `DefaultsConfig.inventory_schema` | nested dict | Schema-within-a-stanza |
+| `inventory_schema.canonical_fields:` | `InventorySchemaConfig.canonical_fields` | list of strings | |
+| `inventory_schema.field_synonyms:` | `InventorySchemaConfig.field_synonyms` | dict: canonical → {display_name, synonyms} | **SAME KEY** fourth occurrence; inventory-specific scope |
+| `inventory_schema.enrichment_bindings:` | `InventorySchemaConfig.enrichment_bindings` | dict: canonical → source_attr | Maps canonical key to Python InventoryItem attribute name; magic sentinel `__resolved_fabricator_part_number__` being retired |
+
+**Search output configuration**
+
+| Key path | Python attr | Type | Notes |
+|---|---|---|---|
+| `search:` | (multiple attrs) | nested dict | **DIFFERENT STRUCTURE** from `supplier.search:` |
+| `search.output_fields.default:` | `DefaultsConfig.search_output_fields_default` | list of field names | Output fields for `jbom search` display — not clearly field references |
+| `search.package_tokens:` | `DefaultsConfig.search_package_tokens` | list of package size strings | Used for package intent matching in search heuristics |
+
+**Enrichment / Mode A classification**
+
+| Key path | Python attr | Type | Notes |
+|---|---|---|---|
+| `enrichment_attributes:` | `DefaultsConfig.enrichment_attributes` | dict: category → {show_in_mode_a, suppress} | |
+| `enrichment_attributes.<cat>.show_in_mode_a:` | `EnrichmentCategoryConfig.show_in_mode_a` | list of attribute names | **jBOM-internal concept** ("Mode A") leaked into config vocabulary |
+| `enrichment_attributes.<cat>.suppress:` | `EnrichmentCategoryConfig.suppress` | list of attribute names | |
+
+**Component identity**
+
+| Key | Python attr | Type | Notes |
+|---|---|---|---|
+| `component_id_fields:` | `DefaultsConfig.component_id_fields` | dict: category → [field_names] | Optional fields contributing to ComponentID hash |
+| `field_precedence_policy:` | `DefaultsConfig.field_precedence_policy` | dict: policy_key → [field_names] | Resolve ambiguous bare names; policy keys: `schematic_biased`, `pcb_biased`, `inventory_biased` |
+
+---
+
+### `presets:` top-level stanza
+
+| Structure | Notes |
+|---|---|
+| dict: preset_name → {description, fields: [field_ref]} | Global presets; currently in `presets/common.yaml` wrapping a `presets:` key — a stanza wrapping a key with the same name |
+
+### `transforms:` top-level stanza (new, ADR 0009)
+
+| Structure | Notes |
+|---|---|
+| dict: transform_name → {expr, doc} | `expr` is a Python expression string; `doc` is human-readable |
+
+---
+
+## Smell Catalogue
+
+### S1 — `field_synonyms:` in four contexts with one name
+
+Appears in: `fab:`, `supplier:`, `defaults:`, `defaults.inventory_schema`
+
+Same YAML structure `{canonical: {display_name, synonyms}}` but the "canonical
+key" means something different in each context:
+- `fab:` — fabricator role names (`fab_pn`, `supplier_pn`, `mpn`) for part number field resolution
+- `supplier:` — supplier role name (`supplier_pn`) for this supplier's part number
+- `defaults:` — general component/inventory field names (`manufacturer`, `mpn`, etc.)
+- `defaults.inventory_schema:` — inventory CSV column canonical names (`inventory_ipn`, `manufacturer_part`, etc.)
+
+**Severity: structural** — four different semantic scopes that happen to share a structure.
+The question for step 2.5: are these really one concept or four? If one concept, it belongs in
+one place in the unified schema. If four, they should have four distinct key names.
+
+### S2 — `part_number:` with two incompatible structures
+
+- `fab.part_number:` → `{header: str}` — "what column header to use in the BOM output for the part number"
+- `supplier.part_number:` → `{pattern: regex, example: str}` — "how to validate a part number string"
+
+Same name, completely different structure and semantics.
+
+**Severity: rename** — `fab.part_number:` could become `fab_pn_column:` or fold into `field_synonyms.fab_pn.display_name` (it's partially redundant with that); `supplier.part_number:` could become `supplier.part_number_format:` or `validation:`.
+
+### S3 — `presets:` naming collision
+
+- Top-level `presets:` stanza: global cross-fabricator presets
+- `fab.presets:`: fabricator-specific presets
+
+Same name, same structure, different scope. The top-level `presets:` in `presets/common.yaml`
+is also currently wrapped in a `presets:` key — a file whose top-level content is `presets: {...}`.
+
+**Severity: structural** — either unify them (fabricator presets inherit from global presets)
+or differentiate them (rename one). The `presets/common.yaml` wrapper is also a smell.
+
+### S4 — `search:` with two completely different structures
+
+- `supplier.search:` — API runtime configuration (cache, api, providers, type_query_keywords, fields)
+- `defaults.search:` — BOM/search output field configuration (output_fields, package_tokens)
+
+**Severity: rename** — `defaults.search:` could become `defaults.search_output:` or
+`defaults.catalog_search:`. The names should reflect what they configure, not just "search".
+
+### S5 — `category_route_rules:` is supplier-specific content in `defaults:`
+
+Contains JLCPCB/LCSC internal catalog taxonomy strings (`"Chip Resistor - Surface Mount"`, etc.).
+This is supplier-specific knowledge and belongs in the `supplier:` stanza or a
+supplier-specific `defaults:` extension, not in generic defaults.
+
+**Severity: structural** — belongs in the LCSC supplier config, not in `generic.defaults.yaml`.
+
+### S6 — `show_in_mode_a:` leaks an internal jBOM concept into config vocabulary
+
+"Mode A" is a jBOM workflow implementation concept. Config authors should not need to know
+what "Mode A" is. The key name is opaque without reading jBOM source.
+
+**Severity: rename** — rename to something that describes the *behavior*, not the jBOM-internal
+mode. e.g., `prompt_for_confirmation:` or `designer_review_attributes:`.
+
+### S7 — `search.fields:` in supplier is not a field reference list
+
+`generic.supplier.yaml` has `search.fields: [supplier_part_number, price, stock_quantity, ...]`.
+These are not `namespace:field` references (ADR 0009); they're... search result display field names.
+Not grounded in the field reference system.
+
+**Severity: structural** — these field names need to be connected to the ADR 0009 field
+reference language or given their own explicit vocabulary.
+
+### S8 — `providers.extra` is a completely untyped bag
+
+`search.providers[n].type` is a registered provider type string; everything else in a provider
+config is `extra: dict[str, Any]` — the schema has no idea what's valid inside a provider config.
+
+**Severity: structural** — each provider type could declare its own sub-schema, but currently
+there's no mechanism for this.
+
+### S9 — `dynamic_name:` + `name_source:` are special-casing for one fabricator
+
+These exist only in `generic.fab.yaml` to handle the "Generic" fabricator's behavior of
+using the matched manufacturer's name as its own display name. This is a one-off hack
+embedded in the schema.
+
+**Severity: design smell** — either generalize this concept (any fabricator can be named
+dynamically from a field) or remove it and handle "Generic" behavior in Python directly.
+
+### S10 — `cpl_rotation_range:` has a magic validation constraint in Python only
+
+The constraint that `hi - lo == 360` is validated in `FabricatorConfig.from_yaml_dict()` but
+not documented in any schema. A user who writes `[0, 180]` gets an error with no explanation
+in the schema documentation.
+
+**Severity: documentation** — the constraint should be in the schema spec, not just in Python.
+
+### S11 — `enrichment_bindings:` in `inventory_schema:` maps to Python attribute names
+
+Values like `"__resolved_fabricator_part_number__"` (being retired) and `"ipn"`, `"mfgpn"` are
+Python `InventoryItem` attribute names. The YAML config directly references Python implementation
+internals.
+
+**Severity: structural** — these bindings should reference the ADR 0009 field reference system,
+not Python attribute names.
+
+### S12 — `gerbers.layers:` uses KiCad layer name strings with no validation schema
+
+Values like `"F.Cu"`, `"B.Mask"` are from KiCad's internal layer naming convention. There is
+no documented vocabulary of valid layer names in the schema.
+
+**Severity: documentation** — needs a reference to valid KiCad layer names.
+
+### S13 — `tier_overrides.conditions.operator:` is an undocumented mini-DSL
+
+Valid values: `exists`, `truthy`, `not_empty`, `equals`. This vocabulary exists only in Python.
+
+**Severity: documentation** — needs explicit schema documentation.
+
+### S14 — Old field notation in built-in YAML files
+
+`pcbway.fab.yaml` uses `i:package` (old prefix) in `bom_columns` and `presets.fields`.
+This pre-dates ADR 0009 and must be migrated as part of Phase 1.
+
+**Severity: migration** — mechanical fix during Phase 1 built-in file migration.
+
+### S15 — `presets.fields:` values use pre-ADR 0009 notation throughout
+
+All built-in `presets.fields:` lists use bare names like `"reference"`, `"quantity"`,
+`"fabricator_part_number"` — which must now be `"sch:Reference"`, `"jbom:quantity"`,
+`"jbom:fabricator_part_number"` under the ADR 0009 field reference system.
+
+**Severity: migration** — mechanical update during Phase 1.
+
+---
+
+## Summary: Rename-only vs. Structural Smells
+
+| Smell | Type | Notes |
+|---|---|---|
+| S2 `part_number:` collision | rename | two distinct concepts need two names |
+| S4 `search:` collision | rename | `defaults.search:` → `search_output:` or similar |
+| S6 `show_in_mode_a:` | rename | replace with behavior-describing name |
+| S10 `cpl_rotation_range:` constraint | documentation | document the 360° constraint in schema spec |
+| S12 `gerbers.layers:` | documentation | reference KiCad layer vocabulary |
+| S13 `tier_overrides.conditions.operator:` | documentation | document operator vocabulary |
+| S14, S15 old notation in YAML files | migration | mechanical Phase 1 work |
+| S9 `dynamic_name:` + `name_source:` | design smell | generalize or remove |
+| S1 `field_synonyms:` 4× | structural | clarify whether 1 concept or 4; unify if 1 |
+| S3 `presets:` collision | structural | unify or differentiate scopes |
+| S5 `category_route_rules:` placement | structural | move to supplier stanza |
+| S7 `search.fields:` ungrounded | structural | connect to ADR 0009 field references |
+| S8 `providers.extra` untyped | structural | per-provider sub-schema mechanism |
+| S11 `enrichment_bindings:` Python attrs | structural | replace with field reference language |
+
+The structural smells (bottom half of table) are the input to step 2.5 design analysis.
+The rename/documentation/migration smells can be handled mechanically during Phase 1
+without a new ADR.

--- a/docs/dev/architecture/implementation-plan-250-251.md
+++ b/docs/dev/architecture/implementation-plan-250-251.md
@@ -1,0 +1,305 @@
+# Implementation Plan: Config System Rewrite (#250, #251)
+Branch: feat/config-unified-schema
+Session role: supervisor/reviewer
+Sub-agent role: implementation
+
+## Context
+ADRs 0008, 0009, 0010 and the schema audit (`config-schema-audit.md`) are complete
+and committed on this branch. This document is the ordered action list for
+implementation. The supervising session retains context of the design decisions
+and serves as the reviewer for each phase.
+
+Key principle from ADR 0008 D8: **atomic delivery**. All five phases below land
+in this branch before merge. No intermediate broken state.
+
+## What's already done
+- ADR 0008, 0009, 0010 committed
+- `docs/dev/architecture/config-schema-audit.md` committed
+- Feature branch `feat/config-unified-schema` pushed, PR #267 open
+
+---
+
+## Phase 1a — Pydantic Migration (ADR 0010)
+
+**Objective**: Replace all config `@dataclass` classes with Pydantic v2 `BaseModel`.
+The class definition IS the schema. `from_yaml_dict()` methods are eliminated.
+
+**Driving decisions**: ADR 0010 D1–D5
+
+### Tasks
+
+**1a-1** Add `pydantic>=2.0` to `pyproject.toml` required dependencies.
+Add `pydantic` to PCM vendoring list in `pyproject.toml` package-data or build script.
+Verify: `pip install pydantic` in the test environment; import succeeds.
+
+**1a-2** Migrate supporting leaf types first (no dependencies on other config classes):
+- `FieldSynonym` (in `fabricators.py`, `defaults.py`, `suppliers.py`) →
+  unified `FieldSynonym(BaseModel)` in new `src/jbom/config/field_synonyms.py`
+  (resolves smell S1 partial — one definition, one parser; see 1a-5 for full unification)
+- `TierCondition(BaseModel)` with `TierOperator` enum replacing string DSL
+- `TierRule(BaseModel)`
+- `SearchProviderConfig(BaseModel)` — note `extra` field stays as `Dict[str, Any]`
+  with `model_config = ConfigDict(extra='allow')` for provider-specific keys
+- `EnrichmentCategoryConfig(BaseModel)`
+- `InventorySchemaConfig(BaseModel)`
+
+**1a-3** Migrate `FabricatorConfig` to `BaseModel`:
+- Field names must match YAML keys (see schema audit for current mismatches)
+- `tier_rules` → `@computed_field` derived from `tier_overrides`
+- `cpl_rotation_range` constraint → `@field_validator`
+- `model_config = ConfigDict(extra='ignore')`
+- Remove `from_yaml_dict()` method; replace call sites with `model_validate()`
+- Verify: `FabricatorConfig.model_json_schema()` produces a JSON Schema
+
+**1a-4** Migrate `SupplierConfig` and `DefaultsConfig` to `BaseModel` following
+same pattern as 1a-3.
+
+**1a-5** Implement unified `parse_field_synonyms()` in `src/jbom/config/field_synonyms.py`
+replacing the three divergent parsers (`_parse_field_synonyms` in fabricators.py,
+`_parse_field_synonym_configs` in defaults.py, supplier parser). Wire into the
+three models. (Resolves smell S1.)
+
+**1a-6** Update all consuming code:
+- Run `git grep -rn "\.tier_rules\|\.field_synonyms\|from_yaml_dict"` to find callsites
+- Update attribute references wherever a rename occurred
+- All `from_yaml_dict()` call sites → `model_validate()`
+
+**Acceptance criteria**:
+- All existing tests pass
+- `FabricatorConfig.model_json_schema()` is stable (schema regression test)
+- No `from_yaml_dict()` method exists in any config class
+- No `Field(alias=...)` exists anywhere in the codebase
+- `git grep "from_yaml_dict"` returns zero results
+
+---
+
+## Phase 1b — Unified Config Loader (ADR 0008)
+
+**Objective**: Implement the unified `.jbom.yaml` loading machinery.
+
+**Driving decisions**: ADR 0008 D1–D8, ADR 0009 D1
+
+### Tasks
+
+**1b-1** Implement `src/jbom/config/unified.py`:
+```python
+def load_unified(name: str, *, cwd: Path | None = None) -> dict:
+    """Resolve the full stack: common chain + named profile + extends chain.
+    Returns raw merged dict ready for stanza extraction."""
+
+def fab_stanza(merged: dict) -> FabricatorConfig: ...
+def supplier_stanza(merged: dict) -> SupplierConfig: ...
+def defaults_stanza(merged: dict) -> DefaultsConfig: ...
+```
+The merge engine: dicts deep-merge, lists replace, `null` values delete keys.
+Circular `extends:` detection (raise ValueError on second visit to same name).
+`common.jbom.yaml` files at all search-path levels are merged cumulatively
+(lowest-priority first); named profile files use first-match-wins.
+`policy.jbom.yaml` files are detected and logged as NOTICE (enforcement deferred per ADR 0008 D6).
+
+**1b-2** Update `profile_search.py` to recognize `*.jbom.yaml` only.
+Remove legacy `*.fab.yaml` / `*.supplier.yaml` / `*.defaults.yaml` suffix support.
+
+**1b-3** Wire unified loader into existing public API:
+- `fabricators.py:load_fabricator(fid)` → `unified.load_unified(fid)` → `fab_stanza()`
+- `suppliers.py:load_supplier(sid)` → `unified.load_unified(sid)` → `supplier_stanza()`
+- `defaults.py:load_defaults(name)` → `unified.load_unified(name)` → `defaults_stanza()`
+The external API (`load_fabricator`, `load_supplier`, `load_defaults`) stays unchanged.
+Internal callers transparently pick up the new loader.
+
+**1b-4** Implement per-stanza `id:` override (ADR 0008 D3): a stanza-level `id:` key
+overrides the file-level `id:` for CLI flag generation for that stanza type.
+Update flag auto-generation to use stanza effective id.
+
+**Acceptance criteria**:
+- `load_fabricator("jlc")` resolves `jlc.jbom.yaml` (once that file exists — see 1d)
+- `load_supplier("lcsc")` resolves `jlc.jbom.yaml` (via supplier stanza `id: lcsc`)
+- `extends:` chain resolves correctly; circular chain raises ValueError
+- `common.jbom.yaml` at multiple levels are all merged
+- All existing tests pass (they still use legacy files until Phase 1d)
+
+---
+
+## Phase 1c — Field Reference System (ADR 0009)
+
+**Objective**: Implement the canonical field reference language for `bom_columns`
+and `--fields`.
+
+**Driving decisions**: ADR 0009 D1–D7
+
+### Tasks
+
+**1c-1** Implement `src/jbom/config/fields.py`:
+- `JBOM_NAMESPACE = "jbom"` and constants `SCH`, `PCB`, `INV`, `JBOM`
+- Registry of jBOM-computed field names: `jbom:quantity`, `jbom:fabricator_part_number`,
+  `jbom:smd`
+- `is_jbom_computed(ref: str) -> bool`
+
+**1c-2** Implement `src/jbom/config/field_ref.py`:
+- `FieldRef` dataclass (namespace, field_name, raw_expression)
+- `FieldRefResolver.resolve(ref: str, context: FieldContext) -> str`
+  where `FieldContext` contains the current component/inventory/PCB field values
+- Handles: plain field refs, `namespace:field` refs, `jbom:field` refs, expressions
+
+**1c-3** Implement `src/jbom/config/field_expr.py`:
+- `FieldExpressionEvaluator`:
+  - Scan for `word:word` patterns, bind as `namespace_field` local variables
+  - Bind unqualified source-data names via `field_precedence_policy`
+  - Replace tokens in expression string
+  - `ast.parse(expr, mode='eval')` — expression-only gate
+  - Evaluate in restricted namespace: `{re: re, **compiled_transforms, **field_vars}`
+  - `transforms:` stanza parsing: validate `expr` at load time via `ast.parse`, compile
+    to single-argument callable
+  - Collision detection: `NOTICE`-level `Diagnostic` on shadow; ERROR on duplicate-name
+    in same file (emitted via existing `Diagnostic` infrastructure from #245)
+
+**1c-4** Update `bom_workflow.py` and CLI `--fields` parser to delegate to
+`FieldRefResolver` instead of the current ad-hoc field parsing.
+
+**Acceptance criteria**:
+- `FieldRefResolver.resolve("jbom:quantity", ctx)` returns the computed quantity
+- `FieldRefResolver.resolve("pcb:footprint", ctx)` returns the PCB footprint value
+- `FieldRefResolver.resolve("strip_kicad_library_prefix_from_value(pcb:footprint)", ctx)`
+  returns `"C_0402"` for input `"Capacitors_SMD:C_0402"`
+- `ast.parse("import os", mode='eval')` raises SyntaxError (confirmed rejected)
+- All existing `--fields` tests pass
+
+---
+
+## Phase 1d — Built-in Config File Migration (ADR 0008/0009/0010)
+
+**Objective**: Convert all built-in config files to `.jbom.yaml` format.
+Remove legacy files and directories. All field references use the new notation.
+
+**Driving decisions**: ADR 0008 D7/D8, ADR 0009 D1/D4, config-schema-audit smells S14/S15
+
+### Files to create
+
+**1d-1** `src/jbom/config/common.jbom.yaml` (built-in, shipped with jBOM):
+```yaml
+# Ambient defaults at every search-path level
+
+transforms:
+  strip_kicad_library_prefix_from_value:
+    expr: "re.sub(r'^[^:]+:', '', value)"
+    doc: "Remove KiCad library nickname. 'Capacitors_SMD:C_0402' → 'C_0402'"
+
+fab:
+  gerbers:
+    layer_sets:
+      standard_2_layer:
+        - "F.Cu"
+        - "B.Cu"
+        - "F.Mask"
+        - "B.Mask"
+        - "F.Paste"
+        - "B.Paste"
+        - "F.Silkscreen"
+        - "B.Silkscreen"
+        - "Edge.Cuts"
+
+defaults:
+  field_precedence_policy:
+    schematic_biased: [value, tolerance, footprint, ...]
+    pcb_biased: [x, y, rotation, side, ...]
+    inventory_biased: [manufacturer, manufacturer_part, fabricator_part_number, ...]
+```
+
+**1d-2** `src/jbom/config/generic.jbom.yaml` (no-flag fallback):
+Consolidates content of:
+- `fabricators/generic.fab.yaml` → `fab:` stanza
+- `defaults/generic.defaults.yaml` → `defaults:` stanza (minus `field_precedence_policy` → moves to common.jbom.yaml; minus `category_route_rules` → moves to lcsc.jbom.yaml)
+- `suppliers/generic.supplier.yaml` → `supplier:` stanza
+- `presets/common.yaml` → `presets:` stanza
+All field refs updated to use new notation (`jbom:quantity`, `inv:package`, etc.)
+
+**1d-3** `src/jbom/config/jlc.jbom.yaml`:
+- `fab:` stanza from `fabricators/jlc.fab.yaml` (field refs updated)
+- `supplier:` stanza with `id: lcsc` (from `suppliers/lcsc.supplier.yaml` content)
+- `defaults:` stanza with LCSC-specific parametric query fields and `category_route_rules`
+  (moved from generic.defaults.yaml per smell S5)
+
+**1d-4** `src/jbom/config/pcbway.jbom.yaml`:
+From `fabricators/pcbway.fab.yaml`, field refs updated.
+
+**1d-5** `src/jbom/config/seeed.jbom.yaml`:
+From `fabricators/seeed.fab.yaml` + `suppliers/seeed.supplier.yaml`.
+
+**1d-6** `src/jbom/config/mouser.jbom.yaml`:
+From `suppliers/mouser.supplier.yaml`.
+
+**1d-7** Remaining supplier files: `digikey.jbom.yaml`, `farnell.jbom.yaml`,
+`newark.jbom.yaml` from corresponding `*.supplier.yaml` files.
+
+### Files to remove
+- `src/jbom/config/fabricators/` (entire directory)
+- `src/jbom/config/suppliers/` (entire directory)
+- `src/jbom/config/defaults/` (entire directory)
+- `src/jbom/config/presets/` (entire directory)
+
+### pyproject.toml updates
+- Remove `*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml`, `common.yaml` from package-data
+- Add `*.jbom.yaml` to package-data (all new files included)
+
+**Acceptance criteria**:
+- `load_fabricator("jlc")` succeeds using only `jlc.jbom.yaml`
+- `load_supplier("lcsc")` succeeds via `jlc.jbom.yaml` supplier stanza (`id: lcsc`)
+- `load_supplier("mouser")` succeeds using `mouser.jbom.yaml`
+- No `*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml` files remain
+- No `i:`, `p:`, `c:`, `k:` prefixes in any YAML file
+- All functional tests pass (BDD features pass)
+- `git grep -r "i:package\|p:k:\|c:tolerance"` returns zero results in config files
+
+---
+
+## Phase 1e — Documentation (ADR 0008 acceptance criteria for #250)
+
+**Objective**: Update `docs/README.configuration.md` to document the new convention.
+
+**Driving decisions**: ADR 0008 acceptance criteria for issue #250
+
+### Tasks
+
+**1e-1** Rewrite `docs/README.configuration.md`:
+- New file format (`.jbom.yaml`, stanzas)
+- Search path and `common.jbom.yaml` behaviour
+- `extends:` inheritance and merge semantics
+- Field reference language (`sch:`, `pcb:`, `inv:`, `jbom:`, expressions)
+- `transforms:` stanza and naming convention
+- Per-stanza `id:` override (`--jlc` vs `--lcsc` example)
+- Config examples: single-fabricator, corporate fork, 4-layer override (Story A)
+- Schema reference: `jbom config --schema` stub mention (deferred)
+
+**1e-2** Add `jbom config --schema` command stub that calls
+`FabricatorConfig.model_json_schema()` (even if just prints to stdout).
+
+**Acceptance criteria**:
+- Issue #250 acceptance criteria met: convention documented in `docs/README.configuration.md`
+- `jbom bom --help` and `jbom search --help` reflect the new flag vocabulary
+
+---
+
+## PR and Merge Checklist
+
+Before requesting merge of PR #267:
+- [ ] All five phases committed on this branch
+- [ ] All existing tests pass
+- [ ] All BDD/functional tests pass (including new Stories A–E from ADR 0008)
+- [ ] No `from_yaml_dict()` method exists
+- [ ] No `Field(alias=...)` exists
+- [ ] No legacy prefix notation (`i:`, `p:`, `c:`, `k:`) in any config file
+- [ ] No legacy config file types (`*.fab.yaml`, `*.supplier.yaml`, etc.) remain
+- [ ] `docs/README.configuration.md` updated (closes #250)
+- [ ] CI/CD pipeline passes
+- [ ] PR description updated to reflect implementation
+
+## Supervisor Notes for Review
+
+Key things to verify during implementation review:
+- **1b-1 merge engine**: test null-delete, list-replace, dict deep-merge, circular extends
+- **1c-3 expression evaluator**: verify `ast.parse(mode='eval')` correctly rejects statements
+- **1d-3 jlc.jbom.yaml**: verify `--jlc` (fab) and `--lcsc` (search) both resolve to it
+- **S1 unification** (field_synonyms): ensure the four-scope problem is actually resolved,
+  not just shuffled
+- **Pydantic `model_json_schema()`**: run it on each config class and verify the output
+  is human-readable and complete


### PR DESCRIPTION
## Summary

Complete design foundation for the jBOM config system rewrite (issues #250, #251).
This PR contains **design documents only** — ADRs and a schema audit. Implementation follows as subsequent commits on this branch.

## What's in this PR

### ADR 0008 — Unified `*.jbom.yaml` Configuration Schema
Replaces the current four-file-type system (`*.fab.yaml`, `*.supplier.yaml`, `*.defaults.yaml`, presets) with a single unified format. Key decisions:
- One `.jbom.yaml` suffix, stanza-differentiated (`fab:`, `supplier:`, `defaults:`, `presets:`, `transforms:`)
- Command-scoped stanza consumption; one CLI flag per named profile (`--jlc`)
- Per-stanza `id:` override (e.g., `jlc.jbom.yaml` exposes `--jlc` for `bom` and `--lcsc` for `search`)
- `common.jbom.yaml` ambient defaults at each search-path level (cumulative)
- `policy.jbom.yaml` mandate enforcement reserved (deferred)
- `generic.jbom.yaml` is the no-flag fallback only — not implicit for named profiles
- Atomic delivery: loader + file migration + legacy removal land together (clean break, nothing shipped)

### ADR 0009 — Field Reference System and Value Expressions
Defines the canonical field reference language shared by config `bom_columns` and CLI `--fields`:
- Three source namespaces: `sch:` (schematic), `pcb:` (PCB/placement), `inv:` (inventory)
- `jbom:` namespace for computed fields (`jbom:quantity`, `jbom:fabricator_part_number`, `jbom:smd`)
- Unqualified source-data names (e.g., `value`, `reference`) disambiguated by `field_precedence_policy` in `common.jbom.yaml`
- Python expression evaluation via `namespace:field` preprocessing + `ast.parse(mode='eval')`
- `transforms:` stanza for user-defined/org-defined/jBOM-shipped named transforms (all config-defined, no Python stdlib)
- Naming convention: transform names must include the `value` noun to make the implicit parameter explicit
- Old `c:/p:/i:/k:` prefixes retired with no shim

### ADR 0010 — Pydantic BaseModel as Config Schema Binding Mechanism
Formalizes the YAML-Python binding:
- All config classes become Pydantic v2 `BaseModel`
- Python field name = YAML key name (the class IS the schema)
- `@computed_field` is the only way to have a Python attribute that is not a YAML key
- `Field(alias=...)` is a merge blocker — rename the Python attribute instead
- `model_validate()` replaces all `from_yaml_dict()` methods
- `model_json_schema()` provides machine-readable schema for free
- Phase 1 is a three-layer source refactoring: config models + Python attribute renames + all consuming code

### Config Schema Vocabulary Audit
`docs/dev/architecture/config-schema-audit.md` — mechanical extraction of all sub-stanza keys from the three loader files + built-in YAML files. Identifies 15 smells (6 structural, 9 rename/documentation/migration). Input to implementation.

## Closes (design phase)
Resolves the design portion of #250 and #251. Implementation tracked in the Phase 1 checklist in each ADR.

## Conversation
https://app.warp.dev/conversation/c8e8a575-53a3-4972-a77d-e70f793b2d4b

---
*Co-Authored-By: Oz <oz-agent@warp.dev>*