### PR TITLE
docs: document BOM Footprint as canonical PCB FPID

### DIFF
--- a/docs/README.man1.md
+++ b/docs/README.man1.md
@@ -604,6 +604,23 @@ respects intentional styling.
 awk -F, 'NR==1{print; next}{ $1=toupper($1) }1' bom.csv > bom_uppercase.csv
 ```
 
+## FOOTPRINT COLUMN
+
+`jbom bom` reports the canonical PCB FPID for each component: the literal identifier from
+the `(footprint "Lib:Name" ...)` form in the `.kicad_pcb` file. That value is the
+authoritative record of what was fabricated on the board.
+
+The FPID may differ from:
+- the schematic symbol's `Footprint` property,
+- Fabrication-Toolkit's BOM footprint column (it resolves schematic-side names through
+  KiCad's library system), or
+- project-internal library aliases.
+
+In all cases, the PCB FPID wins because the FPID is what was fabricated. If you want a
+different identifier to appear in the BOM, change it on the PCB (for example via KiCad's
+**Update PCB from Schematic** with **Update attribute content** enabled) and re-run
+`jbom bom`.
+
 ## BOM FIELD PRESETS
 
 Use `-f "+PRESET"` or shorthand fabricator flags (`--jlc`, etc.) to imply a preset.

--- a/docs/README.man4.md
+++ b/docs/README.man4.md
@@ -141,6 +141,18 @@ pads from components that were accidentally omitted from the BOM.
 The plugin's **Exclude DNP components** checkbox has been removed. DNP declarations are now
 always present in the BOM. Procurement filtering can be done downstream on the `DNP` column.
 
+## FOOTPRINT COLUMN
+
+The plugin uses the same Footprint-column contract as `jbom bom`: jBOM emits the canonical
+PCB FPID verbatim from the `.kicad_pcb` `(footprint "Lib:Name" ...)` identifier because that
+is what was fabricated. If this differs from schematic/library aliases or Fabrication-Toolkit
+output, the PCB FPID still wins.
+
+To change what appears in the BOM Footprint column, update the footprint identifier on the PCB
+(for example via **Update PCB from Schematic** with **Update attribute content** enabled),
+then regenerate the BOM. For the full command-line explanation, see
+[README.man1.md](README.man1.md#footprint-column).
+
 ## TROUBLESHOOTING
 
 **Plugin doesn't appear in the list**


### PR DESCRIPTION
## Summary
- Add a new **Footprint column** section to `docs/README.man1.md` clarifying that `jbom bom` emits the canonical PCB FPID verbatim from `.kicad_pcb` (`(footprint "Lib:Name" ...)`).
- Explain why the PCB FPID is authoritative for fabrication and may differ from schematic/library aliases or Fabrication-Toolkit output.
- Add a concise matching **Footprint column** section to `docs/README.man4.md` with a cross-reference to the CLI docs.

## Issue linkage
Closes #297

## Architecture impact
- Documentation-only update.
- No source code, CLI flags, or plugin behavior changes.

## Validation
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m pytest -q`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave`

Co-Authored-By: Oz <oz-agent@warp.dev>
