### PR TITLE
feat!: DNP column in BOM; remove --include-dnp/excluded/all filter flags (issue #294)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Breaking Changes
+- **DNP filter flags removed from `jbom bom`, `jbom parts`, and `jbom pos`** (issue #294):
+  `--include-dnp`, `--include-excluded`, and `--include-all` no longer exist on any of these
+  commands. Each command now has fixed, contract-correct behaviour:
+  - `bom` / `parts`: DNP rows are always included with a `DNP` column marker (`"DNP"` or `""`);
+    `exclude_from_bom` refs are always excluded; virtual symbols are always excluded.
+  - `pos`: DNP rows are always excluded (the P&P machine cannot place them).
+  Procurement consumers that previously relied on the default-exclude-DNP behaviour should
+  filter the `dnp` column: `awk -F, 'NR==1 || $NF != "DNP"' project.bom.csv`.
+
+### Added
+- **DNP column in BOM output** (issue #294): all four fabricator presets (`generic`, `jlc`,
+  `pcbway`, `seeed`) now include a `DNP` column in their default field set. Value is `"DNP"`
+  for Do-Not-Populate components and `""` for populated ones. This satisfies IPC J-STD-001.
+- **DNP-aware BOM aggregation** (issue #294): populated and DNP variants of the same
+  `value+footprint` combination are now kept on separate rows so quantity counts are never
+  inflated by merging a populated row with a DNP row.
+
+### Breaking Changes
 - **Minimum KiCad version raised to 9.0** for the PCM-installed plugin.  Pydantic v2,
   on which the unified profile loader depends, requires CPython 3.9+, which lines up
   with KiCad 9 (CPython 3.9) and KiCad 10 (CPython 3.12).  KiCad 6/7/8 are no longer

--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -233,15 +233,6 @@ Generates a Bill of Materials aggregated by value+package for procurement. Match
 **--list-fields**
 : List available fields and presets, then exit (no project needed).
 
-**--include-dnp**
-: Include "Do Not Populate" components (excluded by default).
-
-**--include-excluded**
-: Include components marked "Exclude from BOM" (excluded by default).
-
-**--include-all**
-: Include all components: DNP, excluded from BOM, and virtual symbols.
-
 **-v, --verbose**
 : Include Match_Quality, Priority, and Notes columns in output.
 
@@ -289,9 +280,6 @@ Generates a component placement file (CPL/POS) from a KiCad PCB for pick-and-pla
 
 **--origin {board,aux}**
 : Coordinate origin. `board` = board lower-left corner; `aux` = auxiliary axis origin (falls back to board if not defined).
-
-**--include-dnp**
-: Include DNP components in the placement file (excluded by default since they are not assembled).
 
 **-v, --verbose**
 : Enable verbose diagnostic output.
@@ -364,15 +352,6 @@ Generates an electro-mechanically aggregated parts list from schematics. `parts`
 
 **--jlc / --pcbway / --seeed / --generic**
 : Shorthand fabricator flags.
-
-**--include-dnp**
-: Include DNP components (excluded by default).
-
-**--include-excluded**
-: Include BOM-excluded components (excluded by default).
-
-**--include-all**
-: Include all components: DNP, excluded, and virtual symbols.
 
 **-v, --verbose**
 : Verbose output.
@@ -574,6 +553,40 @@ jbom audit ./my_project --supplier mouser --api-key YOUR_KEY -o report.csv
 : 0 — success
 : 1 — error (file not found, invalid option, etc.)
 : 2 — warning (one or more BOM components unmatched; BOM was still written)
+
+## COMPONENT ATTRIBUTE HANDLING
+
+KiCad footprints and schematic symbols carry three flag attributes that control how components
+flow through jBOM's three output commands. These flags are fixed at generation time — no CLI
+flags override them.
+
+| Attribute | `jbom bom` / `jbom parts` | `jbom pos` | Notes |
+|---|---|---|---|
+| `exclude_from_board` | not in output | not in output | Symbol-only: no PCB footprint |
+| `exclude_from_bom` | not in output | not in output | Board feature: logo, mounting hole, fiducial |
+| `dnp` (Do Not Populate) | **included, marked `DNP`** | not in output | Variant/rework spares: pad present, part absent |
+| *(none set)* | included | included | Normal populated component |
+
+**BOM/Parts**: `exclude_from_bom` components (mounting holes, fiducials, OSHW logos) are always
+excluded. DNP components are always included and identified by the `DNP` column value `"DNP"`
+(empty string for populated components). This follows IPC J-STD-001: assembly operators must
+be able to distinguish intentionally empty pads from omitted line items.
+
+**POS**: DNP components are always excluded. The P&P machine's input contract is strictly
+"place these components"; the companion BOM is the authoritative source for DNP declarations.
+
+**Full-board audit**: To enumerate every component regardless of flag — including
+`exclude_from_bom` refs, virtual symbols, and all DNP/non-DNP — use `jbom audit`.
+
+**Migration note** (from pre-v8.x): The `--include-dnp`, `--include-excluded`, and
+`--include-all` flags have been removed from `jbom bom`, `jbom parts`, and `jbom pos`.
+DNP rows now appear in BOM/parts output by default, marked in the `DNP` column.
+Procurement workflows that previously excluded DNP rows should filter on the `DNP` column:
+
+```bash
+# Extract only populated (non-DNP) components from the BOM:
+awk -F, 'NR==1 || $NF != "DNP"' project.bom.csv > populated.bom.csv
+```
 
 ## BOM DESIGNATOR CASE POLICY
 

--- a/docs/README.man4.md
+++ b/docs/README.man4.md
@@ -122,6 +122,25 @@ The plugin writes a CSV file to the location specified in the KiCad Generate BOM
 
 Exit code is returned to KiCad (0=success, non-zero=error). Errors are logged to stderr.
 
+## COMPONENT ATTRIBUTE HANDLING
+
+KiCad's three component flag attributes have fixed, contract-correct behavior in jBOM output.
+No plugin checkbox or CLI flag overrides them.
+
+| Attribute | BOM output | CPL/POS output |
+|---|---|---|
+| `exclude_from_board` | not in output | not in output |
+| `exclude_from_bom` | not in output | not in output |
+| `dnp` (Do Not Populate) | **included, marked `DNP`** | not in output |
+| *(none set)* | included | included |
+
+DNP rows appear in the BOM with `"DNP"` in the `DNP` column (empty for populated components).
+This is required by IPC J-STD-001 so assembly operators can distinguish intentionally empty
+pads from components that were accidentally omitted from the BOM.
+
+The plugin's **Exclude DNP components** checkbox has been removed. DNP declarations are now
+always present in the BOM. Procurement filtering can be done downstream on the `DNP` column.
+
 ## TROUBLESHOOTING
 
 **Plugin doesn't appear in the list**

--- a/features/bom/field_system_regression.feature
+++ b/features/bom/field_system_regression.feature
@@ -13,10 +13,10 @@ Feature: BOM Field System and Output Customization
   Scenario: Different fabricators produce different output headers
     When I run jbom command "bom --fabricator generic -o -"
     Then the command should succeed
-    And the output should contain CSV headers "Reference,Quantity,Description,Value,Package,Footprint,Manufacturer,Part Number"
+    And the output should contain CSV headers "Reference,Quantity,Description,Value,Package,Footprint,Manufacturer,Part Number,DNP"
     When I run jbom command "bom --fabricator jlc -o -"
     Then the command should succeed
-    And the output should contain CSV headers "Designator,Quantity,Value,Comment,Footprint,LCSC Part #,Surface Mount"
+    And the output should contain CSV headers "Designator,Quantity,Value,Comment,Footprint,LCSC Part #,Surface Mount,DNP"
     When I run jbom command "bom --fabricator pcbway -o -"
     Then the command should succeed
     And the output should not contain CSV headers "Reference,Quantity,Description,Value,Package,Footprint,Manufacturer,Part Number"
@@ -46,10 +46,10 @@ Feature: BOM Field System and Output Customization
   Scenario: Fabricator-specific presets
     When I run jbom command "bom --fabricator jlc -f +jlc -o -"
     Then the command should succeed
-    And the output should contain CSV headers "Designator,Quantity,Value,Comment,LCSC Part #"
+    And the output should contain CSV headers "Designator,Quantity,Value,Comment,LCSC Part #,DNP"
     When I run jbom command "bom --fabricator generic -f +generic -o -"
     Then the command should succeed
-    And the output should contain CSV headers "Reference,Quantity,Description,Value,Manufacturer,Part Number"
+    And the output should contain CSV headers "Reference,Quantity,Description,Value,Manufacturer,Part Number,DNP"
 
   @regression @current-broken
   Scenario: Mixed syntax - preset plus custom fields

--- a/features/bom/filtering.feature
+++ b/features/bom/filtering.feature
@@ -1,38 +1,76 @@
 Feature: BOM Filtering (DNP / Excluded)
   As a hardware developer
-  I want to control which components are included in the BOM
-  So that I can generate BOMs for different build configurations
+  I want the BOM to reflect the full design intent
+  So that assembly houses have explicit DNP declarations per IPC J-STD-001
 
   Background:
     Given the generic fabricator is selected
 
-  Scenario: Include DNP components when requested
+  Scenario: BOM includes DNP rows with explicit DNP marker by default
+    # IPC J-STD-001 expects DNPs to be declared in writing so the assembly
+    # operator can tell empty pads are intentional. Procurement consumers
+    # filter the dnp column themselves.
     Given a PCB that contains:
-      | Reference | Value | Footprint   | DNP |
-      | R1        | 10K   | R_0805_2012 | No  |
-      | R2        | 22K   | R_0805_2012 | Yes |
-    When I run jbom command "bom --include-dnp -o -"
-    Then the command should succeed
-    And the CSV output has a row where
-      | Reference | Value |
-      | R2        | 22K   |
-
-  Scenario: Exclude DNP components by default
-    Given a PCB that contains:
-      | Reference | Value | Footprint   | DNP |
-      | R1        | 10K   | R_0805_2012 | No  |
-      | R2        | 22K   | R_0805_2012 | Yes |
+      | Reference | Value   | Footprint   | DNP |
+      | R1        | 10K     | R_0805_2012 | No  |
+      | R2        | No_Load | R_0805_2012 | Yes |
     When I run jbom command "bom -o -"
     Then the command should succeed
+    And the CSV output has rows where:
+      | Reference | Value   | DNP |
+      | R1        | 10K     |     |
+      | R2        | No_Load | DNP |
+
+  Scenario: BOM keeps populated and DNP variants of the same part on separate rows
+    # Aggregation key includes the DNP boolean so qty is never inflated by
+    # merging in a DNP row.
+    Given a PCB that contains:
+      | Reference | Value | Footprint   | DNP |
+      | R1        | 10K   | R_0805_2012 | No  |
+      | R2        | 10K   | R_0805_2012 | Yes |
+    When I run jbom command "bom -o -"
+    Then the command should succeed
+    And the CSV output has rows where:
+      | Reference | Value | Quantity | DNP |
+      | R1        | 10K   | 1        |     |
+      | R2        | 10K   | 1        | DNP |
+
+  Scenario: BOM drops exclude_from_bom refs unconditionally
+    # Mounting holes, fiducials, OSHW logos etc. carry exclude_from_bom on
+    # the PCB. Under the simplified contract there is no flag to override
+    # this; full-board audit lives in `jbom audit`.
+    Given a PCB that contains:
+      | Reference | Value | Footprint                | ExcludeFromBOM |
+      | R1        | 10K   | R_0805_2012              | No             |
+      | MH1       | ~     | MountingHole_3.2mm_M3    | Yes            |
+    When I run jbom command "bom -o -"
+    Then the command should succeed
+    And the output should contain "R1"
+    And the output should not contain "MH1"
+
+  Scenario: POS unconditionally drops DNP rows
+    # The mandatory companion BOM declares DNP explicitly. The POS file is
+    # exclusively "place these components" — adding non-placeable rows
+    # makes it inconsistent with the P&P machine's input contract.
+    Given a PCB that contains:
+      | Reference | Value | Footprint   | X | Y | Rotation | Side | DNP |
+      | R1        | 10K   | R_0805_2012 | 5 | 5 | 0        | TOP  | No  |
+      | R2        | 10K   | R_0805_2012 | 6 | 5 | 0        | TOP  | Yes |
+    When I run jbom command "pos -o -"
+    Then the command should succeed
+    And the output should contain "R1"
     And the output should not contain "R2"
 
-  Scenario: Include components excluded from BOM when requested
+  Scenario: BOM CLI no longer accepts the removed filter flags
     Given a PCB that contains:
-      | Reference | Value | Footprint   | ExcludeFromBOM |
-      | R1        | 10K   | R_0805_2012 | No             |
-      | R2        | 22K   | R_0805_2012 | Yes            |
-    When I run jbom command "bom --include-excluded -o -"
-    Then the command should succeed
-    And the CSV output has a row where
-      | Reference | Value |
-      | R2        | 22K   |
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+    When I run jbom command "bom --include-dnp -o -"
+    Then the command should fail
+
+  Scenario: POS CLI no longer accepts --include-dnp
+    Given a PCB that contains:
+      | Reference | Value | Footprint   | X | Y | Rotation | Side |
+      | R1        | 10K   | R_0805_2012 | 5 | 5 | 0        | TOP  |
+    When I run jbom command "pos --include-dnp -o -"
+    Then the command should fail

--- a/features/bom/inventory_enhancement.feature
+++ b/features/bom/inventory_enhancement.feature
@@ -89,12 +89,6 @@ Feature: BOM Inventory Enhancement
     And the output should contain "Inventory enhanced:"
     # Inventory enhancement should work with any fabricator preset
 
-  Scenario: BOM enhancement preserves filtering options
-    When I run jbom command "bom --inventory component_inventory.csv --include-dnp -o console"
-    Then the command should succeed
-    And the output should contain "Bill of Materials"
-    # Should show both enhanced inventory data and respect DNP filtering
-
   Scenario: Multiple inventory files with different component coverage
     When I run jbom command "bom --inventory component_inventory.csv --inventory enhanced_inventory.csv -o - -v"
     Then the command should succeed

--- a/features/parts/filtering.feature
+++ b/features/parts/filtering.feature
@@ -1,13 +1,15 @@
 Feature: Parts List Filtering
   As a hardware developer
-  I want to filter components in my parts list
-  So that I can customize the parts list for different assembly scenarios
+  I want the parts list to enumerate design components
+  So that I have a complete electro-mechanical inventory of the schematic
 
   Background:
     Given a jBOM CSV sandbox
     And the generic fabricator is selected
 
-  Scenario: Exclude DNP components by default
+  Scenario: Parts list includes DNP components by default
+    # Parts list is a design inventory: DNP parts ARE in the design.
+    # They appear without a dedicated dnp column (parts is electro-mechanical).
     Given a schematic that contains:
       | Reference | Value | Footprint   | DNP   |
       | R1        | 10K   | R_0805_2012 | No    |
@@ -16,31 +18,18 @@ Feature: Parts List Filtering
     When I run jbom command "parts"
     Then the command should succeed
     And the CSV output has rows where:
-      | Refs | Value |
-      | R1   | 10K   |
-      | C1   | 100nF |
-    And the CSV output does not contain components where:
-      | Refs |
-      | R2   |
-
-  Scenario: Include DNP components when requested
-    Given a schematic that contains:
-      | Reference | Value | Footprint   | DNP   |
-      | R1        | 10K   | R_0805_2012 | No    |
-      | R2        | 10K   | R_0805_2012 | Yes   |
-      | C1        | 100nF | C_0603_1608 | No    |
-    When I run jbom command "parts --include-dnp"
-    Then the command should succeed
-    And the CSV output has rows where:
       | Refs  | Value |
       | R1,R2 | 10K   |
       | C1    | 100nF |
 
-  Scenario: Exclude components marked as excluded from BOM by default
+  Scenario: Parts list excludes components marked exclude_from_bom
+    # Components explicitly flagged out of the BOM (mounting holes, logos,
+    # fiducials) are excluded. No flag can override this; use jbom audit
+    # for full-board inventory.
     Given a schematic that contains:
       | Reference | Value | Footprint   | ExcludeFromBOM |
       | R1        | 10K   | R_0805_2012 | No             |
-      | R2        | 10K   | R_0805_2012 | Yes            |
+      | MH1       | ~     | R_0805_2012 | Yes            |
       | C1        | 100nF | C_0603_1608 | No             |
     When I run jbom command "parts"
     Then the command should succeed
@@ -50,22 +39,9 @@ Feature: Parts List Filtering
       | C1   | 100nF |
     And the CSV output does not contain components where:
       | Refs |
-      | R2   |
+      | MH1  |
 
-  Scenario: Include excluded components when requested
-    Given a schematic that contains:
-      | Reference | Value | Footprint   | ExcludeFromBOM |
-      | R1        | 10K   | R_0805_2012 | No             |
-      | R2        | 10K   | R_0805_2012 | Yes            |
-      | C1        | 100nF | C_0603_1608 | No             |
-    When I run jbom command "parts --include-excluded"
-    Then the command should succeed
-    And the CSV output has rows where:
-      | Refs  | Value |
-      | R1,R2 | 10K   |
-      | C1    | 100nF |
-
-  Scenario: Exclude virtual symbols automatically
+  Scenario: Parts list excludes virtual symbols automatically
     Given a schematic that contains:
       | Reference | Value | Footprint   |
       | R1        | 10K   | R_0805_2012 |
@@ -79,66 +55,13 @@ Feature: Parts List Filtering
       | R1   | 10K   |
       | C1   | 100nF |
     And the CSV output does not contain components where:
-      | Refs  |
+      | Refs   |
       | #PWR01 |
       | #PWR02 |
 
-  Scenario: Include virtual symbols with --include-all
+  Scenario: Parts CLI no longer accepts removed filter flags
     Given a schematic that contains:
       | Reference | Value | Footprint   |
       | R1        | 10K   | R_0805_2012 |
-      | #PWR01    | GND   |             |
-      | #PWR02    | VCC   |             |
-      | C1        | 100nF | C_0603_1608 |
-    When I run jbom command "parts --include-all"
-    Then the command should succeed
-    And the CSV output has rows where:
-      | Refs   | Value |
-      | R1     | 10K   |
-      | C1     | 100nF |
-      | #PWR01 | GND   |
-      | #PWR02 | VCC   |
-
-  Scenario: Test both DNP and ExcludeFromBOM flags work independently
-    Given a schematic that contains:
-      | Reference | Value | Footprint   | DNP   | ExcludeFromBOM |
-      | R1        | 10K   | R_0805_2012 | No    | No             |
-      | R2        | 10K   | R_0805_2012 | Yes   | No             |
-      | R3        | 10K   | R_0805_2012 | No    | Yes            |
-      | C1        | 100nF | C_0603_1608 | No    | No             |
-    When I run jbom command "parts --include-dnp --include-excluded"
-    Then the command should succeed
-    And the CSV output has rows where:
-      | Refs     | Value |
-      | R1,R2,R3 | 10K   |
-      | C1       | 100nF |
-
-  Scenario: Include only DNP components (exclude ExcludeFromBOM)
-    Given a schematic that contains:
-      | Reference | Value | Footprint   | DNP   | ExcludeFromBOM |
-      | R1        | 10K   | R_0805_2012 | No    | No             |
-      | R2        | 10K   | R_0805_2012 | Yes   | No             |
-      | R3        | 10K   | R_0805_2012 | No    | Yes            |
     When I run jbom command "parts --include-dnp"
-    Then the command should succeed
-    And the CSV output has rows where:
-      | Refs  | Value |
-      | R1,R2 | 10K   |
-    And the CSV output does not contain components where:
-      | Refs |
-      | R3   |
-
-  Scenario: Include only ExcludeFromBOM components (exclude DNP)
-    Given a schematic that contains:
-      | Reference | Value | Footprint   | DNP   | ExcludeFromBOM |
-      | R1        | 10K   | R_0805_2012 | No    | No             |
-      | R2        | 10K   | R_0805_2012 | Yes   | No             |
-      | R3        | 10K   | R_0805_2012 | No    | Yes            |
-    When I run jbom command "parts --include-excluded"
-    Then the command should succeed
-    And the CSV output has rows where:
-      | Refs  | Value |
-      | R1,R3 | 10K   |
-    And the CSV output does not contain components where:
-      | Refs |
-      | R2   |
+    Then the command should fail

--- a/src/jbom/application/bom_workflow.py
+++ b/src/jbom/application/bom_workflow.py
@@ -50,6 +50,7 @@ _BOM_COMPUTED_FIELDS: tuple[str, ...] = (
     "mfgpn",
     "fabricator_part_number",
     "smd",
+    "dnp",
     "lcsc",
     "package",
 )

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -77,7 +77,6 @@ class POSRequest:
     origin: str = "board"
     fields: str | None = None
     list_fields: bool = False
-    include_dnp: bool = False
     verbose: bool = False
     apply_corrections: bool = False
 
@@ -106,7 +105,6 @@ class POSRequest:
             str(self.fields).strip() if self.fields is not None else None,
         )
         object.__setattr__(self, "list_fields", bool(self.list_fields))
-        object.__setattr__(self, "include_dnp", bool(self.include_dnp))
         object.__setattr__(self, "verbose", bool(self.verbose))
         object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
 
@@ -614,10 +612,6 @@ class POSWorkflow:
             smd_only=request.smd_only,
             layer_filter=request.layer or None,
         )
-        if request.verbose and request.include_dnp:
-            diagnostics.append(
-                Diagnostic("info", "Including DNP components in POS output")
-            )
 
         board = load_board(pcb_file)
         pos_data = POSGenerator(placement_options).generate_pos_data(board)
@@ -645,7 +639,8 @@ class POSWorkflow:
         )
         diagnostics.extend(merge_diagnostics)
         pos_data = enrich_pos_with_merge_namespaces(pos_data, merge_result)
-        pos_data = apply_pos_dnp_filter(pos_data, include_dnp=request.include_dnp)
+        # POS unconditionally drops DNP rows — the P&P machine cannot place them.
+        pos_data = apply_pos_dnp_filter(pos_data, include_dnp=False)
 
         # Part 2: fold CPL rotations into the fab's required output range,
         # unconditionally — fires even without --apply-corrections.

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -200,7 +200,6 @@ def _build_pos_job_request(args: argparse.Namespace) -> JobRequest:
         "origin": str(args.origin or "board"),
         "verbose": bool(args.verbose),
         "list_fields": bool(args.list_fields),
-        "include_dnp": bool(getattr(args, "include_dnp", False)),
         "apply_corrections": bool(getattr(args, "apply_corrections", False)),
     }
     return JobRequest(
@@ -226,7 +225,6 @@ def _build_pos_request(
         origin=str(args.origin or "board"),
         fields=args.fields if args.fields is not None else None,
         list_fields=bool(args.list_fields),
-        include_dnp=bool(getattr(args, "include_dnp", False)),
         verbose=bool(args.verbose),
         apply_corrections=bool(getattr(args, "apply_corrections", False)),
     )

--- a/src/jbom/common/component_filters.py
+++ b/src/jbom/common/component_filters.py
@@ -12,84 +12,39 @@ from jbom.common.types import Component
 def add_component_filter_arguments(
     parser: argparse.ArgumentParser, command_type: str = "full"
 ) -> None:
-    """Add component filtering arguments to a CLI parser.
+    """No-op: component filter flags have been removed.
 
-    Args:
-        parser: The argument parser to add filtering options to
-        command_type: Type of command ("full", "pos") to determine which flags to add
+    BOM/Parts use fixed contract-correct defaults (DNP included, exclude_from_bom
+    excluded, virtual symbols excluded).  POS always drops DNP rows.
+    This function is retained as a no-op to avoid import churn at call sites.
     """
-    # Filtering options group
-    filter_group = parser.add_argument_group("component filtering")
-
-    # DNP filtering applies to all commands
-    dnp_help = {
-        "pos": (
-            'Include "Do Not Populate" components in placement file '
-            "(default: excluded since they are not placed during assembly)"
-        ),
-        "full": 'Include "Do Not Populate" components (default: excluded)',
-    }
-
-    filter_group.add_argument(
-        "--include-dnp",
-        action="store_true",
-        help=dnp_help.get(command_type, dnp_help["full"]),
-    )
-
-    # BOM exclusion and virtual symbols only apply to BOM/Parts commands
-    if command_type == "full":
-        filter_group.add_argument(
-            "--include-excluded",
-            action="store_true",
-            help="Include components excluded from BOM (default: excluded)",
-        )
-
-        filter_group.add_argument(
-            "--include-all",
-            action="store_true",
-            help="Include all components (DNP, excluded from BOM, and virtual symbols)",
-        )
 
 
 def create_filter_config(
     args: argparse.Namespace, command_type: str = "full"
 ) -> Dict[str, Any]:
-    """Create filter configuration from CLI arguments.
+    """Return fixed contract-correct filter configuration.
 
     Args:
-        args: Parsed CLI arguments with filter flags
-        command_type: Type of command ("full", "pos") to determine applicable filters
+        args: Parsed CLI arguments (no filter flags are read; kept for call-site compat)
+        command_type: Type of command ("full" for BOM/Parts, "pos" for placement)
 
     Returns:
         Dictionary of filter parameters for service generators
     """
     if command_type == "pos":
-        # POS shows components that get physically placed/populated during assembly
-        # - DNP components are NOT placed by default (exclude_dnp=True)
-        # - BOM-excluded components (mounting holes, logos) still need placement coordinates
-        # - Virtual symbols never have physical placement coordinates
+        # POS: only physically-placed components. DNP = Do Not Place.
         return {
-            "exclude_dnp": not getattr(
-                args, "include_dnp", False
-            ),  # Exclude DNP by default
-            "include_only_bom": False,  # Include BOM-excluded (they still get placed)
-            "include_virtual_symbols": False,  # Virtual symbols have no placement
+            "exclude_dnp": True,
+            "include_only_bom": False,  # BOM-excluded parts (logos, mounting holes) still get placed
+            "include_virtual_symbols": False,
         }
-    else:
-        # Full filtering for BOM/Parts commands
-        # --include-all overrides individual flags
-        if getattr(args, "include_all", False):
-            return {
-                "exclude_dnp": False,
-                "include_only_bom": False,
-                "include_virtual_symbols": True,
-            }
-        else:
-            return {
-                "exclude_dnp": not getattr(args, "include_dnp", False),
-                "include_only_bom": not getattr(args, "include_excluded", False),
-                "include_virtual_symbols": False,
-            }
+    # BOM/Parts: enumerate all design components. DNP rows are included and marked.
+    return {
+        "exclude_dnp": False,
+        "include_only_bom": True,
+        "include_virtual_symbols": False,
+    }
 
 
 def apply_component_filters(
@@ -109,7 +64,7 @@ def apply_component_filters(
     filtered = []
 
     # Extract filter settings with defaults
-    exclude_dnp = filters.get("exclude_dnp", True)
+    exclude_dnp = filters.get("exclude_dnp", False)
     include_only_bom = filters.get("include_only_bom", True)
     include_virtual_symbols = filters.get("include_virtual_symbols", False)
 

--- a/src/jbom/config/profiles/generic.jbom.yaml
+++ b/src/jbom/config/profiles/generic.jbom.yaml
@@ -42,6 +42,7 @@ fab:
     "Footprint": "footprint"
     "Manufacturer": "manufacturer"
     "Part Number": "jbom:fabricator_part_number"
+    "DNP": "jbom:dnp"
 
   pos_columns:
     "Designator": "reference"
@@ -78,6 +79,7 @@ fab:
         - "footprint"
         - "manufacturer"
         - "jbom:fabricator_part_number"
+        - "jbom:dnp"
     generic:
       description: "Generic preset alias"
       fields:
@@ -87,6 +89,7 @@ fab:
         - "value"
         - "manufacturer"
         - "jbom:fabricator_part_number"
+        - "jbom:dnp"
 
   cli_aliases:
     flags: ["--generic"]

--- a/src/jbom/config/profiles/jlc.jbom.yaml
+++ b/src/jbom/config/profiles/jlc.jbom.yaml
@@ -75,6 +75,7 @@ fab:
     "Footprint": "strip_kicad_library_prefix_from_value(pcb:footprint)"
     "LCSC": "jbom:fabricator_part_number"  # JLCPCB requires this column name in BOM
     "Surface Mount": "jbom:smd"
+    "DNP": "jbom:dnp"
 
   pos_columns:
     "Designator": "reference"
@@ -95,6 +96,7 @@ fab:
         - "strip_kicad_library_prefix_from_value(pcb:footprint)"
         - "jbom:fabricator_part_number"
         - "jbom:smd"
+        - "jbom:dnp"
     jlc:
       description: "JLC preset alias"
       fields:
@@ -103,6 +105,7 @@ fab:
         - "value"
         - "description"
         - "jbom:fabricator_part_number"
+        - "jbom:dnp"
 
   cli_aliases:
     flags: ["--jlc"]

--- a/src/jbom/config/profiles/pcbway.jbom.yaml
+++ b/src/jbom/config/profiles/pcbway.jbom.yaml
@@ -40,6 +40,7 @@ fab:
     "Comment": "description"
     "Package": "inv:package"
     "Manufacturer Part Number": "jbom:fabricator_part_number"
+    "DNP": "jbom:dnp"
 
   pos_columns:
     "Designator": "reference"
@@ -59,6 +60,7 @@ fab:
         - "description"
         - "inv:package"
         - "jbom:fabricator_part_number"
+        - "jbom:dnp"
 
   cli_aliases:
     flags: ["--pcbway"]

--- a/src/jbom/config/profiles/seeed.jbom.yaml
+++ b/src/jbom/config/profiles/seeed.jbom.yaml
@@ -36,6 +36,7 @@ fab:
     "Value": "value"
     "Package": "inv:package"
     "Seeed Part Number": "jbom:fabricator_part_number"
+    "DNP": "jbom:dnp"
 
   pos_columns:
     "Designator": "reference"
@@ -52,6 +53,7 @@ fab:
         - "jbom:quantity"
         - "inv:package"
         - "jbom:fabricator_part_number"
+        - "jbom:dnp"
 
   cli_aliases:
     flags: ["--seeed"]

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -289,7 +289,6 @@ class JBOMFabricationDialog(wx.Dialog):
             return cb
 
         self._cb_smd_only = _cb("SMD only (placement)", False)
-        self._cb_exclude_dnp = _cb("Exclude DNP components")
         self._cb_fill_zones = _cb("Fill all zones before Gerbers")
         self._cb_fill_zones.SetToolTip(
             "Fill all zones before Gerbers. Skipped automatically if zones are "
@@ -334,7 +333,6 @@ class JBOMFabricationDialog(wx.Dialog):
 
         for cb in (
             self._cb_smd_only,
-            self._cb_exclude_dnp,
             self._cb_fill_zones,
             self._cb_backup,
             self._cb_open_folder,

--- a/src/jbom/services/bom_field_resolver.py
+++ b/src/jbom/services/bom_field_resolver.py
@@ -59,6 +59,10 @@ def resolve_bom_field_value(
 
     if parsed_field.is_expression or parsed_field.namespace:
         return resolved_value
+    if resolved_field_token == "dnp":
+        # dnp is a bool attribute; return "DNP" or "" without going through
+        # _get_attribute_value which would coerce False -> "No".
+        return "DNP" if entry.attributes.get("dnp") else ""
     if resolved_field_token == "package":
         return derive_package_from_footprint(entry.footprint)
     if resolved_field_token == "lcsc":
@@ -141,14 +145,17 @@ def _build_computed_field_values(
         fabricator_config=fabricator_config,
     )
     smd_value = _resolve_smd_indicator(entry)
+    dnp_value = "DNP" if entry.attributes.get("dnp") else ""
     return {
         "reference": entry.references_string,
         "quantity": entry.quantity,
         "fabricator_part_number": fabricator_part_number,
         "smd": smd_value,
+        "dnp": dnp_value,
         "jbom:quantity": entry.quantity,
         "jbom:fabricator_part_number": fabricator_part_number,
         "jbom:smd": smd_value,
+        "jbom:dnp": dnp_value,
     }
 
 

--- a/src/jbom/services/bom_generator.py
+++ b/src/jbom/services/bom_generator.py
@@ -120,14 +120,14 @@ class BOMGenerator:
     def _get_aggregation_key(self, component: Component) -> tuple:
         """Get aggregation key for grouping components."""
         if self.aggregation_strategy == "value_footprint":
-            return (component.value, component.footprint)
+            return (component.value, component.footprint, component.dnp)
         elif self.aggregation_strategy == "value_only":
-            return (component.value,)
+            return (component.value, component.dnp)
         elif self.aggregation_strategy == "lib_id_value":
-            return (component.lib_id, component.value)
+            return (component.lib_id, component.value, component.dnp)
         else:
             # Default to value_footprint
-            return (component.value, component.footprint)
+            return (component.value, component.footprint, component.dnp)
 
     def _create_bom_entry(self, components: List[Component]) -> BOMEntry:
         """Create a BOM entry from a group of similar components."""
@@ -153,6 +153,9 @@ class BOMGenerator:
                         or not merged_attributes[normalized_key]
                     ):
                         merged_attributes[normalized_key] = value.strip()
+
+        # Propagate typed Component flags into attributes so field resolvers can surface them.
+        merged_attributes["dnp"] = base_component.dnp
 
         return BOMEntry(
             references=references,

--- a/src/jbom/services/parts_list_generator.py
+++ b/src/jbom/services/parts_list_generator.py
@@ -120,6 +120,9 @@ class PartsListGenerator:
         for group in grouped_components.values():
             representative = group[0]
             refs = natural_sort_references([component.reference for component in group])
+            attrs = representative.properties.copy()
+            # Propagate typed Component flags into attributes for uniform field access.
+            attrs["dnp"] = representative.dnp
             entry = PartsListEntry(
                 refs=refs,
                 value=representative.value,
@@ -132,7 +135,7 @@ class PartsListGenerator:
                 voltage=self._component_property(representative, ["Voltage", "V"]),
                 dielectric=self._component_property(representative, ["Dielectric"]),
                 lib_id=representative.lib_id,
-                attributes=representative.properties.copy(),
+                attributes=attrs,
             )
             entries.append(entry)
 

--- a/tests/integration/test_service_composition.py
+++ b/tests/integration/test_service_composition.py
@@ -79,14 +79,14 @@ class TestServiceComposition:
         assert len(components) == 4  # All components loaded
 
         assert bom_data.project_name == "TestProject"
-        assert (
-            bom_data.total_line_items == 2
-        )  # R1+R2 aggregated, C1 separate, R3 filtered out
-        assert bom_data.total_components == 3  # 2 resistors + 1 capacitor
+        # Under the new contract: R1+R2 aggregated (populated), R3 separate (DNP),
+        # C1 separate. 3 line items total.
+        assert bom_data.total_line_items == 3
+        assert bom_data.total_components == 4  # all components including DNP R3
 
         # Verify aggregation worked correctly
 
-        # R1 and R2 should be aggregated
+        # R1 and R2 should be aggregated (both populated, same value+footprint)
         resistor_entry = next(e for e in bom_data.entries if "R1" in e.references)
         assert sorted(resistor_entry.references) == ["R1", "R2"]
         assert resistor_entry.value == "10K"
@@ -100,9 +100,11 @@ class TestServiceComposition:
         assert capacitor_entry.quantity == 1
         assert capacitor_entry.attributes["voltage"] == "50V"
 
-        # R3 should not appear (filtered out due to DNP)
+        # R3 appears as its own DNP row (new contract: DNP included, marked)
         all_references = [ref for entry in bom_data.entries for ref in entry.references]
-        assert "R3" not in all_references
+        assert "R3" in all_references
+        r3_entry = next(e for e in bom_data.entries if "R3" in e.references)
+        assert r3_entry.attributes["dnp"] is True
 
     def test_service_configuration_independence(self):
         """Test that services can be configured independently."""

--- a/tests/services/generators/test_bom_generator.py
+++ b/tests/services/generators/test_bom_generator.py
@@ -200,8 +200,12 @@ class TestBOMGenerator:
         ]
         assert bom_data.entries[0].references == ["GND0", "LEDCOM0"]
 
-    def test_apply_filters_exclude_dnp(self):
-        """Test filtering excludes DNP components."""
+    def test_apply_filters_dnp_included_by_default(self):
+        """DNP components are included in BOM by default (IPC J-STD-001 contract).
+
+        They appear as separate rows marked with the dnp attribute.
+        Use explicit exclude_dnp=True to filter them out.
+        """
         generator = BOMGenerator()
         components = [
             Component(
@@ -228,12 +232,23 @@ class TestBOMGenerator:
             ),
         ]
 
+        # Default: both components included, separate rows (different dnp key)
         bom_data = generator.generate_bom_data(components)
-
-        assert len(bom_data.entries) == 1
-        assert bom_data.entries[0].references == ["R1"]
+        assert len(bom_data.entries) == 2
         assert bom_data.metadata["total_input_components"] == 2
-        assert bom_data.metadata["filtered_components"] == 1
+        assert bom_data.metadata["filtered_components"] == 2
+
+        # Explicit exclude: only R1
+        bom_data_excl = generator.generate_bom_data(
+            components,
+            filters={
+                "exclude_dnp": True,
+                "include_only_bom": True,
+                "include_virtual_symbols": False,
+            },
+        )
+        assert len(bom_data_excl.entries) == 1
+        assert bom_data_excl.entries[0].references == ["R1"]
 
     def test_apply_filters_exclude_not_in_bom(self):
         """Test filtering excludes components not in BOM."""

--- a/tests/services/test_bom_workflow.py
+++ b/tests/services/test_bom_workflow.py
@@ -169,6 +169,133 @@ def test_generation_orchestration_handles_cross_resolution_and_returns_payload(
 
 
 # ---------------------------------------------------------------------------
+# BOM DNP contract
+# ---------------------------------------------------------------------------
+
+
+def test_bom_generator_includes_dnp_rows_by_default() -> None:
+    """DNP rows appear in BOM output by default (no exclude_dnp filter)."""
+    from jbom.services.bom_generator import BOMGenerator
+    from jbom.common.types import Component
+
+    components = [
+        Component(
+            reference="R1",
+            lib_id="Device:R",
+            value="10K",
+            footprint="R_0805",
+            dnp=False,
+        ),
+        Component(
+            reference="R2",
+            lib_id="Device:R",
+            value="No_Load",
+            footprint="R_0805",
+            dnp=True,
+        ),
+    ]
+    bom_data = BOMGenerator("value_footprint").generate_bom_data(
+        components,
+        "Project",
+        {
+            "exclude_dnp": False,
+            "include_only_bom": True,
+            "include_virtual_symbols": False,
+        },
+    )
+    refs = {e.references[0] for e in bom_data.entries}
+    assert "R1" in refs
+    assert "R2" in refs  # DNP row included
+
+
+def test_bom_entry_dnp_attribute_is_set() -> None:
+    """BOMEntry.attributes['dnp'] reflects the component's DNP flag."""
+    from jbom.services.bom_generator import BOMGenerator
+    from jbom.common.types import Component
+
+    components = [
+        Component(
+            reference="R1",
+            lib_id="Device:R",
+            value="10K",
+            footprint="R_0805",
+            dnp=False,
+        ),
+        Component(
+            reference="R2", lib_id="Device:R", value="10K", footprint="R_0805", dnp=True
+        ),
+    ]
+    bom_data = BOMGenerator("value_footprint").generate_bom_data(
+        components,
+        "Project",
+        {
+            "exclude_dnp": False,
+            "include_only_bom": True,
+            "include_virtual_symbols": False,
+        },
+    )
+    by_ref = {e.references[0]: e for e in bom_data.entries}
+    assert by_ref["R1"].attributes["dnp"] is False
+    assert by_ref["R2"].attributes["dnp"] is True
+
+
+def test_bom_dnp_field_resolver_emits_dnp_marker() -> None:
+    """resolve_bom_field_value returns 'DNP' for DNP entries and '' for populated ones."""
+    from jbom.services.bom_generator import BOMEntry
+    from jbom.services.bom_field_resolver import resolve_bom_field_value
+
+    populated = BOMEntry(
+        references=["R1"],
+        value="10K",
+        footprint="R_0805",
+        quantity=1,
+        attributes={"dnp": False},
+    )
+    dnp_entry = BOMEntry(
+        references=["R2"],
+        value="10K",
+        footprint="R_0805",
+        quantity=1,
+        attributes={"dnp": True},
+    )
+
+    assert resolve_bom_field_value(populated, "dnp") == ""
+    assert resolve_bom_field_value(dnp_entry, "dnp") == "DNP"
+
+
+def test_bom_aggregation_separates_populated_and_dnp_variants() -> None:
+    """Populated and DNP variants of the same value+footprint are on separate rows."""
+    from jbom.services.bom_generator import BOMGenerator
+    from jbom.common.types import Component
+
+    components = [
+        Component(
+            reference="R1",
+            lib_id="Device:R",
+            value="10K",
+            footprint="R_0805",
+            dnp=False,
+        ),
+        Component(
+            reference="R2", lib_id="Device:R", value="10K", footprint="R_0805", dnp=True
+        ),
+    ]
+    bom_data = BOMGenerator("value_footprint").generate_bom_data(
+        components,
+        "Project",
+        {
+            "exclude_dnp": False,
+            "include_only_bom": True,
+            "include_virtual_symbols": False,
+        },
+    )
+    # Must be two separate rows — not merged into qty 2
+    assert len(bom_data.entries) == 2
+    for entry in bom_data.entries:
+        assert entry.quantity == 1
+
+
+# ---------------------------------------------------------------------------
 # synthesize_bom_components_from_pcb
 # ---------------------------------------------------------------------------
 

--- a/tests/services/test_pos_workflow.py
+++ b/tests/services/test_pos_workflow.py
@@ -83,7 +83,6 @@ def test_pos_workflow_runs_without_cli_import(
         POSRequest(
             input_path=str(tmp_path),
             fields="reference,x,y",
-            include_dnp=False,
             fabricator="generic",
         )
     )

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -45,8 +45,12 @@ def test_bom_help_includes_fabricator_choices():
 
 def test_bom_help_shows_key_options():
     out = run_help(["bom"]).lower()
-    for token in ["--include-dnp", "--inventory", "-o", "--output"]:
+    # --include-dnp was removed; DNP rows are always included per IPC J-STD-001
+    for token in ["--inventory", "-o", "--output"]:
         assert token in out
+    assert (
+        "--include-dnp" not in out
+    ), "--include-dnp should no longer appear in BOM help"
 
 
 def test_pos_help_shows_core_flags():


### PR DESCRIPTION
## Summary

Implements issue #294: simplified BOM/parts/POS filter contract with explicit DNP declaration per IPC J-STD-001.

## Breaking changes

- `--include-dnp`, `--include-excluded`, `--include-all` removed from `jbom bom`, `jbom parts`, and `jbom pos`. Each command now has fixed contract behavior:
  - `bom` / `parts`: DNP rows always included, marked in new `DNP` column
  - `pos`: DNP rows always excluded (P&P machine contract)
- `POSRequest.include_dnp` field removed

**Migration**: consumers that previously excluded DNP by default should filter on the `DNP` column:
```bash
awk -F, 'NR==1 || $NF != "DNP"' project.bom.csv > populated.bom.csv
```

## Added

- `DNP` column in all four fabricator BOM presets (`generic`, `jlc`, `pcbway`, `seeed`)
- DNP-aware aggregation key: populated and DNP variants of same `value+footprint` stay on separate rows
- `dnp` attribute propagated from `Component.dnp` into `BOMEntry.attributes` and `PartsListEntry.attributes`
- `dnp` computed field in `bom_field_resolver` returning `"DNP"` or `""`

## Parts list

Parts list enumerates all design components including DNP (they ARE in the design). No default `dnp` column; available via `-f dnp`.

## Testing

- ✅ 1397 unit tests pass (4 new DNP contract tests added)
- ✅ `features/bom/filtering.feature` replaced with 6 IPC J-STD-001 contract scenarios
- ✅ `features/parts/filtering.feature` rewritten for new contract
- ✅ All pre-commit hooks pass

## Documentation

- `docs/README.man1.md`: new "Component Attribute Handling" section + flag reference updated
- `docs/README.man4.md`: plugin DNP handling section
- `docs/CHANGELOG.md`: breaking change + migration note

Closes #294

Co-Authored-By: Oz <oz-agent@warp.dev>