### PR TITLE
docs(plugin,agents): align --inventory docs and add agent skill setup

### DIFF
--- a/.agents/skills/assign-issue/SKILL.md
+++ b/.agents/skills/assign-issue/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: assign-issue
+description: Resolves a GitHub issue either in the current agent session or by launching a child agent, while enforcing collaborative checkpoints and the jBOM git workflow. Use when the user provides an issue number and asks to assign/resolve it with /collaborative mode and /git-workflow, optionally choosing a model for a child agent.
+---
+
+# assign-issue
+
+## Quick start
+
+Use this skill when the user says things like:
+- "Take issue #123"
+- "Assign #123 to an agent and resolve it"
+- "Work issue #123 in collaborative mode with git workflow"
+- "Spawn a child agent for #123 using model X"
+
+## Inputs
+
+Required:
+- GitHub issue number (`#N`)
+
+Optional:
+- execution mode: `current-session` or `child-agent`
+- child model: user-requested `model_id` (child-agent mode only; defaults to `auto (cost efficient)` when not specified)
+
+## Workflow
+
+### 1) Intake and activation
+
+1. Confirm target issue number.
+2. Activate collaborative behavior (`/collaborative`) for decision checkpoints.
+3. Apply `git-workflow` for branch/commit/PR mechanics.
+
+### 2) Choose execution mode
+
+If mode is not specified, ask the user to pick:
+- A) current-session
+- B) child-agent
+
+#### Mode A: current-session
+
+Continue execution in this agent session.
+
+#### Mode B: child-agent
+
+1. Launch an independent child agent for implementation.
+2. If user provided a model, pass it as `model_id`.
+3. If no model is provided, set `model_id` to `auto` (cost efficient default).
+4. Instruct child to:
+   - run collaborative checkpoints on ambiguity/alternatives
+   - follow `git-workflow` requirements
+   - report progress, risks, and validation results
+
+#### Recommended child-agent handoff prompt template
+
+Use this as the default per-child handoff prompt:
+
+Resolve GitHub issue #<N> in this repository.
+Operating mode requirements:
+- Use collaborative checkpoints whenever alternatives or ambiguities appear.
+- Pause, present options with tradeoffs, and wait for user decision before proceeding.
+- Follow the `git-workflow` skill for branch naming, iterative pre-commit loop, semantic commits, and PR creation.
+Execution requirements:
+- Create a feature branch named `feature/issue-<N>-<brief-slug>` (or `fix/issue-<N>-<brief-slug>` when appropriate).
+- Implement the fix/feature, run required tests, and summarize validation results.
+- Open a PR linked to the issue (`Closes #<N>` when appropriate).
+- Post/update issue comments with progress and final resolution summary.
+Reporting requirements:
+- Send concise status updates at key milestones.
+- Report blockers immediately with concrete options and a recommendation.
+
+### 3) Read and frame the issue
+
+1. Fetch issue details/comments with `gh issue view <N> --comments`.
+2. Summarize:
+   - problem statement
+   - acceptance criteria
+   - unknowns/ambiguities
+3. If ambiguous, stop and run a collaborative checkpoint before coding.
+
+### 4) Assign and announce ownership
+
+1. Assign issue to the working assignee/identity.
+2. Post a short "starting work" comment with planned approach.
+3. If markdown has zsh quoting hazards, use `gh-issues-zsh-safe` patterns.
+
+### 5) Implement with collaborative checkpoints
+
+1. Create feature branch:
+   - `feature/issue-N-brief-description` or `fix/issue-N-brief-description`
+2. Work in short cycles:
+   - status update
+   - pause on alternatives/ambiguity
+   - options + recommendation
+   - wait for user decision
+3. Resume only after explicit user decision.
+
+### 6) Validate and commit via git-workflow
+
+1. Run required tests and project gates.
+2. Run iterative pre-commit loop until clean.
+3. Commit with:
+   - issue linkage (`Refs #N` / `Closes #N`)
+   - `Co-Authored-By: Oz <oz-agent@warp.dev>`
+
+### 7) Push, PR, and issue closure loop
+
+1. Push feature branch.
+2. Open PR linked to issue (`Closes #N` when appropriate).
+3. Add substantive issue comment with:
+   - change summary
+   - validation run
+   - PR link
+4. Transition/close issue per project process.
+
+## Guardrails
+
+- Never commit directly to `main`.
+- Do not skip collaborative checkpoints when requirements are unclear.
+- If user says "normal mode" or "continue directly", exit collaborative mode and proceed.
+- If user requests child mode + specific model, honor model selection.
+- Do not close issue without resolution context and verification evidence.
+
+## Done criteria
+
+- Issue scope implemented and validated.
+- PR created and linked to issue.
+- Issue updated with clear resolution context.

--- a/.agents/skills/collaborative/SKILL.md
+++ b/.agents/skills/collaborative/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: collaborative
+description: Structures collaborative agent-user problem solving with adaptive tone, explicit status reporting, decision checkpoints, and shared understanding before execution continues. Use when the user requests collaborative-mode, says "collaborative mode", wants interactive brainstorming on alternatives, or invokes /collaborative.
+---
+
+# Collaborative
+
+## Quick start
+
+When this skill is active, run work in short cycles:
+1. Share current status and next step.
+2. Stop at decisions or ambiguities instead of guessing.
+3. Present options with tradeoffs.
+4. Wait for user brainstorming/questions.
+5. Rank options quickly and confirm shared understanding.
+6. Resume only after the user gives a definitive decision.
+
+## Exit mode (explicit off mechanism)
+
+Deactivate collaborative mode immediately when the user says any equivalent of:
+- "exit collaborative mode"
+- "turn off collaborative mode"
+- "normal mode"
+- "continue directly"
+- "no more checkpoints"
+
+On deactivation:
+- acknowledge mode exit in one line
+- stop decision checkpoints
+- continue with normal execution style
+- do not re-enable collaborative behavior unless explicitly requested again
+
+## Tone policy (adaptive hybrid)
+
+- Default voice: neutral facilitator (concise, direct, objective).
+- At decision checkpoints: hard technical partner (clear tradeoffs, explicit risks, concrete recommendation).
+- During exploratory brainstorming: add light coach-like warmth to support iteration without losing precision.
+- Follow user energy: terse in, terse out; detailed in, slightly richer detail out.
+- Avoid flattery, filler, and unnecessary verbosity.
+
+## Workflow
+
+### 1) Progress reporting
+
+- Give concise status updates while working.
+- Each update should include:
+  - what changed
+  - what is next
+  - whether a decision is needed
+  - the current tone context if needed (default/checkpoint/brainstorming)
+
+### 2) Decision checkpoint (mandatory)
+
+Trigger a checkpoint when:
+- two or more viable alternatives exist
+- a requirement is ambiguous
+- a tradeoff affects scope, risk, maintainability, or delivery time
+
+At a checkpoint:
+- pause implementation
+- explain the ambiguity/decision in 1-3 lines
+- provide 2-4 options with pros/cons
+- ask a focused question to unblock
+
+### 3) Collaborative analysis
+
+When the user responds with questions or suggestions:
+- evaluate each suggestion quickly
+- provide a short ranking (best -> fallback) with rationale
+- explicitly confirm shared understanding before moving on
+
+Suggested format:
+- Option A — abstract : reason
+- Option B — abstract : reason
+- Risks and pitfalls: (if any...)
+- Recommendation: Option A
+
+### 4) Resume execution
+
+Only continue when the user gives a definitive choice and asks to proceed.
+Then:
+- restate the chosen decision in one line
+- explain the immediate next action
+- execute using that decision
+
+## Guardrails
+
+- Do not silently choose among major alternatives.
+- Do not treat brainstorming as final approval.
+- If intent is still unclear, ask one focused follow-up question and wait.
+- If user requests direct execution or asks to disable collaboration, exit mode immediately and proceed without checkpoint pauses.
+- Treat collaborative mode as opt-in and session-local, not sticky by default across unrelated requests.
+
+## Trigger examples
+
+- "Use collaborative-mode for this task."
+- "/collaborative"
+- "Let's brainstorm this together before you implement."
+- "Pause at decision points and get my input."

--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -174,6 +174,44 @@ For zsh-safe gh authoring patterns (issue bodies, comments,
 multi-line content), see the `gh-issues-zsh-safe` skill once it
 lands.
 
+## Merge strategy and post-merge cleanup
+
+Use **rebase-merge** for PRs in this repository. Rebase merges rewrite
+commit SHAs, so do not rely only on ancestry checks when deciding
+whether to delete branches.
+Normative expectation:
+
+- A human maintainer performs the merge in GitHub UI.
+- Agents prepare the PR, validation evidence, and merge recommendation.
+- Agents must not execute merge commands unless the user explicitly
+  requests the agent to perform the merge.
+
+Preferred merge options (when merge is being performed):
+
+- GitHub UI: **Rebase and merge**
+- CLI: `gh pr merge <number> --rebase` (agent only with explicit user request)
+
+After merge, verify and clean branches with a patch-equivalence check:
+
+```bash
+# 1) Refresh refs
+git fetch --prune origin
+
+# 2) Verify branch patch is present in main
+#    '-' means already applied (safe to delete), '+' means still unique
+git cherry -v main feature/issue-N-brief-description
+
+# 3) If safe (all '-' or no output), delete local branch
+git branch -d feature/issue-N-brief-description
+
+# 4) Delete remote branch if it still exists
+git push origin --delete feature/issue-N-brief-description || true
+```
+
+If `git cherry` shows `+` entries, do **not** delete the branch yet.
+Investigate first (wrong target branch, partial merge, or outstanding
+commits not represented in `main`).
+
 ## Required co-author attribution
 
 Every commit made by Oz must include the co-author line in the

--- a/WARP.md
+++ b/WARP.md
@@ -114,3 +114,17 @@ tracked by #305.
 - ✅ **DOCUMENT**: Include co-author attribution in commits
 
 This workflow ensures proper tracking, collaboration, and code quality while maintaining project velocity and stakeholder visibility.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for this repository (via `gh`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default canonical label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Domain docs are single-context: root `CONTEXT.md` (when present) and ADRs in `docs/architecture/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/architecture/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, proceed silently. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (configured for this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/architecture/adr/
+│   ├── 0001-some-decision.md
+│   └── 0002-another-decision.md
+└── src/
+```
+
+Multi-context repo (if `CONTEXT-MAP.md` exists at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/architecture/adr/            ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                 ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+- `needs-triage` -> `needs-triage` (maintainer needs to evaluate this issue)
+- `needs-info` -> `needs-info` (waiting on reporter for more information)
+- `ready-for-agent` -> `ready-for-agent` (fully specified, ready for an AFK agent)
+- `ready-for-human` -> `ready-for-human` (requires human implementation)
+- `wontfix` -> `wontfix` (will not be actioned)
+
+When a skill mentions a role (for example "apply the AFK-ready triage label"), use the corresponding label string from this mapping.

--- a/kicad_jbom_plugin.py
+++ b/kicad_jbom_plugin.py
@@ -7,25 +7,25 @@ No logic duplication - just argument translation.
 
 Usage in KiCad (Eeschema -> Tools -> Generate BOM):
   Command: python3 /absolute/path/to/kicad_jbom_plugin.py %I
-           -i /path/to/INVENTORY.xlsx -o %O [-v] [-d] [-f FIELDS]
+           --inventory /path/to/INVENTORY.xlsx -o %O [-v] [-d] [-f FIELDS]
 
 Plugin Arguments:
-  %I         - KiCad schematic path (provided by KiCad)
-  %O         - Output BOM file path (provided by KiCad)
-  -i FILE    - Inventory file (.csv/.xlsx/.xls/.numbers)
-  -v         - Verbose mode (adds match quality columns)
-  -d         - Debug mode (adds matching diagnostics)
-  -f FIELDS  - Field specification (e.g., +jlc or Reference,Value,LCSC)
+  %I              - KiCad schematic path (provided by KiCad)
+  %O              - Output BOM file path (provided by KiCad)
+  --inventory FILE - Inventory file (.csv/.xlsx/.xls/.numbers)
+  -v              - Verbose mode (adds match quality columns)
+  -d              - Debug mode (adds matching diagnostics)
+  -f FIELDS       - Field specification (e.g., +jlc or Reference,Value,LCSC)
 
 Examples:
   # Basic usage with inventory
-  python3 kicad_jbom_plugin.py %I -i inventory.xlsx -o %O
+  python3 kicad_jbom_plugin.py %I --inventory inventory.xlsx -o %O
 
   # With JLCPCB preset
-  python3 kicad_jbom_plugin.py %I -i inventory.xlsx -o %O -f +jlc
+  python3 kicad_jbom_plugin.py %I --inventory inventory.xlsx -o %O -f +jlc
 
   # Verbose mode with custom fields
-  python3 kicad_jbom_plugin.py %I -i inventory.xlsx -o %O -v -f "Reference,Value,LCSC,Package"
+  python3 kicad_jbom_plugin.py %I --inventory inventory.xlsx -o %O -v -f "Reference,Value,LCSC,Package"
 """
 import sys
 import subprocess
@@ -35,14 +35,14 @@ def main():
     """
     Translate KiCad plugin arguments to jBOM CLI and execute.
 
-    KiCad calls:    kicad_jbom_plugin.py SCHEMATIC -i INV -o OUT [OPTIONS]
-    We execute:     jbom bom SCHEMATIC -i INV -o OUT [OPTIONS]
+    KiCad calls:    kicad_jbom_plugin.py SCHEMATIC --inventory INV -o OUT [OPTIONS]
+    We execute:     jbom bom SCHEMATIC --inventory INV -o OUT [OPTIONS]
 
     The only difference is inserting the 'bom' subcommand.
     All other arguments pass through unchanged.
     """
-    # sys.argv[1:] = [SCHEMATIC, -i, INV, -o, OUT, ...]
-    # We need:       [bom, SCHEMATIC, -i, INV, -o, OUT, ...]
+    # sys.argv[1:] = [SCHEMATIC, --inventory, INV, -o, OUT, ...]
+    # We need:       [bom, SCHEMATIC, --inventory, INV, -o, OUT, ...]
     jbom_args = ["bom"] + sys.argv[1:]
 
     # Execute jBOM CLI using the same Python interpreter


### PR DESCRIPTION
## Summary

This PR now contains two related documentation tracks combined on one branch to avoid risky history rewrites during cleanup after parallel agent activity in the same checkout:

1. **Issue #311 fix (plugin docs correctness)**
   - `kicad_jbom_plugin.py` previously documented `-i` as a short form for `--inventory`.
   - jBOM CLI subcommands do not currently support `-i`, so plugin docs/comments were corrected to use `--inventory` consistently.

2. **Agent workflow/skills setup docs**
   - Added collaborative and issue-assignment skills.
   - Added `docs/agents/` configuration docs (issue tracker, triage labels, domain docs).
   - Added `## Agent skills` section wiring in `WARP.md`.

## Changes

### Issue #311 scope
- `kicad_jbom_plugin.py`
  - replaced `-i` references with `--inventory` in module docstring, examples, `main()` docstring, and inline comments.

### Agent skills/setup scope
- `.agents/skills/collaborative/SKILL.md` (new)
- `.agents/skills/assign-issue/SKILL.md` (new)
- `docs/agents/issue-tracker.md` (new)
- `docs/agents/triage-labels.md` (new)
- `docs/agents/domain.md` (new)
- `WARP.md` (added Agent skills section)

## Validation

- pre-commit: all hooks passed
- pytest: 1397/1397 passed
- behave: 259/259 scenarios passed, 47 features passed, 0 failed

Closes #311

_Conversation: https://app.warp.dev/conversation/cd7d717a-9a4a-4d4d-8da7-b29fa24b20c1_
_Run: https://oz.warp.dev/runs/019e62bd-9236-7d72-84cd-731874dfc1f1_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
