### PR TITLE
docs(247-followup): reconcile post-merge content from main (F-018)

### DIFF
--- a/docs/design/configuration-semantics.md
+++ b/docs/design/configuration-semantics.md
@@ -76,6 +76,24 @@ These semantics extend the `extends:` deep-merge machinery already present in
 `defaults.py` to cover all stanza types uniformly. The unified loader reuses
 the same merge engine rather than introducing a second one.
 
+## `field_synonyms` mechanism
+
+`field_synonyms` defines canonical field intents and accepted aliases in
+unified profiles. At runtime, synonyms are matched case-insensitively and
+normalized to canonical keys (for example `fab_pn`, `supplier_pn`, `mpn`),
+while CSV output headers use the configured `display_name`.
+
+This allows CLI field arguments, config field references, schematic/PCB
+properties, and inventory headers to accept legacy or vendor-specific naming
+without changing internal semantics.
+
+`fab.field_synonyms` controls fabrication output semantics;
+`supplier.field_synonyms` controls supplier ID / supplier part-number mapping
+for supplier workflows.
+
+Profile docs should keep only fabricator/supplier-specific rationale inline and
+defer mechanism-level behavior to this section.
+
 ## Field reference namespace
 
 All field references in jBOM configuration follow the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -572,6 +572,7 @@ jbom inventory ./my_project --supplier lcsc -o inventory.csv
 
 **Parts CSV**
 : Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per electro-mechanical group with a `Refs` column of collapsed references. Use `-o -` for CSV to stdout.
+: DNP rows are included in the default row set. Add `-f dnp` when an explicit DNP marker column is required.
 
 **Exit Codes**
 : 0 — success
@@ -588,13 +589,17 @@ flags override them.
 |---|---|---|---|
 | `exclude_from_board` | not in output | not in output | Symbol-only: no PCB footprint |
 | `exclude_from_bom` | not in output | not in output | Board feature: logo, mounting hole, fiducial |
-| `dnp` (Do Not Populate) | **included, marked `DNP`** | not in output | Variant/rework spares: pad present, part absent |
+| `dnp` (Do Not Populate) | included (see command notes below) | not in output | Variant/rework spares: pad present, part absent |
 | *(none set)* | included | included | Normal populated component |
 
-**BOM/Parts**: `exclude_from_bom` components (mounting holes, fiducials, OSHW logos) are always
+**BOM**: `exclude_from_bom` components (mounting holes, fiducials, OSHW logos) are always
 excluded. DNP components are always included and identified by the `DNP` column value `"DNP"`
 (empty string for populated components). This follows IPC J-STD-001: assembly operators must
 be able to distinguish intentionally empty pads from omitted line items.
+
+**Parts**: DNP components are always included in the output row set. The default parts projection
+does not include a dedicated `DNP` column; include one explicitly via `-f dnp` (or a custom
+projection that includes `dnp`) when a marker column is required.
 
 **POS**: DNP components are always excluded. The P&P machine's input contract is strictly
 "place these components"; the companion BOM is the authoritative source for DNP declarations.
@@ -604,7 +609,8 @@ be able to distinguish intentionally empty pads from omitted line items.
 
 **Migration note** (from pre-v8.x): The `--include-dnp`, `--include-excluded`, and
 `--include-all` flags have been removed from `jbom bom`, `jbom parts`, and `jbom pos`.
-DNP rows now appear in BOM/parts output by default, marked in the `DNP` column.
+DNP rows now appear in BOM output by default, marked in the `DNP` column.
+Parts output includes DNP rows by default; add `-f dnp` to expose an explicit marker column.
 Procurement workflows that previously excluded DNP rows should filter on the `DNP` column:
 
 ```bash
@@ -650,19 +656,19 @@ different identifier to appear in the BOM, change it on the PCB (for example via
 Use `-f "+PRESET"` or shorthand fabricator flags (`--jlc`, etc.) to imply a preset.
 
 **+default**
-: Reference, Quantity, Description, Value, Footprint, Manufacturer, MFGPN, Fabricator, Fabricator Part Number, Datasheet, SMD. Alias: `+standard`.
+: Reference, Quantity, Description, Value, Footprint, Manufacturer, MFGPN, Fabricator, Fabricator Part Number, Datasheet, SMD, DNP. Alias: `+standard`.
 
 **+jlc**
-: Reference, Quantity, Value, Description, LCSC/Fabricator Part Number, SMD. JLCPCB column order. Enabled by `--jlc`.
+: Reference, Quantity, Value, Description, LCSC/Fabricator Part Number, SMD, DNP. JLCPCB column order. Enabled by `--jlc`.
 
 **+pcbway**
-: PCBWay-compatible column set. Enabled by `--pcbway`.
+: PCBWay-compatible column set including DNP marker column. Enabled by `--pcbway`.
 
 **+seeed**
-: Seeed Studio Fusion PCBA column set. Enabled by `--seeed`.
+: Seeed Studio Fusion PCBA column set including DNP marker column. Enabled by `--seeed`.
 
 **+generic**
-: Reference, Quantity, Description, Value, Package, Footprint, Manufacturer, Part Number. Enabled by `--generic`.
+: Reference, Quantity, Description, Value, Package, Footprint, Manufacturer, Part Number, DNP. Enabled by `--generic`.
 
 **+minimal**
 : Reference, Quantity, Value, LCSC. Bare minimum for quick exports.

--- a/docs/reference/inventory-format.md
+++ b/docs/reference/inventory-format.md
@@ -84,6 +84,9 @@ user; jBOM exposes them to the BOM-generation pipeline by name.
 **Package**
 : Physical package code (`0603`, `0805`, `1206`, `SOT-23`, `SOIC-8`, `QFN-32`, etc.).
   Extracted from the schematic footprint and matched exactly.
+: The BOM `Footprint` output column remains the canonical PCB FPID
+  (`pcb:footprint`) taken from the `.kicad_pcb` footprint identifier; this FPID
+  policy does not add new required inventory-schema columns.
 
 **Priority**
 : Integer ranking (1 = most preferred, higher = less preferred). When multiple

--- a/docs/reference/kicad-plugin.md
+++ b/docs/reference/kicad-plugin.md
@@ -67,7 +67,7 @@ are configurable; see [Custom fabricator configuration](#custom-fabricator-confi
 | Description | component description |
 | Value | component value |
 | Package | package code |
-| Footprint | KiCad footprint path |
+| Footprint | canonical PCB FPID from `.kicad_pcb` footprint identifier |
 | Manufacturer | manufacturer name from inventory |
 | Part Number | resolved fabricator part number (Supplier+SPN) |
 
@@ -79,7 +79,7 @@ are configurable; see [Custom fabricator configuration](#custom-fabricator-confi
 | Quantity | aggregate count |
 | Value | component value |
 | Comment | component description |
-| Footprint | KiCad footprint path |
+| Footprint | canonical PCB FPID from `.kicad_pcb` footprint identifier |
 | LCSC | resolved part number — required column name for JLCPCB upload |
 | Surface Mount | SMD flag |
 
@@ -138,6 +138,18 @@ JLCPCB treats blank `LCSC` entries as consigned parts.
 For complete column definitions including optional matching attributes
 (`Tolerance`, `Voltage`, `Current`, etc.), see the
 [inventory file format reference](./inventory-format.md).
+
+## Component attribute contract (DNP / excluded flags)
+
+The plugin follows the same BOM-component contract as `jbom bom`:
+
+- `exclude_from_board` and `exclude_from_bom` footprints are always excluded.
+- DNP footprints are always included in BOM output and marked in the `DNP`
+  column (`"DNP"` for DNP rows, empty string otherwise).
+
+The older plugin-side "Exclude DNP components" behavior is no longer part of
+the contract. If procurement needs a populated-only BOM, filter downstream on
+the `DNP` column.
 
 ## Custom fabricator configuration
 


### PR DESCRIPTION
## Summary
- add an explicit `field_synonyms` mechanism section to `docs/design/configuration-semantics.md`
- reconcile `docs/reference/cli.md` with current DNP contract and preset column behavior
  - keep code-accurate parts behavior: DNP rows included by default, explicit marker via `-f dnp`
- reconcile `docs/reference/kicad-plugin.md` with canonical PCB FPID footprint wording and DNP contract
- add an FPID schema-impact note in `docs/reference/inventory-format.md`

## Validation
- `pre-commit`
  - passed
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m pytest tests/ -v`
  - passed: 1402 passed
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress`
  - passed: 47 features, 259 scenarios, 0 failed

Closes #312
Refs #271
Refs #294

Co-Authored-By: Oz <oz-agent@warp.dev>
