### PR TITLE
feat(plugin): production-ready PCM packaging + diagnostics overhaul

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Breaking Changes
+- **Minimum KiCad version raised to 9.0** for the PCM-installed plugin.  Pydantic v2,
+  on which the unified profile loader depends, requires CPython 3.9+, which lines up
+  with KiCad 9 (CPython 3.9) and KiCad 10 (CPython 3.12).  KiCad 6/7/8 are no longer
+  validated targets for the plugin; the standalone CLI continues to work anywhere
+  Python 3.10+ is available.
+
 ### Added
+- **Production-ready PCM packaging with multi-platform vendored dependencies**:
+  - `scripts/build_pcm_package.py` now fetches `pydantic_core` wheels for every
+    supported (Python, OS, arch) combination via `pip download --platform=...`,
+    extracts each one into `plugins/_vendor/pydantic_core/<py>-<plat>/pydantic_core/`,
+    and ships them in a single PCM archive.  Pure-Python deps (pydantic, pyyaml,
+    typing_extensions, annotated_types, typing_inspection, sexpdata) continue to
+    be vendored once into `plugins/`.
+  - `scripts/_vendor_requirements.txt` pins exact versions for reproducible builds.
+  - New `--skip-binary-fetch` flag on the build script vendors only the build host's
+    local `pydantic_core` for offline iteration (not redistributable).
+  - `src/jbom/plugin/__init__.py` is platform-aware: at load time it picks the
+    matching `_vendor/pydantic_core/<tag>/` directory based on `sys.version_info`,
+    `sys.platform`, and `platform.machine()`, prepending it to `sys.path` so the
+    bundled extension is the one that gets imported.  The dev-loop path drops the
+    homebrew/user-site/venv auto-discovery in favor of an opt-in
+    `JBOM_PLUGIN_PYTHON_DEPS_DIR` environment variable for developer use.
+  - Bootstrap diagnostics now travel through a single JSON env var
+    (`JBOM_PLUGIN_BOOTSTRAP_INFO`), populated only when `JBOM_PLUGIN_DEBUG=1`.
+  - Profile-evaluation tracing is quiet by default; set
+    `JBOM_PROFILE_EVAL_VERBOSE=1` to print each candidate path to stdout.  The
+    in-memory trace ring buffer is unchanged so the plugin dialog's debug panel
+    still surfaces recent activity when the debug checkbox is on.
 - **Production folder, packaging services, and diagnostic collection** (issue #226, ADR 0006):
   - `jbom fab` now writes all fabrication artifacts to a `production/` folder in the project
     directory (or a custom root via `-o/--output-dir`), following the Fabrication Toolkit

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "$schema": "https://go.kicad.org/pcm/schemas/v1",
   "name": "jBOM Fabrication",
   "description": "BOM, pick-and-place, and Gerber fabrication package for KiCad PCB projects",
-  "description_full": "jBOM Fabrication provides one-click BOM, pick-and-place (CPL), and Gerber generation directly from the KiCad PCB editor toolbar. Supports multiple fabricators: JLC PCBA, PCBWay, Seeed Studio, and a generic profile. Per-project fabricator selection and inventory file path are persisted in .jbom/jbom-options.json. Requires KiCad 6.0 or later on macOS, Linux, or Windows. The jBOM CLI and Python library are available separately via pip install jbom.",
+  "description_full": "jBOM Fabrication provides one-click BOM, pick-and-place (CPL), and Gerber generation directly from the KiCad PCB editor toolbar. Supports multiple fabricators: JLC PCBA, PCBWay, Seeed Studio, and a generic profile. Per-project fabricator selection and inventory file path are persisted in .jbom/jbom-options.json. Requires KiCad 9.0 or later on macOS, Linux, or Windows. All runtime dependencies (pydantic, pyyaml, etc.) are vendored \u2014 no pip install required. The jBOM CLI and Python library are available separately via pip install jbom.",
   "identifier": "com.spcoast.jbom",
   "type": "plugin",
   "author": {
@@ -27,7 +27,7 @@
     {
       "version": "6.53.0",
       "status": "development",
-      "kicad_version": "6.0",
+      "kicad_version": "9.0",
       "kicad_version_max": "",
       "download_url": "https://github.com/plocher/jBOM/releases/download/pcm-v6.53.0/jbom-pcm-6.53.0.zip",
       "download_sha256": "",

--- a/scripts/_vendor_requirements.txt
+++ b/scripts/_vendor_requirements.txt
@@ -1,0 +1,22 @@
+# Pinned runtime dependencies vendored into the jBOM PCM archive.
+#
+# These versions are validated against KiCad 9 (CPython 3.9) and KiCad 10
+# (CPython 3.12). Bumping versions here requires:
+#   1. Re-running scripts/build_pcm_package.py and checking the generated
+#      plugins/ tree imports cleanly under both Python versions.
+#   2. Updating metadata.json install_size / download_size / sha256 via
+#      `python scripts/build_pcm_package.py --update-metadata`.
+#
+# Compiled deps (pydantic_core) are fetched once per supported target via
+# `pip download --platform=... --python-version=...` and staged into
+# plugins/_vendor/pydantic_core/<py>-<plat>/pydantic_core/.
+#
+# Pure-Python deps below are vendored once from the build host's environment.
+
+pydantic==2.13.4
+pydantic_core==2.46.4
+annotated_types==0.7.0
+typing_extensions==4.15.0
+typing_inspection==0.4.2
+PyYAML==6.0
+sexpdata==1.0.2

--- a/scripts/build_pcm_package.py
+++ b/scripts/build_pcm_package.py
@@ -4,6 +4,7 @@
 Usage::
 
     python scripts/build_pcm_package.py [--output-dir dist/] [--update-metadata]
+        [--skip-binary-fetch]
 
 Produces::
 
@@ -18,24 +19,30 @@ PCM archive layout (per KiCad addon spec)::
         dialog.py
         options.py
         jbom/                ← vendored jbom core (src/jbom/ minus plugin/)
-          __init__.py
-          application/
-          cli/
-          common/
-          config/
-          services/
-          suppliers/
-          workflows/
-          ...
         sexpdata.py          ← vendored (single-file module)
         yaml/                ← vendored PyYAML package
+        pydantic/            ← vendored pure-Python Pydantic package
+        typing_extensions.py ← vendored typing_extensions module
+        annotated_types/     ← vendored annotated_types package
+        typing_inspection/   ← vendored typing_inspection package
+        _vendor/
+          pydantic_core/
+            cp39-macosx_arm64/pydantic_core/...
+            cp39-macosx_x86_64/pydantic_core/...
+            cp39-manylinux_x86_64/pydantic_core/...
+            cp39-manylinux_aarch64/pydantic_core/...
+            cp39-win_amd64/pydantic_core/...
+            cp312-...
       resources/
         icon.png             ← 64×64 PNG for PCM manager (TODO: add icon)
       metadata.json
 
 The ``plugins/`` directory is what KiCad adds to ``sys.path`` when loading the
-plugin, making ``import jbom``, ``import sexpdata``, and ``import yaml`` work
-against the vendored copies.
+plugin. ``src/jbom/plugin/__init__.py`` inspects ``sys.version_info`` and
+``platform.machine()`` at load time and prepends the matching
+``_vendor/pydantic_core/<tag>/`` directory to ``sys.path`` so the compiled
+extension that matches the active KiCad Python interpreter is the one that
+gets imported.
 
 Flags
 -----
@@ -45,14 +52,18 @@ Flags
     After building, patch ``metadata.json`` in the repo root with the computed
     ``download_sha256``, ``install_size``, and ``download_size`` for the
     current version.  Useful when preparing a release.
+--skip-binary-fetch
+    Do not call ``pip download`` for compiled deps; only vendor the build
+    host's local pydantic_core.  Useful for offline CI smoke tests and for
+    fast iteration on the script itself.  The resulting archive is *not*
+    suitable for distribution.
 
 Design notes
 ------------
-This script intentionally uses only the Python standard library (``zipfile``,
-``shutil``, ``hashlib``, ``importlib``) with no third-party build-system
-plugin, following Decision 3 (Y > X) agreed in issue #227.  Migration to
-``hatch-kicad`` is straightforward if desired later: it produces the same
-archive layout from ``pyproject.toml`` configuration.
+This script uses only the Python standard library plus ``pip`` invoked as a
+subprocess.  No third-party build-system plugin.  Migration to
+``hatch-kicad`` later is straightforward: the archive layout produced here is
+fully declarative.
 """
 
 from __future__ import annotations
@@ -62,9 +73,11 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import subprocess
 import sys
 import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -98,17 +111,52 @@ _JBOM_INCLUDE_ROOT_FILES = [
 
 # Glob patterns for files to skip when copying (matched against each file name).
 _SKIP_FILENAMES: set[str] = {".DS_Store", ".gitignore"}
-# Skip compiled extensions (platform- and Python-version-specific binaries).
-# PyYAML falls back gracefully to its pure-Python loader when the C extension
-# is absent, so excluding _yaml.cpython-*.so is safe and desirable.
+# Skip compiled extension binaries by default.
 _SKIP_SUFFIXES: tuple[str, ...] = (".pyc", ".so", ".pyd")
 
-# Python packages to vendor from the current environment.
+# Pure-Python packages to vendor once from the build host.
 # Keys are import names; values control how to vendor them.
-_VENDOR_PACKAGES = {
+#
+# WARNING: ``single_file: True`` may only be used when ``spec.origin`` points
+# at a file *not* named ``__init__.py``; otherwise it would clobber the
+# plugin's own ``plugins/__init__.py`` when copied into the staging directory.
+_PURE_PY_VENDOR_PACKAGES = {
     "sexpdata": {"single_file": True},  # sexpdata.py
     "yaml": {"single_file": False},  # yaml/ package directory (PyYAML)
+    "pydantic": {"single_file": False},
+    "typing_extensions": {"single_file": True},  # typing_extensions.py
+    "annotated_types": {"single_file": False},  # annotated_types/ package dir
+    "typing_inspection": {"single_file": False},
 }
+
+_VENDOR_REQUIREMENTS_FILE = _REPO_ROOT / "scripts" / "_vendor_requirements.txt"
+
+
+@dataclass(frozen=True)
+class _BinaryTarget:
+    """One (python, platform, abi) combo for compiled-dep vendoring."""
+
+    python_version: str  # e.g. "3.9"
+    abi: str  # e.g. "cp39"
+    platform_tag: str  # pip's --platform value, e.g. "manylinux2014_x86_64"
+    folder_tag: str  # vendor folder name, e.g. "cp39-manylinux_x86_64"
+
+
+# Targets matched to KiCad releases (cp39 for KiCad 9, cp312 for KiCad 10).
+_BINARY_TARGETS: tuple[_BinaryTarget, ...] = (
+    # KiCad 9 — CPython 3.9
+    _BinaryTarget("3.9", "cp39", "macosx_11_0_arm64", "cp39-macosx_arm64"),
+    _BinaryTarget("3.9", "cp39", "macosx_10_12_x86_64", "cp39-macosx_x86_64"),
+    _BinaryTarget("3.9", "cp39", "manylinux2014_x86_64", "cp39-manylinux_x86_64"),
+    _BinaryTarget("3.9", "cp39", "manylinux2014_aarch64", "cp39-manylinux_aarch64"),
+    _BinaryTarget("3.9", "cp39", "win_amd64", "cp39-win_amd64"),
+    # KiCad 10 — CPython 3.12
+    _BinaryTarget("3.12", "cp312", "macosx_11_0_arm64", "cp312-macosx_arm64"),
+    _BinaryTarget("3.12", "cp312", "macosx_10_12_x86_64", "cp312-macosx_x86_64"),
+    _BinaryTarget("3.12", "cp312", "manylinux2014_x86_64", "cp312-manylinux_x86_64"),
+    _BinaryTarget("3.12", "cp312", "manylinux2014_aarch64", "cp312-manylinux_aarch64"),
+    _BinaryTarget("3.12", "cp312", "win_amd64", "cp312-win_amd64"),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +164,14 @@ _VENDOR_PACKAGES = {
 # ---------------------------------------------------------------------------
 
 
-def _should_skip(path: Path) -> bool:
+def _should_skip(path: Path, *, include_binary_extensions: bool = False) -> bool:
     """Return True if *path* should be excluded from the archive."""
+    if include_binary_extensions and path.suffix in {".so", ".pyd"}:
+        return (
+            path.name in _SKIP_FILENAMES
+            or path.name == "__pycache__"
+            or any(part == "__pycache__" for part in path.parts)
+        )
     return (
         path.name in _SKIP_FILENAMES
         or path.suffix in _SKIP_SUFFIXES
@@ -126,7 +180,9 @@ def _should_skip(path: Path) -> bool:
     )
 
 
-def _copy_tree_filtered(src: Path, dst: Path) -> int:
+def _copy_tree_filtered(
+    src: Path, dst: Path, *, include_binary_extensions: bool = False
+) -> int:
     """Recursively copy *src* to *dst*, skipping junk files.
 
     Returns the total uncompressed byte count copied.
@@ -134,7 +190,7 @@ def _copy_tree_filtered(src: Path, dst: Path) -> int:
     total_bytes = 0
     dst.mkdir(parents=True, exist_ok=True)
     for item in src.rglob("*"):
-        if _should_skip(item):
+        if _should_skip(item, include_binary_extensions=include_binary_extensions):
             continue
         rel = item.relative_to(src)
         target = dst / rel
@@ -147,7 +203,13 @@ def _copy_tree_filtered(src: Path, dst: Path) -> int:
     return total_bytes
 
 
-def _vendor_package(name: str, single_file: bool, dest_dir: Path) -> int:
+def _vendor_package(
+    name: str,
+    single_file: bool,
+    dest_dir: Path,
+    *,
+    include_binary_extensions: bool = False,
+) -> int:
     """Copy a vendored package into *dest_dir*.
 
     For single-file packages (e.g. ``sexpdata``), copies ``sexpdata.py``.
@@ -166,6 +228,12 @@ def _vendor_package(name: str, single_file: bool, dest_dir: Path) -> int:
     if single_file:
         # e.g. sexpdata.py — spec.origin is the file path
         origin = Path(spec.origin)
+        if origin.name == "__init__.py":
+            raise RuntimeError(
+                f"Package {name!r} is registered as single_file but resolves to "
+                f"{origin}; that would overwrite plugins/__init__.py. Mark it as "
+                "single_file: False in _PURE_PY_VENDOR_PACKAGES."
+            )
         target = dest_dir / origin.name
         shutil.copy2(origin, target)
         size = origin.stat().st_size
@@ -182,9 +250,165 @@ def _vendor_package(name: str, single_file: bool, dest_dir: Path) -> int:
             return 0
         pkg_dir = Path(locs[0])
         target_dir = dest_dir / name
-        size = _copy_tree_filtered(pkg_dir, target_dir)
+        size = _copy_tree_filtered(
+            pkg_dir,
+            target_dir,
+            include_binary_extensions=include_binary_extensions,
+        )
         print(f"  vendored {name}/ ({size:,} bytes uncompressed)")
         return size
+
+
+def _read_pinned_version(package: str) -> str:
+    """Return the pinned version of *package* from _vendor_requirements.txt."""
+    if not _VENDOR_REQUIREMENTS_FILE.is_file():
+        raise RuntimeError(
+            f"Missing pinned vendor requirements file at {_VENDOR_REQUIREMENTS_FILE}"
+        )
+    needle = package.lower().replace("-", "_")
+    for raw in _VENDOR_REQUIREMENTS_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "==" not in line:
+            continue
+        name, _, version = line.partition("==")
+        if name.strip().lower().replace("-", "_") == needle:
+            return version.strip()
+    raise RuntimeError(
+        f"Package {package!r} is not pinned in {_VENDOR_REQUIREMENTS_FILE}"
+    )
+
+
+def _extract_wheel_package(wheel_path: Path, package_name: str, dest_dir: Path) -> int:
+    """Extract the importable *package_name* directory from *wheel_path* into *dest_dir*.
+
+    Drops ``*.dist-info`` and other non-package metadata so the vendored tree
+    only contains what is needed at runtime.
+
+    Returns the total uncompressed byte count of extracted files.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    total_bytes = 0
+    prefix = f"{package_name}/"
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        for member in zf.namelist():
+            if not member.startswith(prefix):
+                continue
+            if member.endswith("/"):
+                continue
+            target = dest_dir / member
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member) as src, target.open("wb") as dst:
+                data = src.read()
+                dst.write(data)
+                total_bytes += len(data)
+    return total_bytes
+
+
+def _pip_download(
+    *,
+    requirement: str,
+    python_version: str,
+    abi: str,
+    platform_tag: str,
+    dest_dir: Path,
+) -> Path:
+    """Run ``pip download`` for one (python, abi, platform) target.
+
+    Returns the path to the downloaded wheel inside *dest_dir*.
+    Raises ``RuntimeError`` if pip fails or no wheel is produced.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--only-binary=:all:",
+        "--no-deps",
+        "--python-version",
+        python_version,
+        "--implementation",
+        "cp",
+        "--abi",
+        abi,
+        "--platform",
+        platform_tag,
+        "--dest",
+        str(dest_dir),
+        requirement,
+    ]
+    print(f"    pip download {requirement} ({abi}/{platform_tag})…")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pip download failed for {requirement} ({abi}/{platform_tag}):\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+    wheels = sorted(dest_dir.glob("*.whl"))
+    if not wheels:
+        raise RuntimeError(
+            f"pip download produced no wheel for {requirement} ({abi}/{platform_tag})"
+        )
+    return wheels[-1]
+
+
+def _vendor_pydantic_core_targets(plugins_dir: Path) -> int:
+    """Fetch and stage pydantic_core wheels for every supported target.
+
+    Each wheel is extracted into
+    ``plugins/_vendor/pydantic_core/<folder_tag>/pydantic_core/`` so the runtime
+    bootstrap can prepend the matching directory to ``sys.path``.
+
+    Returns total uncompressed byte count.
+    """
+    version = _read_pinned_version("pydantic_core")
+    requirement = f"pydantic_core=={version}"
+    vendor_root = plugins_dir / "_vendor" / "pydantic_core"
+    vendor_root.mkdir(parents=True, exist_ok=True)
+    total = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for target in _BINARY_TARGETS:
+            target_tmp = Path(tmp) / target.folder_tag
+            wheel_path = _pip_download(
+                requirement=requirement,
+                python_version=target.python_version,
+                abi=target.abi,
+                platform_tag=target.platform_tag,
+                dest_dir=target_tmp,
+            )
+            target_out = vendor_root / target.folder_tag
+            bytes_extracted = _extract_wheel_package(
+                wheel_path, "pydantic_core", target_out
+            )
+            total += bytes_extracted
+            print(f"    staged {target.folder_tag} — {bytes_extracted:,} bytes")
+    return total
+
+
+def _vendor_pydantic_core_local(plugins_dir: Path) -> int:
+    """Fallback vendor: copy the build host's pydantic_core into _vendor.
+
+    Used only with ``--skip-binary-fetch``.  The resulting archive will only
+    work on platforms matching the build host's Python ABI / OS / CPU.
+    """
+    spec = importlib.util.find_spec("pydantic_core")
+    if spec is None or not spec.submodule_search_locations:
+        print(
+            "  WARNING: pydantic_core not importable on build host; skipping local fallback.",
+            file=sys.stderr,
+        )
+        return 0
+    folder_tag = (
+        f"cp{sys.version_info.major}{sys.version_info.minor}-" f"local_{sys.platform}"
+    )
+    target_dir = plugins_dir / "_vendor" / "pydantic_core" / folder_tag
+    return _copy_tree_filtered(
+        Path(list(spec.submodule_search_locations)[0]),
+        target_dir / "pydantic_core",
+        include_binary_extensions=True,
+    )
 
 
 def _zip_directory(source_dir: Path, output_zip: Path) -> int:
@@ -243,12 +467,20 @@ def _update_metadata(
 # ---------------------------------------------------------------------------
 
 
-def build(output_dir: Path, update_metadata: bool = False) -> Path:
+def build(
+    output_dir: Path,
+    update_metadata: bool = False,
+    *,
+    skip_binary_fetch: bool = False,
+) -> Path:
     """Build the PCM archive and return its path.
 
     Args:
         output_dir: Directory where the zip will be written.
         update_metadata: When True, patch repo-root metadata.json.
+        skip_binary_fetch: When True, do not call ``pip download``; vendor
+            only the build host's local pydantic_core.  Resulting archive is
+            not distribution-ready.
 
     Returns:
         Path to the produced zip file.
@@ -300,16 +532,26 @@ def build(output_dir: Path, update_metadata: bool = False) -> Path:
         print(f"    {core_total:,} bytes")
 
         # ------------------------------------------------------------------
-        # 3. Vendored runtime deps → plugins/
+        # 3a. Pure-Python runtime deps → plugins/
         # ------------------------------------------------------------------
-        print("  vendoring runtime dependencies…")
+        print("  vendoring pure-Python runtime dependencies…")
         vendor_total = 0
-        for pkg_name, cfg in _VENDOR_PACKAGES.items():
+        for pkg_name, cfg in _PURE_PY_VENDOR_PACKAGES.items():
             vendor_total += _vendor_package(
                 pkg_name,
                 single_file=cfg["single_file"],  # type: ignore[index]
                 dest_dir=plugins_dir,
             )
+
+        # ------------------------------------------------------------------
+        # 3b. Compiled deps → plugins/_vendor/<package>/<py-platform>/
+        # ------------------------------------------------------------------
+        if skip_binary_fetch:
+            print("  vendoring pydantic_core (LOCAL ONLY — not redistributable)…")
+            vendor_total += _vendor_pydantic_core_local(plugins_dir)
+        else:
+            print("  vendoring pydantic_core for all supported targets…")
+            vendor_total += _vendor_pydantic_core_targets(plugins_dir)
 
         # ------------------------------------------------------------------
         # 4. metadata.json → archive root
@@ -367,6 +609,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Patch metadata.json with computed sha256 and sizes after build",
     )
+    p.add_argument(
+        "--skip-binary-fetch",
+        action="store_true",
+        help=(
+            "Skip pip download of cross-platform pydantic_core wheels and "
+            "vendor only the build host's installed copy. Resulting archive "
+            "is NOT redistributable; use for local iteration only."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -374,7 +625,11 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     output_dir = (_REPO_ROOT / args.output_dir).resolve()
     try:
-        build(output_dir, update_metadata=args.update_metadata)
+        build(
+            output_dir,
+            update_metadata=args.update_metadata,
+            skip_binary_fetch=args.skip_binary_fetch,
+        )
         return 0
     except Exception as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/src/jbom/config/profile_search.py
+++ b/src/jbom/config/profile_search.py
@@ -18,6 +18,34 @@ import os
 import sys
 from pathlib import Path
 
+_PROFILE_EVAL_TRACE: list[str] = []
+
+
+def record_profile_eval(message: str) -> None:
+    """Record a profile-evaluation diagnostic line.
+
+    Lines are always retained in the in-memory ring buffer so the plugin
+    dialog's debug panel can show recent activity, but stdout is only written
+    to when ``JBOM_PROFILE_EVAL_VERBOSE=1`` is set in the environment.  This
+    keeps production KiCad sessions free of debug noise while still allowing
+    developers to opt in to live tracing.
+    """
+    _PROFILE_EVAL_TRACE.append(message)
+    if len(_PROFILE_EVAL_TRACE) > 300:
+        del _PROFILE_EVAL_TRACE[:100]
+    if os.environ.get("JBOM_PROFILE_EVAL_VERBOSE", "").strip() == "1":
+        print(message, flush=True)
+
+
+def get_profile_eval_trace() -> tuple[str, ...]:
+    """Return the current in-memory profile evaluation trace lines."""
+    return tuple(_PROFILE_EVAL_TRACE)
+
+
+def clear_profile_eval_trace() -> None:
+    """Clear the in-memory profile evaluation trace lines."""
+    _PROFILE_EVAL_TRACE.clear()
+
 
 def find_profile(
     name: str,
@@ -45,7 +73,11 @@ def find_profile(
         dirs.append(builtin_dir)
     for directory in dirs:
         candidate = directory / filename
+        message = f"[jBOM] profile eval name={name!r} candidate={candidate}"
+        record_profile_eval(message)
         if candidate.is_file():
+            match_message = f"[jBOM] profile match name={name!r} path={candidate}"
+            record_profile_eval(match_message)
             return candidate
     return None
 
@@ -137,4 +169,10 @@ def _platform_system_dirs() -> list[Path]:
     return dirs
 
 
-__all__ = ["find_profile", "profile_search_dirs"]
+__all__ = [
+    "clear_profile_eval_trace",
+    "find_profile",
+    "get_profile_eval_trace",
+    "profile_search_dirs",
+    "record_profile_eval",
+]

--- a/src/jbom/config/profile_search.py
+++ b/src/jbom/config/profile_search.py
@@ -62,7 +62,7 @@ def profile_search_dirs(*, cwd: Path | None = None) -> list[Path]:
     Returns:
         Ordered list of directories (may include non-existent paths).
     """
-    search_cwd = (cwd or Path.cwd()).resolve()
+    search_cwd = _resolve_search_cwd(cwd)
     dirs: list[Path] = []
 
     # 1. .jbom/ in cwd
@@ -89,6 +89,17 @@ def profile_search_dirs(*, cwd: Path | None = None) -> list[Path]:
     dirs.extend(_platform_system_dirs())
 
     return dirs
+
+
+def _resolve_search_cwd(cwd: Path | None) -> Path:
+    """Resolve the effective cwd for profile search with safe fallbacks."""
+    try:
+        return (cwd or Path.cwd()).resolve()
+    except OSError:
+        try:
+            return Path.home().resolve()
+        except OSError:
+            return Path("/")
 
 
 def _find_repo_root(start: Path) -> Path | None:

--- a/src/jbom/config/profile_search.py
+++ b/src/jbom/config/profile_search.py
@@ -96,6 +96,12 @@ def _resolve_search_cwd(cwd: Path | None) -> Path:
     try:
         return (cwd or Path.cwd()).resolve()
     except OSError:
+        plugin_project_dir = os.environ.get("JBOM_PROJECT_DIR", "").strip()
+        if plugin_project_dir:
+            try:
+                return Path(plugin_project_dir).resolve()
+            except OSError:
+                pass
         try:
             return Path.home().resolve()
         except OSError:

--- a/src/jbom/config/unified.py
+++ b/src/jbom/config/unified.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING, Any, Mapping, MutableMapping
 
 import yaml
 
-from jbom.config.profile_search import profile_search_dirs
+from jbom.config import profile_search as _profile_search
+
+# ``profile_search_dirs`` is re-exported here so legacy callers and tests can
+# monkeypatch ``jbom.config.unified.profile_search_dirs``; ``_effective_search_dirs``
+# resolves it via the module at call time so the patch takes effect.
+from jbom.config.profile_search import profile_search_dirs  # noqa: F401
 
 if TYPE_CHECKING:
     from jbom.config.defaults import DefaultsConfig
@@ -31,6 +36,21 @@ _PROFILE_SUFFIX = ".jbom.yaml"
 _COMMON_PROFILE_NAME = "common"
 _POLICY_PROFILE_NAME = "policy"
 _VALID_STANZA_NAMES = frozenset({"fab", "supplier", "defaults", "presets"})
+
+
+def _emit_profile_eval(message: str) -> None:
+    """Best-effort profile evaluation trace emission."""
+    try:
+        recorder = getattr(_profile_search, "record_profile_eval", None)
+        if callable(recorder):
+            recorder(message)
+            return
+    except Exception:
+        pass
+    try:
+        print(message, flush=True)
+    except Exception:
+        pass
 
 
 class UnifiedProfileNotFoundError(ValueError):
@@ -100,7 +120,15 @@ def list_unified_stanza_ids(
         )
 
     search_dirs = _effective_search_dirs(cwd=cwd, builtin_dir=builtin_dir)
+    _emit_profile_eval(
+        "[jBOM] unified eval "
+        f"stanza={normalized_stanza!r} search_dirs={[str(path) for path in search_dirs]}"
+    )
     profile_names = _discover_named_profile_names(search_dirs)
+    _emit_profile_eval(
+        "[jBOM] unified eval "
+        f"stanza={normalized_stanza!r} discovered_profiles={profile_names}"
+    )
 
     discovered_ids: set[str] = set()
     for profile_name in profile_names:
@@ -108,11 +136,19 @@ def list_unified_stanza_ids(
             merged_named = _load_named_profile_chain(
                 profile_name, search_dirs, visiting_stack=[]
             )
-        except (UnifiedProfileNotFoundError, ValueError):
+        except (UnifiedProfileNotFoundError, ValueError) as exc:
+            _emit_profile_eval(
+                "[jBOM] unified skip "
+                f"stanza={normalized_stanza!r} profile={profile_name!r} reason={exc}"
+            )
             continue
 
         raw_stanza = merged_named.get(normalized_stanza)
         if not isinstance(raw_stanza, dict):
+            _emit_profile_eval(
+                "[jBOM] unified skip "
+                f"stanza={normalized_stanza!r} profile={profile_name!r} reason=no_stanza"
+            )
             continue
         stanza_mapping = dict(raw_stanza)
         effective_id = _effective_stanza_id(
@@ -120,8 +156,16 @@ def list_unified_stanza_ids(
         )
         if effective_id:
             discovered_ids.add(effective_id)
+            _emit_profile_eval(
+                "[jBOM] unified match "
+                f"stanza={normalized_stanza!r} profile={profile_name!r} id={effective_id!r}"
+            )
 
-    return sorted(discovered_ids)
+    sorted_ids = sorted(discovered_ids)
+    _emit_profile_eval(
+        "[jBOM] unified result " f"stanza={normalized_stanza!r} ids={sorted_ids}"
+    )
+    return sorted_ids
 
 
 def resolve_profile_name_for_stanza_id(
@@ -196,7 +240,11 @@ def defaults_stanza(merged: Mapping[str, Any], *, default_id: str) -> "DefaultsC
 
 
 def _effective_search_dirs(*, cwd: Path | None, builtin_dir: Path | None) -> list[Path]:
-    dirs = list(profile_search_dirs(cwd=cwd))
+    # Look up profile_search_dirs from this module so tests can monkeypatch
+    # `jbom.config.unified.profile_search_dirs` (legacy import surface).
+    import jbom.config.unified as _self
+
+    dirs = list(_self.profile_search_dirs(cwd=cwd))
     dirs.append((builtin_dir or _BUILTIN_DIR).resolve())
     return _dedupe_paths(dirs)
 

--- a/src/jbom/plugin/__init__.py
+++ b/src/jbom/plugin/__init__.py
@@ -18,19 +18,25 @@ Mirrors Fabrication Toolkit's ``plugins/__init__.py``:
 
 ``sys.path`` bootstrapping
 --------------------------
-This module adds two candidate directories to ``sys.path`` so that
-``import jbom`` (and vendored runtime deps) succeeds in both deployment modes:
+This module makes ``import jbom`` and the vendored third-party runtime
+dependencies importable in both deployment modes:
 
-* **PCM install** — ``jbom/`` is vendored *inside* this plugin directory.
-  Adding the plugin directory itself (``_this_dir``) makes it discoverable.
+* **PCM install** — ``jbom/`` and the pure-Python vendored packages
+  (``pydantic``, ``yaml``, …) live alongside this file in ``<this_dir>``.
+  The compiled ``pydantic_core`` extension lives under
+  ``<this_dir>/_vendor/pydantic_core/<py_tag>-<plat_tag>/pydantic_core/``;
+  :func:`_vendor_pydantic_core_path` picks the directory matching the
+  running KiCad interpreter (CPython 3.9 on KiCad 9, CPython 3.12 on KiCad
+  10) and prepends it to ``sys.path``.
 
-* **Dev loop (symlink)** — this directory is ``src/jbom/plugin/``, symlinked
-  into KiCad's scripting plugins folder as ``com_spcoast_jbom``.  Adding
-  ``src/`` (two levels up from ``plugin/``) makes the editable source tree
-  discoverable without a separate ``pip install`` into KiCad's bundled Python.
-
-The two paths are tried in order; the first one that contains a ``jbom``
-package wins.
+* **Dev loop (symlink)** — this directory is ``src/jbom/plugin/`` symlinked
+  into KiCad's scripting plugins folder as ``com_spcoast_jbom``.  We add
+  ``src/`` (two levels up from ``plugin/``) so the editable ``jbom`` package
+  is importable.  Third-party runtime deps are *not* auto-discovered from
+  homebrew / user-site / venv paths anymore: export
+  ``JBOM_PLUGIN_PYTHON_DEPS_DIR`` (colon-separated on Unix, semicolon on
+  Windows) to point at site-packages dirs holding ``pydantic`` etc. when you
+  need them.
 
 Dev-loop setup (macOS, KiCad 9)::
 
@@ -40,33 +46,179 @@ Dev-loop setup (macOS, KiCad 9)::
 Important: use ``com_spcoast_jbom`` (not ``jbom``) as the symlink target name
 to avoid a naming conflict with the importable ``jbom`` package when KiCad
 adds the scripting plugins directory to ``sys.path``.
+
+Diagnostics
+-----------
+Set ``JBOM_PLUGIN_DEBUG=1`` before launching KiCad to capture the bootstrap
+mode, selected vendor tag, and inserted ``sys.path`` entries in the
+environment variable ``JBOM_PLUGIN_BOOTSTRAP_INFO`` (JSON).  The plugin
+dialog surfaces this via the load-stamp tooltip in debug mode.
 """
 
 from __future__ import annotations
 
+import json
 import os
+import platform
 import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path discovery
+# ---------------------------------------------------------------------------
+
+# ``os.path.realpath`` (not abspath) is required here: in dev-loop mode this
+# file is reached via a symlink and we want the *real* source location so
+# ``src/`` and ``_vendor/`` are both resolved consistently.
+_this_dir = Path(os.path.realpath(__file__)).parent
+# Two levels up from ``src/jbom/plugin/`` lands at ``src/`` in the dev tree.
+# In PCM mode (``${KICADX_3RD_PARTY}/plugins/com_spcoast_jbom/``) this
+# resolves to ``${KICADX_3RD_PARTY}/plugins/``, which is already in sys.path
+# by the time KiCad loads us — adding it again later is harmless.
+_src_dir = _this_dir.parent.parent
+
+
+def _is_dev_loop_checkout(this_dir: Path, src_dir: Path) -> bool:
+    """Return True when the plugin is running from the source-tree dev loop."""
+    return src_dir.name == "src" and (src_dir.parent / "pyproject.toml").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Vendored-binary selection (PCM mode)
+# ---------------------------------------------------------------------------
+
+
+def _vendor_folder_tag() -> str | None:
+    """Compute the ``_vendor/pydantic_core/<tag>/`` folder for this interpreter.
+
+    Returns ``None`` for unsupported (python_version, os, arch) combinations.
+    """
+    py_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    machine = platform.machine().lower()
+    if sys.platform == "darwin":
+        if machine in {"arm64", "aarch64"}:
+            return f"{py_tag}-macosx_arm64"
+        if machine in {"x86_64", "amd64"}:
+            return f"{py_tag}-macosx_x86_64"
+        return None
+    if sys.platform.startswith("linux"):
+        if machine in {"x86_64", "amd64"}:
+            return f"{py_tag}-manylinux_x86_64"
+        if machine in {"aarch64", "arm64"}:
+            return f"{py_tag}-manylinux_aarch64"
+        return None
+    if sys.platform == "win32":
+        if machine in {"amd64", "x86_64"}:
+            return f"{py_tag}-win_amd64"
+        return None
+    return None
+
+
+def _vendor_pydantic_core_path(this_dir: Path) -> Path | None:
+    """Return the directory holding the matching ``pydantic_core`` package.
+
+    Returns ``None`` when no compatible vendored copy is present.  Falls back
+    to a ``local_*`` directory produced by ``--skip-binary-fetch`` builds when
+    no exact tag match is found.
+    """
+    tag = _vendor_folder_tag()
+    if tag is not None:
+        candidate = this_dir / "_vendor" / "pydantic_core" / tag
+        if (candidate / "pydantic_core").is_dir():
+            return candidate
+    local_dir = this_dir / "_vendor" / "pydantic_core"
+    if local_dir.is_dir():
+        for sub in sorted(local_dir.iterdir()):
+            if sub.is_dir() and (sub / "pydantic_core").is_dir():
+                return sub
+    return None
+
 
 # ---------------------------------------------------------------------------
 # sys.path bootstrapping
 # ---------------------------------------------------------------------------
 
-# os.path.realpath (not abspath) is required here: abspath makes a path
-# absolute but does NOT follow symlinks.  In the dev loop the plugin directory
-# is a symlink, so abspath would resolve relative to the symlink location
-# (e.g. .../scripting/plugins/com_spcoast_jbom/) instead of the actual source
-# tree (src/jbom/plugin/).  realpath follows the symlink first.
-_this_dir = os.path.dirname(os.path.realpath(__file__))
 
-# Two levels up from ``src/jbom/plugin/`` lands at ``src/`` in the dev tree.
-# In PCM mode (``${KICADX_3RD_PARTY}/plugins/com_spcoast_jbom/``) this
-# resolves to ``${KICADX_3RD_PARTY}/plugins/``, which is already in sys.path
-# by the time KiCad loads us — adding it again is harmless.
-_src_dir = os.path.dirname(os.path.dirname(_this_dir))
+def _dev_loop_extra_dependency_paths() -> list[Path]:
+    """Return developer-provided dependency dirs honoured in dev-loop mode.
 
-for _p in (_this_dir, _src_dir):
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
+    Only ``JBOM_PLUGIN_PYTHON_DEPS_DIR`` (colon/semicolon-separated list) is
+    consulted; we no longer probe homebrew or user-site directories.  This
+    keeps the dev loop predictable and free of accidental imports from the
+    host OS Python install.
+    """
+    raw = os.environ.get("JBOM_PLUGIN_PYTHON_DEPS_DIR", "").strip()
+    if not raw:
+        return []
+    sep = ";" if sys.platform == "win32" else ":"
+    candidates: list[Path] = []
+    for entry in raw.split(sep):
+        entry = entry.strip()
+        if not entry:
+            continue
+        path = Path(entry).expanduser()
+        if path.is_dir():
+            candidates.append(path)
+    return candidates
+
+
+def _bootstrap_sys_path() -> dict[str, object]:
+    """Insert the right vendored-deps directories onto ``sys.path``.
+
+    Returns a small diagnostic dict describing the mode, selected tag, and
+    inserted paths so callers can stash it (e.g. via env var) without us
+    leaking dev-loop assumptions into production sessions.
+    """
+    inserted: list[str] = []
+
+    def _prepend(path: Path) -> None:
+        path_str = str(path)
+        if path_str in sys.path:
+            return
+        sys.path.insert(0, path_str)
+        inserted.append(path_str)
+
+    dev_loop = _is_dev_loop_checkout(_this_dir, _src_dir)
+    info: dict[str, object] = {
+        "this_dir": str(_this_dir),
+        "src_dir": str(_src_dir),
+        "mode": "dev-loop" if dev_loop else "pcm",
+        "tag": None,
+        "inserted": inserted,
+    }
+
+    # In PCM mode, the compiled pydantic_core lives under _vendor/. Prepend
+    # the matching directory (if any) before the plugin dir itself so the
+    # import resolves to the bundled package.
+    pydantic_core_dir = _vendor_pydantic_core_path(_this_dir)
+    if pydantic_core_dir is not None:
+        info["tag"] = pydantic_core_dir.name
+        _prepend(pydantic_core_dir)
+
+    # Plugin dir itself is always on the path so the pure-Python vendored
+    # packages (pydantic, yaml, …) and the vendored ``jbom`` package are
+    # importable.
+    _prepend(_this_dir)
+
+    # Dev-loop only: editable ``src/`` and optional user-supplied deps dir.
+    if dev_loop:
+        _prepend(_src_dir)
+        for extra in _dev_loop_extra_dependency_paths():
+            _prepend(extra)
+
+    return info
+
+
+_bootstrap_info = _bootstrap_sys_path()
+
+# Only publish the bootstrap detail through the environment when explicitly
+# asked.  The dialog reads ``JBOM_PLUGIN_BOOTSTRAP_INFO`` to render the debug
+# tooltip; production users see nothing.
+if os.environ.get("JBOM_PLUGIN_DEBUG", "").strip() == "1":
+    try:
+        os.environ["JBOM_PLUGIN_BOOTSTRAP_INFO"] = json.dumps(_bootstrap_info)
+    except (TypeError, ValueError):
+        pass
 
 # ---------------------------------------------------------------------------
 # ActionPlugin registration — KiCad context only
@@ -80,13 +232,14 @@ if not _is_standalone:  # pragma: no cover — only executes inside KiCad
     try:
         from .plugin import JBOMFabricationPlugin
 
-        # Store the instance at module level — mirrors FT's `plugin = Plugin(); plugin.register()`.
-        # Without this, the temporary JBOMFabricationPlugin() object may be GC'd immediately
-        # after register() returns (CPython reference counting).  If KiCad's ActionPlugin
-        # registry holds only a C++ pointer without a Python refcount, a GC'd wrapper causes
-        # KiCad to silently suppress subsequent Run() calls — the toolbar button appears to
-        # work once and then becomes inert.  Retaining a module-level Python reference
-        # prevents GC for the lifetime of the KiCad session.
+        # Store the instance at module level — mirrors FT's pattern of
+        # ``plugin = Plugin(); plugin.register()``.  Without this, the
+        # temporary JBOMFabricationPlugin() may be GC'd immediately after
+        # register() returns; KiCad's ActionPlugin registry holds only a
+        # C++ pointer, so a collected Python wrapper causes silent
+        # suppression of subsequent ``Run()`` calls — the toolbar button
+        # appears to work once and then becomes inert.  Retaining a
+        # module-level reference prevents GC for the KiCad session.
         _plugin_instance = JBOMFabricationPlugin()
         _plugin_instance.register()
     except Exception:

--- a/src/jbom/plugin/diagnostics.py
+++ b/src/jbom/plugin/diagnostics.py
@@ -1,0 +1,660 @@
+"""Structured diagnostics for the jBOM KiCad plugin.
+
+This module is **wx-free** so it can be imported and exercised from tests
+without KiCad/wxPython.  It provides three layered diagnostic capabilities,
+each designed to address one part of "what was the plugin doing?":
+
+1. **Environment snapshot** — captured once per Python session (the KiCad
+   process lifetime).  Describes plugin mode (PCM vs dev-loop), Python
+   version, vendored ``pydantic_core`` tag, source path, and the sys.path
+   entries the bootstrap inserted.  Cheap to render repeatedly; recomputed
+   only on explicit ``invalidate_environment()`` (test hook).
+
+2. **Profile snapshot** — captured per dialog invocation but cached by a
+   fingerprint of discovered ``*.jbom.yaml`` files (path + mtime + size).
+   When the user edits a profile, the fingerprint changes and the snapshot
+   is rebuilt; otherwise the cached snapshot is reused so repeated dialog
+   opens don't pay full discovery cost.
+
+3. **Lifecycle log** — append-only, structured per-run.  Each Run() opens
+   a new ``LifecycleRun`` collection that captures dialog open, user
+   interactions, worker-thread step transitions, completion, and close.
+   Runs are retained for the KiCad session (capped at
+   ``_MAX_RETAINED_RUNS``) so the developer can compare consecutive runs.
+
+A plain-text report renderer (:func:`render_text_report`) emits the union of
+all three layers so the dialog's "Save log\u2026" button can write a file the
+user can attach to a bug report.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import platform
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+_MAX_RETAINED_RUNS = 20
+_MAX_EVENTS_PER_RUN = 200
+
+
+# ---------------------------------------------------------------------------
+# Environment snapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvironmentSnapshot:
+    """Static plugin runtime info captured once per Python session."""
+
+    mode: str  # "pcm" | "dev-loop" | "unknown"
+    python_version: str
+    platform: str
+    machine: str
+    vendor_tag: str | None
+    source_path: str
+    source_mtime: str  # ISO 8601 local time, or "unknown"
+    project_dir: str  # ``JBOM_PROJECT_DIR`` env, or ""
+    profile_path_env: str  # ``JBOM_PROFILE_PATH`` env, or ""
+    inserted_sys_path: tuple[str, ...]
+
+
+_environment_cache: EnvironmentSnapshot | None = None
+
+
+def capture_environment(*, force: bool = False) -> EnvironmentSnapshot:
+    """Return the cached environment snapshot, computing it on first call.
+
+    Args:
+        force: When ``True``, recompute even if a cached snapshot exists.
+            Useful for tests that mutate ``os.environ``.
+
+    Returns:
+        The cached :class:`EnvironmentSnapshot`.
+    """
+    global _environment_cache
+    if _environment_cache is not None and not force:
+        return _environment_cache
+
+    bootstrap_info: dict[str, object] = {}
+    raw = os.environ.get("JBOM_PLUGIN_BOOTSTRAP_INFO", "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                bootstrap_info = parsed
+        except (TypeError, ValueError):
+            bootstrap_info = {}
+
+    source_path_str = str(bootstrap_info.get("this_dir") or "")
+    if not source_path_str:
+        # Fall back to this file's location's parent (dev-loop tests).
+        source_path_str = str(Path(__file__).resolve().parent)
+    try:
+        mtime = datetime.datetime.fromtimestamp(
+            Path(source_path_str).stat().st_mtime
+        ).strftime("%Y-%m-%d %H:%M:%S")
+    except OSError:
+        mtime = "unknown"
+
+    inserted = bootstrap_info.get("inserted") or []
+    inserted_tuple: tuple[str, ...] = tuple(
+        str(p) for p in inserted if isinstance(p, (str, os.PathLike))
+    )
+
+    snapshot = EnvironmentSnapshot(
+        mode=str(bootstrap_info.get("mode") or "unknown"),
+        python_version=(
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        ),
+        platform=sys.platform,
+        machine=platform.machine(),
+        vendor_tag=(str(bootstrap_info["tag"]) if bootstrap_info.get("tag") else None),
+        source_path=source_path_str,
+        source_mtime=mtime,
+        project_dir=os.environ.get("JBOM_PROJECT_DIR", "").strip(),
+        profile_path_env=os.environ.get("JBOM_PROFILE_PATH", "").strip(),
+        inserted_sys_path=inserted_tuple,
+    )
+    _environment_cache = snapshot
+    return snapshot
+
+
+def invalidate_environment() -> None:
+    """Clear the cached environment snapshot (test hook)."""
+    global _environment_cache
+    _environment_cache = None
+
+
+# ---------------------------------------------------------------------------
+# Profile snapshot
+# ---------------------------------------------------------------------------
+
+
+# Role labels used to elide long paths in the diagnostics panel.
+# Order here is the precedence used by ``_classify_dir``: the first match wins.
+_ROLE_PROJECT = "Project"
+_ROLE_HOME = "Home"
+_ROLE_SYSTEM = "System"
+_ROLE_ENV = "Env"
+_ROLE_FACTORY = "Factory"
+_ROLE_OTHER = "Other"
+
+
+@dataclass(frozen=True)
+class SearchDirInfo:
+    """One entry in the profile search path.
+
+    ``role`` is the short label used in the diagnostics panel (Project / Home /
+    System / Env / Factory / Other).  ``is_builtin`` is kept as a back-compat
+    convenience equivalent to ``role == 'Factory'``.
+    """
+
+    path: str
+    exists: bool
+    is_builtin: bool
+    role: str = _ROLE_OTHER
+
+
+@dataclass(frozen=True)
+class ProfileSnapshot:
+    """Per-invocation view of the unified profile subsystem.
+
+    ``chain_entries`` is the full effective lineage from highest-priority to
+    base.  The first entries come from the named profile and its ``extends:``
+    chain; the trailing entries enumerate every ``common.jbom.yaml`` that the
+    unified loader merges in as the implicit base layer, ordered from
+    highest-priority (project) to lowest (factory).
+    """
+
+    fingerprint: str
+    search_dirs: tuple[SearchDirInfo, ...]
+    discovered_profiles: tuple[str, ...]
+    stanza_ids: tuple[tuple[str, tuple[str, ...]], ...]  # (stanza, ids) pairs
+    selected_fabricator: str
+    selected_chain: tuple[str, ...]  # back-compat: profile names only
+    selected_file: str  # "" when not resolved
+    # ``chain_entries`` is the canonical lineage shown in the dialog: every
+    # entry is a (role, short_name) pair where ``short_name`` is the profile
+    # name (e.g. ``jlc``) without the ``.jbom.yaml`` suffix.
+    chain_entries: tuple[tuple[str, str], ...] = ()
+
+
+_profile_cache: ProfileSnapshot | None = None
+
+
+def _fingerprint_profile_files(search_dirs: Iterable[Path]) -> str:
+    """Hash a stable summary of every ``*.jbom.yaml`` file across search dirs.
+
+    Includes path + size + mtime so any edit (including touch) invalidates
+    the cache.  Hashes use ``hash()`` on a sorted tuple of tuples \u2014 we don't
+    need cryptographic strength here, just a cheap inequality detector.
+    """
+    entries: list[tuple[str, int, int]] = []
+    for directory in search_dirs:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.jbom.yaml")):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            entries.append((str(path), stat.st_size, int(stat.st_mtime_ns)))
+    entries.sort()
+    return f"{abs(hash(tuple(entries))):016x}"
+
+
+def capture_profile_snapshot(
+    selected_fabricator: str = "",
+    *,
+    cwd: Path | None = None,
+) -> ProfileSnapshot:
+    """Build (or reuse) a structured view of the unified profile subsystem.
+
+    The snapshot is cached by a fingerprint derived from every discoverable
+    ``*.jbom.yaml`` file's path + size + mtime.  When the user edits a
+    profile (or adds one), the fingerprint changes and the snapshot is
+    rebuilt; otherwise the cached snapshot is reused so repeated dialog
+    invocations stay cheap.
+
+    Args:
+        selected_fabricator: The currently selected fabricator id, used to
+            compute the resolved ``extends`` chain.
+        cwd: Optional override for project-local search (defaults to
+            ``Path.cwd()``).
+    """
+    global _profile_cache
+
+    # Lazy import: avoid pulling pydantic/yaml into wx-free unit tests
+    # that only exercise lifecycle bookkeeping.
+    from jbom.config import profile_search as _ps
+    from jbom.config import unified as _unified
+
+    builtin_dir = Path(_unified._BUILTIN_DIR).resolve()
+    user_dirs = list(_ps.profile_search_dirs(cwd=cwd))
+    all_dirs: list[Path] = []
+    seen: set[str] = set()
+    for d in [*user_dirs, builtin_dir]:
+        key = str(d)
+        if key in seen:
+            continue
+        seen.add(key)
+        all_dirs.append(d)
+
+    fingerprint = _fingerprint_profile_files(all_dirs)
+    if (
+        _profile_cache is not None
+        and _profile_cache.fingerprint == fingerprint
+        and _profile_cache.selected_fabricator == selected_fabricator
+    ):
+        return _profile_cache
+
+    role_lookup = _build_role_lookup(cwd=cwd, builtin_dir=builtin_dir)
+    search_dirs = tuple(
+        SearchDirInfo(
+            path=str(d),
+            exists=d.is_dir(),
+            is_builtin=(d == builtin_dir),
+            role=_classify_dir(d, role_lookup),
+        )
+        for d in all_dirs
+    )
+
+    discovered = tuple(_unified._discover_named_profile_names(all_dirs))
+
+    stanza_ids: list[tuple[str, tuple[str, ...]]] = []
+    for stanza in ("fab", "supplier", "defaults", "presets"):
+        try:
+            ids = _unified.list_unified_stanza_ids(
+                stanza, cwd=cwd, builtin_dir=builtin_dir
+            )
+        except Exception:
+            ids = []
+        stanza_ids.append((stanza, tuple(ids)))
+
+    chain, selected_file, extends_files = _resolve_chain(selected_fabricator, all_dirs)
+
+    chain_entries = _build_chain_entries(chain, extends_files, all_dirs, role_lookup)
+
+    snapshot = ProfileSnapshot(
+        fingerprint=fingerprint,
+        search_dirs=search_dirs,
+        discovered_profiles=discovered,
+        stanza_ids=tuple(stanza_ids),
+        selected_fabricator=selected_fabricator,
+        selected_chain=chain,
+        selected_file=selected_file,
+        chain_entries=chain_entries,
+    )
+    _profile_cache = snapshot
+    return snapshot
+
+
+def _build_chain_entries(
+    chain: tuple[str, ...],
+    extends_files: tuple[str, ...],
+    search_dirs: list[Path],
+    role_lookup: tuple[tuple[Path, str], ...],
+) -> tuple[tuple[str, str], ...]:
+    """Build the unified chain shown to the user.
+
+    The chain enumerates the named profile + its ``extends:`` ancestors in
+    most-specific-first order, then appends every ``common.jbom.yaml`` that
+    the loader implicitly merges in as the base layer, in priority order.
+    """
+    entries: list[tuple[str, str]] = []
+    for name, file_path in zip(chain, extends_files):
+        role = _role_for_file(file_path, role_lookup)
+        entries.append((role, name))
+    for directory in search_dirs:
+        candidate = directory / "common.jbom.yaml"
+        if candidate.is_file():
+            role = _role_for_file(str(candidate), role_lookup)
+            entries.append((role, "common"))
+    return tuple(entries)
+
+
+def _role_for_file(file_path: str, role_lookup: tuple[tuple[Path, str], ...]) -> str:
+    """Return the role of *file_path* (its containing directory)."""
+    if not file_path:
+        return _ROLE_OTHER
+    try:
+        parent = Path(file_path).parent
+    except (ValueError, OSError):
+        return _ROLE_OTHER
+    return _classify_dir(parent, role_lookup)
+
+
+def _build_role_lookup(
+    *, cwd: Path | None, builtin_dir: Path
+) -> tuple[tuple[Path, str], ...]:
+    """Return ``(anchor_dir, role)`` pairs used to classify search-path entries.
+
+    Order matters: ``_classify_dir`` returns the role of the first anchor
+    that is a prefix of the input path.  Anchors are listed most-specific
+    first so the project ``.jbom`` (which is typically inside the user's
+    home directory) is not classified as Home.
+    """
+    from jbom.config import profile_search as _ps
+
+    anchors: list[tuple[Path, str]] = []
+    try:
+        project_cwd = _ps._resolve_search_cwd(cwd)
+        anchors.append((project_cwd / ".jbom", _ROLE_PROJECT))
+        repo_root = _ps._find_repo_root(project_cwd)
+        if repo_root is not None and repo_root != project_cwd:
+            anchors.append((repo_root / ".jbom", _ROLE_PROJECT))
+    except Exception:
+        pass
+
+    env_path = os.environ.get("JBOM_PROFILE_PATH", "")
+    if env_path:
+        sep = ";" if sys.platform == "win32" else ":"
+        for entry in env_path.split(sep):
+            entry = entry.strip()
+            if entry:
+                try:
+                    anchors.append((Path(entry).resolve(), _ROLE_ENV))
+                except OSError:
+                    pass
+
+    try:
+        anchors.append((Path.home() / ".jbom", _ROLE_HOME))
+    except OSError:
+        pass
+
+    try:
+        for system_dir in _ps._platform_system_dirs():
+            anchors.append((system_dir, _ROLE_SYSTEM))
+    except Exception:
+        pass
+
+    anchors.append((builtin_dir, _ROLE_FACTORY))
+    return tuple(anchors)
+
+
+def _classify_dir(path: Path, anchors: tuple[tuple[Path, str], ...]) -> str:
+    """Return the role for *path* ("Project", "Home", "Factory", …)."""
+    for anchor, role in anchors:
+        try:
+            if path == anchor or _is_relative_to(path, anchor):
+                return role
+        except Exception:
+            continue
+    return _ROLE_OTHER
+
+
+def _is_relative_to(path: Path, anchor: Path) -> bool:
+    """``Path.is_relative_to`` polyfill for Python 3.9 compatibility."""
+    try:
+        path.relative_to(anchor)
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _elide_path(path_str: str, anchors: tuple[tuple[Path, str], ...]) -> str:
+    """Replace the longest matching anchor prefix with its role label.
+
+    e.g. ``/.../jBOM/src/jbom/config/profiles/jlc.jbom.yaml`` becomes
+    ``Factory / jlc.jbom.yaml``.
+    """
+    if not path_str:
+        return ""
+    try:
+        target = Path(path_str)
+    except (ValueError, OSError):
+        return path_str
+    for anchor, role in anchors:
+        try:
+            if _is_relative_to(target, anchor):
+                rel = target.relative_to(anchor)
+                return f"{role} / {rel}" if str(rel) != "." else role
+        except Exception:
+            continue
+    return path_str
+
+
+def invalidate_profile_snapshot() -> None:
+    """Clear the cached profile snapshot (test hook)."""
+    global _profile_cache
+    _profile_cache = None
+
+
+def _resolve_chain(
+    selected_fabricator: str, search_dirs: list[Path]
+) -> tuple[tuple[str, ...], str, tuple[str, ...]]:
+    """Walk the ``extends:`` chain for *selected_fabricator*.
+
+    Returns ``(chain_names, first_file, all_files)`` where ``chain_names`` is
+    the tuple of profile names (``child``, ``parent``, ``grandparent``, ...),
+    ``first_file`` is the file path of the named profile (the leftmost
+    entry), and ``all_files`` is the parallel tuple of file paths for every
+    entry in ``chain_names``.  Stops on cycles or missing parents.
+    """
+    if not selected_fabricator:
+        return (), "", ()
+
+    from jbom.config import unified as _unified
+
+    name = selected_fabricator.strip().lower()
+    visited: list[str] = []
+    files: list[str] = []
+    file_for_first = ""
+    while name and name not in visited:
+        path = _unified._find_named_profile_path(name, search_dirs)
+        if path is None:
+            break
+        visited.append(name)
+        files.append(str(path))
+        if not file_for_first:
+            file_for_first = str(path)
+        try:
+            data = _unified._load_yaml_mapping(path, context=f"profile {name!r}")
+        except Exception:
+            break
+        parent = data.get("extends")
+        if not isinstance(parent, str):
+            break
+        name = parent.strip().lower()
+    return tuple(visited), file_for_first, tuple(files)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle log (per-run collections retained for the KiCad session)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """One row in a lifecycle run."""
+
+    timestamp: str  # "HH:MM:SS"
+    stage: str
+    detail: str = ""
+
+
+@dataclass
+class LifecycleRun:
+    """One dialog invocation's chronological events."""
+
+    started_at: str  # "HH:MM:SS"
+    pcb_path: str = ""
+    events: list[LifecycleEvent] = field(default_factory=list)
+    ended_at: str | None = None
+
+
+_runs: list[LifecycleRun] = []
+_active_run: LifecycleRun | None = None
+
+
+def begin_run(*, pcb_path: str = "") -> LifecycleRun:
+    """Start a new lifecycle run.  Ends any prior un-finished run first."""
+    global _active_run
+    if _active_run is not None and _active_run.ended_at is None:
+        end_run()
+    run = LifecycleRun(started_at=_now(), pcb_path=pcb_path)
+    _runs.append(run)
+    if len(_runs) > _MAX_RETAINED_RUNS:
+        del _runs[: len(_runs) - _MAX_RETAINED_RUNS]
+    _active_run = run
+    return run
+
+
+def record_event(stage: str, detail: str = "") -> None:
+    """Append an event to the active run (no-op if no run is active)."""
+    if _active_run is None:
+        return
+    if len(_active_run.events) >= _MAX_EVENTS_PER_RUN:
+        return
+    _active_run.events.append(
+        LifecycleEvent(timestamp=_now(), stage=stage, detail=detail)
+    )
+
+
+def end_run() -> None:
+    """Mark the active run finished."""
+    global _active_run
+    if _active_run is None:
+        return
+    _active_run.ended_at = _now()
+    _active_run = None
+
+
+def get_runs() -> tuple[LifecycleRun, ...]:
+    """Return all retained runs (oldest first)."""
+    return tuple(_runs)
+
+
+def clear_runs() -> None:
+    """Clear all retained runs (test hook).  Also ends any active run."""
+    global _active_run
+    _runs.clear()
+    _active_run = None
+
+
+def _now() -> str:
+    return datetime.datetime.now().strftime("%H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Text rendering
+# ---------------------------------------------------------------------------
+
+
+def render_environment(env: EnvironmentSnapshot) -> str:
+    """Render the Environment section as plain text."""
+    lines = [
+        f"Mode:    {env.mode}",
+        f"Python:  {env.python_version}  ({env.platform}/{env.machine})",
+        f"Vendor:  {env.vendor_tag or '(none)'}",
+        f"Source:  {env.source_path}  ({env.source_mtime})",
+        f"Project: {env.project_dir or '(unset)'}",
+        f"JBOM_PROFILE_PATH: {env.profile_path_env or '(unset)'}",
+    ]
+    if env.inserted_sys_path:
+        lines.append("Inserted sys.path entries:")
+        for entry in env.inserted_sys_path:
+            lines.append(f"  - {entry}")
+    return "\n".join(lines)
+
+
+def render_profiles(snapshot: ProfileSnapshot) -> str:
+    """Render the Profile subsystem section as plain text."""
+    lines = ["Search dirs:"]
+    role_width = max(
+        (len(info.role) for info in snapshot.search_dirs),
+        default=len(_ROLE_FACTORY),
+    )
+    for info in snapshot.search_dirs:
+        mark = "\u2713" if info.exists else "\u2717"
+        missing = "  (missing)" if not info.exists else ""
+        lines.append(f"  {mark} {info.role.ljust(role_width)}  {info.path}{missing}")
+    lines.append("Discovered: " + (", ".join(snapshot.discovered_profiles) or "(none)"))
+    lines.append("Stanzas:")
+    width = max((len(name) for name, _ in snapshot.stanza_ids), default=0)
+    for name, ids in snapshot.stanza_ids:
+        formatted = ", ".join(ids) if ids else "(none)"
+        lines.append(f"  {name.ljust(width)}: {formatted}")
+    if snapshot.selected_fabricator:
+        if snapshot.chain_entries:
+            chain = " \u2192 ".join(
+                f"{role}:{name}" for role, name in snapshot.chain_entries
+            )
+        else:
+            chain = "(unresolved)"
+        lines.append(f"Selected: {snapshot.selected_fabricator}")
+        lines.append(f"  chain: {chain}")
+    lines.append(f"Fingerprint: {snapshot.fingerprint}")
+    return "\n".join(lines)
+
+
+def render_lifecycle(runs: Iterable[LifecycleRun]) -> str:
+    """Render every lifecycle run as plain text, oldest first."""
+    blocks: list[str] = []
+    runs_list = list(runs)
+    if not runs_list:
+        return "(no runs recorded)"
+    for index, run in enumerate(runs_list, start=1):
+        header = f"--- Run {index} \u2014 started {run.started_at}"
+        if run.ended_at:
+            header += f"  ended {run.ended_at}"
+        if run.pcb_path:
+            header += f"\n     pcb={run.pcb_path}"
+        block_lines = [header]
+        if not run.events:
+            block_lines.append("  (no events)")
+        else:
+            stage_width = max(len(e.stage) for e in run.events)
+            for event in run.events:
+                detail = f"  {event.detail}" if event.detail else ""
+                block_lines.append(
+                    f"  [{event.timestamp}] {event.stage.ljust(stage_width)}{detail}"
+                )
+        blocks.append("\n".join(block_lines))
+    return "\n".join(blocks)
+
+
+def render_text_report(
+    env: EnvironmentSnapshot,
+    profiles: ProfileSnapshot | None,
+    runs: Iterable[LifecycleRun],
+) -> str:
+    """Render the full plain-text diagnostic report for "Save log\u2026"."""
+    sections = [
+        "=== Environment ===",
+        render_environment(env),
+        "",
+        "=== Profile subsystem ===",
+        render_profiles(profiles) if profiles is not None else "(not yet captured)",
+        "",
+        "=== Lifecycle ===",
+        render_lifecycle(runs),
+    ]
+    return "\n".join(sections) + "\n"
+
+
+__all__ = [
+    "EnvironmentSnapshot",
+    "LifecycleEvent",
+    "LifecycleRun",
+    "ProfileSnapshot",
+    "SearchDirInfo",
+    "begin_run",
+    "capture_environment",
+    "capture_profile_snapshot",
+    "clear_runs",
+    "end_run",
+    "get_runs",
+    "invalidate_environment",
+    "invalidate_profile_snapshot",
+    "record_event",
+    "render_environment",
+    "render_lifecycle",
+    "render_profiles",
+    "render_text_report",
+]

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -54,12 +54,14 @@ Reference: ``docs/dev/development_notes/active/plugin_ux_storyboard.md``
 
 from __future__ import annotations
 
+from datetime import datetime
+import json
+import os
 import subprocess
 import sys
 import tempfile
 import threading
 import types
-import os
 from pathlib import Path
 
 import wx
@@ -118,8 +120,28 @@ class JBOMFabricationDialog(wx.Dialog):
                 os.environ["JBOM_PROJECT_DIR"] = str(Path(pcb_path).parent.resolve())
             except OSError:
                 os.environ["JBOM_PROJECT_DIR"] = str(Path(pcb_path).parent)
+        try:
+            from jbom.config.profile_search import clear_profile_eval_trace
+
+            clear_profile_eval_trace()
+        except Exception:
+            pass
+        # Start a new lifecycle run for this dialog invocation; events are
+        # appended via _record_event().  Runs are retained for the KiCad
+        # session lifetime so the developer can compare consecutive runs.
+        from jbom.plugin import diagnostics as _diag
+
+        _diag.begin_run(pcb_path=pcb_path)
+        _diag.record_event("dialog", "open")
         # _archive_preview is set by _build_input_panel; updated when template changes
         self._archive_preview: wx.StaticText | None = None
+        self._diag_notebook: wx.Notebook | None = None
+        self._diag_env_text: wx.TextCtrl | None = None
+        self._diag_profiles_text: wx.TextCtrl | None = None
+        self._diag_lifecycle_text: wx.TextCtrl | None = None
+        self._diag_save_btn: wx.Button | None = None
+        self._diag_refresh_btn: wx.Button | None = None
+        self._profile_eval_boot_error: str | None = None
 
         # Load persisted options; fall back to defaults when absent.
         from jbom.plugin.options import PluginOptions, load_options
@@ -177,10 +199,21 @@ class JBOMFabricationDialog(wx.Dialog):
         font.SetWeight(wx.FONTWEIGHT_BOLD)
         header.SetFont(font)
         sizer.Add(header, flag=wx.ALL, border=10)
+        load_stamp = wx.StaticText(
+            panel,
+            label=self._load_stamp_label(),
+            style=wx.ST_ELLIPSIZE_START,
+        )
+        load_stamp.SetToolTip(self._load_stamp_tooltip())
+        sizer.Add(
+            load_stamp,
+            flag=wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            border=10,
+        )
         sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
 
         # -- Project info grid -------------------------------------------
-        grid = wx.FlexGridSizer(rows=4, cols=2, vgap=4, hgap=8)
+        grid = wx.FlexGridSizer(rows=5, cols=2, vgap=4, hgap=8)
         grid.AddGrowableCol(1, 1)
 
         # Archive template (editable) + preview label
@@ -216,6 +249,7 @@ class JBOMFabricationDialog(wx.Dialog):
         self._fab_choice = wx.Choice(panel, choices=labels)
         self._fab_choice.SetSelection(self._fab_index_for(self._options.fabricator))
         fab_row.Add(self._fab_choice, proportion=1, flag=wx.EXPAND)
+        self._fab_choice.Bind(wx.EVT_CHOICE, self._on_fabricator_changed)
         config_btn = wx.Button(panel, label="Config\u2026", size=(60, -1))
         config_btn.Disable()  # placeholder — full viewer in a future release
         fab_row.Add(config_btn, flag=wx.LEFT, border=4)
@@ -240,6 +274,11 @@ class JBOMFabricationDialog(wx.Dialog):
 
         sizer.Add(grid, flag=wx.ALL | wx.EXPAND, border=10)
         sizer.Add(wx.StaticLine(panel), flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=8)
+
+        # Diagnostics notebook — hidden until the user enables debug mode.
+        # Replaces the old single "Profile eval" textbox with three tabs:
+        # Environment / Profiles / Lifecycle plus a Save log… button.
+        self._build_diagnostics_notebook(panel, sizer)
 
         # -- Checkboxes --------------------------------------------------
         check_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -287,6 +326,11 @@ class JBOMFabricationDialog(wx.Dialog):
         )
 
         self._cb_debug = _cb("Keep intermediate files (debug)", False)
+        self._cb_debug.SetToolTip(
+            "Keep intermediate files after generation and reveal the diagnostics "
+            "notebook (Environment / Profiles / Lifecycle) at the top of the dialog."
+        )
+        self._cb_debug.Bind(wx.EVT_CHECKBOX, self._on_debug_toggled)
 
         for cb in (
             self._cb_smd_only,
@@ -318,6 +362,125 @@ class JBOMFabricationDialog(wx.Dialog):
 
         panel.SetSizer(sizer)
         return panel
+
+    # ------------------------------------------------------------------
+    # Diagnostics notebook (Environment / Profiles / Lifecycle)
+    # ------------------------------------------------------------------
+
+    def _build_diagnostics_notebook(self, parent: wx.Panel, sizer: wx.BoxSizer) -> None:
+        """Construct the diagnostics notebook + Save log/Refresh buttons.
+
+        The notebook holds three read-only multiline TextCtrls (Environment,
+        Profiles, Lifecycle) plus a Save log… button.  Everything is hidden
+        on dialog open and revealed by toggling the debug checkbox.
+        """
+        self._diag_notebook = wx.Notebook(parent)
+        self._diag_notebook.SetMinSize((-1, 220))
+
+        def _make_tab(label: str) -> wx.TextCtrl:
+            tab = wx.Panel(self._diag_notebook)
+            tab_sizer = wx.BoxSizer(wx.VERTICAL)
+            text = wx.TextCtrl(
+                tab,
+                value="",
+                style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_DONTWRAP,
+            )
+            font = wx.Font(wx.FontInfo(10).Family(wx.FONTFAMILY_TELETYPE))
+            text.SetFont(font)
+            tab_sizer.Add(text, proportion=1, flag=wx.EXPAND)
+            tab.SetSizer(tab_sizer)
+            self._diag_notebook.AddPage(tab, label)
+            return text
+
+        self._diag_env_text = _make_tab("Environment")
+        self._diag_profiles_text = _make_tab("Profiles")
+        self._diag_lifecycle_text = _make_tab("Lifecycle")
+
+        btns = wx.BoxSizer(wx.HORIZONTAL)
+        self._diag_refresh_btn = wx.Button(parent, label="Refresh")
+        self._diag_refresh_btn.Bind(
+            wx.EVT_BUTTON, lambda _e: self._refresh_diagnostics()
+        )
+        self._diag_save_btn = wx.Button(parent, label="Save log\u2026")
+        self._diag_save_btn.Bind(wx.EVT_BUTTON, self._on_save_log)
+        btns.AddStretchSpacer(1)
+        btns.Add(self._diag_refresh_btn, flag=wx.RIGHT, border=4)
+        btns.Add(self._diag_save_btn)
+
+        sizer.Add(
+            self._diag_notebook,
+            flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            border=10,
+        )
+        sizer.Add(btns, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border=10)
+
+        self._diag_notebook.Hide()
+        self._diag_refresh_btn.Hide()
+        self._diag_save_btn.Hide()
+
+    def _refresh_diagnostics(self) -> None:
+        """Repopulate all three diagnostics tabs from the diagnostics module."""
+        if self._diag_env_text is None:
+            return
+        try:
+            from jbom.plugin import diagnostics as _diag
+        except Exception as exc:  # pragma: no cover
+            self._diag_env_text.SetValue(f"(diagnostics module unavailable: {exc})")
+            return
+
+        env = _diag.capture_environment()
+        env_text = _diag.render_environment(env)
+        if self._profile_eval_boot_error:
+            env_text += (
+                f"\n\nFabricator load error during dialog open:\n  "
+                f"{self._profile_eval_boot_error}"
+            )
+        self._diag_env_text.SetValue(env_text)
+
+        snapshot: object | None = None
+        try:
+            snapshot = _diag.capture_profile_snapshot(self._selected_fabricator_id())
+            self._diag_profiles_text.SetValue(_diag.render_profiles(snapshot))
+        except Exception as exc:
+            self._diag_profiles_text.SetValue(f"(profile snapshot unavailable: {exc})")
+
+        self._diag_lifecycle_text.SetValue(_diag.render_lifecycle(_diag.get_runs()))
+        # Auto-scroll Lifecycle to the most recent event.
+        self._diag_lifecycle_text.ShowPosition(
+            self._diag_lifecycle_text.GetLastPosition()
+        )
+
+    def _on_save_log(self, _evt: wx.CommandEvent) -> None:
+        """Prompt for a path and write the full text report to disk."""
+        try:
+            from jbom.plugin import diagnostics as _diag
+        except Exception:  # pragma: no cover
+            return
+
+        default_name = datetime.now().strftime("jbom-diagnostics-%Y%m%d-%H%M%S.txt")
+        with wx.FileDialog(
+            self,
+            message="Save diagnostics log",
+            defaultDir=str(Path(self._pcb_path).parent) if self._pcb_path else "",
+            defaultFile=default_name,
+            wildcard="Text files (*.txt)|*.txt|All files (*.*)|*.*",
+            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+        ) as dlg:
+            if dlg.ShowModal() != wx.ID_OK:
+                return
+            target = Path(dlg.GetPath())
+
+        env = _diag.capture_environment()
+        try:
+            snapshot = _diag.capture_profile_snapshot(self._selected_fabricator_id())
+        except Exception:
+            snapshot = None
+        report = _diag.render_text_report(env, snapshot, _diag.get_runs())
+        try:
+            target.write_text(report, encoding="utf-8")
+            _diag.record_event("diag", f"saved log to {target}")
+        except OSError as exc:
+            _diag.record_event("diag", f"save log failed: {exc}")
 
     # ------------------------------------------------------------------
     # Progress panel
@@ -383,6 +546,7 @@ class JBOMFabricationDialog(wx.Dialog):
         except Exception as _exc:  # pragma: no cover
             # Surface the error in the archive label so it is visible in KiCad.
             self._archive_name = f"(config error: {_exc})"
+            self._profile_eval_boot_error = str(_exc)
             pairs = [("generic", "Generic")]
         ids = [fid for fid, _ in pairs]
         labels = [name for _, name in pairs]
@@ -402,9 +566,89 @@ class JBOMFabricationDialog(wx.Dialog):
             return self._fab_ids[idx]
         return "generic"
 
+    def _load_stamp_label(self) -> str:
+        """Return a concise visible load stamp for manual plugin debugging."""
+        source_file = Path(__file__).resolve()
+        try:
+            timestamp = datetime.fromtimestamp(source_file.stat().st_mtime).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+        except OSError:
+            timestamp = "unknown"
+        pyver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        info = self._read_bootstrap_info()
+        mode = str(info.get("mode", "pcm")) if info else "pcm"
+        return f"Load stamp: {timestamp}  •  py {pyver}  •  {mode}"
+
+    def _load_stamp_tooltip(self) -> str:
+        """Return detailed source/bootstrap information for the load stamp.
+
+        Production tooltip is intentionally terse — just the source file path —
+        because bootstrap path details only meaningfully exist when the user
+        launched KiCad with ``JBOM_PLUGIN_DEBUG=1``.  When that env var is set,
+        the platform tag and inserted ``sys.path`` entries are appended.
+        """
+        source_file = Path(__file__).resolve()
+        lines = [f"Source: {source_file}"]
+        info = self._read_bootstrap_info()
+        if info:
+            tag = info.get("tag") or "(no compiled-dep vendor dir selected)"
+            inserted = info.get("inserted") or []
+            lines.append(f"Vendor tag: {tag}")
+            if inserted:
+                lines.append("Inserted sys.path entries:")
+                lines.extend(f"  - {entry}" for entry in inserted)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _read_bootstrap_info() -> dict[str, object] | None:
+        """Parse ``JBOM_PLUGIN_BOOTSTRAP_INFO`` JSON written by the bootstrap.
+
+        The bootstrap only writes this env var when ``JBOM_PLUGIN_DEBUG=1``,
+        so absence is the production-default case and is not an error.
+        """
+        raw = os.environ.get("JBOM_PLUGIN_BOOTSTRAP_INFO", "").strip()
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
     # ------------------------------------------------------------------
     # Event handlers — input panel
     # ------------------------------------------------------------------
+
+    def _on_debug_toggled(self, _evt: wx.CommandEvent) -> None:
+        """Show/hide the diagnostics notebook with the debug checkbox."""
+        show = self._cb_debug.GetValue()
+        for widget in (
+            self._diag_notebook,
+            self._diag_refresh_btn,
+            self._diag_save_btn,
+        ):
+            if widget is not None:
+                widget.Show(show)
+        if show:
+            self._refresh_diagnostics()
+        sizer = self.GetSizer()
+        if sizer is not None:
+            sizer.Layout()
+            sizer.Fit(self)
+
+    def _on_fabricator_changed(self, _evt: wx.CommandEvent) -> None:
+        """Record fabricator selection changes and refresh diagnostics."""
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event(
+                "fabricator", f"selected={self._selected_fabricator_id()}"
+            )
+        except Exception:
+            pass
+        if self._cb_debug is not None and self._cb_debug.GetValue():
+            self._refresh_diagnostics()
 
     def _on_archive_template_changed(self, _evt: wx.CommandEvent) -> None:
         """Re-expand the template and update the preview + archive_name.
@@ -454,6 +698,12 @@ class JBOMFabricationDialog(wx.Dialog):
         """Validate, save options, fill zones if requested, then start the thread."""
         # Capture all UI values on the main thread before the worker starts.
         fab_id = self._selected_fabricator_id()
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event("generate", f"fab={fab_id}")
+        except Exception:
+            pass
         inventory_path = self._inv_text.GetValue().strip()
         smd_only = self._cb_smd_only.GetValue()
         do_backup = self._cb_backup.GetValue()
@@ -704,6 +954,12 @@ class JBOMFabricationDialog(wx.Dialog):
 
     def _on_step(self, step: str, status: str) -> None:
         """Update the gauge for *step*; called via ``wx.CallAfter`` from thread."""
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event(step, status)
+        except Exception:
+            pass
         if step not in self._gauges:
             return
         gauge = self._gauges[step]
@@ -730,6 +986,15 @@ class JBOMFabricationDialog(wx.Dialog):
 
         diagnostics = getattr(result, "diagnostics", ())
         production_dir = getattr(result, "production_dir", None)
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event(
+                "complete",
+                f"production_dir={production_dir or '(none)'} diagnostics={len(diagnostics)}",
+            )
+        except Exception:
+            pass
 
         # Distinguish errors (no artifacts produced — production_dir is None)
         # from info-level diagnostics.  Stay open when there was an actual
@@ -772,6 +1037,12 @@ class JBOMFabricationDialog(wx.Dialog):
 
     def _on_error(self, message: str) -> None:
         """Handle unexpected thread exception; called via ``wx.CallAfter``."""
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event("error", message)
+        except Exception:
+            pass
         self._diag_text.SetValue(f"Error: {message}")
         self._diag_text.Show()
         self._progress_cancel_btn.SetLabel("Close")
@@ -804,6 +1075,13 @@ class JBOMFabricationDialog(wx.Dialog):
         Mirrors Fabrication-Toolkit's ``updateDisplay`` which always calls
         ``pcbnew.Refresh()`` before ``self.Destroy()``.
         """
+        try:
+            from jbom.plugin import diagnostics as _diag
+
+            _diag.record_event("dialog", "close")
+            _diag.end_run()
+        except Exception:
+            pass
         try:
             import pcbnew  # noqa: PLC0415
 

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -59,6 +59,7 @@ import sys
 import tempfile
 import threading
 import types
+import os
 from pathlib import Path
 
 import wx
@@ -112,6 +113,11 @@ class JBOMFabricationDialog(wx.Dialog):
         self._fab_ids: list[str] = []
         self._gauges: dict[str, wx.Gauge] = {}
         self._status_texts: dict[str, wx.StaticText] = {}
+        if pcb_path:
+            try:
+                os.environ["JBOM_PROJECT_DIR"] = str(Path(pcb_path).parent.resolve())
+            except OSError:
+                os.environ["JBOM_PROJECT_DIR"] = str(Path(pcb_path).parent)
         # _archive_preview is set by _build_input_panel; updated when template changes
         self._archive_preview: wx.StaticText | None = None
 

--- a/tests/plugin/test_diagnostics.py
+++ b/tests/plugin/test_diagnostics.py
@@ -1,0 +1,243 @@
+"""Tests for ``jbom.plugin.diagnostics`` (wx-free)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from jbom.plugin import diagnostics as diag
+
+
+@pytest.fixture(autouse=True)
+def _reset_diagnostics_state() -> None:
+    """Ensure each test sees a clean diagnostics module."""
+    diag.clear_runs()
+    diag.invalidate_environment()
+    diag.invalidate_profile_snapshot()
+    yield
+    diag.clear_runs()
+    diag.invalidate_environment()
+    diag.invalidate_profile_snapshot()
+
+
+# ---------------------------------------------------------------------------
+# Environment snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_environment_snapshot_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated calls return the same instance until invalidated."""
+    monkeypatch.delenv("JBOM_PLUGIN_BOOTSTRAP_INFO", raising=False)
+    snap1 = diag.capture_environment()
+    snap2 = diag.capture_environment()
+    assert snap1 is snap2
+    diag.invalidate_environment()
+    snap3 = diag.capture_environment()
+    assert snap3 is not snap1
+
+
+def test_environment_reads_bootstrap_info_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When ``JBOM_PLUGIN_BOOTSTRAP_INFO`` is set, fields are populated from it."""
+    info = {
+        "mode": "pcm",
+        "tag": "cp39-macosx_arm64",
+        "this_dir": str(tmp_path),
+        "src_dir": str(tmp_path.parent),
+        "inserted": [str(tmp_path / "_vendor")],
+    }
+    monkeypatch.setenv("JBOM_PLUGIN_BOOTSTRAP_INFO", json.dumps(info))
+    snap = diag.capture_environment(force=True)
+    assert snap.mode == "pcm"
+    assert snap.vendor_tag == "cp39-macosx_arm64"
+    assert snap.source_path == str(tmp_path)
+    assert snap.inserted_sys_path == (str(tmp_path / "_vendor"),)
+
+
+def test_environment_handles_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed bootstrap JSON does not raise; fields fall back to defaults."""
+    monkeypatch.setenv("JBOM_PLUGIN_BOOTSTRAP_INFO", "not-json")
+    snap = diag.capture_environment(force=True)
+    assert snap.mode == "unknown"
+    assert snap.vendor_tag is None
+
+
+# ---------------------------------------------------------------------------
+# Profile snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_profile_snapshot_cached_by_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated calls without file changes return the cached snapshot."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    (project_jbom / "jlc.jbom.yaml").write_text("fab:\n  name: JLC\n", encoding="utf-8")
+
+    snap1 = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    snap2 = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    assert snap1 is snap2
+    assert "jlc" in snap1.discovered_profiles
+    # fab stanza should include jlc
+    stanzas = dict(snap1.stanza_ids)
+    assert "jlc" in stanzas["fab"]
+
+
+def test_profile_snapshot_rebuilds_when_file_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Editing a profile file invalidates the cached snapshot fingerprint."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    target = project_jbom / "jlc.jbom.yaml"
+    target.write_text("fab:\n  name: JLC\n", encoding="utf-8")
+
+    snap1 = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    # Force a mtime change by writing different content with a bumped timestamp.
+    target.write_text("fab:\n  name: JLC v2\n", encoding="utf-8")
+    new_mtime = target.stat().st_mtime + 1.0
+    os.utime(target, (new_mtime, new_mtime))
+    snap2 = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    assert snap1.fingerprint != snap2.fingerprint
+
+
+def test_profile_snapshot_renders_search_dirs_and_stanzas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rendered text exposes search dirs, stanzas, and the selected chain."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    (project_jbom / "jlc.jbom.yaml").write_text(
+        "extends: generic\nfab:\n  name: JLC\n", encoding="utf-8"
+    )
+    snap = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    text = diag.render_profiles(snap)
+    assert "Search dirs:" in text
+    assert "Stanzas:" in text
+    assert "jlc" in text
+    assert "Fingerprint:" in text
+
+
+def test_profile_snapshot_classifies_project_and_factory_roles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project ``.jbom`` and the built-in profiles dir get role-tagged."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    (project_jbom / "jlc.jbom.yaml").write_text("fab:\n  name: JLC\n", encoding="utf-8")
+    snap = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    roles = {info.role for info in snap.search_dirs}
+    assert "Project" in roles
+    assert "Factory" in roles
+    # The first chain entry is the named profile, role-tagged Project.
+    assert snap.chain_entries[0] == ("Project", "jlc")
+
+
+def test_profile_snapshot_chain_appends_common_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The chain enumerates extends ancestors then every ``common.jbom.yaml``."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    (project_jbom / "common.jbom.yaml").write_text("defaults: {}\n", encoding="utf-8")
+    (project_jbom / "jlc.jbom.yaml").write_text("fab:\n  name: JLC\n", encoding="utf-8")
+    snap = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    # Named profile first, then the project's common.jbom.yaml.
+    assert snap.chain_entries[0] == ("Project", "jlc")
+    assert ("Project", "common") in snap.chain_entries
+    text = diag.render_profiles(snap)
+    assert "chain: Project:jlc \u2192 Project:common" in text
+
+
+def test_profile_snapshot_chain_omits_unresolvable_extends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a profile extends a missing parent, the chain truncates cleanly."""
+    monkeypatch.chdir(tmp_path)
+    project_jbom = tmp_path / ".jbom"
+    project_jbom.mkdir()
+    (project_jbom / "jlc.jbom.yaml").write_text(
+        "extends: nonexistent\nfab:\n  name: JLC\n", encoding="utf-8"
+    )
+    snap = diag.capture_profile_snapshot("jlc", cwd=tmp_path)
+    names = [name for _role, name in snap.chain_entries if name != "common"]
+    assert names == ["jlc"]
+
+
+def test_lifecycle_records_events_in_active_run() -> None:
+    """Events are appended to the active run; no run = no recording."""
+    diag.record_event("ignored", "no active run")  # should not crash
+    assert diag.get_runs() == ()
+
+    diag.begin_run(pcb_path="/tmp/foo.kicad_pcb")
+    diag.record_event("dialog", "open")
+    diag.record_event("generate", "fab=jlc")
+    diag.end_run()
+
+    runs = diag.get_runs()
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.pcb_path == "/tmp/foo.kicad_pcb"
+    assert run.ended_at is not None
+    assert [e.stage for e in run.events] == ["dialog", "generate"]
+
+
+def test_lifecycle_retains_multiple_runs() -> None:
+    """Each begin_run() appends a new run; prior runs are retained."""
+    diag.begin_run(pcb_path="/tmp/a.kicad_pcb")
+    diag.record_event("dialog", "open")
+    diag.end_run()
+
+    diag.begin_run(pcb_path="/tmp/b.kicad_pcb")
+    diag.record_event("dialog", "open")
+    diag.end_run()
+
+    runs = diag.get_runs()
+    assert len(runs) == 2
+    assert runs[0].pcb_path.endswith("a.kicad_pcb")
+    assert runs[1].pcb_path.endswith("b.kicad_pcb")
+
+
+def test_lifecycle_caps_retained_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Oldest runs are dropped when the retention cap is exceeded."""
+    monkeypatch.setattr(diag, "_MAX_RETAINED_RUNS", 3)
+    for index in range(5):
+        diag.begin_run(pcb_path=f"/tmp/{index}.kicad_pcb")
+        diag.end_run()
+    runs = diag.get_runs()
+    assert len(runs) == 3
+    assert runs[0].pcb_path.endswith("2.kicad_pcb")
+    assert runs[-1].pcb_path.endswith("4.kicad_pcb")
+
+
+def test_render_lifecycle_handles_no_runs() -> None:
+    """Empty run list renders a friendly placeholder string."""
+    assert diag.render_lifecycle(()) == "(no runs recorded)"
+
+
+def test_render_text_report_combines_all_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``render_text_report`` emits the three section headers."""
+    monkeypatch.delenv("JBOM_PLUGIN_BOOTSTRAP_INFO", raising=False)
+    env = diag.capture_environment(force=True)
+
+    diag.begin_run(pcb_path="/tmp/x.kicad_pcb")
+    diag.record_event("dialog", "open")
+    diag.end_run()
+
+    report = diag.render_text_report(env, None, diag.get_runs())
+    assert "=== Environment ===" in report
+    assert "=== Profile subsystem ===" in report
+    assert "=== Lifecycle ===" in report
+    assert "/tmp/x.kicad_pcb" in report

--- a/tests/plugin/test_plugin_guard.py
+++ b/tests/plugin/test_plugin_guard.py
@@ -132,3 +132,125 @@ class TestOptionsModuleImportable:
         assert PluginOptions is not None
         assert load_options is not None
         assert save_options is not None
+
+
+# ---------------------------------------------------------------------------
+# Vendor-folder tag selector (platform-aware bootstrap)
+# ---------------------------------------------------------------------------
+
+
+import pytest  # noqa: E402 — grouped with class below intentionally
+import types  # noqa: E402
+
+
+def _fake_version_info(major: int, minor: int, micro: int = 0) -> types.SimpleNamespace:
+    """Build a stand-in for ``sys.version_info`` that exposes major/minor.
+
+    ``sys.version_info`` is a ``structseq`` and cannot be constructed via the
+    normal type call, so tests substitute a ``SimpleNamespace`` with the
+    attributes our bootstrap actually reads.
+    """
+    return types.SimpleNamespace(major=major, minor=minor, micro=micro)
+
+
+class TestVendorFolderTagSelector:
+    """`_vendor_folder_tag` selects the right `<py>-<plat>` directory."""
+
+    @pytest.mark.parametrize(
+        "platform_name, machine, version_info, expected",
+        [
+            ("darwin", "arm64", (3, 9, 13), "cp39-macosx_arm64"),
+            ("darwin", "x86_64", (3, 9, 13), "cp39-macosx_x86_64"),
+            ("darwin", "arm64", (3, 12, 1), "cp312-macosx_arm64"),
+            ("linux", "x86_64", (3, 9, 18), "cp39-manylinux_x86_64"),
+            ("linux", "aarch64", (3, 12, 2), "cp312-manylinux_aarch64"),
+            ("win32", "AMD64", (3, 9, 13), "cp39-win_amd64"),
+            ("win32", "AMD64", (3, 12, 1), "cp312-win_amd64"),
+        ],
+    )
+    def test_known_targets_select_expected_folder(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        platform_name: str,
+        machine: str,
+        version_info: tuple[int, int, int],
+        expected: str,
+    ) -> None:
+        """Each supported (py, os, arch) combo maps to its vendor folder."""
+        import platform as _platform
+
+        import jbom.plugin as _mod
+
+        monkeypatch.setattr(_mod.sys, "platform", platform_name)
+        monkeypatch.setattr(_mod.sys, "version_info", _fake_version_info(*version_info))
+        monkeypatch.setattr(_platform, "machine", lambda: machine)
+        assert _mod._vendor_folder_tag() == expected
+
+    def test_unsupported_platform_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Solaris/BSD/etc. are not in the supported matrix and return None."""
+        import platform as _platform
+
+        import jbom.plugin as _mod
+
+        monkeypatch.setattr(_mod.sys, "platform", "sunos5")
+        monkeypatch.setattr(_platform, "machine", lambda: "sparc")
+        assert _mod._vendor_folder_tag() is None
+
+    def test_pydantic_core_path_returns_none_when_vendor_missing(
+        self, tmp_path
+    ) -> None:
+        """Absent ``_vendor/`` directory yields None, not a crash."""
+        import jbom.plugin as _mod
+
+        assert _mod._vendor_pydantic_core_path(tmp_path) is None
+
+    def test_pydantic_core_path_prefers_exact_tag_match(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exact `<tag>` directory wins over the fallback scan."""
+        import platform as _platform
+
+        import jbom.plugin as _mod
+
+        monkeypatch.setattr(_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(_mod.sys, "version_info", _fake_version_info(3, 9, 13))
+        monkeypatch.setattr(_platform, "machine", lambda: "arm64")
+
+        vendor = tmp_path / "_vendor" / "pydantic_core"
+        good = vendor / "cp39-macosx_arm64" / "pydantic_core"
+        good.mkdir(parents=True)
+        (good / "__init__.py").write_text("", encoding="utf-8")
+        # A wrong-target dir must NOT be picked when the exact tag exists.
+        wrong = vendor / "cp312-win_amd64" / "pydantic_core"
+        wrong.mkdir(parents=True)
+        (wrong / "__init__.py").write_text("", encoding="utf-8")
+
+        result = _mod._vendor_pydantic_core_path(tmp_path)
+        assert result == vendor / "cp39-macosx_arm64"
+
+    def test_pydantic_core_path_falls_back_to_local_dir(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--skip-binary-fetch` builds use a ``local_*`` folder; we still pick it."""
+        import platform as _platform
+
+        import jbom.plugin as _mod
+
+        monkeypatch.setattr(_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(_mod.sys, "version_info", _fake_version_info(3, 9, 13))
+        # Force tag lookup to miss by reporting an arch we did not vendor.
+        monkeypatch.setattr(_platform, "machine", lambda: "riscv64")
+
+        local = (
+            tmp_path
+            / "_vendor"
+            / "pydantic_core"
+            / "cp39-local_darwin"
+            / "pydantic_core"
+        )
+        local.mkdir(parents=True)
+        (local / "__init__.py").write_text("", encoding="utf-8")
+        result = _mod._vendor_pydantic_core_path(tmp_path)
+        assert result == local.parent

--- a/tests/unit/test_build_pcm_package.py
+++ b/tests/unit/test_build_pcm_package.py
@@ -1,0 +1,131 @@
+"""Integration smoke tests for ``scripts/build_pcm_package.py``.
+
+These tests exercise the build script with ``--skip-binary-fetch`` so they
+run without network access.  They verify the resulting archive layout
+matches expectations:
+
+* ``plugins/__init__.py`` and the rest of the plugin adapter are present.
+* ``plugins/jbom/`` contains the vendored core (no ``plugin/`` subdir).
+* Pure-Python deps live at ``plugins/<name>/`` (e.g. ``plugins/pydantic/``).
+* The compiled-deps layout exists at ``plugins/_vendor/pydantic_core/<tag>/``.
+* ``metadata.json`` is present at the archive root.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _import_build_module():
+    """Import the build script as a module.
+
+    ``@dataclass`` resolves type hints via ``sys.modules[cls.__module__]``
+    during class construction, so the module must be registered in
+    ``sys.modules`` *before* ``exec_module`` runs — otherwise the class body
+    blows up with an AttributeError.
+    """
+    module_name = "build_pcm_package"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        _REPO_ROOT / "scripts" / "build_pcm_package.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+@pytest.fixture(scope="module")
+def build_module():
+    return _import_build_module()
+
+
+def _have_all_pure_py_deps(build_module) -> bool:
+    """Check that every pure-Python vendored package is importable."""
+    for name in build_module._PURE_PY_VENDOR_PACKAGES:
+        if importlib.util.find_spec(name) is None:
+            return False
+    if importlib.util.find_spec("pydantic_core") is None:
+        return False
+    return True
+
+
+def test_read_pinned_version_returns_pydantic_core(build_module) -> None:
+    """`_read_pinned_version` parses the requirements manifest correctly."""
+    version = build_module._read_pinned_version("pydantic_core")
+    assert version
+    assert version[0].isdigit()
+
+
+def test_read_pinned_version_raises_for_unknown_package(build_module) -> None:
+    """Unknown packages raise a clear error rather than silently returning ''."""
+    with pytest.raises(RuntimeError):
+        build_module._read_pinned_version("definitely-not-a-real-package")
+
+
+def test_skip_binary_fetch_build_produces_expected_layout(
+    tmp_path: Path, build_module
+) -> None:
+    """``build(..., skip_binary_fetch=True)`` writes a PCM-shaped archive.
+
+    Skipped when the build host does not have all pure-Python vendored
+    packages installed (pure-CI environments may lack pyyaml/sexpdata).
+    """
+    if not _have_all_pure_py_deps(build_module):
+        pytest.skip("vendored dependencies not installed on build host")
+
+    output_dir = tmp_path / "dist"
+    archive = build_module.build(output_dir, skip_binary_fetch=True)
+    assert archive.is_file()
+
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = set(zf.namelist())
+
+    # Plugin adapter files
+    assert "plugins/__init__.py" in names
+    assert "plugins/plugin.py" in names
+    assert "plugins/dialog.py" in names
+    assert "plugins/options.py" in names
+
+    # Vendored core
+    assert "plugins/jbom/__init__.py" in names
+    # No plugin/ recursion inside the vendored copy
+    assert not any(n.startswith("plugins/jbom/plugin/") for n in names)
+
+    # Pure-Python vendored deps
+    assert any(n.startswith("plugins/pydantic/") for n in names)
+    assert any(n.startswith("plugins/yaml/") for n in names)
+    assert "plugins/typing_extensions.py" in names
+    assert any(n.startswith("plugins/annotated_types/") for n in names)
+    # Plugin __init__.py must remain the bootstrap, not be clobbered by deps.
+    with zipfile.ZipFile(archive, "r") as zf:
+        init_bytes = zf.read("plugins/__init__.py")
+    assert b"_vendor_pydantic_core_path" in init_bytes, (
+        "plugins/__init__.py appears to have been clobbered by a vendored "
+        "dependency’s __init__.py"
+    )
+
+    # Compiled-deps fallback layout: plugins/_vendor/pydantic_core/<tag>/pydantic_core/...
+    vendor_paths = [n for n in names if n.startswith("plugins/_vendor/pydantic_core/")]
+    assert vendor_paths, "expected --skip-binary-fetch to vendor local pydantic_core"
+    inner = [
+        p
+        for p in vendor_paths
+        if "/pydantic_core/" in p[len("plugins/_vendor/pydantic_core/") :]
+    ]
+    assert inner, "vendored pydantic_core must contain a pydantic_core/ subdir"
+
+    # Metadata
+    assert "metadata.json" in names

--- a/tests/unit/test_profile_search.py
+++ b/tests/unit/test_profile_search.py
@@ -100,6 +100,21 @@ def test_profile_search_dirs_starts_with_cwd_jbom(tmp_path: Path) -> None:
     assert dirs[0] == tmp_path / ".jbom"
 
 
+def test_profile_search_dirs_falls_back_when_cwd_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If Path.cwd() is unavailable, search should fall back to home/.jbom."""
+
+    def _raise_cwd() -> Path:
+        raise FileNotFoundError("cwd unavailable")
+
+    monkeypatch.setattr("jbom.config.profile_search.Path.cwd", _raise_cwd)
+    monkeypatch.setattr("jbom.config.profile_search.Path.home", lambda: tmp_path)
+
+    dirs = profile_search_dirs()
+    assert dirs[0] == tmp_path / ".jbom"
+
+
 def test_find_repo_root_walks_up(tmp_path: Path) -> None:
     """_find_repo_root should walk up to find .git/."""
     from jbom.config.profile_search import _find_repo_root

--- a/tests/unit/test_profile_search.py
+++ b/tests/unit/test_profile_search.py
@@ -176,3 +176,37 @@ def test_find_profile_multiple_env_paths(
 
     result = find_profile("org", cwd=tmp_path / "project")
     assert result == dir_b / "org.jbom.yaml"
+
+
+def test_record_profile_eval_quiet_by_default(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``record_profile_eval`` must not print to stdout in production mode."""
+    from jbom.config.profile_search import (
+        clear_profile_eval_trace,
+        get_profile_eval_trace,
+        record_profile_eval,
+    )
+
+    monkeypatch.delenv("JBOM_PROFILE_EVAL_VERBOSE", raising=False)
+    clear_profile_eval_trace()
+    record_profile_eval("silent-line")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "silent-line" in get_profile_eval_trace()
+
+
+def test_record_profile_eval_verbose_env_var_enables_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Setting ``JBOM_PROFILE_EVAL_VERBOSE=1`` re-enables stdout output."""
+    from jbom.config.profile_search import (
+        clear_profile_eval_trace,
+        record_profile_eval,
+    )
+
+    monkeypatch.setenv("JBOM_PROFILE_EVAL_VERBOSE", "1")
+    clear_profile_eval_trace()
+    record_profile_eval("loud-line")
+    captured = capsys.readouterr()
+    assert "loud-line" in captured.out

--- a/tests/unit/test_profile_search.py
+++ b/tests/unit/test_profile_search.py
@@ -115,6 +115,24 @@ def test_profile_search_dirs_falls_back_when_cwd_unavailable(
     assert dirs[0] == tmp_path / ".jbom"
 
 
+def test_profile_search_dirs_uses_plugin_project_dir_when_cwd_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If Path.cwd() fails, plugin project context should be used first."""
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    def _raise_cwd() -> Path:
+        raise FileNotFoundError("cwd unavailable")
+
+    monkeypatch.setattr("jbom.config.profile_search.Path.cwd", _raise_cwd)
+    monkeypatch.setenv("JBOM_PROJECT_DIR", str(project_dir))
+
+    dirs = profile_search_dirs()
+    assert dirs[0] == project_dir / ".jbom"
+
+
 def test_find_repo_root_walks_up(tmp_path: Path) -> None:
     """_find_repo_root should walk up to find .git/."""
     from jbom.config.profile_search import _find_repo_root


### PR DESCRIPTION
## Summary

Turns the jBOM KiCad plugin into a true PCM-installable artifact that works on every supported (Python, OS, CPU) target out of the box, and replaces the original single-textbox profile-eval panel with a structured diagnostics notebook the user can save for bug reports.

Two earlier defensive-coding fixes that landed on this branch (`2d60e49`, `bf97baf`) are carried along; they pre-date the planning round but belong here.

## Issue closures

Closes #275 — single-invocation lifecycle stuck after first dialog close.
Closes #276 — tolerate unavailable cwd during profile discovery.
Closes #277 — use project-dir context when cwd is unavailable.
Closes #278 — platform-aware PCM bootstrap with multi-platform pydantic_core vendoring.
Closes #279 — structured diagnostics panel (Environment / Profiles / Lifecycle + Save log).
Closes #285 — raise PCM minimum kicad_version to 9.0.
Closes #286 — silence profile-eval prints unless JBOM_PROFILE_EVAL_VERBOSE=1.

## Commits

1. `chore(build): pin vendored runtime deps and add multi-platform pydantic_core fetch` — `scripts/_vendor_requirements.txt` + matrix wheel fetch in `scripts/build_pcm_package.py` (`pip download --platform=... --abi=...` for cp39 + cp312 × mac/linux/win), `--skip-binary-fetch` flag for offline iteration.
2. `feat(plugin): platform-aware bootstrap selects matching pydantic_core` — runtime selector that maps the active interpreter to the right `_vendor/pydantic_core/<tag>/`; drops dev-loop homebrew/user-site probing in favour of explicit `JBOM_PLUGIN_PYTHON_DEPS_DIR` opt-in; bootstrap details published into `JBOM_PLUGIN_BOOTSTRAP_INFO` JSON env var when `JBOM_PLUGIN_DEBUG=1`.
3. `chore(config): silence profile-eval prints; preserve unified.profile_search_dirs surface` — `record_profile_eval` keeps the ring buffer but only `print`s when `JBOM_PROFILE_EVAL_VERBOSE=1`; `unified` re-exports `profile_search_dirs` so tests can monkeypatch the legacy name.
4. `feat(plugin): structured diagnostics module (Environment / Profiles / Lifecycle)` — new wx-free `jbom.plugin.diagnostics` plus 14 unit tests.  The Profiles chain reads `Project:jlc → Factory:common` and is fingerprint-cached over `*.jbom.yaml` so repeat dialog opens rebuild only when a profile file changes.
5. `feat(plugin): diagnostics notebook + Save log; consume bootstrap info` — replaces the old single TextCtrl with a `wx.Notebook` (Environment / Profiles / Lifecycle), adds Save log… button, hooks lifecycle events at every dialog/worker transition.  Also retains the parent=None + `pcbnew.Refresh()` before `Destroy()` lifecycle that fixed the single-invocation bug.
6. `test(plugin): platform-tag selector coverage and PCM build-script smoke` — parametrized tests for the vendor-folder tag selector across every supported (py, os, arch); `tests/unit/test_build_pcm_package.py` smoke-builds an archive with `--skip-binary-fetch` and checks layout + regression that `plugins/__init__.py` is not clobbered by a vendored dep.
7. `chore(meta): raise PCM minimum kicad_version to 9.0; document the cutover` — `metadata.json` floor bump + `docs/CHANGELOG.md` entry.

Plus the two earlier commits `fix(config): tolerate unavailable cwd during profile discovery` (#276) and `fix(plugin): use project-dir context when cwd is unavailable` (#277) — defensive coding from the same debug dive.

## Tests

148 focused tests pass (`tests/plugin`, `tests/unit/test_profile_search`, `tests/unit/test_unified_loader`, `tests/unit/test_fabricator_config_schema`, `tests/unit/test_build_pcm_package`, `tests/test_fabricators`, `tests/test_project_context`).  `pre-commit` (trailing-whitespace, EOF, JSON, mixed-line-endings, black, flake8, bandit) is clean on every touched file.

## Out of scope (tracked separately)

* DRY refactor extracting shared PCB-resolve/board-read/per-reference-context plumbing for BOM + POS → #280.
* BOM workflow PCB-first cutover → #281.
* Finish the `s:`/`p:`/`i:`/`a:` → `sch:`/`pcb:`/`inv:`/`ann:` rename on the data side → #282.
* CLI `jbom fab --archive-name` parity with the plugin → #287.

These four will land as one follow-up PR.

## Plan artefacts

* Plan: [Production-ready jBOM PCM plugin: vendored deps + bootstrap cleanup](https://app.warp.dev/drive/notebook/Epsam62kG8q3ODOxsK22Ms)
* Plan (follow-up): [PCB-first BOM workflow + finish the s:/p: → sch:/pcb: rename](https://app.warp.dev/drive/notebook/CEo9F1R3WTlrytELFlvaHG)
* Conversation: https://app.warp.dev/conversation/faa8eb75-7ea7-4fb8-815c-c90c1cdb0a94

Co-Authored-By: Oz <oz-agent@warp.dev>