### PR TITLE
Docs: add designator case preservation policy (issue #292)

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -575,6 +575,22 @@ jbom audit ./my_project --supplier mouser --api-key YOUR_KEY -o report.csv
 : 1 — error (file not found, invalid option, etc.)
 : 2 — warning (one or more BOM components unmatched; BOM was still written)
 
+## BOM DESIGNATOR CASE POLICY
+
+Designators (reference designators like R1, C2, U3) are preserved exactly as written in the `.kicad_pcb` file.
+KiCad allows mixed-case designators by design (e.g., `U$1`, `License1`, `MountingHole1`, `IO_SEL`, `gnd0`).
+jBOM does not normalize case.
+
+**Comparison with other tools**: Some tools (e.g., Fabrication-Toolkit) uppercase all designators at read time
+(so `License1` becomes `LICENSE1`). jBOM preserves the user's choice of case, which is less surprising and
+respects intentional styling.
+
+**If you need uppercase output**: You can post-process the CSV downstream. For example:
+
+```bash
+awk -F, 'NR==1{print; next}{ $1=toupper($1) }1' bom.csv > bom_uppercase.csv
+```
+
 ## BOM FIELD PRESETS
 
 Use `-f "+PRESET"` or shorthand fabricator flags (`--jlc`, etc.) to imply a preset.

--- a/features/bom/core.feature
+++ b/features/bom/core.feature
@@ -93,7 +93,7 @@ Feature: BOM Generation (Core Functionality)
       | R1        | 10K       | R_0805_2012   |
     When I run jbom command "bom -f reference,quantity,value -o -"
     Then the command should succeed
-    And the CSV output should contain "License1"
-    And the CSV output should contain "Prop1"
-    And the CSV output should not contain "LICENSE1"
-    And the CSV output should not contain "PROP1"
+    And the output should contain "License1"
+    And the output should contain "Prop1"
+    And the output should not contain "LICENSE1"
+    And the output should not contain "PROP1"

--- a/features/bom/core.feature
+++ b/features/bom/core.feature
@@ -81,3 +81,19 @@ Feature: BOM Generation (Core Functionality)
     And the CSV output has rows where:
       | Reference | Value | S:Value | P:Value |
       | R1        | 9K99  | 10K     | 9K99    |
+
+  Scenario: BOM preserves mixed-case designators from KiCad
+    # KiCad allows mixed-case designators by design (e.g., License1, Prop1).
+    # jBOM does not uppercase them at read time; they survive unchanged to output.
+    # This contrasts with tools like Fabrication-Toolkit that normalize to uppercase.
+    Given a PCB that contains:
+      | Reference | Value     | Footprint     |
+      | License1  | OSHW      | LICENSE_LOGO  |
+      | Prop1     | Custom    | CUSTOM_SHAPE  |
+      | R1        | 10K       | R_0805_2012   |
+    When I run jbom command "bom -f reference,quantity,value -o -"
+    Then the command should succeed
+    And the CSV output should contain "License1"
+    And the CSV output should contain "Prop1"
+    And the CSV output should not contain "LICENSE1"
+    And the CSV output should not contain "PROP1"


### PR DESCRIPTION
## Summary

This PR documents jBOM's designator case preservation policy to address issue #292.

## Context

Under PR #289, jBOM was evaluated for cross-project compatibility with Fabrication-Toolkit (FT). A minor cosmetic difference was noted:
- **FT behavior**: Uppercases all designators at read time (e.g., `License1` → `LICENSE1`)
- **jBOM behavior**: Preserves designators exactly as written in `.kicad_pcb`

This is not a bug—KiCad intentionally allows mixed-case designators (e.g., `U$1`, `License1`, `IO_SEL`), and jBOM's preserve-as-is approach respects user intent.

## Changes

1. **docs/README.man1.md**
   - Added new "BOM Designator Case Policy" section under BOM COMMAND
   - Explains that designators are preserved exactly as written in the PCB file
   - Contrasts with tools like Fabrication-Toolkit that normalize case
   - Provides example awk command for users who need uppercase output

2. **features/bom/core.feature**
   - Added functional test: "BOM preserves mixed-case designators from KiCad"
   - Uses realistic mixed-case references (License1, Prop1)
   - Asserts that designators survive unchanged in BOM output
   - Verifies that uppercase variants do NOT appear

## Acceptance Criteria Met

✅ Documentation in `docs/README.man1.md` (new "Designator Case Policy" section)
✅ Behave scenario in `features/bom/core.feature` asserting preservation
✅ No source code changes (documentation and test only)
✅ Examples of mixed-case refs from real projects (License1, Prop1)

Fixes #292

Co-Authored-By: Oz <oz-agent@warp.dev>