### PR TITLE
refactor(config): finish canonical data-side namespace migration

### DIFF
--- a/features/bom/core.feature
+++ b/features/bom/core.feature
@@ -46,7 +46,7 @@ Feature: BOM Generation (Core Functionality)
     And the output should contain "No components found"
 
   # The next two scenarios drive divergent sch/pcb fixtures on purpose to
-  # validate the user-facing debugging aid: BOM exposes both `s:` and `p:`
+  # validate the user-facing debugging aid: BOM exposes both `sch:` and `pcb:`
   # namespaces so DRC issues are easy to see.  This is the only family of
   # BOM scenarios that legitimately needs a schematic alongside the PCB.
 
@@ -60,14 +60,14 @@ Feature: BOM Generation (Core Functionality)
     When I run jbom command "bom --list-fields"
     Then the command should succeed
     And the output should contain "Name"
-    And the output should contain "s:"
-    And the output should contain "p:"
-    And the output should contain "i:"
-    And the output should contain "s:value"
-    And the output should contain "p:value"
-    And the output should contain "s:lcsc"
+    And the output should contain "sch:"
+    And the output should contain "pcb:"
+    And the output should contain "inv:"
+    And the output should contain "sch:value"
+    And the output should contain "pcb:value"
+    And the output should contain "sch:lcsc"
     And the output should contain "quantity"
-    And the output should not contain "a:"
+    And the output should not contain "ann:"
 
   Scenario: BOM unqualified fields use PIS source priority
     Given a schematic that contains:
@@ -76,11 +76,11 @@ Feature: BOM Generation (Core Functionality)
     And a PCB that contains:
       | Reference | X | Y | Footprint   | Value |
       | R1        | 5 | 3 | R_0805_2012 | 9K99  |
-    When I run jbom command "bom -f reference,quantity,value,fabricator_part_number,s:value,p:value -o -"
+    When I run jbom command "bom -f reference,quantity,value,fabricator_part_number,sch:value,pcb:value -o -"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value | S:Value | P:Value |
-      | R1        | 9K99  | 10K     | 9K99    |
+      | Reference | Value | SCH:Value | PCB:Value |
+      | R1        | 9K99  | 10K       | 9K99      |
 
   Scenario: BOM preserves mixed-case designators from KiCad
     # KiCad allows mixed-case designators by design (e.g., License1, Prop1).

--- a/features/bom/field_system_regression.feature
+++ b/features/bom/field_system_regression.feature
@@ -55,20 +55,20 @@ Feature: BOM Field System and Output Customization
   Scenario: Mixed syntax - preset plus custom fields
     # +minimal uses the 'spn' field; without --jlc the column header is 'SPN'.
     # JLC fabricator maps fabricator_part_number → 'LCSC Part #' header via bom_columns.
-    When I run jbom command "bom -f +minimal,Manufacturer,I:Voltage -o -"
+    When I run jbom command "bom -f +minimal,Manufacturer,inv:voltage -o -"
     Then the command should succeed
     And the output should contain "Reference"
     And the output should contain "Value"
     And the output should contain "SPN"
     And the output should contain "Manufacturer"
-    And the output should contain "I:Voltage"
+    And the output should contain "INV:Voltage"
 
   @regression @current-broken
   Scenario: Inventory field prefixing
     Given an inventory file with fields "Voltage,Tolerance,Package"
-    When I run jbom command "bom --inventory inventory.csv -f Reference,Value,I:Voltage,I:Tolerance -o -"
+    When I run jbom command "bom --inventory inventory.csv -f Reference,Value,inv:voltage,inv:tolerance -o -"
     Then the command should succeed
-    And the output should contain CSV headers "Reference,Value,I:Voltage,I:Tolerance"
+    And the output should contain CSV headers "Reference,Value,INV:Voltage,INV:Tolerance"
 
   @regression @current-broken
   Scenario: Unknown fields are accepted and produce blank columns

--- a/features/bom/sch_pcb_divergence.feature
+++ b/features/bom/sch_pcb_divergence.feature
@@ -7,29 +7,29 @@ Feature: BOM exposes sch-vs-pcb divergence as a DRC debugging aid
   # The PCB-first BOM contract makes ``board.footprints`` the canonical row
   # set; the schematic is otherwise invisible to the BOM.  These scenarios
   # exercise the user-facing debugging aid: when the project has *both* a
-  # schematic and a PCB and they disagree, the ``s:`` and ``p:`` field
+  # schematic and a PCB and they disagree, the ``sch:`` and ``pcb:`` field
   # namespaces remain available so the user can see the divergence side by
   # side without running ERC/DRC.
 
   Background:
     Given the generic fabricator is selected
 
-  Scenario: BOM defaults to the PCB footprint, schematic stays visible via s:
+  Scenario: BOM defaults to the PCB footprint, schematic stays visible via sch:
     Given a schematic that contains:
       | Reference | Value | Footprint   |
       | R1        | 10K   | R_0805_2012 |
     And a PCB that contains:
       | Reference | X | Y | Footprint   | Value |
       | R1        | 5 | 3 | R_0603_1608 | 10K   |
-    When I run jbom command "bom -f reference,quantity,footprint,s:footprint,p:footprint -o -"
+    When I run jbom command "bom -f reference,quantity,footprint,sch:footprint,pcb:footprint -o -"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Footprint   | S:Footprint | P:Footprint |
-      | R1        | R_0603_1608 | R_0805_2012 | R_0603_1608 |
+      | Reference | Footprint   | SCH:Footprint | PCB:Footprint |
+      | R1        | R_0603_1608 | R_0805_2012   | R_0603_1608   |
 
-  Scenario: BOM only surfaces s:/p: namespaces when the user explicitly selects them
+  Scenario: BOM only surfaces sch:/pcb: namespaces when the user explicitly selects them
     # Same divergent project as above, but the default field set does not
-    # expose `s:` / `p:` columns -- only `footprint` (PCB-biased) shows up.
+    # expose `sch:` / `pcb:` columns -- only `footprint` (PCB-biased) shows up.
     Given a schematic that contains:
       | Reference | Value | Footprint   |
       | R1        | 10K   | R_0805_2012 |
@@ -39,8 +39,8 @@ Feature: BOM exposes sch-vs-pcb divergence as a DRC debugging aid
     When I run jbom command "bom -o -"
     Then the command should succeed
     And the output should contain "R_0603_1608"
-    And the output should not contain "S:Footprint"
-    And the output should not contain "P:Footprint"
+    And the output should not contain "SCH:Footprint"
+    And the output should not contain "PCB:Footprint"
 
   Scenario: Divergent values are visible side by side for DRC debugging
     Given a schematic that contains:
@@ -49,8 +49,8 @@ Feature: BOM exposes sch-vs-pcb divergence as a DRC debugging aid
     And a PCB that contains:
       | Reference | X | Y | Footprint   | Value |
       | R1        | 5 | 3 | R_0805_2012 | 9K99  |
-    When I run jbom command "bom -f reference,quantity,value,s:value,p:value -o -"
+    When I run jbom command "bom -f reference,quantity,value,sch:value,pcb:value -o -"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value | S:Value | P:Value |
-      | R1        | 9K99  | 10K     | 9K99    |
+      | Reference | Value | SCH:Value | PCB:Value |
+      | R1        | 9K99  | 10K       | 9K99      |

--- a/features/parts/core.feature
+++ b/features/parts/core.feature
@@ -66,13 +66,13 @@ Feature: Parts List Generation (Core Functionality)
       | C1        | 8 | 3 | C_0603_1608 |
       | C20       | 9 | 3 | C_0603_1608 |
       | U1        | 1 | 1 | SOIC-8_3.9x4.9mm |
-    When I run jbom command "parts -f refs,s:footprint,a:footprint"
+    When I run jbom command "parts -f refs,sch:footprint,ann:footprint"
     Then the command should succeed
     And the output should contain these fields:
-      | Refs | S:Footprint | A:Footprint |
+      | Refs | SCH:Footprint | ANN:Footprint |
     And the CSV output has rows where:
-      | Refs      | S:Footprint | A:Footprint |
-      | R1,R2,R10 | R_0805_2012 |             |
+      | Refs      | SCH:Footprint | ANN:Footprint |
+      | R1,R2,R10 | R_0805_2012   |               |
 
   Scenario: Parts list-fields includes merge namespace fields
     # Parts is schematic-driven (it groups schematic components by
@@ -87,13 +87,13 @@ Feature: Parts List Generation (Core Functionality)
     When I run jbom command "parts --list-fields"
     Then the command should succeed
     And the output should contain "Known parts fields"
-    And the output should contain "s:"
-    And the output should contain "p:"
-    And the output should contain "i:"
-    And the output should contain "s:value"
-    And the output should contain "p:footprint"
+    And the output should contain "sch:"
+    And the output should contain "pcb:"
+    And the output should contain "inv:"
+    And the output should contain "sch:value"
+    And the output should contain "pcb:footprint"
     And the output should not contain "c:value"
-    And the output should not contain "a:"
+    And the output should not contain "ann:"
 
   Scenario: Parts unqualified fields use SIP source priority
     Given a schematic that contains:
@@ -102,8 +102,8 @@ Feature: Parts List Generation (Core Functionality)
     And a PCB that contains:
       | Reference | X | Y | Footprint   | Value |
       | R1        | 5 | 3 | R_0805_2012 | 9K99  |
-    When I run jbom command "parts -f refs,value,s:value,p:value"
+    When I run jbom command "parts -f refs,value,sch:value,pcb:value"
     Then the command should succeed
     And the CSV output has rows where:
-      | Refs | Value | S:Value | P:Value |
-      | R1   | 10K   | 10K     | 9K99    |
+      | Refs | Value | SCH:Value | PCB:Value |
+      | R1   | 10K   | 10K       | 9K99      |

--- a/features/pos/core.feature
+++ b/features/pos/core.feature
@@ -79,17 +79,17 @@ Feature: POS Generation (Core Functionality)
     And a PCB that contains:
       | Reference | X | Y | Side | Footprint   | Value |
       | R1        | 5 | 3 | TOP  | R_0805_2012 | 9K99  |
-    When I run jbom command "pos -f reference,value,s:value,p:value -o -"
+    When I run jbom command "pos -f reference,value,sch:value,pcb:value -o -"
     Then the command should succeed
     And the CSV output has rows where:
-      | Reference | Value | S:Value | P:Value |
-      | R1        | 9K99  | 10K     | 9K99    |
+      | Reference | Value | SCH:Value | PCB:Value |
+      | R1        | 9K99  | 10K       | 9K99      |
 
   Scenario: POS list-fields excludes annotation namespace column
     When I run jbom command "pos --list-fields"
     Then the command should succeed
     And the output should contain "Known POS fields"
-    And the output should contain "s:"
-    And the output should contain "p:"
-    And the output should contain "i:"
-    And the output should not contain "a:"
+    And the output should contain "sch:"
+    And the output should contain "pcb:"
+    And the output should contain "inv:"
+    And the output should not contain "ann:"

--- a/src/jbom/application/bom_workflow.py
+++ b/src/jbom/application/bom_workflow.py
@@ -392,7 +392,7 @@ def synthesize_bom_components_from_pcb(
       ``Update PCB from Schematic`` overrides and is what the assembler
       reads off the board).  The schematic value is only consulted when
       the PCB carries no ``Value`` property for that reference.
-    * Auxiliary fields surfaced from the schematic for ``s:``-namespace
+    * Auxiliary fields surfaced from the schematic for ``sch:``-namespace
       visibility (DRC-debug): ``tolerance``, ``voltage``, ``current``,
       ``wavelength``.  These never affect BOM aggregation; they just
       ride along on the synthesized component for the user.
@@ -567,7 +567,7 @@ def enrich_bom_with_merge_namespaces(
     bom_data: BOMData,
     merge_result: ComponentMergeResult | None,
 ) -> BOMData:
-    """Attach stable merge-model namespaces (`s:/p:/a:`) onto BOM entries."""
+    """Attach stable merge-model namespaces (`sch:/pcb:/ann:`) onto BOM entries."""
 
     if merge_result is None or not merge_result.records:
         return bom_data
@@ -656,7 +656,7 @@ def _entry_has_inventory_dnp(entry: BOMEntry) -> bool:
     inventory_dnp = entry.attributes.get("inventory_dnp")
     if _is_truthy_inventory_dnp(inventory_dnp):
         return True
-    namespaced_dnp = entry.attributes.get("i:dnp")
+    namespaced_dnp = entry.attributes.get("inv:dnp")
     if _is_truthy_inventory_dnp(namespaced_dnp):
         return True
     return False
@@ -811,12 +811,12 @@ def _entry_has_namespaced_field(entry: BOMEntry, namespaced_field: str) -> bool:
 def _resolve_entry_device_footprint(entry: BOMEntry) -> str:
     """Resolve concrete device footprint with PCB-first precedence."""
 
-    has_pcb_footprint = _entry_has_namespaced_field(entry, "p:footprint")
-    pcb_footprint = str(entry.attributes.get("p:footprint", "") or "").strip()
+    has_pcb_footprint = _entry_has_namespaced_field(entry, "pcb:footprint")
+    pcb_footprint = str(entry.attributes.get("pcb:footprint", "") or "").strip()
     if has_pcb_footprint:
         return pcb_footprint
 
-    schematic_footprint = str(entry.attributes.get("s:footprint", "") or "").strip()
+    schematic_footprint = str(entry.attributes.get("sch:footprint", "") or "").strip()
     fallback_footprint = str(entry.footprint or "").strip()
     for candidate in (schematic_footprint, fallback_footprint):
         if _is_concrete_footprint(candidate):
@@ -881,7 +881,7 @@ def enforce_bom_device_footprints(bom_data: BOMData) -> BOMData:
 
     metadata = dict(bom_data.metadata)
     metadata["device_footprint_contract"] = "enforced"
-    metadata["device_footprint_precedence"] = "p>s"
+    metadata["device_footprint_precedence"] = "pcb>sch"
     return BOMData(
         project_name=bom_data.project_name,
         entries=updated_entries,

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -217,7 +217,7 @@ def enrich_pos_with_merge_namespaces(
     pos_data: list[dict[str, Any]],
     merge_result: ComponentMergeResult | None,
 ) -> list[dict[str, Any]]:
-    """Attach merge namespace fields (`s:/p:/a:`) onto POS row dictionaries."""
+    """Attach merge namespace fields (`sch:/pcb:/ann:`) onto POS row dictionaries."""
 
     if merge_result is None or not merge_result.records:
         return pos_data
@@ -352,8 +352,7 @@ def _is_truthy_dnp_marker(value: object) -> bool:
 
 def _entry_has_dnp_marker(entry: dict[str, Any]) -> bool:
     """Return True when a POS row contains schematic/inventory DNP flags."""
-
-    for key in ("dnp", "s:dnp", "i:dnp"):
+    for key in ("dnp", "sch:dnp", "inv:dnp"):
         if _is_truthy_dnp_marker(entry.get(key)):
             return True
     return False

--- a/src/jbom/cli/audit.py
+++ b/src/jbom/cli/audit.py
@@ -700,17 +700,17 @@ def _normalize_mismatch_field_name(raw_field: str) -> str:
 
 
 def _format_merge_mismatch_cell_value(raw_value: str) -> str:
-    """Render mismatch source summary as multiline s:/p: cell text when possible."""
+    """Render mismatch source summary as multiline sch:/pcb: cell text when possible."""
     text = str(raw_value or "").strip()
     if not text:
         return ""
-    schematic_match = re.search(r"\bs:\s*(.*?)(?:,\s*p:\s*|$)", text)
-    pcb_match = re.search(r"\bp:\s*(.*)$", text)
+    schematic_match = re.search(r"\bsch:\s*(.*?)(?:,\s*pcb:\s*|$)", text)
+    pcb_match = re.search(r"\bpcb:\s*(.*)$", text)
     if schematic_match and pcb_match:
         schematic_value = schematic_match.group(1).strip()
         pcb_value = pcb_match.group(1).strip()
-        return f"s:{schematic_value}\np:{pcb_value}"
-    return text.replace(", p:", "\np:")
+        return f"sch:{schematic_value}\npcb:{pcb_value}"
+    return text.replace(", pcb:", "\npcb:")
 
 
 def _build_project_audit_summary(

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -30,6 +30,12 @@ from jbom.config.fabricators import (
     get_available_fabricators,
     get_fabricator_presets,
 )
+from jbom.config.fields import (
+    ANNOTATION_NAMESPACE,
+    INV_NAMESPACE,
+    PCB_NAMESPACE,
+    SCH_NAMESPACE,
+)
 from jbom.common.fields import (
     get_available_presets,
     normalize_field_name,
@@ -59,14 +65,14 @@ from jbom.application.jobs.contracts import (
 )
 from jbom.application.jobs.runner import JobEventStream, JobRunPayload, JobRunner
 
-_BOM_SOURCE_PRIORITY = "pis"
+_BOM_SOURCE_PRIORITY = [PCB_NAMESPACE, INV_NAMESPACE, SCH_NAMESPACE]
 
 
 def _enrich_bom_with_merge_namespaces(
     bom_data: BOMData,
     merge_result: ComponentMergeResult | None,
 ) -> BOMData:
-    """Attach stable merge-model namespaces (`s:/p:/a:`) onto BOM entries."""
+    """Attach stable merge-model namespaces (`sch:/pcb:/ann:`) onto BOM entries."""
     return _service_enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
 
@@ -324,9 +330,9 @@ def _list_available_fields(
     matrix_rows = FieldListingService().build_namespace_matrix(known_fields.keys())
     columns = [
         Column(header="Name", key="Name", preferred_width=22, wrap=False),
-        Column(header="s:", key="s:", preferred_width=16, wrap=False),
-        Column(header="p:", key="p:", preferred_width=16, wrap=False),
-        Column(header="i:", key="i:", preferred_width=16, wrap=False),
+        Column(header="sch:", key="sch:", preferred_width=16, wrap=False),
+        Column(header="pcb:", key="pcb:", preferred_width=16, wrap=False),
+        Column(header="inv:", key="inv:", preferred_width=16, wrap=False),
     ]
     print_table(
         [row.to_console_row() for row in matrix_rows],
@@ -710,24 +716,32 @@ def _build_bom_row_sources(
     *,
     include_unqualified_fallback: bool,
 ) -> dict[str, dict[str, object]]:
-    """Build source field maps for one BOM row (`s`, `p`, `i`)."""
+    """Build source field maps for one BOM row (`sch`, `pcb`, `inv`)."""
 
-    row_sources: dict[str, dict[str, object]] = {"s": {}, "p": {}, "i": {}}
+    row_sources: dict[str, dict[str, object]] = {
+        SCH_NAMESPACE: {},
+        PCB_NAMESPACE: {},
+        INV_NAMESPACE: {},
+    }
     for attr_key, attr_value in entry.attributes.items():
         normalized_key = normalize_field_name(str(attr_key or ""))
         prefix, separator, remainder = normalized_key.partition(":")
-        if separator and prefix in {"s", "p", "i"} and remainder:
+        if (
+            separator
+            and prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}
+            and remainder
+        ):
             row_sources[prefix][remainder] = attr_value
 
     if include_unqualified_fallback:
         # Keep unqualified behavior stable when merge enrichment is absent.
         if entry.value:
-            row_sources["s"].setdefault("value", entry.value)
+            row_sources[SCH_NAMESPACE].setdefault("value", entry.value)
         if entry.footprint:
-            row_sources["s"].setdefault("footprint", entry.footprint)
+            row_sources[SCH_NAMESPACE].setdefault("footprint", entry.footprint)
         package_value = _get_attribute_value(entry, "package")
         if package_value:
-            row_sources["s"].setdefault("package", package_value)
+            row_sources[SCH_NAMESPACE].setdefault("package", package_value)
 
     return row_sources
 
@@ -739,15 +753,14 @@ def _resolve_annotation_field_value(
     fabricator_id: str,
     fabricator_config: Optional[FabricatorConfig],
 ) -> str:
-    """Render `a:*` fields as deterministic source annotation lines."""
+    """Render `ann:*` fields as deterministic source annotation lines."""
 
-    explicit = _get_attribute_value(entry, f"a:{annotation_field}")
+    explicit = _get_attribute_value(entry, f"{ANNOTATION_NAMESPACE}:{annotation_field}")
     if explicit:
         return explicit
 
     lines: list[tuple[str, str]] = []
-
-    for namespace in ("s", "p"):
+    for namespace in (SCH_NAMESPACE, PCB_NAMESPACE):
         value = _resolve_namespaced_field_value(
             entry,
             namespace,
@@ -760,13 +773,13 @@ def _resolve_annotation_field_value(
 
     inventory_value = _resolve_namespaced_field_value(
         entry,
-        "i",
+        INV_NAMESPACE,
         annotation_field,
         fabricator_id=fabricator_id,
         fabricator_config=fabricator_config,
     )
     if inventory_value:
-        lines.append(("i", inventory_value))
+        lines.append((INV_NAMESPACE, inventory_value))
 
     if not lines:
         return ""

--- a/src/jbom/cli/parts.py
+++ b/src/jbom/cli/parts.py
@@ -44,9 +44,15 @@ from jbom.common.component_filters import (
     create_filter_config,
 )
 from jbom.config.fabricators import get_available_fabricators
+from jbom.config.fields import (
+    ANNOTATION_NAMESPACE,
+    INV_NAMESPACE,
+    PCB_NAMESPACE,
+    SCH_NAMESPACE,
+)
 from jbom.cli.formatting import Column, print_table, get_terminal_width
 
-_PARTS_SOURCE_PRIORITY = "sip"
+_PARTS_SOURCE_PRIORITY = [SCH_NAMESPACE, INV_NAMESPACE, PCB_NAMESPACE]
 _PARTS_COMPUTED_FIELDS: tuple[str, ...] = (
     "refs",
     "value",
@@ -113,7 +119,7 @@ def _enrich_parts_with_merge_namespaces(
     parts_data: PartsListData,
     merge_result: ComponentMergeResult | None,
 ) -> PartsListData:
-    """Attach merge namespace attributes (`s:/p:/a:`) to parts entries."""
+    """Attach merge namespace attributes (`sch:/pcb:/ann:`) to parts entries."""
 
     if merge_result is None or not merge_result.records:
         return parts_data
@@ -225,9 +231,9 @@ def _list_available_parts_fields(
     )
     columns = [
         Column(header="Name", key="Name", preferred_width=22, wrap=False),
-        Column(header="s:", key="s:", preferred_width=16, wrap=False),
-        Column(header="p:", key="p:", preferred_width=16, wrap=False),
-        Column(header="i:", key="i:", preferred_width=16, wrap=False),
+        Column(header="sch:", key="sch:", preferred_width=16, wrap=False),
+        Column(header="pcb:", key="pcb:", preferred_width=16, wrap=False),
+        Column(header="inv:", key="inv:", preferred_width=16, wrap=False),
     ]
     print_table(
         [row.to_console_row() for row in matrix_rows],
@@ -606,9 +612,9 @@ def _get_parts_field_value(entry: PartsListEntry, field: str) -> str:
     row_sources = _build_parts_row_sources(entry)
 
     namespace_prefix, separator, _ = field.partition(":")
-    if separator and namespace_prefix in {"s", "p", "i"}:
+    if separator and namespace_prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}:
         return resolve_field(field, row_sources, priority=_PARTS_SOURCE_PRIORITY)
-    if separator and namespace_prefix == "a":
+    if separator and namespace_prefix == ANNOTATION_NAMESPACE:
         return str(entry.attributes.get(field, "") or "")
     if field in {"value", "footprint", "package", "tolerance", "voltage", "dielectric"}:
         return resolve_field(
@@ -636,34 +642,42 @@ def _get_parts_field_value(entry: PartsListEntry, field: str) -> str:
 
 
 def _build_parts_row_sources(entry: PartsListEntry) -> dict[str, dict[str, object]]:
-    """Build source field maps for one parts row (`s`, `p`, `i`)."""
+    """Build source field maps for one parts row (`sch`, `pcb`, `inv`)."""
 
-    row_sources: dict[str, dict[str, object]] = {"s": {}, "p": {}, "i": {}}
+    row_sources: dict[str, dict[str, object]] = {
+        SCH_NAMESPACE: {},
+        PCB_NAMESPACE: {},
+        INV_NAMESPACE: {},
+    }
     for key, value in entry.attributes.items():
         normalized_key = normalize_field_name(str(key or ""))
         prefix, separator, remainder = normalized_key.partition(":")
-        if separator and prefix in {"s", "p", "i"} and remainder:
+        if (
+            separator
+            and prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}
+            and remainder
+        ):
             row_sources[prefix][remainder] = value
         elif normalized_key:
-            row_sources["s"].setdefault(normalized_key, value)
+            row_sources[SCH_NAMESPACE].setdefault(normalized_key, value)
 
     if entry.value:
-        row_sources["s"].setdefault("value", entry.value)
+        row_sources[SCH_NAMESPACE].setdefault("value", entry.value)
     if entry.footprint:
-        row_sources["s"].setdefault("footprint", entry.footprint)
+        row_sources[SCH_NAMESPACE].setdefault("footprint", entry.footprint)
     if entry.package:
-        row_sources["s"].setdefault("package", entry.package)
+        row_sources[SCH_NAMESPACE].setdefault("package", entry.package)
     if entry.part_type:
-        row_sources["s"].setdefault("part_type", entry.part_type)
-        row_sources["s"].setdefault("type", entry.part_type)
+        row_sources[SCH_NAMESPACE].setdefault("part_type", entry.part_type)
+        row_sources[SCH_NAMESPACE].setdefault("type", entry.part_type)
     if entry.tolerance:
-        row_sources["s"].setdefault("tolerance", entry.tolerance)
+        row_sources[SCH_NAMESPACE].setdefault("tolerance", entry.tolerance)
     if entry.voltage:
-        row_sources["s"].setdefault("voltage", entry.voltage)
+        row_sources[SCH_NAMESPACE].setdefault("voltage", entry.voltage)
     if entry.dielectric:
-        row_sources["s"].setdefault("dielectric", entry.dielectric)
+        row_sources[SCH_NAMESPACE].setdefault("dielectric", entry.dielectric)
     if entry.lib_id:
-        row_sources["s"].setdefault("lib_id", entry.lib_id)
+        row_sources[SCH_NAMESPACE].setdefault("lib_id", entry.lib_id)
 
     return row_sources
 

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -39,12 +39,13 @@ from jbom.common.cli_fabricator import (
 from jbom.common.component_filters import add_component_filter_arguments
 from jbom.common.fields import normalize_field_name
 from jbom.config.fabricators import FabricatorConfig
+from jbom.config.fields import INV_NAMESPACE, PCB_NAMESPACE, SCH_NAMESPACE
 from jbom.services.fabricator_projection_service import FabricatorProjectionService
 from jbom.services.field_listing_service import FieldListingService
 from jbom.services.pos_field_resolver import resolve_pos_field_value
 
 _NUMERIC_POS_FIELDS: frozenset[str] = frozenset({"x", "y", "rotation"})
-_POS_SOURCE_PRIORITY = "pis"
+_POS_SOURCE_PRIORITY = [PCB_NAMESPACE, INV_NAMESPACE, SCH_NAMESPACE]
 _MAX_POS_CONSOLE_COLUMN_WIDTH = 50
 
 
@@ -334,9 +335,9 @@ def _list_available_pos_fields(
     )
     columns = [
         Column(header="Name", key="Name", preferred_width=22, wrap=False),
-        Column(header="s:", key="s:", preferred_width=16, wrap=False),
-        Column(header="p:", key="p:", preferred_width=16, wrap=False),
-        Column(header="i:", key="i:", preferred_width=16, wrap=False),
+        Column(header="sch:", key="sch:", preferred_width=16, wrap=False),
+        Column(header="pcb:", key="pcb:", preferred_width=16, wrap=False),
+        Column(header="inv:", key="inv:", preferred_width=16, wrap=False),
     ]
     print_table(
         [row.to_console_row() for row in matrix_rows],
@@ -546,30 +547,38 @@ def _get_pos_field_value(
 
 
 def _build_pos_row_sources(entry: dict[str, Any]) -> dict[str, dict[str, object]]:
-    """Build source field maps for one POS row (`s`, `p`, `i`)."""
+    """Build source field maps for one POS row (`sch`, `pcb`, `inv`)."""
 
-    row_sources: dict[str, dict[str, object]] = {"s": {}, "p": {}, "i": {}}
+    row_sources: dict[str, dict[str, object]] = {
+        SCH_NAMESPACE: {},
+        PCB_NAMESPACE: {},
+        INV_NAMESPACE: {},
+    }
     for key, value in entry.items():
         normalized_key = normalize_field_name(str(key or ""))
         prefix, separator, remainder = normalized_key.partition(":")
-        if separator and prefix in {"s", "p", "i"} and remainder:
+        if (
+            separator
+            and prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}
+            and remainder
+        ):
             row_sources[prefix][remainder] = value
         elif normalized_key:
-            row_sources["p"].setdefault(normalized_key, value)
+            row_sources[PCB_NAMESPACE].setdefault(normalized_key, value)
 
     if entry.get("x_raw"):
-        row_sources["p"].setdefault("x", entry.get("x_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("x", entry.get("x_raw"))
     elif entry.get("x_mm") is not None:
-        row_sources["p"].setdefault("x", f"{entry['x_mm']:.4f}")
+        row_sources[PCB_NAMESPACE].setdefault("x", f"{entry['x_mm']:.4f}")
 
     if entry.get("y_raw"):
-        row_sources["p"].setdefault("y", entry.get("y_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("y", entry.get("y_raw"))
     elif entry.get("y_mm") is not None:
-        row_sources["p"].setdefault("y", f"{entry['y_mm']:.4f}")
+        row_sources[PCB_NAMESPACE].setdefault("y", f"{entry['y_mm']:.4f}")
 
     if entry.get("rotation_raw") is not None:
-        row_sources["p"].setdefault("rotation", entry.get("rotation_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("rotation", entry.get("rotation_raw"))
     elif entry.get("rotation") is not None:
-        row_sources["p"].setdefault("rotation", f"{entry['rotation']:.1f}")
+        row_sources[PCB_NAMESPACE].setdefault("rotation", f"{entry['rotation']:.1f}")
 
     return row_sources

--- a/src/jbom/common/fields.py
+++ b/src/jbom/common/fields.py
@@ -60,20 +60,20 @@ def normalize_field_name(field: str) -> str:
     if not field:
         return ""
 
-    # Handle prefixes (I:, S:, P:, and A:) separately
+    # Handle canonical source/annotation prefixes separately
     prefix = ""
-    if field.lower().startswith("i:"):
-        prefix = "i:"
-        field = field[2:]
-    elif field.lower().startswith("s:"):
-        prefix = "s:"
-        field = field[2:]
-    elif field.lower().startswith("p:"):
-        prefix = "p:"
-        field = field[2:]
-    elif field.lower().startswith("a:"):
-        prefix = "a:"
-        field = field[2:]
+    if field.lower().startswith("sch:"):
+        prefix = "sch:"
+        field = field[4:]
+    elif field.lower().startswith("pcb:"):
+        prefix = "pcb:"
+        field = field[4:]
+    elif field.lower().startswith("inv:"):
+        prefix = "inv:"
+        field = field[4:]
+    elif field.lower().startswith("ann:"):
+        prefix = "ann:"
+        field = field[4:]
 
     # Replace spaces and hyphens with underscores
     field = field.replace(" ", "_").replace("-", "_")
@@ -101,7 +101,7 @@ def field_to_header(field: str) -> str:
     Examples:
         'match_quality' -> 'Match Quality'
         'lcsc' -> 'LCSC'
-        'i:package' -> 'I:Package'
+        'inv:package' -> 'INV:Package'
         'mfgpn' -> 'MFGPN'
 
     Args:
@@ -115,18 +115,21 @@ def field_to_header(field: str) -> str:
 
     # Handle prefixes
     prefix = ""
-    if field.lower().startswith("i:"):
-        prefix = "I:"
-        field = field[2:]
-    elif field.lower().startswith("s:"):
-        prefix = "S:"
-        field = field[2:]
-    elif field.lower().startswith("p:"):
-        prefix = "P:"
-        field = field[2:]
-    elif field.lower().startswith("a:"):
-        prefix = "A:"
-        field = field[2:]
+    if field.lower().startswith("inv:"):
+        prefix = "INV:"
+        field = field[4:]
+    elif field.lower().startswith("sch:"):
+        prefix = "SCH:"
+        field = field[4:]
+    elif field.lower().startswith("pcb:"):
+        prefix = "PCB:"
+        field = field[4:]
+    elif field.lower().startswith("ann:"):
+        prefix = "ANN:"
+        field = field[4:]
+    elif field.lower().startswith("jbom:"):
+        prefix = "JBOM:"
+        field = field[5:]
 
     # Split on underscores and handle each part
     parts = field.split("_")
@@ -149,7 +152,7 @@ def field_to_header(field: str) -> str:
 # Field presets - easily extensible data structure
 # All field names stored in normalized snake_case internally
 # Standard BOM fields don't need qualification (reference, quantity, value, etc.)
-# Inventory-specific fields are qualified with i: to avoid ambiguity
+# Inventory-specific fields are qualified with inv: to avoid ambiguity
 FIELD_PRESETS = {
     "default": {
         "fields": [
@@ -263,8 +266,8 @@ def get_available_presets() -> Dict[str, str]:
     return {name: info["description"] for name, info in FIELD_PRESETS.items()}
 
 
-# Valid source prefixes for k: stacking
-_K_MODIFIER_SOURCES: frozenset[str] = frozenset({"s", "p", "i"})
+# Valid canonical source prefixes for k: stacking
+_K_MODIFIER_SOURCES: frozenset[str] = frozenset({"sch", "pcb", "inv"})
 
 
 def split_kicad_strip_field(field: str) -> "tuple[str, str] | None":
@@ -273,23 +276,23 @@ def split_kicad_strip_field(field: str) -> "tuple[str, str] | None":
     The ``k:`` modifier strips the ``LIBRARY:NAME`` prefix from a KiCad field
     value, returning only the ``NAME`` part (e.g. ``SPCoast:0603-RES`` →
     ``0603-RES``).  It must be combined with a source prefix to be
-    unambiguous.  Bare ``k:`` silently defaults to ``i:`` (inventory source);
+    unambiguous.  Bare ``k:`` silently defaults to ``inv:`` (inventory source);
     callers should log a note when verbose/debug mode is active.
 
     Supported forms::
 
-        "k:footprint"       → ("i", "footprint")  # defaults to inventory
-        "i:k:footprint"     → ("i", "footprint")
-        "s:k:footprint"     → ("s", "footprint")
-        "p:k:footprint"     → ("p", "footprint")
-        "k:lib_id"          → ("i", "lib_id")
+        "k:footprint"         → ("inv", "footprint")  # defaults to inventory
+        "inv:k:footprint"     → ("inv", "footprint")
+        "sch:k:footprint"     → ("sch", "footprint")
+        "pcb:k:footprint"     → ("pcb", "footprint")
+        "k:lib_id"            → ("inv", "lib_id")
 
     Returns ``None`` when ``field`` does not use the ``k:`` modifier.
     """
     if field.startswith("k:"):
         inner = field[2:]
         if inner:
-            return "i", inner
+            return "inv", inner
         return None
 
     for src in _K_MODIFIER_SOURCES:

--- a/src/jbom/config/field_ref.py
+++ b/src/jbom/config/field_ref.py
@@ -31,20 +31,16 @@ _DEFAULT_SOURCE_PRIORITY: tuple[str, ...] = (
 )
 
 _SOURCE_NAMESPACE_ALIASES: dict[str, str] = {
-    "s": SCH_NAMESPACE,
-    "sch": SCH_NAMESPACE,
-    "c": SCH_NAMESPACE,
-    "p": PCB_NAMESPACE,
-    "pcb": PCB_NAMESPACE,
-    "i": INV_NAMESPACE,
-    "inv": INV_NAMESPACE,
+    SCH_NAMESPACE: SCH_NAMESPACE,
+    PCB_NAMESPACE: PCB_NAMESPACE,
+    INV_NAMESPACE: INV_NAMESPACE,
 }
 
 _ALL_NAMESPACE_ALIASES: dict[str, str] = {
-    **_SOURCE_NAMESPACE_ALIASES,
+    SCH_NAMESPACE: SCH_NAMESPACE,
+    PCB_NAMESPACE: PCB_NAMESPACE,
+    INV_NAMESPACE: INV_NAMESPACE,
     ANNOTATION_NAMESPACE: ANNOTATION_NAMESPACE,
-    "ann": ANNOTATION_NAMESPACE,
-    "annotation": ANNOTATION_NAMESPACE,
     JBOM_NAMESPACE: JBOM_NAMESPACE,
 }
 
@@ -82,12 +78,12 @@ class FieldContext:
         transforms: Mapping[str, TransformCallable] | None = None,
         source_priority: Sequence[str] | None = None,
     ) -> FieldContext:
-        """Construct context from legacy `s`/`p`/`i` row-source maps."""
+        """Construct context from canonical `sch`/`pcb`/`inv` row-source maps."""
 
         return cls(
-            schematic=row_sources.get("s") or {},
-            pcb=row_sources.get("p") or {},
-            inventory=row_sources.get("i") or {},
+            schematic=row_sources.get(SCH_NAMESPACE) or {},
+            pcb=row_sources.get(PCB_NAMESPACE) or {},
+            inventory=row_sources.get(INV_NAMESPACE) or {},
             computed=computed or {},
             annotations=annotations or {},
             transforms=transforms or {},
@@ -125,7 +121,7 @@ class FieldContext:
         return _mapping_has_normalized_key(self.computed, normalized_field_name)
 
     def resolve_annotation(self, field_name: str) -> str:
-        """Resolve one annotation (`a:*`) field from context."""
+        """Resolve one annotation (`ann:*`) field from context."""
 
         return _lookup_normalized_value(self.annotations, field_name)
 
@@ -363,7 +359,7 @@ def _normalize_computed_mapping(raw_mapping: Mapping[str, object]) -> dict[str, 
 def _normalize_annotation_mapping(
     raw_mapping: Mapping[str, object]
 ) -> dict[str, object]:
-    """Normalize annotation mapping and allow optional `a:` key prefix."""
+    """Normalize annotation mapping and allow optional `ann:` key prefix."""
 
     normalized: dict[str, object] = {}
     for key, value in (raw_mapping or {}).items():

--- a/src/jbom/config/fields.py
+++ b/src/jbom/config/fields.py
@@ -8,12 +8,13 @@ SCH_NAMESPACE = "sch"
 PCB_NAMESPACE = "pcb"
 INV_NAMESPACE = "inv"
 JBOM_NAMESPACE = "jbom"
-ANNOTATION_NAMESPACE = "a"
+ANNOTATION_NAMESPACE = "ann"
 
 SCH = SCH_NAMESPACE
 PCB = PCB_NAMESPACE
 INV = INV_NAMESPACE
 JBOM = JBOM_NAMESPACE
+ANN = ANNOTATION_NAMESPACE
 
 JBOM_COMPUTED_FIELD_NAMES: frozenset[str] = frozenset(
     {
@@ -46,6 +47,7 @@ def is_jbom_computed(ref: str) -> bool:
 
 
 __all__ = [
+    "ANN",
     "ANNOTATION_NAMESPACE",
     "INV",
     "INV_NAMESPACE",

--- a/src/jbom/services/annotation_service.py
+++ b/src/jbom/services/annotation_service.py
@@ -490,25 +490,25 @@ def _normalize_repair_update_value_with_baseline(
         return parsed_value["bare_value"]
 
     parsed_baseline = _parse_merge_notation_value(baseline_value)
-    baseline_s = parsed_baseline["source_values"].get(
-        "s", parsed_baseline["bare_value"]
+    baseline_schematic = parsed_baseline["source_values"].get(
+        "sch", parsed_baseline["bare_value"]
     )
-    baseline_p = parsed_baseline["source_values"].get(
-        "p", parsed_baseline["bare_value"]
+    baseline_pcb = parsed_baseline["source_values"].get(
+        "pcb", parsed_baseline["bare_value"]
     )
 
-    resolved_s = parsed_value["source_values"].get("s", baseline_s)
-    resolved_p = parsed_value["source_values"].get("p", baseline_p)
+    resolved_schematic = parsed_value["source_values"].get("sch", baseline_schematic)
+    resolved_pcb = parsed_value["source_values"].get("pcb", baseline_pcb)
 
-    if resolved_s:
-        return resolved_s
-    if resolved_p:
-        return resolved_p
+    if resolved_schematic:
+        return resolved_schematic
+    if resolved_pcb:
+        return resolved_pcb
     return ""
 
 
 def _parse_merge_notation_value(raw_value: str) -> dict[str, Any]:
-    """Parse s:/p: merge notation from a repairs cell value."""
+    """Parse sch:/pcb: merge notation from a repairs cell value."""
     text = str(raw_value or "").strip()
     if not text:
         return {
@@ -526,7 +526,7 @@ def _parse_merge_notation_value(raw_value: str) -> dict[str, Any]:
         if ":" in line:
             source, value = line.split(":", 1)
             source_key = source.strip().lower()
-            if source_key in {"s", "p"}:
+            if source_key in {"sch", "pcb"}:
                 source_values[source_key] = value.strip()
                 has_merge_notation = True
                 continue

--- a/src/jbom/services/bom_field_resolver.py
+++ b/src/jbom/services/bom_field_resolver.py
@@ -16,11 +16,17 @@ from jbom.config.field_expr import (
     TransformCallable,
 )
 from jbom.config.field_ref import FieldContext, FieldRefResolver
+from jbom.config.fields import (
+    ANNOTATION_NAMESPACE,
+    INV_NAMESPACE,
+    PCB_NAMESPACE,
+    SCH_NAMESPACE,
+)
 from jbom.config.fabricators import FabricatorConfig
 from jbom.config.unified import load_unified
 
 # Source priority: PCB first, then inventory, then schematic
-_BOM_SOURCE_PRIORITY = ["p", "i", "s"]
+_BOM_SOURCE_PRIORITY = [PCB_NAMESPACE, INV_NAMESPACE, SCH_NAMESPACE]
 
 
 def resolve_bom_field_value(
@@ -127,7 +133,7 @@ def _build_field_context(
         row_sources,
         computed=computed_fields,
         annotations=annotation_fields,
-        source_priority=("p", "i", "s"),
+        source_priority=(PCB_NAMESPACE, INV_NAMESPACE, SCH_NAMESPACE),
     )
 
 
@@ -163,15 +169,16 @@ def _build_annotation_field_values(
     entry: BOMEntry,
     row_sources: Mapping[str, Mapping[str, object]],
 ) -> dict[str, str]:
-    """Build concrete `a:*` annotation values from source fields and explicit attrs."""
+    """Build concrete `ann:*` annotation values from source fields and explicit attrs."""
 
     annotations: dict[str, str] = {}
 
     for attribute_key, attribute_value in entry.attributes.items():
         normalized_key = normalize_field_name(str(attribute_key or ""))
-        if not normalized_key.startswith("a:"):
+        annotation_prefix = f"{ANNOTATION_NAMESPACE}:"
+        if not normalized_key.startswith(annotation_prefix):
             continue
-        annotation_key = normalized_key[2:]
+        annotation_key = normalized_key[len(annotation_prefix) :]
         if not annotation_key:
             continue
         annotation_value = _coerce_output_value(attribute_value)
@@ -199,10 +206,10 @@ def _render_source_annotation_value(
     field_name: str,
     row_sources: Mapping[str, Mapping[str, object]],
 ) -> str:
-    """Render `a:<field>` output lines in stable source order."""
+    """Render `ann:<field>` output lines in stable source order."""
 
     lines: list[tuple[str, str]] = []
-    for namespace in ("s", "p", "i"):
+    for namespace in (SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE):
         value = resolve_field(
             f"{namespace}:{field_name}",
             row_sources,
@@ -284,25 +291,33 @@ def _build_bom_row_sources(
     *,
     include_unqualified_fallback: bool,
 ) -> dict[str, dict[str, object]]:
-    """Build source field maps for one BOM row (`s`, `p`, `i`)."""
-    row_sources: dict[str, dict[str, object]] = {"s": {}, "p": {}, "i": {}}
+    """Build source field maps for one BOM row (`sch`, `pcb`, `inv`)."""
+    row_sources: dict[str, dict[str, object]] = {
+        SCH_NAMESPACE: {},
+        PCB_NAMESPACE: {},
+        INV_NAMESPACE: {},
+    }
     for attr_key, attr_value in entry.attributes.items():
         normalized_key = normalize_field_name(str(attr_key or ""))
         prefix, separator, remainder = normalized_key.partition(":")
-        if separator and prefix in {"s", "p", "i"} and remainder:
+        if (
+            separator
+            and prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}
+            and remainder
+        ):
             row_sources[prefix][remainder] = attr_value
 
     if include_unqualified_fallback:
         # Keep unqualified behavior stable when merge enrichment is absent.
         if entry.references_string:
-            row_sources["s"].setdefault("reference", entry.references_string)
+            row_sources[SCH_NAMESPACE].setdefault("reference", entry.references_string)
         if entry.value:
-            row_sources["s"].setdefault("value", entry.value)
+            row_sources[SCH_NAMESPACE].setdefault("value", entry.value)
         if entry.footprint:
-            row_sources["s"].setdefault("footprint", entry.footprint)
+            row_sources[SCH_NAMESPACE].setdefault("footprint", entry.footprint)
         package_value = _get_attribute_value(entry, "package")
         if package_value:
-            row_sources["s"].setdefault("package", package_value)
+            row_sources[SCH_NAMESPACE].setdefault("package", package_value)
 
     return row_sources
 

--- a/src/jbom/services/component_merge_service.py
+++ b/src/jbom/services/component_merge_service.py
@@ -1,7 +1,7 @@
 """Component merge service for source namespace-aware workflows.
 
 Current scope:
-- build deterministic source and annotation fields (`s:*`, `p:*`, `a:*`)
+- build deterministic source and annotation fields (`sch:*`, `pcb:*`, `ann:*`)
 - emit structured mismatch metadata for source disagreements
 """
 
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 from jbom.common.reference_sort import natural_reference_sort_key
+from jbom.config.fields import ANNOTATION_NAMESPACE, PCB_NAMESPACE, SCH_NAMESPACE
 
 from jbom.services.project_component_collector import (
     ProjectComponentGraph,
@@ -59,8 +60,8 @@ def resolve_grouped_merge_namespace_values(
 ) -> dict[str, str]:
     """Resolve grouped namespace values for one aggregated output entry.
 
-    `s:*` and `p:*` fields are emitted only when grouped references agree.
-    `a:*` fields are always human-oriented: when grouped references disagree on
+    `sch:*` and `pcb:*` fields are emitted only when grouped references agree.
+    `ann:*` fields are always human-oriented: when grouped references disagree on
     annotation text, render a deterministic reference-indexed summary.
     """
 
@@ -117,14 +118,14 @@ def _resolve_grouped_annotation_field_value(
     *,
     field_key: str,
 ) -> str:
-    """Resolve grouped `a:*` annotation text for one field key.
+    """Resolve grouped `ann:*` annotation text for one field key.
 
     Contract:
     - If all grouped references resolve to one summary, return only the summary.
     - If grouped references resolve to multiple summaries, render deterministic
       reference-indexed segments joined by ` || `.
     - Mismatch summaries prefer concise diagnostic wording:
-      `S: and P: differ\\ns:<value>\\np:<value>`.
+      `sch: and pcb: differ\\nsch:<value>\\npcb:<value>`.
     - Non-mismatch summaries collapse to one source value when available.
     """
 
@@ -165,7 +166,7 @@ def _annotation_field_name(field_key: str) -> str:
     """Return the unprefixed field name for an annotation key."""
 
     prefix, separator, remainder = str(field_key or "").partition(":")
-    if separator and prefix == "a" and remainder:
+    if separator and prefix == ANNOTATION_NAMESPACE and remainder:
         return remainder
     return str(field_key or "")
 
@@ -178,8 +179,12 @@ def _build_grouped_annotation_summary(
 ) -> str:
     """Build one grouped annotation summary for a merged reference record."""
 
-    source_s = str(record.source_fields.get(f"s:{field_name}", "")).strip()
-    source_p = str(record.source_fields.get(f"p:{field_name}", "")).strip()
+    source_s = str(
+        record.source_fields.get(f"{SCH_NAMESPACE}:{field_name}", "")
+    ).strip()
+    source_p = str(
+        record.source_fields.get(f"{PCB_NAMESPACE}:{field_name}", "")
+    ).strip()
     explicit_annotation = str(record.annotated_fields.get(field_key, "")).strip()
 
     if source_s and source_p and source_s != source_p:
@@ -200,10 +205,10 @@ def _format_mismatch_annotation_summary(
     source_s: str,
     source_p: str,
 ) -> str:
-    """Render concise mismatch annotation text for grouped `a:*` output."""
-    lines: list[str] = ["S: and P: differ"]
-    lines.append(f"s:{source_s}")
-    lines.append(f"p:{source_p}")
+    """Render concise mismatch annotation text for grouped `ann:*` output."""
+    lines: list[str] = [f"{SCH_NAMESPACE}: and {PCB_NAMESPACE}: differ"]
+    lines.append(f"{SCH_NAMESPACE}:{source_s}")
+    lines.append(f"{PCB_NAMESPACE}:{source_p}")
 
     return "\n".join(lines)
 
@@ -266,15 +271,15 @@ class ComponentMergeService:
     def _build_source_fields(
         self, project_record: ProjectReferenceRecord
     ) -> dict[str, str]:
-        """Build source namespace fields (`s:*`, `p:*`) for one reference."""
+        """Build source namespace fields (`sch:*`, `pcb:*`) for one reference."""
 
         source_fields: dict[str, str] = {}
         schematic_fields = self._extract_schematic_fields(project_record)
         pcb_fields = self._extract_pcb_fields(project_record)
         for field_name, field_value in schematic_fields.items():
-            source_fields[f"s:{field_name}"] = field_value
+            source_fields[f"{SCH_NAMESPACE}:{field_name}"] = field_value
         for field_name, field_value in pcb_fields.items():
-            source_fields[f"p:{field_name}"] = field_value
+            source_fields[f"{PCB_NAMESPACE}:{field_name}"] = field_value
         return source_fields
 
     def _build_mismatches(
@@ -286,8 +291,8 @@ class ComponentMergeService:
 
         mismatches: list[MergeMismatchRecord] = []
         for field_name in self._iter_source_field_names(source_fields):
-            schematic_value = source_fields.get(f"s:{field_name}", "")
-            pcb_value = source_fields.get(f"p:{field_name}", "")
+            schematic_value = source_fields.get(f"{SCH_NAMESPACE}:{field_name}", "")
+            pcb_value = source_fields.get(f"{PCB_NAMESPACE}:{field_name}", "")
             if not schematic_value or not pcb_value or schematic_value == pcb_value:
                 continue
             mismatches.append(
@@ -295,7 +300,10 @@ class ComponentMergeService:
                     reference=reference,
                     field_key=field_name,
                     severity="warning",
-                    source_values={"s": schematic_value, "p": pcb_value},
+                    source_values={
+                        SCH_NAMESPACE: schematic_value,
+                        PCB_NAMESPACE: pcb_value,
+                    },
                 )
             )
         return mismatches
@@ -303,17 +311,23 @@ class ComponentMergeService:
     def _build_annotated_fields(
         self, mismatches: list[MergeMismatchRecord]
     ) -> dict[str, str]:
-        """Build `a:*` annotation cells from mismatch records."""
+        """Build `ann:*` annotation cells from mismatch records."""
 
         annotated: dict[str, str] = {}
         for mismatch in mismatches:
             source_lines = []
-            if mismatch.source_values.get("s"):
-                source_lines.append(f"s:{mismatch.source_values['s']}")
-            if mismatch.source_values.get("p"):
-                source_lines.append(f"p:{mismatch.source_values['p']}")
+            if mismatch.source_values.get(SCH_NAMESPACE):
+                source_lines.append(
+                    f"{SCH_NAMESPACE}:{mismatch.source_values[SCH_NAMESPACE]}"
+                )
+            if mismatch.source_values.get(PCB_NAMESPACE):
+                source_lines.append(
+                    f"{PCB_NAMESPACE}:{mismatch.source_values[PCB_NAMESPACE]}"
+                )
             if source_lines:
-                annotated[f"a:{mismatch.field_key}"] = "\n".join(source_lines)
+                annotated[f"{ANNOTATION_NAMESPACE}:{mismatch.field_key}"] = "\n".join(
+                    source_lines
+                )
         return annotated
 
     def _extract_schematic_fields(
@@ -437,8 +451,9 @@ class ComponentMergeService:
 
         field_names: set[str] = set()
         for prefixed_name in source_fields:
-            if prefixed_name.startswith("s:") or prefixed_name.startswith("p:"):
-                field_names.add(prefixed_name[2:])
+            prefix, separator, field_name = prefixed_name.partition(":")
+            if separator and field_name and prefix in {SCH_NAMESPACE, PCB_NAMESPACE}:
+                field_names.add(field_name)
         return tuple(sorted(field_names))
 
     def _get_component_property(

--- a/src/jbom/services/field_listing_service.py
+++ b/src/jbom/services/field_listing_service.py
@@ -7,7 +7,8 @@ from typing import Iterable, Mapping, Sequence
 
 from jbom.common.fields import normalize_field_name
 
-_SOURCE_PREFIXES: tuple[str, ...] = ("s", "p", "i")
+_SOURCE_PREFIXES: tuple[str, ...] = ("sch", "pcb", "inv")
+_DEFAULT_PRIORITY: tuple[str, ...] = ("pcb", "inv", "sch")
 
 
 @dataclass(frozen=True)
@@ -15,23 +16,23 @@ class FieldNamespaceMatrixRow:
     """One row in the namespace matrix view for a canonical field name."""
 
     name: str
-    s_token: str = ""
-    p_token: str = ""
-    i_token: str = ""
+    sch_token: str = ""
+    pcb_token: str = ""
+    inv_token: str = ""
 
     def to_console_row(self) -> dict[str, str]:
         """Convert row to a console table mapping with fixed matrix columns."""
 
         return {
             "Name": self.name,
-            "s:": self.s_token,
-            "p:": self.p_token,
-            "i:": self.i_token,
+            "sch:": self.sch_token,
+            "pcb:": self.pcb_token,
+            "inv:": self.inv_token,
         }
 
 
 def normalize_priority(priority: str | Sequence[str]) -> tuple[str, ...]:
-    """Normalize source-priority specifiers into an ordered (s|p|i) tuple."""
+    """Normalize source-priority specifiers into canonical source token order."""
 
     if isinstance(priority, str):
         compact = priority.strip().lower()
@@ -44,16 +45,20 @@ def normalize_priority(priority: str | Sequence[str]) -> tuple[str, ...]:
                 if token.strip()
             ]
         else:
-            tokens = list(compact)
+            tokens = [normalize_field_name(compact).strip()]
     else:
-        tokens = [str(token or "").strip().lower() for token in priority if token]
+        tokens = [
+            normalize_field_name(str(token or "")).strip()
+            for token in priority
+            if token
+        ]
 
     if len(tokens) != 3:
         raise ValueError("priority must specify exactly three source tokens")
     if len(set(tokens)) != 3:
         raise ValueError("priority cannot include duplicate source tokens")
     if any(token not in _SOURCE_PREFIXES for token in tokens):
-        raise ValueError("priority may only contain source tokens: s, p, i")
+        raise ValueError("priority may only contain source tokens: sch, pcb, inv")
 
     return tuple(tokens)
 
@@ -62,7 +67,7 @@ def resolve_field(
     field_name: str,
     row_sources: Mapping[str, Mapping[str, object] | None],
     *,
-    priority: str | Sequence[str] = "pis",
+    priority: str | Sequence[str] = _DEFAULT_PRIORITY,
 ) -> str:
     """Resolve one field token from row source maps under source-priority rules."""
 
@@ -107,7 +112,7 @@ def _resolve_unqualified_field(
     field_name: str,
     row_sources: Mapping[str, Mapping[str, object] | None],
     *,
-    priority: str | Sequence[str] = "pis",
+    priority: str | Sequence[str] = _DEFAULT_PRIORITY,
 ) -> str:
     """Resolve an unqualified field using ordered source-priority lookup."""
 
@@ -128,15 +133,15 @@ def get_field_names(
     """Discover normalized field names from schematic/PCB/inventory sources."""
 
     normalized_source = str(source or "all").strip().lower()
-    if normalized_source not in {"s", "p", "i", "all"}:
-        raise ValueError("source must be one of: s, p, i, all")
+    if normalized_source not in {"sch", "pcb", "inv", "all"}:
+        raise ValueError("source must be one of: sch, pcb, inv, all")
 
     discovered: set[str] = set()
-    if normalized_source in {"s", "all"}:
+    if normalized_source in {"sch", "all"}:
         discovered.update(_discover_schematic_fields(schematic_components or []))
-    if normalized_source in {"p", "all"}:
+    if normalized_source in {"pcb", "all"}:
         discovered.update(_discover_pcb_fields(pcb_components or []))
-    if normalized_source in {"i", "all"}:
+    if normalized_source in {"inv", "all"}:
         discovered.update(_discover_inventory_fields(inventory_column_names or []))
     return discovered
 
@@ -147,7 +152,7 @@ def get_namespaced_field_tokens(
     pcb_components: Iterable[object] | None = None,
     inventory_column_names: Iterable[str] | None = None,
 ) -> set[str]:
-    """Return discovered source field tokens formatted as s:/p:/i: entries."""
+    """Return discovered source field tokens formatted as sch:/pcb:/inv: entries."""
 
     tokens: set[str] = set()
     for source in _SOURCE_PREFIXES:
@@ -168,7 +173,7 @@ class FieldListingService:
         self,
         field_tokens: Iterable[str],
     ) -> list[FieldNamespaceMatrixRow]:
-        """Group available tokens into Name|s:|p:|i: rows."""
+        """Group available tokens into Name|sch:|pcb:|inv: rows."""
 
         grouped: dict[str, dict[str, str]] = {}
         for raw_token in field_tokens:
@@ -180,7 +185,7 @@ class FieldListingService:
             if separator and prefix in _SOURCE_PREFIXES and remainder:
                 canonical_name = remainder
                 slot = prefix
-            elif separator and prefix == "a":
+            elif separator and prefix == "ann":
                 continue
             else:
                 canonical_name = normalized_token
@@ -190,9 +195,9 @@ class FieldListingService:
                 canonical_name,
                 {
                     "name": "",
-                    "s": "",
-                    "p": "",
-                    "i": "",
+                    "sch": "",
+                    "pcb": "",
+                    "inv": "",
                 },
             )
             if not row[slot]:
@@ -204,9 +209,9 @@ class FieldListingService:
             matrix_rows.append(
                 FieldNamespaceMatrixRow(
                     name=row["name"] or canonical_name,
-                    s_token=row["s"],
-                    p_token=row["p"],
-                    i_token=row["i"],
+                    sch_token=row["sch"],
+                    pcb_token=row["pcb"],
+                    inv_token=row["inv"],
                 )
             )
         return matrix_rows

--- a/src/jbom/services/inventory_matcher.py
+++ b/src/jbom/services/inventory_matcher.py
@@ -194,8 +194,8 @@ class InventoryMatcher:
         """
         attributes = entry.attributes or {}
         resolved_footprint = str(
-            attributes.get("p:footprint")
-            or attributes.get("s:footprint")
+            attributes.get("pcb:footprint")
+            or attributes.get("sch:footprint")
             or entry.footprint
             or ""
         ).strip()

--- a/src/jbom/services/inventory_overlay_service.py
+++ b/src/jbom/services/inventory_overlay_service.py
@@ -2,7 +2,7 @@
 
 The overlay workflow has two stages:
 1. optionally enrich merged BOM entries with inventory matching results.
-2. project inventory-facing attributes into explicit `i:*` namespace fields.
+2. project inventory-facing attributes into explicit `inv:*` namespace fields.
 
 Projected namespace fields are defined by defaults `inventory_schema`
 canonical fields so schema evolution is centralized in one profile.
@@ -29,7 +29,7 @@ class InventoryOverlayResult:
 
 
 class InventoryOverlayService:
-    """Apply inventory enhancement and project explicit `i:*` namespace fields."""
+    """Apply inventory enhancement and project explicit `inv:*` namespace fields."""
 
     def __init__(
         self,
@@ -94,7 +94,7 @@ class InventoryOverlayService:
         )
 
     def _project_inventory_namespace_fields(self, entry: BOMEntry) -> BOMEntry:
-        """Project normalized entry attributes into explicit `i:*` namespace keys."""
+        """Project normalized entry attributes into explicit `inv:*` namespace keys."""
 
         attributes = dict(entry.attributes)
 
@@ -103,14 +103,14 @@ class InventoryOverlayService:
             for field_name in self._namespace_fields:
                 value = self._coerce_inventory_value(attributes.get(field_name))
                 if value:
-                    attributes[f"i:{field_name}"] = value
+                    attributes[f"inv:{field_name}"] = value
 
-        if not self._coerce_inventory_value(attributes.get("i:package")):
+        if not self._coerce_inventory_value(attributes.get("inv:package")):
             package_value = self._coerce_inventory_value(attributes.get("package"))
             if not package_value:
                 package_value = derive_package_from_footprint(entry.footprint)
             if package_value:
-                attributes["i:package"] = package_value
+                attributes["inv:package"] = package_value
 
         return BOMEntry(
             references=entry.references,

--- a/src/jbom/services/pcb_reader.py
+++ b/src/jbom/services/pcb_reader.py
@@ -288,7 +288,7 @@ class DefaultKiCadReaderService(KiCadReaderService):
                             # completely different library name (e.g. KiCad
                             # stdlib vs. a vendor library).  We preserve it
                             # under ``attributes['schematic_footprint']``
-                            # so the BOM can expose ``s:footprint`` for
+                            # so the BOM can expose ``sch:footprint`` for
                             # DRC-debug scenarios, but the FPID is never
                             # overwritten.
                             attributes["schematic_footprint"] = val

--- a/src/jbom/services/pos_field_resolver.py
+++ b/src/jbom/services/pos_field_resolver.py
@@ -10,10 +10,16 @@ from typing import Any, Optional
 from jbom.common.fields import normalize_field_name, split_kicad_strip_field
 from jbom.common.component_utils import derive_package_from_footprint
 from jbom.services.field_listing_service import resolve_field
+from jbom.config.fields import (
+    ANNOTATION_NAMESPACE,
+    INV_NAMESPACE,
+    PCB_NAMESPACE,
+    SCH_NAMESPACE,
+)
 from jbom.config.fabricators import FabricatorConfig
 
 # Source priority: PCB first, then inventory, then schematic
-_POS_SOURCE_PRIORITY = ["p", "i", "s"]
+_POS_SOURCE_PRIORITY = [PCB_NAMESPACE, INV_NAMESPACE, SCH_NAMESPACE]
 
 
 def resolve_pos_field_value(
@@ -25,7 +31,7 @@ def resolve_pos_field_value(
 ) -> str:
     """Extract and resolve a field value from a POS entry.
 
-    Handles standard fields, namespaced fields (s:, p:, i:, a:), position
+    Handles standard fields, namespaced fields (sch:, pcb:, inv:, ann:), position
     coordinates (x, y, rotation), and KiCad strip modifiers (k:). Applies
     fabricator-specific projection and source precedence rules.
 
@@ -43,14 +49,15 @@ def resolve_pos_field_value(
     row_sources = _build_pos_row_sources(entry)
 
     # Handle k: modifier — KiCad LIBRARY:NAME → NAME (strip library nickname).
-    # "k:footprint" defaults to inventory source; use "i:k:", "s:k:", "p:k:" explicitly.
+    # "k:footprint" defaults to inventory source; use
+    # "inv:k:", "sch:k:", "pcb:k:" explicitly.
     kicad_parts = split_kicad_strip_field(field)
     if kicad_parts is not None:
         source, inner = kicad_parts
         if field.startswith("k:"):
             logging.getLogger(__name__).debug(
-                "k:%s: no source prefix specified, defaulting to i: (inventory). "
-                "Use i:k:, s:k:, or p:k: to be explicit.",
+                "k:%s: no source prefix specified, defaulting to inv: (inventory). "
+                "Use inv:k:, sch:k:, or pcb:k: to be explicit.",
                 inner,
             )
         raw = resolve_field(
@@ -60,9 +67,9 @@ def resolve_pos_field_value(
 
     # Handle namespaced fields
     namespace_prefix, separator, _ = field.partition(":")
-    if separator and namespace_prefix in {"s", "p", "i"}:
+    if separator and namespace_prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}:
         return resolve_field(field, row_sources, priority=_POS_SOURCE_PRIORITY)
-    if separator and namespace_prefix == "a":
+    if separator and namespace_prefix == ANNOTATION_NAMESPACE:
         return str(entry.get(field, "") or "")
 
     # Handle position coordinates
@@ -123,30 +130,38 @@ def _resolve_fabricator_part_number(
 
 
 def _build_pos_row_sources(entry: dict[str, Any]) -> dict[str, dict[str, object]]:
-    """Build source field maps for one POS row (`s`, `p`, `i`)."""
-    row_sources: dict[str, dict[str, object]] = {"s": {}, "p": {}, "i": {}}
+    """Build source field maps for one POS row (`sch`, `pcb`, `inv`)."""
+    row_sources: dict[str, dict[str, object]] = {
+        SCH_NAMESPACE: {},
+        PCB_NAMESPACE: {},
+        INV_NAMESPACE: {},
+    }
     for key, value in entry.items():
         normalized_key = normalize_field_name(str(key or ""))
         prefix, separator, remainder = normalized_key.partition(":")
-        if separator and prefix in {"s", "p", "i"} and remainder:
+        if (
+            separator
+            and prefix in {SCH_NAMESPACE, PCB_NAMESPACE, INV_NAMESPACE}
+            and remainder
+        ):
             row_sources[prefix][remainder] = value
         elif normalized_key:
-            row_sources["p"].setdefault(normalized_key, value)
+            row_sources[PCB_NAMESPACE].setdefault(normalized_key, value)
 
     if entry.get("x_raw"):
-        row_sources["p"].setdefault("x", entry.get("x_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("x", entry.get("x_raw"))
     elif entry.get("x_mm") is not None:
-        row_sources["p"].setdefault("x", f"{entry['x_mm']:.4f}")
+        row_sources[PCB_NAMESPACE].setdefault("x", f"{entry['x_mm']:.4f}")
 
     if entry.get("y_raw"):
-        row_sources["p"].setdefault("y", entry.get("y_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("y", entry.get("y_raw"))
     elif entry.get("y_mm") is not None:
-        row_sources["p"].setdefault("y", f"{entry['y_mm']:.4f}")
+        row_sources[PCB_NAMESPACE].setdefault("y", f"{entry['y_mm']:.4f}")
 
     if entry.get("rotation_raw") is not None:
-        row_sources["p"].setdefault("rotation", entry.get("rotation_raw"))
+        row_sources[PCB_NAMESPACE].setdefault("rotation", entry.get("rotation_raw"))
     elif entry.get("rotation") is not None:
-        row_sources["p"].setdefault("rotation", f"{entry['rotation']:.1f}")
+        row_sources[PCB_NAMESPACE].setdefault("rotation", f"{entry['rotation']:.1f}")
 
     return row_sources
 

--- a/src/jbom/services/sophisticated_inventory_matcher.py
+++ b/src/jbom/services/sophisticated_inventory_matcher.py
@@ -372,7 +372,7 @@ class SophisticatedInventoryMatcher:
         """
 
         properties = component.properties or {}
-        for key in ("spn", "SPN", "i:spn", "lcsc", "LCSC", "i:lcsc"):
+        for key in ("spn", "SPN", "inv:spn", "lcsc", "LCSC", "inv:lcsc"):
             value = str(properties.get(key, "")).strip()
             if value:
                 return value

--- a/tests/services/matchers/test_inventory_matcher.py
+++ b/tests/services/matchers/test_inventory_matcher.py
@@ -218,7 +218,7 @@ class TestInventoryMatcher:
             1,
             "Connector:Conn_01x04",
             {
-                "p:footprint": "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical"
+                "pcb:footprint": "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical"
             },
         )
 

--- a/tests/services/test_pos_workflow.py
+++ b/tests/services/test_pos_workflow.py
@@ -53,7 +53,7 @@ def test_pos_workflow_runs_without_cli_import(
             return [
                 {
                     "reference": "U1",
-                    "s:dnp": "yes",
+                    "sch:dnp": "yes",
                     "x_mm": 1.0,
                     "y_mm": 1.0,
                     "rotation": 0.0,

--- a/tests/unit/test_annotate_repairs.py
+++ b/tests/unit/test_annotate_repairs.py
@@ -225,10 +225,10 @@ def test_repairs_wide_missing_placeholders_are_not_applied(tmp_path: Path) -> No
 @pytest.mark.parametrize(
     ("suggested_value", "expected_value"),
     [
-        ("p:something\\ns:else", "else"),
-        ("s:else\\np:something", "else"),
-        ("p:something", "sss"),
-        ("s:else", "else"),
+        ("pcb:something\\nsch:else", "else"),
+        ("sch:else\\npcb:something", "else"),
+        ("pcb:something", "sss"),
+        ("sch:else", "else"),
         ("something", "something"),
     ],
 )
@@ -247,7 +247,7 @@ def test_repairs_wide_merge_notation_uses_current_row_fallbacks(
                 "RowType": "CURRENT",
                 "UUID": "uuid-r1",
                 "RefDes": "R1",
-                "Value": "s:sss\\np:ppp",
+                "Value": "sch:sss\\npcb:ppp",
                 "Action": "",
             },
             {

--- a/tests/unit/test_audit_cli.py
+++ b/tests/unit/test_audit_cli.py
@@ -635,7 +635,7 @@ def test_project_mode_includes_merge_mismatch_diagnostics_in_notes() -> None:
             uuid="uuid-r1",
             category="RES",
             field="footprint",
-            current_value="s:SCH:0603, p:PCB:0402",
+            current_value="sch:SCH:0603, pcb:PCB:0402",
             suggested_value="PCB:0402",
             description="R1 footprint mismatch",
         ),
@@ -653,8 +653,8 @@ def test_project_mode_includes_merge_mismatch_diagnostics_in_notes() -> None:
     current = next(row for row in written if row["RowType"] == "CURRENT")
     suggested = next(row for row in written if row["RowType"] == "SUGGESTED")
     assert current["Notes"] == "R1: heuristics are sufficient"
-    assert current["Footprint"] == "s:SCH:0603\np:PCB:0402"
-    assert suggested["Footprint"] == "s:SCH:0603\np:PCB:0402"
+    assert current["Footprint"] == "sch:SCH:0603\npcb:PCB:0402"
+    assert suggested["Footprint"] == "sch:SCH:0603\npcb:PCB:0402"
 
 
 def test_project_mode_matchability_exact_for_supplier_identifier_and_led_color() -> (

--- a/tests/unit/test_audit_service.py
+++ b/tests/unit/test_audit_service.py
@@ -343,8 +343,8 @@ def test_audit_project_emits_merge_mismatch_rows_for_pcb_disagreement(
     assert mismatch_row.severity == Severity.WARN
     assert mismatch_row.ref_des == "R1"
     assert mismatch_row.field == "footprint"
-    assert "s:Resistor_SMD:R_0603_1608Metric" in mismatch_row.description
-    assert "p:Resistor_SMD:R_0402_1005Metric" in mismatch_row.description
+    assert "sch:Resistor_SMD:R_0603_1608Metric" in mismatch_row.description
+    assert "pcb:Resistor_SMD:R_0402_1005Metric" in mismatch_row.description
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bom_cli_field_resolution.py
+++ b/tests/unit/test_bom_cli_field_resolution.py
@@ -86,43 +86,43 @@ def test_entry_smd_lookup_requires_all_known_references_smd() -> None:
 
 
 def test_inventory_package_field_uses_namespaced_value_when_present() -> None:
-    entry = _make_entry({"i:package": "0603-LED"})
-    assert _get_field_value(entry, "i:package", fabricator_id="jlc") == "0603-LED"
+    entry = _make_entry({"inv:package": "0603-LED"})
+    assert _get_field_value(entry, "inv:package", fabricator_id="jlc") == "0603-LED"
 
 
 def test_inventory_package_field_is_strict_namespace_only() -> None:
     entry = _make_entry({"package": "0603-LED"})
-    assert _get_field_value(entry, "i:package", fabricator_id="jlc") == ""
+    assert _get_field_value(entry, "inv:package", fabricator_id="jlc") == ""
 
 
 def test_inventory_package_field_is_blank_without_overlay_projection() -> None:
     entry = _make_entry({}, footprint="SignalMast-ColorLight-SingleHead:0603-LED")
-    assert _get_field_value(entry, "i:package", fabricator_id="jlc") == ""
+    assert _get_field_value(entry, "inv:package", fabricator_id="jlc") == ""
 
 
-def test_s_namespace_field_is_strict_source_namespace() -> None:
-    entry = _make_entry({"description": "Pull-up resistor", "s:value": "9k99"})
-    assert _get_field_value(entry, "s:value", fabricator_id="jlc") == "9k99"
-    assert _get_field_value(entry, "s:description", fabricator_id="jlc") == ""
+def test_sch_namespace_field_is_strict_source_namespace() -> None:
+    entry = _make_entry({"description": "Pull-up resistor", "sch:value": "9k99"})
+    assert _get_field_value(entry, "sch:value", fabricator_id="jlc") == "9k99"
+    assert _get_field_value(entry, "sch:description", fabricator_id="jlc") == ""
 
 
-def test_p_namespace_field_returns_explicit_value_only() -> None:
-    explicit_entry = _make_entry({"p:footprint": "PCB:0603"})
+def test_pcb_namespace_field_returns_explicit_value_only() -> None:
+    explicit_entry = _make_entry({"pcb:footprint": "PCB:0603"})
     assert (
-        _get_field_value(explicit_entry, "p:footprint", fabricator_id="jlc")
+        _get_field_value(explicit_entry, "pcb:footprint", fabricator_id="jlc")
         == "PCB:0603"
     )
 
     fallback_entry = _make_entry({})
-    assert _get_field_value(fallback_entry, "p:footprint", fabricator_id="jlc") == ""
+    assert _get_field_value(fallback_entry, "pcb:footprint", fabricator_id="jlc") == ""
 
 
 def test_unqualified_value_prefers_p_then_i_then_s_sources() -> None:
     entry = _make_entry(
         {
-            "s:value": "10K",
-            "p:value": "9K99",
-            "i:value": "10K-INV",
+            "sch:value": "10K",
+            "pcb:value": "9K99",
+            "inv:value": "10K-INV",
         }
     )
 
@@ -132,28 +132,30 @@ def test_unqualified_value_prefers_p_then_i_then_s_sources() -> None:
 def test_unqualified_value_uses_inventory_when_pcb_value_missing() -> None:
     entry = _make_entry(
         {
-            "s:value": "10K",
-            "i:value": "10K-INV",
+            "sch:value": "10K",
+            "inv:value": "10K-INV",
         }
     )
 
     assert _get_field_value(entry, "value", fabricator_id="jlc") == "10K-INV"
 
 
-def test_a_namespace_field_renders_source_annotation_lines_on_mismatch() -> None:
+def test_ann_namespace_field_renders_source_annotation_lines_on_mismatch() -> None:
     entry = _make_entry(
-        {"s:footprint": "SCH:0603", "p:footprint": "PCB:0402"},
+        {"sch:footprint": "SCH:0603", "pcb:footprint": "PCB:0402"},
         footprint="SCH:0603",
     )
     assert (
-        _get_field_value(entry, "a:footprint", fabricator_id="jlc")
-        == "s:SCH:0603\np:PCB:0402"
+        _get_field_value(entry, "ann:footprint", fabricator_id="jlc")
+        == "sch:SCH:0603\npcb:PCB:0402"
     )
 
 
-def test_a_namespace_field_prefers_explicit_annotation_value() -> None:
-    entry = _make_entry({"a:value": "s:10k\np:9k99"})
-    assert _get_field_value(entry, "a:value", fabricator_id="jlc") == "s:10k\np:9k99"
+def test_ann_namespace_field_prefers_explicit_annotation_value() -> None:
+    entry = _make_entry({"ann:value": "sch:10k\npcb:9k99"})
+    assert (
+        _get_field_value(entry, "ann:value", fabricator_id="jlc") == "sch:10k\npcb:9k99"
+    )
 
 
 def test_merge_namespace_enrichment_adds_uniform_values_to_grouped_entry() -> None:
@@ -175,18 +177,18 @@ def test_merge_namespace_enrichment_adds_uniform_values_to_grouped_entry() -> No
             "R1": MergedReferenceRecord(
                 reference="R1",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0603",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0603",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0603"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0603",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0603",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0603"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0603"},
             ),
         },
         mismatches=tuple(),
@@ -196,9 +198,9 @@ def test_merge_namespace_enrichment_adds_uniform_values_to_grouped_entry() -> No
     enriched = _enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
     attrs = enriched.entries[0].attributes
-    assert attrs["s:footprint"] == "SCH:0603"
-    assert attrs["p:footprint"] == "PCB:0603"
-    assert attrs["a:footprint"] == "S: and P: differ\ns:SCH:0603\np:PCB:0603"
+    assert attrs["sch:footprint"] == "SCH:0603"
+    assert attrs["pcb:footprint"] == "PCB:0603"
+    assert attrs["ann:footprint"] == "sch: and pcb: differ\nsch:SCH:0603\npcb:PCB:0603"
     assert enriched.metadata["merge_model_enabled"] is True
     assert enriched.metadata["merge_model_reference_count"] == 2
     assert enriched.metadata["merge_model_mismatch_count"] == 0
@@ -223,25 +225,25 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
             "R1": MergedReferenceRecord(
                 reference="R1",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0402",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0402",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0402"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
                 source_fields={
-                    "s:footprint": "PCB:0603",
-                    "p:footprint": "PCB:0603",
+                    "sch:footprint": "PCB:0603",
+                    "pcb:footprint": "PCB:0603",
                 },
             ),
             "R10": MergedReferenceRecord(
                 reference="R10",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0402",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0402",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0402"},
             ),
         },
         mismatches=tuple(),
@@ -251,8 +253,8 @@ def test_merge_namespace_enrichment_summarizes_divergent_grouped_annotations() -
     enriched = _enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
     assert (
-        enriched.entries[0].attributes["a:footprint"]
-        == "R1,R10 -> S: and P: differ\ns:SCH:0603\np:PCB:0402 || "
+        enriched.entries[0].attributes["ann:footprint"]
+        == "R1,R10 -> sch: and pcb: differ\nsch:SCH:0603\npcb:PCB:0402 || "
         "R2 -> PCB:0603"
     )
 
@@ -275,11 +277,11 @@ def test_merge_namespace_enrichment_skips_conflicting_grouped_values() -> None:
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                source_fields={"s:value": "10k", "p:rotation": "0"},
+                source_fields={"sch:value": "10k", "pcb:rotation": "0"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
-                source_fields={"s:value": "10k", "p:rotation": "90"},
+                source_fields={"sch:value": "10k", "pcb:rotation": "90"},
             ),
         },
         mismatches=tuple(),
@@ -289,8 +291,8 @@ def test_merge_namespace_enrichment_skips_conflicting_grouped_values() -> None:
     enriched = _enrich_bom_with_merge_namespaces(bom_data, merge_result)
 
     attrs = enriched.entries[0].attributes
-    assert attrs["s:value"] == "10k"
-    assert "p:rotation" not in attrs
+    assert attrs["sch:value"] == "10k"
+    assert "pcb:rotation" not in attrs
 
 
 def test_inventory_dnp_filter_excludes_rows_by_default() -> None:

--- a/tests/unit/test_component_merge_service.py
+++ b/tests/unit/test_component_merge_service.py
@@ -72,11 +72,11 @@ def test_merge_creates_namespaced_records_and_mismatch_annotations() -> None:
     assert len(result.mismatches) == 1
     mismatch = result.mismatches[0]
     assert mismatch.field_key == "footprint"
-    assert mismatch.source_values == {"s": "SCH:0603", "p": "PCB:0402"}
+    assert mismatch.source_values == {"sch": "SCH:0603", "pcb": "PCB:0402"}
     merged = result.records["R1"]
-    assert merged.source_fields["s:footprint"] == "SCH:0603"
-    assert merged.source_fields["p:footprint"] == "PCB:0402"
-    assert merged.annotated_fields["a:footprint"] == "s:SCH:0603\np:PCB:0402"
+    assert merged.source_fields["sch:footprint"] == "SCH:0603"
+    assert merged.source_fields["pcb:footprint"] == "PCB:0402"
+    assert merged.annotated_fields["ann:footprint"] == "sch:SCH:0603\npcb:PCB:0402"
 
 
 def test_merge_without_pcb_record_has_no_source_disagreement() -> None:
@@ -90,6 +90,6 @@ def test_merge_without_pcb_record_has_no_source_disagreement() -> None:
     result = service.merge(graph)
 
     merged = result.records["R2"]
-    assert merged.source_fields["s:value"] == "1k"
-    assert merged.source_fields["s:footprint"] == "SCH:0805"
+    assert merged.source_fields["sch:value"] == "1k"
+    assert merged.source_fields["sch:footprint"] == "SCH:0805"
     assert merged.mismatches == tuple()

--- a/tests/unit/test_fabricator_projection_service.py
+++ b/tests/unit/test_fabricator_projection_service.py
@@ -39,11 +39,11 @@ def test_build_projection_unknown_fabricator_uses_default_headers() -> None:
     projection = service.build_projection(
         fabricator_id="nonexistent-fabricator",
         output_type="bom",
-        selected_fields=["reference", "i:package"],
+        selected_fields=["reference", "inv:package"],
     )
 
     assert projection.fabricator_config is None
-    assert projection.headers == ("Reference", "I:Package")
+    assert projection.headers == ("Reference", "INV:Package")
 
 
 def test_build_projection_maps_jlc_pos_headers() -> None:

--- a/tests/unit/test_field_listing_service.py
+++ b/tests/unit/test_field_listing_service.py
@@ -41,7 +41,7 @@ def _make_pcb_component() -> PcbComponent:
 def test_get_field_names_discovers_schematic_fields() -> None:
     names = get_field_names(
         schematic_components=[_make_schematic_component()],
-        source="s",
+        source="sch",
     )
 
     assert {"value", "footprint", "lcsc", "manufacturer"} <= names
@@ -50,7 +50,7 @@ def test_get_field_names_discovers_schematic_fields() -> None:
 def test_get_field_names_discovers_pcb_fields() -> None:
     names = get_field_names(
         pcb_components=[_make_pcb_component()],
-        source="p",
+        source="pcb",
     )
 
     assert {"footprint", "package", "value", "lcsc"} <= names
@@ -59,7 +59,7 @@ def test_get_field_names_discovers_pcb_fields() -> None:
 def test_get_field_names_discovers_inventory_column_names() -> None:
     names = get_field_names(
         inventory_column_names=["Voltage", "Tolerance"],
-        source="i",
+        source="inv",
     )
 
     assert names == {"voltage", "tolerance"}
@@ -78,58 +78,58 @@ def test_get_field_names_source_all_returns_union() -> None:
 
 def test_build_namespace_matrix_excludes_annotation_namespace_column() -> None:
     row = FieldListingService().build_namespace_matrix(
-        ["value", "s:value", "p:value", "i:value", "a:value"]
+        ["value", "sch:value", "pcb:value", "inv:value", "ann:value"]
     )[0]
     console = row.to_console_row()
 
-    assert set(console.keys()) == {"Name", "s:", "p:", "i:"}
-    assert row.s_token == "s:value"
-    assert row.p_token == "p:value"
-    assert row.i_token == "i:value"
+    assert set(console.keys()) == {"Name", "sch:", "pcb:", "inv:"}
+    assert row.sch_token == "sch:value"
+    assert row.pcb_token == "pcb:value"
+    assert row.inv_token == "inv:value"
 
 
 def test_normalize_priority_accepts_string_and_sequence_forms() -> None:
-    assert normalize_priority("pis") == ("p", "i", "s")
-    assert normalize_priority(("s", "i", "p")) == ("s", "i", "p")
+    assert normalize_priority("pcb,inv,sch") == ("pcb", "inv", "sch")
+    assert normalize_priority(("sch", "inv", "pcb")) == ("sch", "inv", "pcb")
 
 
 def test_normalize_priority_rejects_invalid_forms() -> None:
     with pytest.raises(ValueError):
-        normalize_priority("ppi")
+        normalize_priority("pcb,pcb,inv")
 
     with pytest.raises(ValueError):
-        normalize_priority("pix")
+        normalize_priority("pcb,inv,foo")
 
 
 def test_resolve_field_reads_only_requested_source_for_namespaced_tokens() -> None:
     row_sources = {
-        "s": {"value": "10K"},
-        "p": {"value": "9K99"},
-        "i": {"value": "10K-INV"},
+        "sch": {"value": "10K"},
+        "pcb": {"value": "9K99"},
+        "inv": {"value": "10K-INV"},
     }
 
-    assert resolve_field("s:value", row_sources) == "10K"
-    assert resolve_field("p:value", row_sources) == "9K99"
-    assert resolve_field("i:value", row_sources) == "10K-INV"
-    assert resolve_field("p:footprint", row_sources) == ""
+    assert resolve_field("sch:value", row_sources) == "10K"
+    assert resolve_field("pcb:value", row_sources) == "9K99"
+    assert resolve_field("inv:value", row_sources) == "10K-INV"
+    assert resolve_field("pcb:footprint", row_sources) == ""
 
 
 def test_resolve_field_uses_priority_order_for_unqualified_tokens() -> None:
     row_sources = {
-        "s": {"value": "10K"},
-        "p": {"value": "9K99"},
-        "i": {"value": "10K-INV"},
+        "sch": {"value": "10K"},
+        "pcb": {"value": "9K99"},
+        "inv": {"value": "10K-INV"},
     }
 
-    assert resolve_field("value", row_sources, priority="pis") == "9K99"
-    assert resolve_field("value", row_sources, priority="sip") == "10K"
+    assert resolve_field("value", row_sources, priority="pcb,inv,sch") == "9K99"
+    assert resolve_field("value", row_sources, priority="sch,inv,pcb") == "10K"
 
 
 def test_resolve_field_returns_empty_for_unsupported_namespace() -> None:
     row_sources = {
-        "s": {"value": "10K"},
-        "p": {"value": "9K99"},
-        "i": {"value": "10K-INV"},
+        "sch": {"value": "10K"},
+        "pcb": {"value": "9K99"},
+        "inv": {"value": "10K-INV"},
     }
 
-    assert resolve_field("a:value", row_sources) == ""
+    assert resolve_field("ann:value", row_sources) == ""

--- a/tests/unit/test_field_namespace_prefixes.py
+++ b/tests/unit/test_field_namespace_prefixes.py
@@ -5,18 +5,18 @@ from jbom.common.fields import field_to_header, normalize_field_name
 
 
 def test_normalize_field_name_preserves_supported_namespace_prefixes() -> None:
-    assert normalize_field_name("s:Footprint") == "s:footprint"
-    assert normalize_field_name("p:Mount Type") == "p:mount_type"
-    assert normalize_field_name("a:Value") == "a:value"
-    assert normalize_field_name("i:Package") == "i:package"
+    assert normalize_field_name("sch:Footprint") == "sch:footprint"
+    assert normalize_field_name("pcb:Mount Type") == "pcb:mount_type"
+    assert normalize_field_name("ann:Value") == "ann:value"
+    assert normalize_field_name("inv:Package") == "inv:package"
 
 
 def test_field_to_header_formats_supported_namespace_prefixes() -> None:
-    assert field_to_header("s:footprint") == "S:Footprint"
-    assert field_to_header("p:mount_type") == "P:Mount Type"
-    assert field_to_header("a:value") == "A:Value"
+    assert field_to_header("sch:footprint") == "SCH:Footprint"
+    assert field_to_header("pcb:mount_type") == "PCB:Mount Type"
+    assert field_to_header("ann:value") == "ANN:Value"
     assert field_to_header("c:value") == "C:value"
-    assert field_to_header("i:package") == "I:Package"
+    assert field_to_header("inv:package") == "INV:Package"
 
 
 def test_parse_fields_argument_accepts_namespace_prefixed_tokens() -> None:
@@ -27,7 +27,7 @@ def test_parse_fields_argument_accepts_namespace_prefixed_tokens() -> None:
     }
 
     selected = parse_fields_argument(
-        "reference,s:footprint,p:mount_type,a:value,i:package",
+        "reference,sch:footprint,pcb:mount_type,ann:value,inv:package",
         available,
         fabricator_id="generic",
         context="bom",
@@ -35,8 +35,8 @@ def test_parse_fields_argument_accepts_namespace_prefixed_tokens() -> None:
 
     assert selected == [
         "reference",
-        "s:footprint",
-        "p:mount_type",
-        "a:value",
-        "i:package",
+        "sch:footprint",
+        "pcb:mount_type",
+        "ann:value",
+        "inv:package",
     ]

--- a/tests/unit/test_inventory_overlay_service.py
+++ b/tests/unit/test_inventory_overlay_service.py
@@ -33,7 +33,7 @@ class _StubInventoryMatcher:
         return self.result
 
 
-def test_overlay_without_inventory_adds_i_package_fallback() -> None:
+def test_overlay_without_inventory_adds_inv_package_fallback() -> None:
     service = InventoryOverlayService()
     bom_data = BOMData(
         project_name="Demo",
@@ -55,11 +55,11 @@ def test_overlay_without_inventory_adds_i_package_fallback() -> None:
         project_name="Demo",
     )
 
-    assert result.bom_data.entries[0].attributes["i:package"] == "0603-LED"
+    assert result.bom_data.entries[0].attributes["inv:package"] == "0603-LED"
     assert result.bom_data.metadata["inventory_overlay_mode"] == "project_fallback_only"
 
 
-def test_overlay_with_inventory_projects_i_namespace_fields() -> None:
+def test_overlay_with_inventory_projects_inv_namespace_fields() -> None:
     matched_entry = BOMEntry(
         references=["R1"],
         value="10k",
@@ -86,10 +86,10 @@ def test_overlay_with_inventory_projects_i_namespace_fields() -> None:
 
     assert matcher.calls == [(Path("/tmp/inventory.csv"), "jlc", "Demo", False)]
     attributes = result.bom_data.entries[0].attributes
-    assert attributes["i:manufacturer"] == "Yageo"
-    assert attributes["i:manufacturer_part"] == "RC0603"
-    assert attributes["i:package"] == "0603"
-    assert attributes["i:smd"] == "Yes"
+    assert attributes["inv:manufacturer"] == "Yageo"
+    assert attributes["inv:manufacturer_part"] == "RC0603"
+    assert attributes["inv:package"] == "0603"
+    assert attributes["inv:smd"] == "Yes"
     assert result.bom_data.metadata["inventory_overlay_mode"] == "inventory_applied"
 
 
@@ -111,8 +111,8 @@ def test_overlay_without_inventory_match_does_not_project_non_package_fields() -
     )
 
     attributes = result.bom_data.entries[0].attributes
-    assert "i:manufacturer" not in attributes
-    assert attributes["i:package"] == derive_package_from_footprint(
+    assert "inv:manufacturer" not in attributes
+    assert attributes["inv:package"] == derive_package_from_footprint(
         "Resistor_SMD:R_0603_1608Metric"
     )
 

--- a/tests/unit/test_parts_cli_field_resolution.py
+++ b/tests/unit/test_parts_cli_field_resolution.py
@@ -64,11 +64,11 @@ def test_get_parts_field_value_reads_namespaced_attributes() -> None:
         refs=["R1"],
         value="10k",
         footprint="R_0603",
-        attributes={"s:value": "9k99"},
+        attributes={"sch:value": "9k99"},
     )
 
     assert _get_parts_field_value(entry, "refs") == "R1"
-    assert _get_parts_field_value(entry, "s:value") == "9k99"
+    assert _get_parts_field_value(entry, "sch:value") == "9k99"
 
 
 def test_get_parts_field_value_reads_explicit_namespaced_fields() -> None:
@@ -77,15 +77,15 @@ def test_get_parts_field_value_reads_explicit_namespaced_fields() -> None:
         value="10k",
         footprint="R_0603",
         attributes={
-            "s:footprint": "R_0603",
-            "p:footprint": "R_0603",
-            "i:voltage": "25V",
+            "sch:footprint": "R_0603",
+            "pcb:footprint": "R_0603",
+            "inv:voltage": "25V",
         },
     )
 
-    assert _get_parts_field_value(entry, "s:footprint") == "R_0603"
-    assert _get_parts_field_value(entry, "p:footprint") == "R_0603"
-    assert _get_parts_field_value(entry, "i:voltage") == "25V"
+    assert _get_parts_field_value(entry, "sch:footprint") == "R_0603"
+    assert _get_parts_field_value(entry, "pcb:footprint") == "R_0603"
+    assert _get_parts_field_value(entry, "inv:voltage") == "25V"
 
 
 def test_unqualified_parts_value_prefers_s_then_i_then_p() -> None:
@@ -94,9 +94,9 @@ def test_unqualified_parts_value_prefers_s_then_i_then_p() -> None:
         value="",
         footprint="R_0603",
         attributes={
-            "s:value": "10K",
-            "i:value": "10K-INV",
-            "p:value": "9K99",
+            "sch:value": "10K",
+            "inv:value": "10K-INV",
+            "pcb:value": "9K99",
         },
     )
 
@@ -109,8 +109,8 @@ def test_unqualified_parts_value_uses_inventory_when_schematic_missing() -> None
         value="",
         footprint="R_0603",
         attributes={
-            "i:value": "10K-INV",
-            "p:value": "9K99",
+            "inv:value": "10K-INV",
+            "pcb:value": "9K99",
         },
     )
 
@@ -134,13 +134,13 @@ def test_enrich_parts_with_merge_namespaces_adds_uniform_fields() -> None:
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                source_fields={"s:value": "10k", "p:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99"},
+                source_fields={"sch:value": "10k", "pcb:value": "9k99"},
+                annotated_fields={"ann:value": "sch:10k\npcb:9k99"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
-                source_fields={"s:value": "10k", "p:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99"},
+                source_fields={"sch:value": "10k", "pcb:value": "9k99"},
+                annotated_fields={"ann:value": "sch:10k\npcb:9k99"},
             ),
         },
         mismatches=tuple(),
@@ -150,9 +150,9 @@ def test_enrich_parts_with_merge_namespaces_adds_uniform_fields() -> None:
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
 
     attrs = enriched.entries[0].attributes
-    assert attrs["s:value"] == "10k"
-    assert attrs["p:value"] == "9k99"
-    assert attrs["a:value"] == "S: and P: differ\ns:10k\np:9k99"
+    assert attrs["sch:value"] == "10k"
+    assert attrs["pcb:value"] == "9k99"
+    assert attrs["ann:value"] == "sch: and pcb: differ\nsch:10k\npcb:9k99"
     assert enriched.metadata["merge_model_enabled"] is True
     assert enriched.metadata["merge_model_reference_count"] == 2
     assert enriched.metadata["merge_model_mismatch_count"] == 0
@@ -176,25 +176,25 @@ def test_enrich_parts_with_merge_namespaces_summarizes_divergent_annotations() -
             "R1": MergedReferenceRecord(
                 reference="R1",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0402",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0402",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0402"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
                 source_fields={
-                    "s:footprint": "PCB:0603",
-                    "p:footprint": "PCB:0603",
+                    "sch:footprint": "PCB:0603",
+                    "pcb:footprint": "PCB:0603",
                 },
             ),
             "R10": MergedReferenceRecord(
                 reference="R10",
                 source_fields={
-                    "s:footprint": "SCH:0603",
-                    "p:footprint": "PCB:0402",
+                    "sch:footprint": "SCH:0603",
+                    "pcb:footprint": "PCB:0402",
                 },
-                annotated_fields={"a:footprint": "s:SCH:0603\np:PCB:0402"},
+                annotated_fields={"ann:footprint": "sch:SCH:0603\npcb:PCB:0402"},
             ),
         },
         mismatches=tuple(),
@@ -203,8 +203,8 @@ def test_enrich_parts_with_merge_namespaces_summarizes_divergent_annotations() -
 
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
     assert (
-        enriched.entries[0].attributes["a:footprint"]
-        == "R1,R10 -> S: and P: differ\ns:SCH:0603\np:PCB:0402 || "
+        enriched.entries[0].attributes["ann:footprint"]
+        == "R1,R10 -> sch: and pcb: differ\nsch:SCH:0603\npcb:PCB:0402 || "
         "R2 -> PCB:0603"
     )
 
@@ -226,11 +226,11 @@ def test_enrich_parts_with_merge_namespaces_skips_conflicting_grouped_values() -
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                source_fields={"s:value": "9k99", "p:rotation": "0"},
+                source_fields={"sch:value": "9k99", "pcb:rotation": "0"},
             ),
             "R2": MergedReferenceRecord(
                 reference="R2",
-                source_fields={"s:value": "9k99", "p:rotation": "90"},
+                source_fields={"sch:value": "9k99", "pcb:rotation": "90"},
             ),
         },
         mismatches=tuple(),
@@ -239,5 +239,5 @@ def test_enrich_parts_with_merge_namespaces_skips_conflicting_grouped_values() -
 
     enriched = _enrich_parts_with_merge_namespaces(parts_data, merge_result)
     attrs = enriched.entries[0].attributes
-    assert attrs["s:value"] == "9k99"
-    assert "p:rotation" not in attrs
+    assert attrs["sch:value"] == "9k99"
+    assert "pcb:rotation" not in attrs

--- a/tests/unit/test_pos_cli_field_resolution.py
+++ b/tests/unit/test_pos_cli_field_resolution.py
@@ -75,8 +75,8 @@ def test_enrich_pos_with_merge_namespaces_adds_namespaced_fields() -> None:
         records={
             "R1": MergedReferenceRecord(
                 reference="R1",
-                source_fields={"s:value": "10k", "p:value": "9k99"},
-                annotated_fields={"a:value": "s:10k\np:9k99"},
+                source_fields={"sch:value": "10k", "pcb:value": "9k99"},
+                annotated_fields={"ann:value": "sch:10k\npcb:9k99"},
             )
         },
         mismatches=tuple(),
@@ -85,9 +85,9 @@ def test_enrich_pos_with_merge_namespaces_adds_namespaced_fields() -> None:
 
     enriched = _enrich_pos_with_merge_namespaces(pos_rows, merge_result)
 
-    assert enriched[0]["s:value"] == "10k"
-    assert enriched[0]["p:value"] == "9k99"
-    assert enriched[0]["a:value"] == "s:10k\np:9k99"
+    assert enriched[0]["sch:value"] == "10k"
+    assert enriched[0]["pcb:value"] == "9k99"
+    assert enriched[0]["ann:value"] == "sch:10k\npcb:9k99"
 
 
 def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -> None:
@@ -96,7 +96,7 @@ def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -
         records={
             "R2": MergedReferenceRecord(
                 reference="R2",
-                source_fields={"s:value": "1k"},
+                source_fields={"sch:value": "1k"},
             )
         },
         mismatches=tuple(),
@@ -105,25 +105,25 @@ def test_enrich_pos_with_merge_namespaces_keeps_rows_without_reference_match() -
 
     enriched = _enrich_pos_with_merge_namespaces(pos_rows, merge_result)
 
-    assert "s:value" not in enriched[0]
+    assert "sch:value" not in enriched[0]
 
 
 def test_get_pos_field_value_reads_explicit_namespaced_fields() -> None:
     entry = {
-        "s:value": "10k",
-        "p:footprint": "R_0603",
+        "sch:value": "10k",
+        "pcb:footprint": "R_0603",
     }
 
-    assert _get_pos_field_value(entry, "s:value") == "10k"
-    assert _get_pos_field_value(entry, "p:footprint") == "R_0603"
+    assert _get_pos_field_value(entry, "sch:value") == "10k"
+    assert _get_pos_field_value(entry, "pcb:footprint") == "R_0603"
 
 
 def test_unqualified_pos_value_prefers_p_then_i_then_s() -> None:
     entry = {
         "value": "",
-        "s:value": "10K",
-        "p:value": "9K99",
-        "i:value": "10K-INV",
+        "sch:value": "10K",
+        "pcb:value": "9K99",
+        "inv:value": "10K-INV",
     }
 
     assert _get_pos_field_value(entry, "value") == "9K99"
@@ -132,8 +132,8 @@ def test_unqualified_pos_value_prefers_p_then_i_then_s() -> None:
 def test_unqualified_pos_value_uses_inventory_when_pcb_missing() -> None:
     entry = {
         "value": "",
-        "s:value": "10K",
-        "i:value": "10K-INV",
+        "sch:value": "10K",
+        "inv:value": "10K-INV",
     }
 
     assert _get_pos_field_value(entry, "value") == "10K-INV"
@@ -141,15 +141,15 @@ def test_unqualified_pos_value_uses_inventory_when_pcb_missing() -> None:
 
 def test_pos_dnp_filter_excludes_schematic_dnp_rows_by_default() -> None:
     rows = [
-        {"reference": "U1", "s:dnp": "Yes"},
-        {"reference": "U2", "s:dnp": "No"},
+        {"reference": "U1", "sch:dnp": "Yes"},
+        {"reference": "U2", "sch:dnp": "No"},
     ]
     filtered = _apply_pos_dnp_filter(rows, component_filters={"exclude_dnp": True})
     assert [row["reference"] for row in filtered] == ["U2"]
 
 
 def test_pos_dnp_filter_respects_include_dnp_flag() -> None:
-    rows = [{"reference": "U1", "s:dnp": "Yes"}]
+    rows = [{"reference": "U1", "sch:dnp": "Yes"}]
     filtered = _apply_pos_dnp_filter(rows, component_filters={"exclude_dnp": False})
     assert [row["reference"] for row in filtered] == ["U1"]
 


### PR DESCRIPTION
## Summary
- complete the data-side namespace migration to canonical long prefixes only: `sch:`, `pcb:`, `inv:`, `ann:`
- remove remaining short-prefix usage/expectations in merge, resolver, CLI, audit, and overlay paths
- update affected unit/service tests plus BDD feature scenarios to assert canonical-only namespace behavior
- preserve/confirm source-priority behavior under canonical tokens (BOM/POS/parts) and canonical list-fields matrix output

Closes #282

## Validation
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src pytest -q` (`1397 passed`)
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress` (`47 features passed, 0 failed, 1 skipped`)

Co-Authored-By: Oz <oz-agent@warp.dev>
