### PR TITLE
test(features): add edge-case scenarios for project input resolution (F-016)

### DIFF
--- a/features/project/directory.feature
+++ b/features/project/directory.feature
@@ -60,3 +60,22 @@ Feature: Directory-based Project References
     Given an empty directory "empty_dir"
     When I run jbom command "bom empty_dir"
     Then the command should fail
+
+  Scenario: Directory input with trailing slash behaves like directory input without slash
+    Given a project "myproject" placed in "project_dir"
+    And a PCB that contains:
+      | Reference | Value | Footprint     |
+      | R1        | 10K   | R_0805_2012   |
+    When I run jbom command "bom project_dir"
+    And I run jbom command "bom project_dir/"
+    Then the command should succeed
+    And the two command outputs should be identical
+
+  Scenario: BOM command follows a symlinked project directory
+    Given a project "myproject" placed in "real_project"
+    And a PCB that contains:
+      | Reference | Value | Footprint     |
+      | R1        | 10K   | R_0805_2012   |
+    And I create symlink "linked_project" to "real_project"
+    When I run jbom command "bom linked_project"
+    Then the command should succeed

--- a/features/project/file.feature
+++ b/features/project/file.feature
@@ -105,3 +105,29 @@ Feature: File-based Project References
   Scenario: Command given nonexistent file fails
     When I run jbom command "bom nonexistent_file.kicad_sch"
     Then the command should fail
+
+  Scenario: BOM command given absolute .kicad_sch path resolves to the matching PCB
+    Given a schematic that contains:
+      | Reference | Value | Footprint     |
+      | R1        | 10K   | R_0805_2012   |
+    And a PCB that contains:
+      | Reference | Value | Footprint     |
+      | R1        | 10K   | R_0805_2012   |
+    When I run jbom using absolute path "project.kicad_sch" for command "bom"
+    Then the command should succeed
+
+  Scenario: POS command given absolute .kicad_pcb path resolves directly to the PCB
+    Given a PCB that contains:
+      | reference | x | y | rotation | side | footprint     |
+      | R1        | 5 | 10| 0        | TOP  | R_0805_2012   |
+    When I run jbom using absolute path "project.kicad_pcb" for command "pos"
+    Then the command should succeed
+
+  Scenario: Inventory command given unreadable .kicad_sch file fails gracefully
+    Given a schematic that contains:
+      | Reference | Value | Footprint     |
+      | R1        | 10K   | R_0805_2012   |
+    And the file "project.kicad_sch" is unreadable
+    When I run jbom command "inventory project.kicad_sch"
+    Then the command should fail
+    And the error output should mention "Permission denied"

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -192,6 +192,20 @@ def step_run_jbom_command(context, args):
     step_run_command(context, f"jbom {args}")
 
 
+@when('I run jbom using absolute path "{path_fragment}" for command "{args}"')
+def step_run_jbom_command_with_absolute_path(context, args, path_fragment):
+    """Run a jbom command by resolving a file path to an absolute path first."""
+    from pathlib import Path
+
+    candidate = Path(path_fragment)
+    absolute_path = (
+        candidate
+        if candidate.is_absolute()
+        else (Path(context.sandbox_root) / candidate)
+    ).resolve()
+    step_run_jbom_command(context, f"{args} {absolute_path}")
+
+
 @given('the sample fixtures under "{rel_path}"')
 def step_have_sample_fixtures(context, rel_path):
     """Copy fixture subtree into the per-scenario temp workspace.


### PR DESCRIPTION
## Summary
- add project-input edge-case BDD scenarios for absolute-path file inputs
- add directory-path edge cases for trailing slash parity and symlinked project directories
- add permission-denied schematic access coverage and an absolute-path command helper step

## Validation
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress features/project/directory.feature features/project/file.feature`
  - passed: 2 features, 26 scenarios, 0 failed
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress`
  - passed: 47 features, 264 scenarios, 0 failed
- `pre-commit`
  - passed (after black auto-format on `features/steps/common_steps.py`)

Closes #308

Co-Authored-By: Oz <oz-agent@warp.dev>
