### PR TITLE
feat(cli): jbom promote canonical-inventory workflow + supplier-implied enrichment

### DIFF
--- a/docs/architecture/adr/0018-promote-scope-and-enrichment-model.md
+++ b/docs/architecture/adr/0018-promote-scope-and-enrichment-model.md
@@ -1,0 +1,142 @@
+# ADR 0018: Promote Command Scope and Enrichment Model
+Date: 2026-05-29
+Status: Accepted
+Related: #323, #324, #325, #327, #329, #330, #331, ADR 0008, ADR 0012, ADR 0013
+
+## Context
+
+`jbom promote` was introduced (issue #323, PR #325) as a way to materialize a
+supplier-export CSV (initially the JLCPCB private parts export) into the
+canonical jBOM inventory schema so downstream `jbom bom`, `jbom audit`, and
+`jbom annotate` workflows can consume it as if it were a curated inventory.
+
+During the implementation and review of PR #325, three architecture-level
+decisions emerged that bound `promote`'s responsibility and shape over time.
+The same review also accepted a number of CLI ergonomics decisions
+(removal of `--source-format` and `--no-enrich`, the supplier-context
+implicit rule); those are part of the user-facing CLI contract and live in
+`docs/reference/cli.md`, not in this ADR.
+
+This ADR records the three scope/direction decisions so they do not live only
+in PR comments and so the followup issues hang off them cleanly.
+
+## Decision drivers
+
+- Preserve jBOM's design principle that fabricator- and supplier-specific
+  knowledge lives in configuration (`*.jbom.yaml`, ADR 0008), not in code.
+- Avoid promoting (no pun intended) a temporary implementation choice into an
+  architectural commitment. Specifically, do not treat free-text description
+  parsing as a strategic data source.
+- Keep individual jBOM commands responsible for one bounded
+  concept. A supplier-invoice transform and an inventory-curation activity
+  are two different bounded concepts even when they touch the same canonical
+  rows.
+- Keep `promote`'s contract narrow enough that it can run offline and
+  per-invoice, and broad enough that the same workflow benefits from
+  supplier-side parametric data when a catalog is available.
+
+## Decisions
+
+### D1. Provider parametric attributes are the primary parameterized data source; description-regex parsing is a last-resort fallback
+
+The original intent of `promote` was:
+
+1. Resolve identity via supplier catalog (deterministic MPN/SPN lookup).
+2. Use the provider's parametric attributes (`SearchResult.attributes`) as
+   the primary source of typed canonical fields such as `Tolerance`, `V`,
+   `A`, `W`, dielectric `Type`, `Datasheet`, etc.
+3. Fall back to a regex parse of the free-text `Description` only where the
+   provider did not supply a field.
+
+The implementation in PR #325 currently runs the description-regex parser
+first and consults the provider only to fill missing canonical fields. That
+inversion is recognised as a temporary shape, retained because reusing the
+provider's parametric data is non-trivial and was scoped out of #325.
+
+The committed direction is the provider-first ordering. The description
+regex parser is intentionally bounded in scope: it must not accumulate
+domain knowledge that belongs in supplier responses, nor should new
+electrical categories be added by extending the regex parser when the
+provider already returns them.
+
+Followup that realises this decision: issue #329.
+
+### D2. Source-export shapes are declarative configuration, not code
+
+A supplier-export CSV shape (header signature, column → canonical-seed
+mapping, traceability columns) is declarative data about a supplier's view
+of its own catalog. Under ADR 0008, that belongs inside the supplier's
+unified `*.jbom.yaml` configuration, under a new `export:` block.
+
+The code-side concern reduces to one `ConfigDrivenAdapter(supplier.export)`
+plus a header-signature auto-detector that walks loaded supplier profiles
+and chooses the highest-confidence match. The in-code `JlcpcbExportAdapter`,
+the `GenericCsvAdapter`, and the `select_adapter` switch shipped in PR #325
+are interim shapes; they will be retired in favour of the config-driven
+adapter.
+
+This decision also reinforces the broader jBOM principle that adding
+support for a new fabricator/supplier is a configuration drop-in, not a
+code change.
+
+Followup that realises this decision: issue #327.
+
+### D3. `promote` is per-invoice; cross-supplier discovery and freshness/lifecycle/stock stamping belong to `inventory`
+
+`promote` operates on one supplier's export and produces canonical inventory
+rows that describe what *that* supplier sees of its own catalog. Two
+adjacent capabilities are explicitly out of scope:
+
+- **Cross-supplier alternative discovery** — looking up the same MPN at
+  other suppliers and emitting additional `Priority>1` rows under the same
+  IPN. This is an inventory-curation activity that grows an already-canonical
+  inventory and belongs in `jbom inventory --supplier <other>` (followup
+  issue #330).
+- **Freshness, lifecycle, and stock stamping** — querying providers for
+  current lifecycle/stock data and stamping canonical columns on existing
+  rows. This is also an inventory-curation activity and shares plumbing
+  with `jbom audit --supplier`; it belongs in `jbom inventory` (followup
+  issue #331).
+
+The promote command stays focused on the per-invoice ETL contract: source
+adapter → semantic extraction → identity → optional supplier enrichment of
+the same MPN/SPN it already saw in the source row → canonical-row output.
+
+## Consequences
+
+### Positive
+
+- The promote command has a clear, bounded contract that does not grow with
+  every adjacent inventory-curation feature.
+- The unified-config direction (ADR 0008) is reinforced rather than
+  contradicted: new supplier shapes are declarative drop-ins, not code
+  changes.
+- The description-regex parser stops accruing maintenance load as the
+  provider-attributes-first ordering lands; its scope is explicitly capped
+  as fallback-only.
+- Followup work has clean issue boundaries: #327, #329, #330, #331 each
+  realise one part of one of these decisions.
+
+### Negative / tradeoffs
+
+- The interim shape shipped in PR #325 (description-first parser, in-code
+  JLC adapter) will require follow-on work before this ADR is fully realised
+  in code.
+- Some near-term feature requests that feel like they belong in `promote`
+  (multi-supplier views, freshness stamping) will be routed to `inventory`
+  instead. The CLI surface must remain consistent enough that this routing
+  is predictable.
+
+### Neutral
+
+- Does not prescribe a concrete provider-attribute mapping schema; that
+  detail belongs to issue #329's implementation.
+- Does not prescribe the exact name or shape of the `supplier.export:`
+  stanza; that detail belongs to issue #327's implementation.
+
+## Provenance
+
+Decisions D1–D3 were established during PR #325 review. The plan that
+drove that PR is preserved as a PR comment for design history. This ADR
+exists so the decisions are durable in `docs/architecture/adr/` and not
+only in PR conversation.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@ jbom pos [PROJECT] [-o OUTPUT] [POS OPTIONS]
 jbom gerbers [PROJECT] [-o OUTPUT_DIR] [--fabricator NAME] [--no-drill] [--netlist] [--dry-run]
 jbom fab [PROJECT] [-o OUTPUT_ROOT] [--fabricator NAME] [--skip-bom] [--skip-pos] [--skip-gerbers] [--debug] [--dry-run]
 jbom inventory [PROJECT] [-o OUTPUT] [--supplier SUPPLIER_ID ...] [--api-key KEY_OR_SUPPLIER_KEY ...] [INVENTORY OPTIONS]
-jbom promote SOURCE_INVENTORY [--supplier SUPPLIER_ID] [--api-key KEY_OR_SUPPLIER_KEY ...] [--jlc] [-o OUTPUT] [-F] [-v]
+jbom promote SOURCE_INVENTORY [--supplier SUPPLIER_ID ...] [--api-key KEY_OR_SUPPLIER_KEY ...] [--jlc] [-o OUTPUT] [-F] [-v]
 jbom parts [PROJECT] [-o OUTPUT] [PARTS OPTIONS]
 jbom search QUERY [SEARCH OPTIONS]
 ```
@@ -355,8 +355,8 @@ The command preserves all source columns and appends one stable metadata column:
 : Path to the supplier-export CSV to promote.
 
 **--supplier SUPPLIER_ID**
-: Supplier context for promotion. The parser accepts repeated values only when they
-  resolve to the same supplier context.
+: Supplier context for promotion. Repeat to express multi-supplier promotion flows,
+  consistent with `jbom inventory` supplier semantics.
 
 **--jlc**
 : Shortcut for `--supplier lcsc`.
@@ -365,8 +365,8 @@ The command preserves all source columns and appends one stable metadata column:
 : Optional API key argument, parsed with the same shape rules as `jbom inventory`:
   - `--api-key KEY`
   - `--api-key SUPPLIER_ID=KEY`
-: In the current promote scaffold, exactly one effective supplier context is allowed.
-  A scoped key for a different supplier context fails fast.
+: In multi-supplier design flows, use supplier-scoped keys (`SUPPLIER_ID=KEY`) or
+  ordered repeated unscoped keys aligned with repeated `--supplier` arguments.
 
 **-o, --output OUTPUT**
 : Output destination.
@@ -380,12 +380,11 @@ The command preserves all source columns and appends one stable metadata column:
 **-v, --verbose**
 : Enable verbose diagnostics.
 
-### Current boundary
+### Design intent
 
-`jbom promote` currently supports one effective supplier context per invocation.
-The command fails fast when overlapping contexts are requested (for example
-`--jlc --supplier lcsc` or `--supplier lcsc --supplier mouser`). This boundary is
-tracked by issue `#324`.
+`jbom promote` is designed to share supplier-selection and API-key mapping semantics
+with `jbom inventory`, so promotion and inventory-enrichment workflows remain
+interchangeable at the CLI contract level.
 
 ### Exit codes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,14 +20,15 @@ jbom bom [PROJECT] [--inventory FILE ...] [-o OUTPUT] [BOM OPTIONS]
 jbom pos [PROJECT] [-o OUTPUT] [POS OPTIONS]
 jbom gerbers [PROJECT] [-o OUTPUT_DIR] [--fabricator NAME] [--no-drill] [--netlist] [--dry-run]
 jbom fab [PROJECT] [-o OUTPUT_ROOT] [--fabricator NAME] [--skip-bom] [--skip-pos] [--skip-gerbers] [--debug] [--dry-run]
-jbom inventory [PROJECT] [-o OUTPUT] [INVENTORY OPTIONS]
+jbom inventory [PROJECT] [-o OUTPUT] [--supplier SUPPLIER_ID ...] [--api-key KEY_OR_SUPPLIER_KEY ...] [INVENTORY OPTIONS]
+jbom promote SOURCE_INVENTORY [--supplier SUPPLIER_ID] [--api-key KEY_OR_SUPPLIER_KEY ...] [--jlc] [-o OUTPUT] [-F] [-v]
 jbom parts [PROJECT] [-o OUTPUT] [PARTS OPTIONS]
 jbom search QUERY [SEARCH OPTIONS]
 ```
 
 ## DESCRIPTION
 
-jBOM provides nine subcommands:
+jBOM provides ten subcommands:
 
 - `audit` — diagnose field-quality issues and inventory coverage gaps in KiCad projects or catalog files
 - `annotate` — back-annotate KiCad schematics with approved field values from an audit report
@@ -36,6 +37,7 @@ jBOM provides nine subcommands:
 - `gerbers` — generate Gerber/drill files from a KiCad PCB file via kicad-cli
 - `fab` — one-shot fabrication: BOM + placement + Gerbers, written to a `production/` folder
 - `inventory` — generate an initial inventory template from schematic components
+- `promote` — scaffold a supplier-export CSV into stable inventory shape by stamping supplier context
 - `parts` — generate an unaggregated parts list (one row per component) from schematics
 - `search` — search external distributor catalogs (e.g. LCSC, Mouser) by keyword or part number
 
@@ -323,7 +325,12 @@ Generates an initial inventory template from schematic components. The output is
 : Auto-populate supplier part numbers during inventory generation. Repeat the flag to enrich from multiple suppliers in one run (for example: `--supplier lcsc --supplier mouser`).
 
 **--api-key KEY**
-: API key override for supplier catalog providers.
+: Supplier API key mapping input. Repeatable and validated against `--supplier`.
+: Supported forms:
+  - single unscoped key: `--api-key KEY` (backward-compatible default key)
+  - supplier-scoped key: `--api-key SUPPLIER_ID=KEY` (repeat for each supplier)
+  - ordered unscoped mapping: repeat unscoped keys and repeat `--supplier` with matching count; keys map by supplier argument order
+: Invalid combinations fail fast (mixed scoped/unscoped values, count mismatches, or scoped supplier IDs not present in `--supplier`).
 
 **--limit N**
 : Maximum candidates applied per supplier per unmatched seed row (default: `1`). In multi-supplier mode, the limit is evaluated independently for each supplier pass.
@@ -333,6 +340,57 @@ Generates an initial inventory template from schematic components. The output is
 
 **-v, --verbose**
 : Show loading and processing diagnostics.
+
+## PROMOTE COMMAND
+
+```
+jbom promote SOURCE_INVENTORY [-o OUTPUT] [OPTIONS]
+```
+
+Promotes a supplier-export CSV into a deterministic, inventory-compatible scaffold.
+The command preserves all source columns and appends one stable metadata column:
+`SupplierContext`.
+
+**SOURCE_INVENTORY** (required)
+: Path to the supplier-export CSV to promote.
+
+**--supplier SUPPLIER_ID**
+: Supplier context for promotion. The parser accepts repeated values only when they
+  resolve to the same supplier context.
+
+**--jlc**
+: Shortcut for `--supplier lcsc`.
+
+**--api-key KEY_OR_SUPPLIER_KEY**
+: Optional API key argument, parsed with the same shape rules as `jbom inventory`:
+  - `--api-key KEY`
+  - `--api-key SUPPLIER_ID=KEY`
+: In the current promote scaffold, exactly one effective supplier context is allowed.
+  A scoped key for a different supplier context fails fast.
+
+**-o, --output OUTPUT**
+: Output destination.
+  - Omit `-o` to write `<input>.promoted.csv` next to the source file.
+  - Use `-o console` or `-o -` for CSV to stdout.
+  - Otherwise, treat the value as a file path.
+
+**-F, --force, --Force**
+: Overwrite an existing output file.
+
+**-v, --verbose**
+: Enable verbose diagnostics.
+
+### Current boundary
+
+`jbom promote` currently supports one effective supplier context per invocation.
+The command fails fast when overlapping contexts are requested (for example
+`--jlc --supplier lcsc` or `--supplier lcsc --supplier mouser`). This boundary is
+tracked by issue `#324`.
+
+### Exit codes
+
+- `0` — success
+- `1` — error
 
 ## PARTS COMMAND
 
@@ -570,6 +628,9 @@ jbom inventory ./my_project --supplier lcsc -o inventory.csv
 **Inventory CSV**
 : Default name `part-inventory.csv` (written in the current working directory when `-o` is omitted). Template with IPN, Category, Value, Package, and related columns.
 
+**Promoted CSV**
+: Default name `<input>.promoted.csv` (written next to the source file when `-o` is omitted). Source columns are preserved and `SupplierContext` is added.
+
 **Parts CSV**
 : Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per electro-mechanical group with a `Refs` column of collapsed references. Use `-o -` for CSV to stdout.
 : DNP rows are included in the default row set. Add `-f dnp` when an explicit DNP marker column is required.
@@ -726,6 +787,26 @@ jbom inventory MyProject/ -o my_inventory.csv
 Generate inventory with one-pass multi-supplier enrichment:
 ```
 jbom inventory MyProject/ --supplier lcsc --supplier mouser --limit 2 -o inventory.csv
+```
+
+Generate inventory with explicit per-supplier API keys:
+```
+jbom inventory MyProject/ --supplier lcsc --supplier mouser --api-key lcsc=KEY_LCSC --api-key mouser=KEY_MOUSER -o inventory.csv
+```
+
+Generate inventory with repeated unscoped API keys mapped by supplier argument order:
+```
+jbom inventory MyProject/ --supplier lcsc --supplier mouser --api-key KEY_LCSC --api-key KEY_MOUSER -o inventory.csv
+```
+
+Promote a supplier export and stamp explicit supplier context:
+```
+jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc -o examples/JLCPCB-INVENTORY.promoted.csv
+```
+
+Promote with shorthand supplier context and scoped API key:
+```
+jbom promote examples/JLCPCB-INVENTORY.csv --jlc --api-key lcsc=KEY123 -o -
 ```
 
 Show only components not yet in an existing inventory:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,7 +37,7 @@ jBOM provides ten subcommands:
 - `gerbers` — generate Gerber/drill files from a KiCad PCB file via kicad-cli
 - `fab` — one-shot fabrication: BOM + placement + Gerbers, written to a `production/` folder
 - `inventory` — generate an initial inventory template from schematic components
-- `promote` — scaffold a supplier-export CSV into stable inventory shape by stamping supplier context
+- `promote` — convert a supplier-export CSV into canonical jBOM inventory rows: parse descriptions, derive identity, and optionally enrich via the selected supplier provider
 - `parts` — generate an unaggregated parts list (one row per component) from schematics
 - `search` — search external distributor catalogs (e.g. LCSC, Mouser) by keyword or part number
 
@@ -347,16 +347,33 @@ Generates an initial inventory template from schematic components. The output is
 jbom promote SOURCE_INVENTORY [-o OUTPUT] [OPTIONS]
 ```
 
-Promotes a supplier-export CSV into a deterministic, inventory-compatible scaffold.
-The command preserves all source columns and appends one stable metadata column:
-`SupplierContext`.
+Converts a supplier-export CSV into canonical jBOM inventory rows. The workflow
+is a small pipeline:
+
+1. A source-export *adapter* normalises each row from a known supplier shape
+   (for example JLCPCB private parts export) into a canonical seed (SPN, MFGPN,
+   manufacturer, description, package, category hint, plus traceability extras).
+2. A pure *description parser* extracts EM fields from the description text and
+   identity hints: Category, Value, Package, Tolerance, Type (MLCC dielectric),
+   V/A/W ratings, Wavelength/mcd/Angle for LEDs, and typed Resistance /
+   Capacitance / Inductance.
+3. An *identity policy* derives a deterministic `IPN` for supported categories
+   (passives + LEDs today) from the parsed identity.
+4. When the user selects an explicit supplier context (`--supplier <id>` or
+   `--jlc`), a *supplier enrichment* step calls the supplier provider's
+   deterministic MPN lookup first, with a keyword search fallback, to fill in
+   `Manufacturer`, `MFGPN`, `Datasheet`, and `SPN`.  Without an explicit
+   supplier flag, the implicit `generic` context carries no catalog and no
+   enrichment is attempted.
+5. The result is written as canonical inventory columns first, followed by any
+   supplemental source columns (qty, pricing) preserved verbatim for traceability.
 
 **SOURCE_INVENTORY** (required)
 : Path to the supplier-export CSV to promote.
 
 **--supplier SUPPLIER_ID**
-: Supplier context for promotion. Repeat to express multi-supplier promotion flows,
-  consistent with `jbom inventory` supplier semantics.
+: Supplier context for promotion. Repeat is accepted and is shape-compatible with
+  `jbom inventory` supplier semantics.
 
 **--jlc**
 : Shortcut for `--supplier lcsc`.
@@ -365,8 +382,6 @@ The command preserves all source columns and appends one stable metadata column:
 : Optional API key argument, parsed with the same shape rules as `jbom inventory`:
   - `--api-key KEY`
   - `--api-key SUPPLIER_ID=KEY`
-: In multi-supplier design flows, use supplier-scoped keys (`SUPPLIER_ID=KEY`) or
-  ordered repeated unscoped keys aligned with repeated `--supplier` arguments.
 
 **-o, --output OUTPUT**
 : Output destination.
@@ -378,13 +393,15 @@ The command preserves all source columns and appends one stable metadata column:
 : Overwrite an existing output file.
 
 **-v, --verbose**
-: Enable verbose diagnostics.
+: Print per-row parse provenance and enrichment outcomes to stderr.
 
 ### Design intent
 
-`jbom promote` is designed to share supplier-selection and API-key mapping semantics
-with `jbom inventory`, so promotion and inventory-enrichment workflows remain
-interchangeable at the CLI contract level.
+`jbom promote` shares supplier-selection and API-key mapping semantics with
+`jbom inventory` so promotion and inventory-enrichment workflows are
+interchangeable at the CLI contract level. The canonical-output schema is the
+same inventory column shape consumed by downstream `jbom bom`, `jbom audit`,
+and `jbom annotate` workflows.
 
 ### Exit codes
 
@@ -628,7 +645,7 @@ jbom inventory ./my_project --supplier lcsc -o inventory.csv
 : Default name `part-inventory.csv` (written in the current working directory when `-o` is omitted). Template with IPN, Category, Value, Package, and related columns.
 
 **Promoted CSV**
-: Default name `<input>.promoted.csv` (written next to the source file when `-o` is omitted). Source columns are preserved and `SupplierContext` is added.
+: Default name `<input>.promoted.csv` (written next to the source file when `-o` is omitted). Canonical inventory columns are written first (`RowType`, `IPN`, `Category`, `Value`, `Package`, `Description`, `Manufacturer`, `MFGPN`, `Supplier`, `SPN`, `Datasheet`, typed EM fields, etc.) with `SupplierContext` carrying the resolved supplier label.  Supplemental source columns from the export (qty, pricing, etc.) are preserved after the canonical block for traceability.
 
 **Parts CSV**
 : Default name `${ProjectName}.parts.csv` (written in the project directory when `-o` is omitted). One row per electro-mechanical group with a `Refs` column of collapsed references. Use `-o -` for CSV to stdout.

--- a/docs/tutorials/inventory-workflows.md
+++ b/docs/tutorials/inventory-workflows.md
@@ -48,19 +48,33 @@ You do not need to specify individual sheet files.
 
 ## Promote a supplier export into canonical inventory shape
 
-When a supplier provides a CSV export, use `jbom promote` to create a deterministic
-inventory scaffold before curation:
+When a supplier provides a CSV export, use `jbom promote` to lift it into the
+canonical jBOM inventory schema in one step:
 
 ```bash
-jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc -o examples/JLCPCB-INVENTORY.promoted.csv
+jbom promote examples/JLCPCB-INVENTORY.csv --jlc -o examples/JLCPCB-INVENTORY.promoted.csv
 ```
 
-The promoted output preserves source columns and adds `SupplierContext`, so downstream
-inventory/BOM workflows have an explicit supplier-context marker.
+The promoted CSV writes canonical inventory columns first (`RowType`, `IPN`,
+`Category`, `Value`, `Package`, `Description`, `Manufacturer`, `MFGPN`,
+`Supplier`, `SPN`, `Datasheet`, typed EM fields such as `Resistance`,
+`Capacitance`, `Tolerance`, `Type`, `V`, `A`, `W`, `Wavelength`, `mcd`, `Angle`)
+and then preserves the source export's supplemental columns (quantity, pricing,
+etc.) after the canonical block for traceability.
 
-`--jlc` is shorthand for `--supplier lcsc`:
+Internally the workflow runs an adapter (e.g. JLCPCB), a pure description and
+EM parser, an identity policy that builds a deterministic IPN for supported
+categories, and — when an explicit supplier context is selected — a supplier
+enrichment step that uses the provider's MPN lookup (with a keyword search
+fallback) to fill `Manufacturer`, `MFGPN`, and `Datasheet`.
+
+The supplier-search behavior is implied by the supplier flags themselves:
 
 ```bash
+# Offline, parse-only: no --supplier / --jlc => implicit 'generic' context => no catalog.
+jbom promote examples/JLCPCB-INVENTORY.csv -o promoted.csv
+
+# Online enrichment: --jlc (or --supplier <id>) selects a catalog => promote queries it.
 jbom promote examples/JLCPCB-INVENTORY.csv --jlc -o promoted.csv
 ```
 
@@ -74,9 +88,13 @@ jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key KEY123 -o -
 jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key lcsc=KEY123 -o -
 ```
 
+Verbose runs (`-v`) print per-row parse provenance and enrichment outcomes to
+stderr, which is useful when validating that descriptions are being interpreted
+the way you expect.
+
 Design intent: `promote` and `inventory` share the same supplier-selection and
-supplier-key mapping pattern, so promotion and enrichment workflows are modeled with
-the same CLI shape.
+supplier-key mapping pattern, so promotion and enrichment workflows are modeled
+with the same CLI shape and produce the same canonical inventory column set.
 
 ---
 

--- a/docs/tutorials/inventory-workflows.md
+++ b/docs/tutorials/inventory-workflows.md
@@ -74,9 +74,9 @@ jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key KEY123 -o -
 jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key lcsc=KEY123 -o -
 ```
 
-Current boundary: `promote` allows one effective supplier context per run. Overlapping
-contexts (for example `--jlc --supplier lcsc` or `--supplier lcsc --supplier mouser`)
-fail fast while the multi-context design is tracked by issue `#324`.
+Design intent: `promote` and `inventory` share the same supplier-selection and
+supplier-key mapping pattern, so promotion and enrichment workflows are modeled with
+the same CLI shape.
 
 ---
 

--- a/docs/tutorials/inventory-workflows.md
+++ b/docs/tutorials/inventory-workflows.md
@@ -7,7 +7,8 @@
 
 This tutorial guides you through common inventory management patterns in jBOM: building an
 inventory from scratch, enhancing it with supplier data, keeping multiple projects in sync,
-and incrementally adding new components without disrupting existing records.
+promoting supplier-export CSVs into canonical inventory shape, and incrementally adding new
+components without disrupting existing records.
 
 ---
 
@@ -42,6 +43,40 @@ are what make the file useful as an inventory source in subsequent runs.
 
 If your project uses hierarchical sheets, jBOM follows the hierarchy automatically.
 You do not need to specify individual sheet files.
+
+---
+
+## Promote a supplier export into canonical inventory shape
+
+When a supplier provides a CSV export, use `jbom promote` to create a deterministic
+inventory scaffold before curation:
+
+```bash
+jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc -o examples/JLCPCB-INVENTORY.promoted.csv
+```
+
+The promoted output preserves source columns and adds `SupplierContext`, so downstream
+inventory/BOM workflows have an explicit supplier-context marker.
+
+`--jlc` is shorthand for `--supplier lcsc`:
+
+```bash
+jbom promote examples/JLCPCB-INVENTORY.csv --jlc -o promoted.csv
+```
+
+API key parsing is shape-compatible with `jbom inventory`:
+
+```bash
+# single unscoped key
+jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key KEY123 -o -
+
+# supplier-scoped key
+jbom promote examples/JLCPCB-INVENTORY.csv --supplier lcsc --api-key lcsc=KEY123 -o -
+```
+
+Current boundary: `promote` allows one effective supplier context per run. Overlapping
+contexts (for example `--jlc --supplier lcsc` or `--supplier lcsc --supplier mouser`)
+fail fast while the multi-context design is tracked by issue `#324`.
 
 ---
 

--- a/features/cli/basics.feature
+++ b/features/cli/basics.feature
@@ -15,6 +15,7 @@ Feature: CLI Basics
     And the output should contain "inventory"
     And the output should contain "search"
     And the output should contain "annotate"
+    And the output should contain "promote"
 
   Scenario: Show version
     When I run jbom command "--version"

--- a/features/inventory/supplier_populate.feature
+++ b/features/inventory/supplier_populate.feature
@@ -72,6 +72,64 @@ Feature: Inventory supplier PN auto-populate
     And the file "result.csv" should contain "G25804"
     And the file "result.csv" should contain "M25804"
 
+  Scenario: Supplier-scoped API keys are accepted for repeatable supplier enrichment
+    Given a supplier profile that contains:
+      | key | value |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | G25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a supplier profile that contains:
+      | key | value |
+      | id  | mouser |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | M25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic --supplier mouser --api-key generic=KEY_GENERIC --api-key mouser=KEY_MOUSER -o result.csv"
+    Then the command should succeed
+    And the file "result.csv" contains exactly 3 data rows
+    And the file "result.csv" should contain "G25804"
+    And the file "result.csv" should contain "M25804"
+
+  Scenario: Repeated unscoped API keys map by supplier argument order
+    Given a supplier profile that contains:
+      | key | value |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | G25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a supplier profile that contains:
+      | key | value |
+      | id  | mouser |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | M25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic --supplier mouser --api-key KEY_GENERIC --api-key KEY_MOUSER -o result.csv"
+    Then the command should succeed
+    And the file "result.csv" contains exactly 3 data rows
+    And the file "result.csv" should contain "G25804"
+    And the file "result.csv" should contain "M25804"
+
+  Scenario: Supplier-scoped API key must match the selected supplier set
+    Given a supplier profile that contains:
+      | key | value |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price |
+      | G25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  |
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic --api-key mouser=KEY_MOUSER -o result.csv"
+    Then the command should fail
+    And the output should contain "not present in --supplier arguments"
+
   Scenario: --limit applies independently to each supplier pass
     Given a supplier profile that contains:
       | key | value |

--- a/features/promote/core.feature
+++ b/features/promote/core.feature
@@ -1,7 +1,7 @@
 Feature: Promote supplier export inventory
   As a jBOM user
-  I want jbom promote to materialize supplier export CSV files into inventory-compatible output
-  So that I can run downstream inventory and BOM workflows deterministically
+  I want jbom promote to materialize supplier export CSV files into canonical inventory rows
+  So that I can run downstream inventory and BOM workflows with semantic content
 
   Scenario: Promote writes default output file with generic supplier context
     Given an inventory file "supplier-export.csv" that contains:
@@ -14,23 +14,14 @@ Feature: Promote supplier export inventory
     And the file "supplier-export.promoted.csv" should contain "generic"
     And the file "supplier-export.promoted.csv" contains exactly 1 data rows
 
-  Scenario: Promote honors explicit supplier context in stdout output
+  Scenario: Promote writes CSV to stdout under the implicit generic context
     Given an inventory file "supplier-export.csv" that contains:
       | JLC Part # | Description |
       | C2286      | 1uF 0603   |
-    When I run "jbom promote supplier-export.csv --supplier lcsc -o -"
+    When I run "jbom promote supplier-export.csv -o -"
     Then the command should succeed
     And the output should contain "SupplierContext"
-    And the output should contain "lcsc"
-
-  Scenario: Promote accepts matching supplier-scoped API key syntax
-    Given an inventory file "supplier-export.csv" that contains:
-      | JLC Part # | Description |
-      | C2286      | 1uF 0603   |
-    When I run "jbom promote supplier-export.csv --supplier lcsc --api-key lcsc=KEY123 -o -"
-    Then the command should succeed
-    And the output should contain "SupplierContext"
-    And the output should contain "lcsc"
+    And the output should contain "generic"
 
   Scenario: Promote rejects supplier-scoped API key for a different supplier context
     Given an inventory file "supplier-export.csv" that contains:
@@ -55,3 +46,30 @@ Feature: Promote supplier export inventory
     When I run "jbom promote supplier-export.csv --supplier lcsc --supplier mouser"
     Then the command should fail
     And the output should contain "tracked by #324"
+
+  Scenario: Promote emits canonical inventory schema for JLC exports
+    Given an inventory file "jlc-export.csv" that contains:
+      | Category    | JLC Part # | MFR Part #         | Footprint | Description                  |
+      | Capacitors  | C2286      | CC0603KRX7R9BB104  | 0603      | 0.1uF 50V X7R 10% 0603       |
+    When I run "jbom promote jlc-export.csv -o -"
+    Then the command should succeed
+    And the output should contain "RowType"
+    And the output should contain "Category"
+    And the output should contain "Value"
+    And the output should contain "Package"
+    And the output should contain "Tolerance"
+    And the output should contain "Capacitance"
+    And the output should contain "SupplierContext"
+
+  Scenario: Promote extracts EM semantics from JLC capacitor descriptions
+    Given an inventory file "jlc-cap.csv" that contains:
+      | Category    | JLC Part # | MFR Part #         | Footprint | Description                  |
+      | Capacitors  | C2286      | CC0603KRX7R9BB104  | 0603      | 0.1uF 50V X7R 10% 0603       |
+    When I run "jbom promote jlc-cap.csv -o promoted.csv"
+    Then the command should succeed
+    And the file "promoted.csv" should contain "CAP"
+    And the file "promoted.csv" should contain "0603"
+    And the file "promoted.csv" should contain "X7R"
+    And the file "promoted.csv" should contain "50V"
+    And the file "promoted.csv" should contain "10%"
+    And the file "promoted.csv" should contain "C2286"

--- a/features/promote/core.feature
+++ b/features/promote/core.feature
@@ -1,0 +1,57 @@
+Feature: Promote supplier export inventory
+  As a jBOM user
+  I want jbom promote to materialize supplier export CSV files into inventory-compatible output
+  So that I can run downstream inventory and BOM workflows deterministically
+
+  Scenario: Promote writes default output file with generic supplier context
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv"
+    Then the command should succeed
+    And a file named "supplier-export.promoted.csv" should exist
+    And the file "supplier-export.promoted.csv" should contain "SupplierContext"
+    And the file "supplier-export.promoted.csv" should contain "generic"
+    And the file "supplier-export.promoted.csv" contains exactly 1 data rows
+
+  Scenario: Promote honors explicit supplier context in stdout output
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv --supplier lcsc -o -"
+    Then the command should succeed
+    And the output should contain "SupplierContext"
+    And the output should contain "lcsc"
+
+  Scenario: Promote accepts matching supplier-scoped API key syntax
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv --supplier lcsc --api-key lcsc=KEY123 -o -"
+    Then the command should succeed
+    And the output should contain "SupplierContext"
+    And the output should contain "lcsc"
+
+  Scenario: Promote rejects supplier-scoped API key for a different supplier context
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv --supplier lcsc --api-key mouser=KEY999"
+    Then the command should fail
+    And the output should contain "not present in --supplier arguments"
+
+  Scenario: Promote fails fast when --jlc overlaps with --supplier
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv --jlc --supplier lcsc"
+    Then the command should fail
+    And the output should contain "tracked by #324"
+
+  Scenario: Promote fails fast when multiple supplier contexts are requested
+    Given an inventory file "supplier-export.csv" that contains:
+      | JLC Part # | Description |
+      | C2286      | 1uF 0603   |
+    When I run "jbom promote supplier-export.csv --supplier lcsc --supplier mouser"
+    Then the command should fail
+    And the output should contain "tracked by #324"

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -21,6 +21,11 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.cli.supplier_args import (
+    normalize_supplier_ids as _normalize_cli_supplier_ids,
+    parse_supplier_api_key_args as _parse_supplier_api_key_args,
+    resolve_supplier_api_key as _resolve_supplier_api_key,
+)
 from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.common.types import Component, InventoryItem
 from jbom.common.options import GeneratorOptions
@@ -185,9 +190,14 @@ def register_command(subparsers) -> None:
     )
     parser.add_argument(
         "--api-key",
-        metavar="KEY",
+        metavar="KEY_OR_SUPPLIER_KEY",
+        action="append",
         default=None,
-        help="API key for the supplier search provider (overrides env vars)",
+        help=(
+            "API key for supplier search providers. "
+            "Use KEY for single-supplier runs, or SUPPLIER_ID=KEY and repeat "
+            "for supplier-scoped keys in multi-supplier runs."
+        ),
     )
     parser.add_argument(
         "--limit",
@@ -478,27 +488,17 @@ def _merge_field_names(all_field_names: set[str]) -> list[str]:
 
 def _normalize_supplier_ids(raw_suppliers: Any) -> list[str]:
     """Normalize and de-duplicate supplier IDs while preserving input order."""
+    return _normalize_cli_supplier_ids(raw_suppliers)
 
-    if raw_suppliers is None:
-        return []
 
-    if isinstance(raw_suppliers, str):
-        candidates = [raw_suppliers]
-    elif isinstance(raw_suppliers, list):
-        candidates = [str(value) for value in raw_suppliers]
-    else:
-        candidates = [str(raw_suppliers)]
+def _resolve_supplier_api_keys(
+    raw_api_keys: Any,
+    *,
+    supplier_ids: list[str],
+) -> tuple[dict[str, str], str | None]:
+    """Resolve supplier-scoped and default API keys from CLI arguments."""
 
-    normalized: list[str] = []
-    seen: set[str] = set()
-    for candidate in candidates:
-        supplier_id = candidate.strip().lower()
-        if not supplier_id or supplier_id in seen:
-            continue
-        seen.add(supplier_id)
-        normalized.append(supplier_id)
-
-    return normalized
+    return _parse_supplier_api_key_args(raw_api_keys, supplier_ids=supplier_ids)
 
 
 def _build_inventory_supplier_services(
@@ -512,8 +512,6 @@ def _build_inventory_supplier_services(
     supplier_ids = _normalize_supplier_ids(getattr(args, "supplier", None))
     if not supplier_ids:
         return []
-
-    api_key = getattr(args, "api_key", None)
     resolved_services: list[tuple[InventorySearchService, SupplierConfig, str]] = []
 
     try:
@@ -521,11 +519,21 @@ def _build_inventory_supplier_services(
         from jbom.services.search.provider_factory import create_search_provider
         from jbom.services.search.inventory_search_service import InventorySearchService
 
+        scoped_api_keys, default_api_key = _resolve_supplier_api_keys(
+            getattr(args, "api_key", None),
+            supplier_ids=supplier_ids,
+        )
+
         for supplier_id in supplier_ids:
             supplier_config = resolve_supplier_by_id(supplier_id)
             if supplier_config is None:
                 print(f"Error: Unknown supplier '{supplier_id}'", file=sys.stderr)
                 continue
+            api_key = _resolve_supplier_api_key(
+                supplier_id,
+                scoped_api_keys=scoped_api_keys,
+                default_api_key=default_api_key,
+            )
 
             provider = create_search_provider(
                 supplier_id,
@@ -539,7 +547,9 @@ def _build_inventory_supplier_services(
             resolved_services.append((service, supplier_config, supplier_id))
 
         return resolved_services
-    except (ValueError, RuntimeError) as exc:
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    except RuntimeError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return []
 

--- a/src/jbom/cli/main.py
+++ b/src/jbom/cli/main.py
@@ -15,6 +15,7 @@ from jbom.cli import (
     inventory,
     pos,
     parts,
+    promote,
     search,
 )
 from jbom.config.defaults import (
@@ -60,6 +61,7 @@ def create_parser() -> argparse.ArgumentParser:
     inventory.register_command(subparsers)
     pos.register_command(subparsers)
     parts.register_command(subparsers)
+    promote.register_command(subparsers)
     search.register_command(subparsers)
     _add_defaults_argument_to_subcommands(subparsers)
 

--- a/src/jbom/cli/promote.py
+++ b/src/jbom/cli/promote.py
@@ -21,6 +21,15 @@ from jbom.cli.supplier_args import (
     resolve_supplier_api_key as _resolve_supplier_api_key,
 )
 from jbom.config.suppliers import get_available_suppliers
+from jbom.services.promote.source_adapters import (
+    detect_source_format,
+    select_adapter,
+)
+from jbom.services.promote.workflow import (
+    PromotionResult,
+    PromotionStats,
+    promote_rows,
+)
 
 _PROMOTE_SUPPLIER_CONTEXT_COLUMN = "SupplierContext"
 _PROMOTE_SUPPLIER_OVERLAP_ERROR = (
@@ -36,8 +45,10 @@ def register_command(subparsers) -> None:
         "promote",
         help="Promote supplier export CSV into canonical inventory shape",
         description=(
-            "Promote supplier-export inventory data into jBOM canonical inventory "
-            "shape (initial scaffold)."
+            "Promote a supplier-export CSV into canonical jBOM inventory rows. "
+            "Parses descriptions and derives identity from each row.  When a "
+            "supplier context is selected (--supplier or --jlc), the supplier's "
+            "catalog is queried to enrich the canonical fields."
         ),
     )
     parser.add_argument(
@@ -110,16 +121,44 @@ def handle_promote(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        rows, fieldnames = _load_inventory_rows(source_path)
+        rows, source_fieldnames = _load_inventory_rows(source_path)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    promoted_rows, promoted_fields = _promote_rows(
+    adapter = select_adapter(detect_source_format(source_fieldnames))
+
+    # Supplier-search is implied by an explicit supplier context: when the user
+    # passes --supplier <id> or --jlc, the workflow attempts catalog enrichment
+    # through that supplier.  When neither flag is provided, the implicit
+    # 'generic' context carries no catalog and no enrichment is attempted.
+    search_service = None
+    if _has_explicit_supplier_context(args):
+        try:
+            search_service = _build_promote_search_service(
+                args, supplier_context=supplier_context
+            )
+        except Exception as exc:  # pragma: no cover - defensive: bad provider config
+            if getattr(args, "verbose", False):
+                print(
+                    f"Note: supplier provider unavailable, continuing without "
+                    f"enrichment ({exc})",
+                    file=sys.stderr,
+                )
+            search_service = None
+
+    supplier_label = _supplier_label_for_context(supplier_context)
+
+    result: PromotionResult = promote_rows(
         rows,
-        fieldnames,
+        adapter=adapter,
         supplier_context=supplier_context,
+        supplier_label=supplier_label,
+        search_service=search_service,
+        verbose=bool(getattr(args, "verbose", False)),
     )
+
+    _print_summary(result.stats, enriched=search_service is not None)
 
     output_path = _default_output_path(source_path)
     destination = resolve_output_destination(
@@ -127,11 +166,23 @@ def handle_promote(args: argparse.Namespace) -> int:
         default_destination=OutputDestination(OutputKind.FILE, path=output_path),
     )
     return _write_promoted_rows(
-        promoted_rows,
-        promoted_fields,
+        result,
         destination=destination,
         force=bool(getattr(args, "force", False)),
     )
+
+
+def _has_explicit_supplier_context(args: argparse.Namespace) -> bool:
+    """Return True when the user explicitly selected a supplier context."""
+
+    if bool(getattr(args, "jlc", False)):
+        return True
+    raw = getattr(args, "supplier", None)
+    if not raw:
+        return False
+    if isinstance(raw, str):
+        return bool(raw.strip())
+    return any(str(value).strip() for value in raw)
 
 
 def _resolve_promote_supplier_context(args: argparse.Namespace) -> str:
@@ -218,30 +269,95 @@ def _load_inventory_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
     return rows, fieldnames
 
 
-def _promote_rows(
-    rows: list[dict[str, str]],
-    fieldnames: list[str],
+# ---------------------------------------------------------------------------
+# Supplier enrichment helpers
+# ---------------------------------------------------------------------------
+
+
+def _supplier_label_for_context(supplier_context: str) -> str:
+    """Return the canonical supplier label for *supplier_context*."""
+
+    try:
+        from jbom.config.suppliers import resolve_supplier_by_id
+
+        cfg = resolve_supplier_by_id(supplier_context)
+        if cfg and getattr(cfg, "supplier_label", ""):
+            return cfg.supplier_label
+    except Exception:
+        pass
+    return supplier_context
+
+
+def _build_promote_search_service(
+    args: argparse.Namespace,
     *,
     supplier_context: str,
-) -> tuple[list[dict[str, str]], list[str]]:
-    """Apply initial promotion metadata to rows.
+):
+    """Best-effort construct an InventorySearchService for enrichment.
 
-    This scaffold keeps all source columns unchanged and appends one
-    deterministic context marker column so downstream promotion phases can
-    evolve from a stable output contract.
+    Returns ``None`` when the supplier provider is unavailable or unknown.
     """
 
-    promoted_fields = list(fieldnames)
-    if _PROMOTE_SUPPLIER_CONTEXT_COLUMN not in promoted_fields:
-        promoted_fields.append(_PROMOTE_SUPPLIER_CONTEXT_COLUMN)
+    try:
+        from jbom.config.suppliers import resolve_supplier_by_id
+        from jbom.services.search.inventory_search_service import (
+            InventorySearchService,
+        )
+        from jbom.services.search.provider_factory import create_search_provider
+    except Exception:
+        return None
 
-    promoted_rows: list[dict[str, str]] = []
-    for source_row in rows:
-        promoted_row = dict(source_row)
-        promoted_row[_PROMOTE_SUPPLIER_CONTEXT_COLUMN] = supplier_context
-        promoted_rows.append(promoted_row)
+    cfg = resolve_supplier_by_id(supplier_context)
+    if cfg is None:
+        return None
 
-    return promoted_rows, promoted_fields
+    scoped_api_keys, default_api_key = _parse_supplier_api_key_args(
+        getattr(args, "api_key", None),
+        supplier_ids=[supplier_context],
+    )
+    api_key = _resolve_supplier_api_key(
+        supplier_context,
+        scoped_api_keys=scoped_api_keys,
+        default_api_key=default_api_key,
+    )
+
+    try:
+        provider = create_search_provider(supplier_context, api_key=api_key, cache=None)
+    except Exception:
+        return None
+
+    if not getattr(provider, "available", lambda: True)():
+        return None
+
+    return InventorySearchService(
+        provider,
+        request_delay_seconds=0.2,
+        verbose=bool(getattr(args, "verbose", False)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output and reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(stats: PromotionStats, *, enriched: bool) -> None:
+    """Print a one-line non-verbose run summary to stderr."""
+
+    if stats.rows_total == 0:
+        return
+    parts: list[str] = [
+        f"rows={stats.rows_total}",
+        f"parsed={stats.rows_parsed}",
+        f"value={stats.rows_with_canonical_value}",
+    ]
+    if enriched:
+        parts.append(f"mpn_hit={stats.rows_enriched_mpn}")
+        parts.append(f"search_hit={stats.rows_enriched_search}")
+        parts.append(f"misses={stats.rows_enrichment_misses}")
+    else:
+        parts.append("enrich=skipped")
+    print("Promote summary: " + " ".join(parts), file=sys.stderr)
 
 
 def _default_output_path(source_path: Path) -> Path:
@@ -253,16 +369,19 @@ def _default_output_path(source_path: Path) -> Path:
 
 
 def _write_promoted_rows(
-    rows: list[dict[str, str]],
-    fieldnames: list[str],
+    result: PromotionResult,
     *,
     destination: OutputDestination,
     force: bool,
 ) -> int:
     """Write promoted rows to requested destination."""
 
+    rows_for_csv = [
+        _merge_row_with_extras(row.canonical, row.extras) for row in result.rows
+    ]
+
     if destination.kind in {OutputKind.CONSOLE, OutputKind.STDOUT}:
-        _write_csv_rows(rows, fieldnames, out=sys.stdout)
+        _write_csv_rows(rows_for_csv, result.fieldnames, out=sys.stdout)
         return 0
 
     if destination.path is None:
@@ -280,13 +399,24 @@ def _write_promoted_rows(
             force=force,
             refused_message=refused,
         ) as handle:
-            _write_csv_rows(rows, fieldnames, out=handle)
+            _write_csv_rows(rows_for_csv, result.fieldnames, out=handle)
     except OutputRefusedError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 
     print(f"Promoted inventory written to {output_path}")
     return 0
+
+
+def _merge_row_with_extras(
+    canonical: dict[str, str], extras: dict[str, str]
+) -> dict[str, str]:
+    """Combine canonical fields and supplemental extras into a single CSV row."""
+
+    merged: dict[str, str] = dict(canonical)
+    for key, value in extras.items():
+        merged.setdefault(key, value)
+    return merged
 
 
 def _write_csv_rows(

--- a/src/jbom/cli/promote.py
+++ b/src/jbom/cli/promote.py
@@ -1,0 +1,308 @@
+"""Promote command - materialize supplier exports into canonical inventory shape."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from jbom.cli.output import (
+    OutputDestination,
+    OutputKind,
+    OutputRefusedError,
+    add_force_argument,
+    open_output_text_file,
+    resolve_output_destination,
+)
+from jbom.cli.supplier_args import (
+    parse_supplier_api_key_args as _parse_supplier_api_key_args,
+    resolve_supplier_api_key as _resolve_supplier_api_key,
+)
+from jbom.config.suppliers import get_available_suppliers
+
+_PROMOTE_SUPPLIER_CONTEXT_COLUMN = "SupplierContext"
+_PROMOTE_SUPPLIER_OVERLAP_ERROR = (
+    "Multiple supplier contexts for `jbom promote` are not supported yet "
+    "(tracked by #324)."
+)
+
+
+def register_command(subparsers) -> None:
+    """Register the ``promote`` command."""
+
+    parser = subparsers.add_parser(
+        "promote",
+        help="Promote supplier export CSV into canonical inventory shape",
+        description=(
+            "Promote supplier-export inventory data into jBOM canonical inventory "
+            "shape (initial scaffold)."
+        ),
+    )
+    parser.add_argument(
+        "source_inventory",
+        help="Path to supplier-export inventory CSV",
+    )
+    parser.add_argument(
+        "--supplier",
+        metavar="SUPPLIER_ID",
+        action="append",
+        default=None,
+        choices=get_available_suppliers(),
+        type=lambda value: str(value).strip().lower(),
+        help=(
+            "Supplier context for promotion. Repeat is allowed only when every "
+            "value resolves to the same supplier."
+        ),
+    )
+    parser.add_argument(
+        "--api-key",
+        metavar="KEY_OR_SUPPLIER_KEY",
+        action="append",
+        default=None,
+        help=(
+            "API key for supplier search providers. "
+            "Use KEY for single-supplier runs, or SUPPLIER_ID=KEY for "
+            "supplier-scoped keys."
+        ),
+    )
+    parser.add_argument(
+        "--jlc",
+        action="store_true",
+        help="Shortcut for --supplier lcsc",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help=(
+            "Output destination: omit for default <input>.promoted.csv, "
+            "use 'console' or '-' for stdout CSV, or provide a file path"
+        ),
+    )
+    add_force_argument(parser)
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Verbose diagnostics",
+    )
+    parser.set_defaults(handler=handle_promote)
+
+
+def handle_promote(args: argparse.Namespace) -> int:
+    """Handle ``jbom promote`` command."""
+
+    source_path = Path(args.source_inventory)
+    if not source_path.exists():
+        print(f"Error: Source inventory file not found: {source_path}", file=sys.stderr)
+        return 1
+
+    try:
+        supplier_context = _resolve_promote_supplier_context(args)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    try:
+        _resolve_promote_api_key(args, supplier_context=supplier_context)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        rows, fieldnames = _load_inventory_rows(source_path)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    promoted_rows, promoted_fields = _promote_rows(
+        rows,
+        fieldnames,
+        supplier_context=supplier_context,
+    )
+
+    output_path = _default_output_path(source_path)
+    destination = resolve_output_destination(
+        getattr(args, "output", None),
+        default_destination=OutputDestination(OutputKind.FILE, path=output_path),
+    )
+    return _write_promoted_rows(
+        promoted_rows,
+        promoted_fields,
+        destination=destination,
+        force=bool(getattr(args, "force", False)),
+    )
+
+
+def _resolve_promote_supplier_context(args: argparse.Namespace) -> str:
+    """Resolve the single effective supplier context for promotion."""
+
+    supplier_values = _normalize_supplier_values(getattr(args, "supplier", None))
+    jlc_enabled = bool(getattr(args, "jlc", False))
+
+    if jlc_enabled and supplier_values:
+        # TODO(#324): Support explicit multi-supplier context composition.
+        raise ValueError(_PROMOTE_SUPPLIER_OVERLAP_ERROR)
+
+    if len(supplier_values) > 1:
+        # TODO(#324): Support deterministic overlap semantics for multiple contexts.
+        raise ValueError(_PROMOTE_SUPPLIER_OVERLAP_ERROR)
+
+    if jlc_enabled:
+        return "lcsc"
+
+    if supplier_values:
+        return supplier_values[0]
+
+    return "generic"
+
+
+def _normalize_supplier_values(raw_values: list[str] | None) -> list[str]:
+    """Normalize and de-duplicate supplier argument values preserving order."""
+
+    if not raw_values:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in raw_values:
+        supplier_id = str(raw_value).strip().lower()
+        if not supplier_id:
+            continue
+        if supplier_id in seen:
+            continue
+        seen.add(supplier_id)
+        normalized.append(supplier_id)
+    return normalized
+
+
+def _resolve_promote_api_key(
+    args: argparse.Namespace,
+    *,
+    supplier_context: str,
+) -> str | None:
+    """Resolve optional API key for the effective promote supplier context."""
+
+    scoped_api_keys, default_api_key = _parse_supplier_api_key_args(
+        getattr(args, "api_key", None),
+        supplier_ids=[supplier_context],
+    )
+    return _resolve_supplier_api_key(
+        supplier_context,
+        scoped_api_keys=scoped_api_keys,
+        default_api_key=default_api_key,
+    )
+
+
+def _load_inventory_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
+    """Load a CSV file as normalized row dictionaries."""
+
+    try:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if not reader.fieldnames:
+                raise ValueError(
+                    f"Source inventory file has no CSV headers: {path}"
+                ) from None
+
+            fieldnames = [str(name).strip() for name in reader.fieldnames if name]
+            rows: list[dict[str, str]] = []
+            for row in reader:
+                normalized_row = {
+                    field: str((row or {}).get(field, "") or "") for field in fieldnames
+                }
+                rows.append(normalized_row)
+    except OSError as exc:
+        raise ValueError(f"Unable to read source inventory file {path}: {exc}") from exc
+
+    return rows, fieldnames
+
+
+def _promote_rows(
+    rows: list[dict[str, str]],
+    fieldnames: list[str],
+    *,
+    supplier_context: str,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Apply initial promotion metadata to rows.
+
+    This scaffold keeps all source columns unchanged and appends one
+    deterministic context marker column so downstream promotion phases can
+    evolve from a stable output contract.
+    """
+
+    promoted_fields = list(fieldnames)
+    if _PROMOTE_SUPPLIER_CONTEXT_COLUMN not in promoted_fields:
+        promoted_fields.append(_PROMOTE_SUPPLIER_CONTEXT_COLUMN)
+
+    promoted_rows: list[dict[str, str]] = []
+    for source_row in rows:
+        promoted_row = dict(source_row)
+        promoted_row[_PROMOTE_SUPPLIER_CONTEXT_COLUMN] = supplier_context
+        promoted_rows.append(promoted_row)
+
+    return promoted_rows, promoted_fields
+
+
+def _default_output_path(source_path: Path) -> Path:
+    """Return default output path for promote command."""
+
+    if source_path.suffix:
+        return source_path.with_name(f"{source_path.stem}.promoted{source_path.suffix}")
+    return source_path.with_name(f"{source_path.name}.promoted.csv")
+
+
+def _write_promoted_rows(
+    rows: list[dict[str, str]],
+    fieldnames: list[str],
+    *,
+    destination: OutputDestination,
+    force: bool,
+) -> int:
+    """Write promoted rows to requested destination."""
+
+    if destination.kind in {OutputKind.CONSOLE, OutputKind.STDOUT}:
+        _write_csv_rows(rows, fieldnames, out=sys.stdout)
+        return 0
+
+    if destination.path is None:
+        raise ValueError("Internal error: output path required for file destination")
+
+    output_path = destination.path
+    refused = (
+        f"Error: Output file '{output_path}' already exists. "
+        "Use -F/--force to overwrite."
+    )
+
+    try:
+        with open_output_text_file(
+            output_path,
+            force=force,
+            refused_message=refused,
+        ) as handle:
+            _write_csv_rows(rows, fieldnames, out=handle)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Promoted inventory written to {output_path}")
+    return 0
+
+
+def _write_csv_rows(
+    rows: list[dict[str, str]],
+    fieldnames: list[str],
+    *,
+    out: TextIO,
+) -> None:
+    """Write CSV rows with deterministic quoting behavior."""
+
+    writer = csv.DictWriter(
+        out,
+        fieldnames=fieldnames,
+        extrasaction="ignore",
+        quoting=csv.QUOTE_ALL,
+    )
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)

--- a/src/jbom/cli/supplier_args.py
+++ b/src/jbom/cli/supplier_args.py
@@ -1,0 +1,149 @@
+"""Shared CLI helpers for supplier-related argument parsing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_supplier_ids(raw_suppliers: Any) -> list[str]:
+    """Normalize and de-duplicate supplier IDs while preserving input order."""
+
+    if raw_suppliers is None:
+        return []
+
+    if isinstance(raw_suppliers, str):
+        candidates = [raw_suppliers]
+    elif isinstance(raw_suppliers, list):
+        candidates = [str(value) for value in raw_suppliers]
+    else:
+        candidates = [str(raw_suppliers)]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        supplier_id = candidate.strip().lower()
+        if not supplier_id or supplier_id in seen:
+            continue
+        seen.add(supplier_id)
+        normalized.append(supplier_id)
+
+    return normalized
+
+
+def parse_supplier_api_key_args(
+    raw_api_keys: Any,
+    *,
+    supplier_ids: list[str],
+) -> tuple[dict[str, str], str | None]:
+    """Parse ``--api-key`` values into supplier-scoped and default keys.
+
+    Supported forms:
+    - ``--api-key KEY`` (single default key, backward compatible)
+    - ``--api-key SUPPLIER_ID=KEY`` (supplier-scoped key; repeatable)
+    - repeated ``--api-key KEY`` values when count matches ``--supplier`` count
+      (mapped by argument order)
+
+    Args:
+        raw_api_keys: Parsed CLI value (None, string, or list of strings).
+        supplier_ids: Supplier IDs selected via ``--supplier`` for validation.
+
+    Returns:
+        ``(scoped_keys, default_key)`` where ``scoped_keys`` maps supplier ID to key.
+
+    Raises:
+        ValueError: Invalid key syntax, duplicate entries, or supplier mismatch.
+    """
+
+    if raw_api_keys is None:
+        return {}, None
+
+    if isinstance(raw_api_keys, str):
+        candidates = [raw_api_keys]
+    elif isinstance(raw_api_keys, list):
+        candidates = [str(value) for value in raw_api_keys]
+    else:
+        candidates = [str(raw_api_keys)]
+
+    scoped_keys: dict[str, str] = {}
+    unscoped_keys: list[str] = []
+    normalized_supplier_ids: list[str] = []
+    normalized_supplier_id_set: set[str] = set()
+    for supplier_id in supplier_ids:
+        normalized_supplier_id = str(supplier_id).strip().lower()
+        if (
+            not normalized_supplier_id
+            or normalized_supplier_id in normalized_supplier_id_set
+        ):
+            continue
+        normalized_supplier_id_set.add(normalized_supplier_id)
+        normalized_supplier_ids.append(normalized_supplier_id)
+
+    for candidate in candidates:
+        token = str(candidate).strip()
+        if not token:
+            continue
+        if "=" in token:
+            supplier_token, key_value = token.split("=", 1)
+            supplier_id = supplier_token.strip().lower()
+            api_key = key_value.strip()
+            if not supplier_id or not api_key:
+                raise ValueError(
+                    f"Invalid --api-key value {token!r}; use KEY or SUPPLIER_ID=KEY"
+                )
+            if (
+                normalized_supplier_id_set
+                and supplier_id not in normalized_supplier_id_set
+            ):
+                raise ValueError(
+                    f"--api-key supplier '{supplier_id}' is not present in --supplier arguments"
+                )
+            if supplier_id in scoped_keys:
+                raise ValueError(
+                    f"Duplicate --api-key entry provided for supplier '{supplier_id}'"
+                )
+            scoped_keys[supplier_id] = api_key
+            continue
+
+        unscoped_keys.append(token)
+
+    if scoped_keys and unscoped_keys:
+        raise ValueError(
+            "Cannot mix scoped and unscoped --api-key values; use either "
+            "KEY values only or SUPPLIER_ID=KEY values only"
+        )
+
+    if scoped_keys:
+        return scoped_keys, None
+
+    if not unscoped_keys:
+        return {}, None
+
+    if len(unscoped_keys) == 1:
+        return {}, unscoped_keys[0]
+
+    if not normalized_supplier_ids:
+        raise ValueError(
+            "Multiple unscoped --api-key values require --supplier arguments "
+            "or explicit SUPPLIER_ID=KEY mapping"
+        )
+
+    if len(unscoped_keys) != len(normalized_supplier_ids):
+        raise ValueError(
+            "Multiple unscoped --api-key values must match the number of --supplier values"
+        )
+
+    return dict(zip(normalized_supplier_ids, unscoped_keys)), None
+
+
+def resolve_supplier_api_key(
+    supplier_id: str,
+    *,
+    scoped_api_keys: dict[str, str],
+    default_api_key: str | None,
+) -> str | None:
+    """Return the effective API key for one supplier."""
+
+    normalized_id = str(supplier_id or "").strip().lower()
+    if not normalized_id:
+        return default_api_key
+    return scoped_api_keys.get(normalized_id, default_api_key)

--- a/src/jbom/services/promote/__init__.py
+++ b/src/jbom/services/promote/__init__.py
@@ -1,0 +1,6 @@
+"""Promote subpackage.
+
+Houses the source-export adapter, description/EM parser, identity policy and
+canonical-row builder used by ``jbom promote`` to turn supplier-export CSV rows
+into canonical jBOM inventory rows.
+"""

--- a/src/jbom/services/promote/description_parser.py
+++ b/src/jbom/services/promote/description_parser.py
@@ -1,0 +1,579 @@
+"""Description-text and EM parser used by ``jbom promote``.
+
+This is a deliberately small, pure-function parser that extracts the most
+common electro-mechanical fields out of supplier-export descriptions and
+identity columns.  The parser is intentionally conservative: it only emits a
+field when the regex match has clear unit semantics.  Ambiguous matches are
+left empty for downstream enrichment.
+
+The shape used by downstream code is :class:`ParsedDescription`, which
+includes a small ``provenance`` map so verbose CLI output can explain which
+fields the parser populated.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from jbom.common.value_parsing import (
+    farad_to_eia,
+    henry_to_eia,
+    ohms_to_eia,
+    parse_cap_to_farad,
+    parse_ind_to_henry,
+    parse_res_to_ohms,
+)
+
+__all__ = [
+    "ParsedDescription",
+    "normalize_description_text",
+    "parse_description",
+]
+
+
+@dataclass
+class ParsedDescription:
+    """Structured fields extracted from a supplier-export description.
+
+    All string fields default to empty.  Numeric typed fields are ``None``
+    when not detected.  ``provenance`` maps populated field names to the
+    matched text token (useful for verbose explanation).
+    """
+
+    category: str = ""
+    value: str = ""
+    package: str = ""
+    tolerance: str = ""
+    type: str = ""
+    voltage: str = ""
+    current: str = ""
+    power: str = ""
+    wavelength: str = ""
+    mcd: str = ""
+    angle: str = ""
+    resistance: Optional[float] = None
+    capacitance: Optional[float] = None
+    inductance: Optional[float] = None
+    provenance: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_description_text(text: str) -> str:
+    """Return *text* with common unicode units normalized to ASCII."""
+
+    if not text:
+        return ""
+    out = str(text)
+    # Normalize micro sign variants to ASCII 'u'.
+    out = out.replace("μ", "u").replace("µ", "u")
+    # Normalize the ohm symbol so token regexes can be ASCII-only.
+    out = out.replace("Ω", "Ohm").replace("ω", "Ohm")
+    # Normalize the ± sign and stray whitespace.
+    out = out.replace("±", "+/-")
+    return out
+
+
+_PACKAGE_TOKENS: tuple[str, ...] = (
+    "0201",
+    "0402",
+    "0603",
+    "0805",
+    "1206",
+    "1210",
+    "1812",
+    "2010",
+    "2512",
+    "2520",
+    "2920",
+    "3216",
+    "3225",
+    "4532",
+    "5025",
+    "6332",
+    "SOT-23",
+    "SOT23",
+    "SOT-223",
+    "SOT223",
+    "SOT-89",
+    "SOT89",
+    "TO-220",
+    "TO-92",
+    "TO-252",
+    "DPAK",
+    "D2PAK",
+    "SOIC-8",
+    "SOIC-14",
+    "SOIC-16",
+    "SOIC",
+    "DIP",
+    "MSOP",
+    "TSSOP",
+    "QFN",
+    "QFP",
+    "TQFP",
+    "LQFP",
+    "BGA",
+    "WLCSP",
+    "SOD-123",
+    "SOD-323",
+    "SMA",
+    "SMB",
+    "SMC",
+)
+
+_PACKAGE_RE = re.compile(
+    r"(?<![A-Za-z0-9])("
+    + "|".join(re.escape(p) for p in _PACKAGE_TOKENS)
+    + r")(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_package(text: str) -> str:
+    """Return the first package token observed in *text*, or empty string."""
+
+    if not text:
+        return ""
+    match = _PACKAGE_RE.search(text)
+    if not match:
+        return ""
+    raw = match.group(1)
+    # Normalize SOT-23, SOT23 etc. to a canonical "0603"-style or "SOT-23" form
+    upper = raw.upper().replace(" ", "")
+    if upper.startswith("SOT") and "-" not in upper:
+        # SOT23 -> SOT-23 etc.
+        digits = upper[3:]
+        if digits.isdigit():
+            return f"SOT-{digits}"
+    return raw
+
+
+# Tolerance like "5%", "1%", "10%", "+/-5%", "+/-10%", "100ppm".
+_TOLERANCE_RE = re.compile(
+    r"(?:\+/?-?\s*)?(\d+(?:\.\d+)?)\s*%|(\d+(?:\.\d+)?)\s*ppm",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_tolerance(text: str) -> str:
+    if not text:
+        return ""
+    match = _TOLERANCE_RE.search(text)
+    if not match:
+        return ""
+    percent = match.group(1)
+    ppm = match.group(2)
+    if percent is not None:
+        return f"{percent}%"
+    return f"{ppm}ppm"
+
+
+# Voltage: "50V", "25 V", "3.3V".  Avoid matching MV/KV by anchoring to a word boundary.
+_VOLTAGE_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)\s*V(?![A-Za-z0-9])",
+)
+
+
+def _detect_voltage(text: str) -> str:
+    if not text:
+        return ""
+    match = _VOLTAGE_RE.search(text)
+    if not match:
+        return ""
+    return f"{match.group(1)}V"
+
+
+# Current: "100mA", "1A", "1.5A".  Avoid matching MA inside words.
+_CURRENT_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)\s*(mA|A)(?![A-Za-z0-9])",
+)
+
+
+def _detect_current(text: str) -> str:
+    if not text:
+        return ""
+    match = _CURRENT_RE.search(text)
+    if not match:
+        return ""
+    number = match.group(1)
+    unit = match.group(2)
+    return f"{number}{unit}"
+
+
+# Power: "0.1W", "1W", "250mW".
+_POWER_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)\s*(mW|W)(?![A-Za-z0-9])",
+)
+
+
+def _detect_power(text: str) -> str:
+    if not text:
+        return ""
+    match = _POWER_RE.search(text)
+    if not match:
+        return ""
+    number = match.group(1)
+    unit = match.group(2)
+    return f"{number}{unit}"
+
+
+# MLCC dielectric subtypes; order matters because NP0 should map ahead of C0G.
+_DIELECTRIC_TOKENS: tuple[tuple[str, str], ...] = (
+    ("NP0", "NP0"),
+    ("C0G", "C0G"),
+    ("X5R", "X5R"),
+    ("X7R", "X7R"),
+    ("X7S", "X7S"),
+    ("Y5V", "Y5V"),
+)
+
+
+def _detect_dielectric(text: str) -> str:
+    if not text:
+        return ""
+    upper = text.upper()
+    for token, canonical in _DIELECTRIC_TOKENS:
+        if re.search(rf"(?<![A-Z0-9]){token}(?![A-Z0-9])", upper):
+            return canonical
+    return ""
+
+
+# Resistance: "10K", "4.7K", "2M2", "100R", "330Ohm", "0R22", "0.1Ohm",
+# "10kOhm".  The token may be either a pure EIA form (e.g. ``10K``), or a
+# numeric value followed by an Ohm suffix, optionally with a K/M/R modifier
+# between the digits and the suffix (``10kOhm``, ``2.2MOhms``).
+_RES_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"("
+    r"\d+(?:\.\d+)?[KMR]\d*[KkMmRr]?"  # 10K, 2M2, 10K0, 4R7
+    r"|\d+[KMRkmr](?=Ohms?\b|\s|$|\W)"  # 10K alone, 10kOhm
+    r"|\d+(?:\.\d+)?[KMRkmr]?\s*(?:Ohm|Ohms)"  # 10kOhm, 330Ohm, 0.1Ohm
+    r")"
+    r"(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_resistance(text: str) -> tuple[Optional[float], str]:
+    """Return (ohms, source_token) when a resistance is detected."""
+
+    if not text:
+        return None, ""
+    for match in _RES_TOKEN_RE.finditer(text):
+        token = match.group(1)
+        normalised = re.sub(r"(?i)\s*ohms?", "", token)
+        ohms = parse_res_to_ohms(normalised)
+        if ohms is not None:
+            return ohms, token
+    return None, ""
+
+
+_CAP_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?\s*(?:p|n|u|m)?F)(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_capacitance(text: str) -> tuple[Optional[float], str]:
+    if not text:
+        return None, ""
+    for match in _CAP_TOKEN_RE.finditer(text):
+        token = match.group(1)
+        farads = parse_cap_to_farad(token)
+        if farads is not None:
+            return farads, token
+    return None, ""
+
+
+_IND_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?\s*(?:n|u|m)H)(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_inductance(text: str) -> tuple[Optional[float], str]:
+    if not text:
+        return None, ""
+    for match in _IND_TOKEN_RE.finditer(text):
+        token = match.group(1)
+        henries = parse_ind_to_henry(token)
+        if henries is not None:
+            return henries, token
+    return None, ""
+
+
+# Wavelength: "620nm", "470 nm".
+_WAVELENGTH_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d{3,4})\s*nm(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_wavelength(text: str) -> str:
+    if not text:
+        return ""
+    match = _WAVELENGTH_RE.search(text)
+    if not match:
+        return ""
+    return f"{match.group(1)}nm"
+
+
+# Brightness: "120mcd", "1500 mcd".
+_MCD_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)\s*mcd(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_mcd(text: str) -> str:
+    if not text:
+        return ""
+    match = _MCD_RE.search(text)
+    if not match:
+        return ""
+    return f"{match.group(1)}mcd"
+
+
+# Viewing angle: "120°" or "120 deg".
+_ANGLE_RE = re.compile(
+    r"(?<![A-Za-z0-9])(\d{2,3})\s*(?:°|deg|degrees?)(?![A-Za-z0-9])",
+    flags=re.IGNORECASE,
+)
+
+
+def _detect_angle(text: str) -> str:
+    if not text:
+        return ""
+    match = _ANGLE_RE.search(text)
+    if not match:
+        return ""
+    return f"{match.group(1)}°"
+
+
+# ---------------------------------------------------------------------------
+# Category derivation (string-only inputs)
+# ---------------------------------------------------------------------------
+
+
+_CATEGORY_HINT_TO_CANONICAL: dict[str, str] = {
+    "capacitor": "CAP",
+    "capacitors": "CAP",
+    "ceramic capacitor": "CAP",
+    "mlcc": "CAP",
+    "resistor": "RES",
+    "resistors": "RES",
+    "inductor": "IND",
+    "inductors": "IND",
+    "ferrite bead": "IND",
+    "ferrite": "IND",
+    "led": "LED",
+    "leds": "LED",
+    "diode": "DIO",
+    "diodes": "DIO",
+    "transistor": "Q",
+    "mosfet": "Q",
+    "ic": "IC",
+    "integrated circuit": "IC",
+    "connector": "CON",
+    "connectors": "CON",
+    "header": "CON",
+    "switch": "SWI",
+    "fuse": "FUS",
+    "crystal": "OSC",
+    "oscillator": "OSC",
+    "relay": "RLY",
+}
+
+
+_DESCRIPTION_KEYWORD_TO_CANONICAL: tuple[tuple[str, str], ...] = (
+    ("MLCC", "CAP"),
+    ("CAPACITOR", "CAP"),
+    ("RESISTOR", "RES"),
+    ("INDUCTOR", "IND"),
+    ("FERRITE", "IND"),
+    ("LED", "LED"),
+    ("ZENER", "DIO"),
+    ("DIODE", "DIO"),
+    ("SCHOTTKY", "DIO"),
+    ("MOSFET", "Q"),
+    ("TRANSISTOR", "Q"),
+    ("REGULATOR", "REG"),
+    ("OSCILLATOR", "OSC"),
+    ("CRYSTAL", "OSC"),
+    ("CONNECTOR", "CON"),
+    ("HEADER", "CON"),
+    ("FUSE", "FUS"),
+    ("SWITCH", "SWI"),
+    ("RELAY", "RLY"),
+)
+
+
+def _normalize_category_hint(hint: str) -> str:
+    if not hint:
+        return ""
+    lowered = hint.strip().lower()
+    return _CATEGORY_HINT_TO_CANONICAL.get(lowered, "")
+
+
+def _category_from_description(text: str) -> str:
+    if not text:
+        return ""
+    upper = text.upper()
+    for token, canonical in _DESCRIPTION_KEYWORD_TO_CANONICAL:
+        if token in upper:
+            return canonical
+    return ""
+
+
+def _category_from_mfgpn_or_spn(mfgpn: str, spn: str) -> str:
+    upper = " ".join((mfgpn or "", spn or "")).upper()
+    if not upper.strip():
+        return ""
+    if "CL10" in upper or "CC0" in upper or "CC1" in upper:
+        return "CAP"
+    if "RC0" in upper or "ERJ" in upper or "RMCF" in upper:
+        return "RES"
+    if "MLZ" in upper or "MLF" in upper:
+        return "IND"
+    return ""
+
+
+def derive_category(
+    *,
+    category_hint: str = "",
+    description: str = "",
+    mfgpn: str = "",
+    spn: str = "",
+) -> str:
+    """Return the canonical category code derived from available signals.
+
+    Returns an empty string when no signal yields a confident category.  The
+    derivation order is intentionally hint-first so users can override the
+    parser by labelling their export.
+    """
+
+    canonical = _normalize_category_hint(category_hint)
+    if canonical:
+        return canonical
+    canonical = _category_from_description(description)
+    if canonical:
+        return canonical
+    return _category_from_mfgpn_or_spn(mfgpn, spn)
+
+
+# ---------------------------------------------------------------------------
+# Parser entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_description(
+    description: str,
+    *,
+    category_hint: str = "",
+    package_hint: str = "",
+    mfgpn: str = "",
+    spn: str = "",
+) -> ParsedDescription:
+    """Parse *description* and identity hints into a :class:`ParsedDescription`.
+
+    The parser is order-independent and tolerates fragmentary descriptions.
+    Numeric typed fields populate alongside string representations of the
+    same value when relevant, so canonical output can pick whichever form is
+    most useful.
+    """
+
+    text = normalize_description_text(description)
+    parsed = ParsedDescription()
+
+    category = derive_category(
+        category_hint=category_hint,
+        description=text,
+        mfgpn=mfgpn,
+        spn=spn,
+    )
+    if category:
+        parsed.category = category
+        parsed.provenance["category"] = (
+            category_hint.strip() or text or mfgpn or spn or ""
+        )
+
+    package = (package_hint or "").strip() or _detect_package(text)
+    if package:
+        parsed.package = package
+        parsed.provenance["package"] = package
+
+    tolerance = _detect_tolerance(text)
+    if tolerance:
+        parsed.tolerance = tolerance
+        parsed.provenance["tolerance"] = tolerance
+
+    voltage = _detect_voltage(text)
+    if voltage:
+        parsed.voltage = voltage
+        parsed.provenance["voltage"] = voltage
+
+    current = _detect_current(text)
+    if current:
+        parsed.current = current
+        parsed.provenance["current"] = current
+
+    power = _detect_power(text)
+    if power:
+        parsed.power = power
+        parsed.provenance["power"] = power
+
+    dielectric = _detect_dielectric(text)
+    if dielectric:
+        parsed.type = dielectric
+        parsed.provenance["type"] = dielectric
+
+    if parsed.category in {"CAP", ""}:
+        capacitance, token = _detect_capacitance(text)
+        if capacitance is not None:
+            parsed.capacitance = capacitance
+            parsed.value = farad_to_eia(capacitance)
+            parsed.provenance["capacitance"] = token
+            if not parsed.category:
+                parsed.category = "CAP"
+
+    if parsed.category in {"RES", ""}:
+        resistance, token = _detect_resistance(text)
+        if resistance is not None:
+            parsed.resistance = resistance
+            parsed.value = ohms_to_eia(resistance)
+            parsed.provenance["resistance"] = token
+            if not parsed.category:
+                parsed.category = "RES"
+
+    if parsed.category in {"IND", ""}:
+        inductance, token = _detect_inductance(text)
+        if inductance is not None:
+            parsed.inductance = inductance
+            parsed.value = henry_to_eia(inductance)
+            parsed.provenance["inductance"] = token
+            if not parsed.category:
+                parsed.category = "IND"
+
+    if parsed.category == "LED" or not parsed.category:
+        wavelength = _detect_wavelength(text)
+        if wavelength:
+            parsed.wavelength = wavelength
+            parsed.provenance["wavelength"] = wavelength
+            if not parsed.category:
+                parsed.category = "LED"
+        mcd = _detect_mcd(text)
+        if mcd:
+            parsed.mcd = mcd
+            parsed.provenance["mcd"] = mcd
+        angle = _detect_angle(text)
+        if angle:
+            parsed.angle = angle
+            parsed.provenance["angle"] = angle
+
+    return parsed

--- a/src/jbom/services/promote/identity.py
+++ b/src/jbom/services/promote/identity.py
@@ -1,0 +1,69 @@
+"""Identity policy used by ``jbom promote``.
+
+The ``build_ipn`` function returns a deterministic Internal Part Number for a
+parsed component, when enough information is present.  The policy is
+intentionally conservative: when an IPN cannot be confidently constructed, the
+function returns an empty string and the workflow leaves the IPN column blank
+so that downstream curation can fill it.
+"""
+
+from __future__ import annotations
+
+import re
+
+from jbom.services.promote.description_parser import ParsedDescription
+
+__all__ = ["build_ipn"]
+
+
+def _sanitize(token: str) -> str:
+    if not token:
+        return ""
+    cleaned = re.sub(r"[^A-Za-z0-9._%+\-]", "", token)
+    cleaned = cleaned.replace("..", ".")
+    return cleaned
+
+
+def _passive_ipn(prefix: str, parsed: ParsedDescription) -> str:
+    parts: list[str] = [prefix]
+    if parsed.value:
+        parts.append(_sanitize(parsed.value))
+    if parsed.type:
+        parts.append(_sanitize(parsed.type))
+    if parsed.tolerance:
+        parts.append(_sanitize(parsed.tolerance))
+    if parsed.package:
+        parts.append(_sanitize(parsed.package))
+    if parsed.voltage:
+        parts.append(_sanitize(parsed.voltage))
+    sanitized = [part for part in parts if part]
+    if len(sanitized) <= 1:
+        return ""
+    return "_".join(sanitized)
+
+
+def build_ipn(parsed: ParsedDescription) -> str:
+    """Return a deterministic IPN for *parsed*, or an empty string.
+
+    Today the policy emits IPNs for passive components (RES/CAP/IND) and LEDs.
+    Other categories return ``""`` so canonical output leaves IPN blank.
+    """
+
+    category = (parsed.category or "").upper()
+    if category == "RES":
+        return _passive_ipn("RES", parsed)
+    if category == "CAP":
+        return _passive_ipn("CAP", parsed)
+    if category == "IND":
+        return _passive_ipn("IND", parsed)
+    if category == "LED":
+        parts = ["LED"]
+        if parsed.wavelength:
+            parts.append(_sanitize(parsed.wavelength))
+        if parsed.package:
+            parts.append(_sanitize(parsed.package))
+        sanitized = [p for p in parts if p]
+        if len(sanitized) <= 1:
+            return ""
+        return "_".join(sanitized)
+    return ""

--- a/src/jbom/services/promote/source_adapters.py
+++ b/src/jbom/services/promote/source_adapters.py
@@ -1,0 +1,243 @@
+"""Source-export adapters for ``jbom promote``.
+
+Adapters convert one row of a supplier-export CSV into a normalized *source
+seed* dictionary that the promote workflow can extend with parsed EM fields,
+identity, and supplier-enrichment data.
+
+The seed dict is intentionally small and canonical:
+
+* ``spn``         — supplier part number (e.g. JLCPCB ``C12345``)
+* ``mfgpn``       — manufacturer part number
+* ``manufacturer``— manufacturer name (when source provides one)
+* ``description`` — free-text description
+* ``package``     — package / footprint code (e.g. ``0603``)
+* ``category_hint`` — best-effort source category string (e.g. ``Capacitors``)
+* ``supplier``    — supplier label (filled by workflow from CLI context)
+* ``extras``      — supplemental source columns (qty, pricing, etc.) for
+                    traceability; preserved in the canonical output.
+
+Adapters are pure data shape; they do not parse free-text descriptions or
+classify components — that is the responsibility of the description parser
+and identity policy modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+
+@dataclass
+class SourceSeed:
+    """Normalized seed row produced by a source adapter."""
+
+    spn: str = ""
+    mfgpn: str = ""
+    manufacturer: str = ""
+    description: str = ""
+    package: str = ""
+    category_hint: str = ""
+    extras: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Header signatures
+# ---------------------------------------------------------------------------
+
+# Columns whose presence strongly indicates a JLCPCB private parts export.
+# JLCPCB has shipped exports with both ``JLC Part #`` and ``JLCPCB Part #``
+# headers, so the signature accepts either spelling.
+_JLC_PART_NUMBER_HEADERS: tuple[str, ...] = ("JLCPCB Part #", "JLC Part #")
+_JLC_SIGNATURE_COLUMNS: frozenset[str] = frozenset({"MFR Part #"})
+
+# Supplemental JLC columns that should be preserved verbatim for traceability.
+_JLC_TRACE_COLUMNS: tuple[str, ...] = (
+    "JLCPCB Parts Qty",
+    "Global Sourcing Parts Qty",
+    "Consigned Parts Qty",
+    "Unit Price($)",
+    "Total Price($)",
+)
+
+
+def detect_source_format(headers: Iterable[str]) -> str:
+    """Return the best-fit source-format identifier for the given headers.
+
+    Args:
+        headers: Iterable of column names from the source CSV.
+
+    Returns:
+        ``"jlc"`` when the headers match a JLCPCB export signature, otherwise
+        ``"generic"``.
+    """
+
+    header_set = {(h or "").strip() for h in headers}
+    has_jlc_part_header = any(
+        header in header_set for header in _JLC_PART_NUMBER_HEADERS
+    )
+    if has_jlc_part_header and _JLC_SIGNATURE_COLUMNS.issubset(header_set):
+        return "jlc"
+    return "generic"
+
+
+# ---------------------------------------------------------------------------
+# Adapter protocol
+# ---------------------------------------------------------------------------
+
+
+class SourceAdapter:
+    """Base class for supplier-export source adapters."""
+
+    #: Stable adapter identifier (``"jlc"`` / ``"generic"`` / ...).
+    source_format: str = "generic"
+
+    def adapt(self, row: Mapping[str, str]) -> SourceSeed:
+        """Convert one source row into a :class:`SourceSeed`.
+
+        Subclasses must implement this method.
+        """
+
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# JLCPCB private-parts export adapter
+# ---------------------------------------------------------------------------
+
+
+class JlcpcbExportAdapter(SourceAdapter):
+    """Adapter for JLCPCB ``Parts Inventory on JLCPCB.csv`` exports."""
+
+    source_format = "jlc"
+
+    def adapt(self, row: Mapping[str, str]) -> SourceSeed:
+        get = lambda key: str((row.get(key) or "")).strip()  # noqa: E731
+
+        spn = ""
+        for header in _JLC_PART_NUMBER_HEADERS:
+            spn = get(header)
+            if spn:
+                break
+
+        extras: dict[str, str] = {}
+        for column in _JLC_TRACE_COLUMNS:
+            value = get(column)
+            if value:
+                extras[column] = value
+
+        return SourceSeed(
+            spn=spn,
+            mfgpn=get("MFR Part #"),
+            manufacturer="",  # JLC export does not provide manufacturer as a column
+            description=get("Description"),
+            package=get("Footprint"),
+            category_hint=get("Category"),
+            extras=extras,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Generic CSV adapter (best-effort canonical-name passthrough)
+# ---------------------------------------------------------------------------
+
+
+_GENERIC_SPN_KEYS = (
+    "SPN",
+    "Supplier Part Number",
+    "Supplier PN",
+    "JLCPCB Part #",
+    "JLC Part #",
+)
+_GENERIC_MFGPN_KEYS = ("MFGPN", "MPN", "MFR Part #", "Manufacturer Part Number")
+_GENERIC_MANUFACTURER_KEYS = ("Manufacturer", "Mfg", "Mfr")
+_GENERIC_PACKAGE_KEYS = ("Package", "Footprint")
+_GENERIC_CATEGORY_KEYS = ("Category", "Type", "Part Type")
+_GENERIC_DESCRIPTION_KEYS = ("Description", "Desc")
+
+
+def _first_nonempty(row: Mapping[str, str], keys: Iterable[str]) -> str:
+    """Return the first non-empty value in *row* for any of *keys*."""
+
+    for key in keys:
+        value = (row.get(key) or "").strip() if row.get(key) is not None else ""
+        if value:
+            return value
+    return ""
+
+
+class GenericCsvAdapter(SourceAdapter):
+    """Best-effort adapter that maps common canonical names through."""
+
+    source_format = "generic"
+
+    def adapt(self, row: Mapping[str, str]) -> SourceSeed:
+        spn = _first_nonempty(row, _GENERIC_SPN_KEYS)
+        mfgpn = _first_nonempty(row, _GENERIC_MFGPN_KEYS)
+        manufacturer = _first_nonempty(row, _GENERIC_MANUFACTURER_KEYS)
+        package = _first_nonempty(row, _GENERIC_PACKAGE_KEYS)
+        category_hint = _first_nonempty(row, _GENERIC_CATEGORY_KEYS)
+        description = _first_nonempty(row, _GENERIC_DESCRIPTION_KEYS)
+
+        # Preserve any source columns that did not feed into canonical fields.
+        used_keys = set(
+            _GENERIC_SPN_KEYS
+            + _GENERIC_MFGPN_KEYS
+            + _GENERIC_MANUFACTURER_KEYS
+            + _GENERIC_PACKAGE_KEYS
+            + _GENERIC_CATEGORY_KEYS
+            + _GENERIC_DESCRIPTION_KEYS
+        )
+        extras: dict[str, str] = {}
+        for key, value in row.items():
+            key_norm = (key or "").strip()
+            if not key_norm or key_norm in used_keys:
+                continue
+            value_str = (value or "").strip() if value is not None else ""
+            if value_str:
+                extras[key_norm] = value_str
+
+        return SourceSeed(
+            spn=spn,
+            mfgpn=mfgpn,
+            manufacturer=manufacturer,
+            description=description,
+            package=package,
+            category_hint=category_hint,
+            extras=extras,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Adapter selection
+# ---------------------------------------------------------------------------
+
+
+def select_adapter(source_format: str) -> SourceAdapter:
+    """Return the adapter implementation for *source_format*.
+
+    Args:
+        source_format: Adapter identifier (``"jlc"``, ``"generic"``).
+
+    Returns:
+        An instance of the requested adapter.
+
+    Raises:
+        ValueError: When *source_format* is not a recognised adapter.
+    """
+
+    key = (source_format or "").strip().lower()
+    if key == "jlc":
+        return JlcpcbExportAdapter()
+    if key == "generic":
+        return GenericCsvAdapter()
+    raise ValueError(f"Unknown promote source format: {source_format!r}")
+
+
+__all__ = [
+    "GenericCsvAdapter",
+    "JlcpcbExportAdapter",
+    "SourceAdapter",
+    "SourceSeed",
+    "detect_source_format",
+    "select_adapter",
+]

--- a/src/jbom/services/promote/workflow.py
+++ b/src/jbom/services/promote/workflow.py
@@ -1,0 +1,375 @@
+"""Promote workflow.
+
+Turns a sequence of supplier-export rows into canonical jBOM inventory rows.
+
+The workflow has three layers:
+
+* a source adapter normalises the row into a :class:`SourceSeed`.
+* the description parser extracts EM fields and category.
+* an optional enrichment step calls the supplier provider's MPN lookup or
+  keyword search to fill in supplier-side data such as ``Manufacturer``,
+  ``MPN``, and ``Datasheet``.
+
+The output is a list of canonical row dictionaries (string-valued) plus a
+matching list of field names that the writer uses to render CSV output.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Optional
+
+from jbom.common.types import InventoryItem
+from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
+from jbom.services.promote.description_parser import (
+    ParsedDescription,
+    parse_description,
+)
+from jbom.services.promote.identity import build_ipn
+from jbom.services.promote.source_adapters import (
+    SourceAdapter,
+    SourceSeed,
+    select_adapter,
+)
+from jbom.services.search.inventory_search_service import (
+    InventorySearchCandidate,
+    InventorySearchRecord,
+    InventorySearchService,
+)
+
+
+CANONICAL_FIELDS: tuple[str, ...] = (
+    "RowType",
+    "ComponentID",
+    "IPN",
+    "Category",
+    "Value",
+    "Package",
+    "Description",
+    "Keywords",
+    "Manufacturer",
+    "MFGPN",
+    "Supplier",
+    "SPN",
+    "Datasheet",
+    "Resistance",
+    "Capacitance",
+    "Inductance",
+    "Tolerance",
+    "Type",
+    "V",
+    "A",
+    "W",
+    "Wavelength",
+    "mcd",
+    "Angle",
+    "Priority",
+    "SupplierContext",
+)
+
+
+@dataclass
+class PromotionStats:
+    """Counters describing what a promote run did, useful in non-verbose output."""
+
+    rows_total: int = 0
+    rows_parsed: int = 0
+    rows_with_canonical_value: int = 0
+    rows_enriched_mpn: int = 0
+    rows_enriched_search: int = 0
+    rows_enrichment_skipped: int = 0
+    rows_enrichment_misses: int = 0
+
+
+@dataclass
+class PromotedRow:
+    """One canonical-row result paired with the diagnostics that produced it."""
+
+    canonical: dict[str, str]
+    extras: dict[str, str] = field(default_factory=dict)
+    parsed: ParsedDescription = field(default_factory=ParsedDescription)
+    enrichment_note: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_to_inventory_item(
+    seed: SourceSeed,
+    parsed: ParsedDescription,
+    *,
+    supplier_label: str,
+) -> InventoryItem:
+    """Build an :class:`InventoryItem` from seed + parsed fields."""
+
+    return InventoryItem(
+        ipn=build_ipn(parsed),
+        keywords="",
+        category=parsed.category,
+        description=seed.description,
+        smd="",
+        value=parsed.value,
+        type=parsed.type,
+        tolerance=parsed.tolerance,
+        voltage=parsed.voltage,
+        amperage=parsed.current,
+        wattage=parsed.power,
+        supplier=supplier_label,
+        spn=seed.spn,
+        manufacturer=seed.manufacturer,
+        mfgpn=seed.mfgpn,
+        datasheet="",
+        package=parsed.package,
+        resistance=parsed.resistance,
+        capacitance=parsed.capacitance,
+        inductance=parsed.inductance,
+    )
+
+
+def _populate_canonical(
+    item: InventoryItem,
+    parsed: ParsedDescription,
+    *,
+    supplier_context: str,
+) -> dict[str, str]:
+    """Materialize an InventoryItem into a stable canonical row dict."""
+
+    row: dict[str, str] = {field_name: "" for field_name in CANONICAL_FIELDS}
+    row["RowType"] = "ITEM"
+    row["IPN"] = item.ipn
+    row["Category"] = item.category
+    row["Value"] = item.value
+    row["Package"] = item.package
+    row["Description"] = item.description
+    row["Manufacturer"] = item.manufacturer
+    row["MFGPN"] = item.mfgpn
+    row["Supplier"] = item.supplier
+    row["SPN"] = item.spn
+    row["Datasheet"] = item.datasheet
+    row["Tolerance"] = item.tolerance
+    row["Type"] = item.type
+    row["V"] = item.voltage
+    row["A"] = item.amperage
+    row["W"] = item.wattage
+    row["Wavelength"] = parsed.wavelength
+    row["mcd"] = parsed.mcd
+    row["Angle"] = parsed.angle
+    row["SupplierContext"] = supplier_context
+    if item.resistance is not None:
+        row["Resistance"] = ohms_to_eia(item.resistance)
+    if item.capacitance is not None:
+        row["Capacitance"] = farad_to_eia(item.capacitance)
+    if item.inductance is not None:
+        row["Inductance"] = henry_to_eia(item.inductance)
+    return row
+
+
+def _format_extras(extras: Mapping[str, str]) -> dict[str, str]:
+    return {key: str(value) for key, value in extras.items() if value}
+
+
+# ---------------------------------------------------------------------------
+# Enrichment
+# ---------------------------------------------------------------------------
+
+
+def _merge_search_result(canonical: dict[str, str], result) -> None:
+    """Apply provider :class:`SearchResult` fields into canonical row."""
+
+    if not canonical.get("Manufacturer") and getattr(result, "manufacturer", ""):
+        canonical["Manufacturer"] = result.manufacturer
+    if not canonical.get("MFGPN") and getattr(result, "mpn", ""):
+        canonical["MFGPN"] = result.mpn
+    if not canonical.get("Datasheet") and getattr(result, "datasheet", ""):
+        canonical["Datasheet"] = result.datasheet
+    if getattr(result, "distributor_part_number", "") and not canonical.get("SPN"):
+        canonical["SPN"] = result.distributor_part_number
+    # Manufacturer-side description is usually richer; do not overwrite existing
+    # source description even when provider returns something.
+
+
+def _enrich_row(
+    canonical: dict[str, str],
+    item: InventoryItem,
+    *,
+    service: Optional[InventorySearchService],
+    verbose: bool,
+) -> tuple[str, bool, bool]:
+    """Best-effort supplier enrichment.
+
+    Returns ``(note, used_mpn, used_search)``.
+    """
+
+    if service is None:
+        return ("no-enrich", False, False)
+
+    provider = getattr(service, "_provider", None)
+    used_mpn = False
+    used_search = False
+
+    if provider is not None and item.mfgpn:
+        try:
+            result = provider.lookup_by_mpn(item.manufacturer, item.mfgpn)
+        except Exception as exc:  # pragma: no cover - defensive
+            if verbose:
+                print(
+                    f"  enrichment: MPN lookup failed for {item.mfgpn!r}: {exc}",
+                    file=sys.stderr,
+                )
+            result = None
+        if result is not None:
+            _merge_search_result(canonical, result)
+            used_mpn = True
+            return ("mpn-hit", used_mpn, used_search)
+
+    # Keyword fallback via service.search, when item is searchable
+    try:
+        records: list[InventorySearchRecord] = service.search([item])
+    except Exception as exc:  # pragma: no cover - defensive
+        if verbose:
+            print(
+                f"  enrichment: keyword search failed: {exc}",
+                file=sys.stderr,
+            )
+        return ("search-error", used_mpn, used_search)
+
+    if not records:
+        return ("no-candidates", used_mpn, used_search)
+
+    record = records[0]
+    candidates: list[InventorySearchCandidate] = record.candidates or []
+    if not candidates:
+        return ("no-candidates", used_mpn, used_search)
+
+    _merge_search_result(canonical, candidates[0].result)
+    used_search = True
+    return ("search-hit", used_mpn, used_search)
+
+
+# ---------------------------------------------------------------------------
+# Workflow entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PromotionResult:
+    """Output of :func:`promote_rows`."""
+
+    rows: list[PromotedRow]
+    fieldnames: list[str]
+    stats: PromotionStats
+
+
+def promote_rows(
+    source_rows: Iterable[Mapping[str, str]],
+    *,
+    adapter: SourceAdapter,
+    supplier_context: str,
+    supplier_label: str = "",
+    search_service: Optional[InventorySearchService] = None,
+    verbose: bool = False,
+) -> PromotionResult:
+    """Promote *source_rows* into canonical inventory rows.
+
+    Args:
+        source_rows: Iterable of source CSV row dictionaries (DictReader-style).
+        adapter: Source adapter used to normalize each row.
+        supplier_context: Stable string written to the ``SupplierContext`` column.
+        supplier_label: Display label written to the ``Supplier`` column.  When
+            empty, the column is left blank.
+        search_service: Optional supplier search service.  When provided, MPN
+            lookup is attempted first, with keyword search as fallback.  When
+            ``None`` no enrichment is performed.
+        verbose: When True, per-row provenance/enrichment notes are written to
+            stderr.
+
+    Returns:
+        :class:`PromotionResult` carrying canonical rows, the ordered fieldname
+        list (canonical + supplemental traceability columns), and a stats
+        block describing what happened.
+    """
+
+    stats = PromotionStats()
+    promoted: list[PromotedRow] = []
+    supplemental_columns: list[str] = []
+    supplemental_seen: set[str] = set()
+
+    rows_list = list(source_rows)
+    stats.rows_total = len(rows_list)
+
+    for source_row in rows_list:
+        seed = adapter.adapt(source_row)
+        parsed = parse_description(
+            seed.description,
+            category_hint=seed.category_hint,
+            package_hint=seed.package,
+            mfgpn=seed.mfgpn,
+            spn=seed.spn,
+        )
+        if parsed.category or parsed.value or parsed.package:
+            stats.rows_parsed += 1
+        if parsed.value:
+            stats.rows_with_canonical_value += 1
+
+        item = _seed_to_inventory_item(
+            seed, parsed, supplier_label=supplier_label or seed.manufacturer
+        )
+        canonical = _populate_canonical(item, parsed, supplier_context=supplier_context)
+
+        note = "no-enrich"
+        if search_service is not None:
+            note, used_mpn, used_search = _enrich_row(
+                canonical,
+                item,
+                service=search_service,
+                verbose=verbose,
+            )
+            if used_mpn:
+                stats.rows_enriched_mpn += 1
+            if used_search:
+                stats.rows_enriched_search += 1
+            if note in {"no-candidates", "search-error"}:
+                stats.rows_enrichment_misses += 1
+        else:
+            stats.rows_enrichment_skipped += 1
+
+        extras = _format_extras(seed.extras)
+        for key in extras.keys():
+            if key not in supplemental_seen and key not in CANONICAL_FIELDS:
+                supplemental_seen.add(key)
+                supplemental_columns.append(key)
+
+        if verbose:
+            provenance_summary = ", ".join(
+                f"{k}={v}" for k, v in parsed.provenance.items()
+            )
+            print(
+                f"  promote: spn={seed.spn or '-'} category={parsed.category or '-'} "
+                f"value={parsed.value or '-'} enrich={note} parsed=[{provenance_summary}]",
+                file=sys.stderr,
+            )
+
+        promoted.append(
+            PromotedRow(
+                canonical=canonical,
+                extras=extras,
+                parsed=parsed,
+                enrichment_note=note,
+            )
+        )
+
+    fieldnames = list(CANONICAL_FIELDS) + supplemental_columns
+    return PromotionResult(rows=promoted, fieldnames=fieldnames, stats=stats)
+
+
+__all__ = [
+    "CANONICAL_FIELDS",
+    "PromotionResult",
+    "PromotionStats",
+    "PromotedRow",
+    "promote_rows",
+    "select_adapter",
+]

--- a/tests/unit/test_cli_defaults_profile.py
+++ b/tests/unit/test_cli_defaults_profile.py
@@ -20,6 +20,7 @@ def test_all_subcommands_accept_defaults_argument() -> None:
         ["inventory", ".", "--defaults", custom],
         ["parts", ".", "--defaults", custom],
         ["pos", ".", "--defaults", custom],
+        ["promote", "supplier-export.csv", "--defaults", custom],
         ["search", "10k resistor", "--defaults", custom],
     ]
 
@@ -38,6 +39,7 @@ def test_all_subcommands_default_defaults_profile_to_generic() -> None:
         ["inventory", "."],
         ["parts", "."],
         ["pos", "."],
+        ["promote", "supplier-export.csv"],
         ["search", "10k resistor"],
     ]
 

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -67,6 +67,7 @@ def test_inventory_help_shows_inventory_interface_tokens():
         "--filter-matches",
         "--per-instance",
         "--supplier",
+        "--api-key",
         "--limit",
         "-o",
         "--output",
@@ -83,6 +84,11 @@ def test_root_help_includes_search_command():
 def test_root_help_includes_annotate_command():
     out = run_help([]).lower()
     assert "annotate" in out
+
+
+def test_root_help_includes_promote_command():
+    out = run_help([]).lower()
+    assert "promote" in out
 
 
 def test_annotate_help_shows_core_flags():
@@ -106,10 +112,20 @@ def test_all_subcommands_show_defaults_option_in_help():
         "inventory",
         "parts",
         "pos",
+        "promote",
         "search",
     ]:
-        out = run_help([command]).lower()
+        sample_args = [command]
+        if command == "promote":
+            sample_args.append("supplier-export.csv")
+        out = run_help(sample_args).lower()
         assert "--defaults" in out, f"jbom {command} --help missing --defaults"
+
+
+def test_promote_help_shows_supplier_flags():
+    out = run_help(["promote", "supplier-export.csv"]).lower()
+    for token in ["--supplier", "--api-key", "--jlc", "-o", "--output"]:
+        assert token in out
 
 
 def test_gerbers_help_shows_key_options():

--- a/tests/unit/test_inventory_supplier_flag.py
+++ b/tests/unit/test_inventory_supplier_flag.py
@@ -12,13 +12,18 @@ Covers:
 """
 
 from __future__ import annotations
+import argparse
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from jbom.cli.inventory import (
+    _build_inventory_supplier_services,
     _enrich_items_with_supplier,
     _enrich_items_with_suppliers,
     _normalize_supplier_ids,
+    _resolve_supplier_api_keys,
 )
 from jbom.common.types import InventoryItem
 from jbom.services.search.inventory_search_service import (
@@ -461,6 +466,202 @@ class TestNormalizeSupplierIds:
 
     def test_accepts_single_string(self) -> None:
         assert _normalize_supplier_ids(" Mouser ") == ["mouser"]
+
+
+class TestResolveSupplierApiKeys:
+    def test_unscoped_key_is_accepted_for_single_supplier(self) -> None:
+        scoped_keys, default_key = _resolve_supplier_api_keys(
+            ["KEY123"],
+            supplier_ids=["lcsc"],
+        )
+
+        assert scoped_keys == {}
+        assert default_key == "KEY123"
+
+    def test_scoped_keys_are_resolved_per_supplier(self) -> None:
+        scoped_keys, default_key = _resolve_supplier_api_keys(
+            ["lcsc=KEY_LCSC", "mouser=KEY_MOUSER"],
+            supplier_ids=["lcsc", "mouser"],
+        )
+
+        assert scoped_keys == {"lcsc": "KEY_LCSC", "mouser": "KEY_MOUSER"}
+        assert default_key is None
+
+    def test_unscoped_keys_zip_to_supplier_order(self) -> None:
+        scoped_keys, default_key = _resolve_supplier_api_keys(
+            ["KEY_LCSC", "KEY_MOUSER"],
+            supplier_ids=["lcsc", "mouser"],
+        )
+
+        assert scoped_keys == {"lcsc": "KEY_LCSC", "mouser": "KEY_MOUSER"}
+        assert default_key is None
+
+    def test_scoped_key_for_unknown_supplier_is_rejected(self) -> None:
+        try:
+            _resolve_supplier_api_keys(
+                ["mouser=KEY_MOUSER"],
+                supplier_ids=["lcsc"],
+            )
+        except ValueError as exc:
+            assert "not present in --supplier arguments" in str(exc)
+        else:
+            assert False, "Expected ValueError for unknown scoped supplier key"
+
+    def test_multiple_unscoped_keys_require_matching_supplier_count(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"must match the number of --supplier values",
+        ):
+            _resolve_supplier_api_keys(
+                ["KEY_ONE", "KEY_TWO"],
+                supplier_ids=["lcsc"],
+            )
+
+    def test_mixed_scoped_and_unscoped_keys_are_rejected(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"Cannot mix scoped and unscoped --api-key values",
+        ):
+            _resolve_supplier_api_keys(
+                ["KEY_DEFAULT", "mouser=KEY_MOUSER"],
+                supplier_ids=["mouser"],
+            )
+
+
+class TestBuildInventorySupplierServicesApiKeys:
+    def test_build_inventory_supplier_services_applies_scoped_keys_per_supplier(
+        self, monkeypatch
+    ) -> None:
+        create_provider_calls: list[tuple[str, str | None]] = []
+
+        class _FakeSupplierConfig:
+            def __init__(self, supplier_label: str) -> None:
+                self.supplier_label = supplier_label
+
+        class _FakeInventorySearchService:
+            def __init__(
+                self, provider: object, request_delay_seconds: float, verbose: bool
+            ) -> None:
+                self.provider = provider
+                self.request_delay_seconds = request_delay_seconds
+                self.verbose = verbose
+
+        def _fake_resolve_supplier_by_id(
+            supplier_id: str,
+        ) -> _FakeSupplierConfig | None:
+            if supplier_id == "lcsc":
+                return _FakeSupplierConfig("LCSC")
+            if supplier_id == "mouser":
+                return _FakeSupplierConfig("Mouser")
+            return None
+
+        def _fake_create_search_provider(
+            supplier_id: str,
+            *,
+            api_key: str | None = None,
+            cache=None,
+        ) -> object:
+            create_provider_calls.append((supplier_id, api_key))
+            return object()
+
+        monkeypatch.setattr(
+            "jbom.config.suppliers.resolve_supplier_by_id",
+            _fake_resolve_supplier_by_id,
+        )
+        monkeypatch.setattr(
+            "jbom.services.search.provider_factory.create_search_provider",
+            _fake_create_search_provider,
+        )
+        monkeypatch.setattr(
+            "jbom.services.search.inventory_search_service.InventorySearchService",
+            _FakeInventorySearchService,
+        )
+
+        args = argparse.Namespace(
+            supplier=["lcsc", "mouser"],
+            api_key=["lcsc=KEY_LCSC", "mouser=KEY_MOUSER"],
+            verbose=False,
+        )
+        services = _build_inventory_supplier_services(args)
+
+        assert len(services) == 2
+        assert create_provider_calls == [
+            ("lcsc", "KEY_LCSC"),
+            ("mouser", "KEY_MOUSER"),
+        ]
+
+    def test_build_inventory_supplier_services_maps_unscoped_keys_by_order(
+        self, monkeypatch
+    ) -> None:
+        create_provider_calls: list[tuple[str, str | None]] = []
+
+        class _FakeSupplierConfig:
+            def __init__(self, supplier_label: str) -> None:
+                self.supplier_label = supplier_label
+
+        class _FakeInventorySearchService:
+            def __init__(
+                self, provider: object, request_delay_seconds: float, verbose: bool
+            ) -> None:
+                self.provider = provider
+                self.request_delay_seconds = request_delay_seconds
+                self.verbose = verbose
+
+        def _fake_resolve_supplier_by_id(
+            supplier_id: str,
+        ) -> _FakeSupplierConfig | None:
+            if supplier_id == "lcsc":
+                return _FakeSupplierConfig("LCSC")
+            if supplier_id == "mouser":
+                return _FakeSupplierConfig("Mouser")
+            return None
+
+        def _fake_create_search_provider(
+            supplier_id: str,
+            *,
+            api_key: str | None = None,
+            cache=None,
+        ) -> object:
+            create_provider_calls.append((supplier_id, api_key))
+            return object()
+
+        monkeypatch.setattr(
+            "jbom.config.suppliers.resolve_supplier_by_id",
+            _fake_resolve_supplier_by_id,
+        )
+        monkeypatch.setattr(
+            "jbom.services.search.provider_factory.create_search_provider",
+            _fake_create_search_provider,
+        )
+        monkeypatch.setattr(
+            "jbom.services.search.inventory_search_service.InventorySearchService",
+            _FakeInventorySearchService,
+        )
+
+        args = argparse.Namespace(
+            supplier=["lcsc", "mouser"],
+            api_key=["KEY_LCSC", "KEY_MOUSER"],
+            verbose=False,
+        )
+        services = _build_inventory_supplier_services(args)
+
+        assert len(services) == 2
+        assert create_provider_calls == [
+            ("lcsc", "KEY_LCSC"),
+            ("mouser", "KEY_MOUSER"),
+        ]
+
+    def test_build_inventory_supplier_services_rejects_unknown_scoped_key(
+        self,
+    ) -> None:
+        args = argparse.Namespace(
+            supplier=["generic"],
+            api_key=["mouser=KEY_MOUSER"],
+            verbose=False,
+        )
+
+        with pytest.raises(ValueError, match=r"not present in --supplier arguments"):
+            _build_inventory_supplier_services(args)
 
 
 def _dynamic_service_with_candidates(

--- a/tests/unit/test_promote_cli.py
+++ b/tests/unit/test_promote_cli.py
@@ -78,16 +78,20 @@ def test_resolve_promote_api_key_rejects_mismatched_scoped_key() -> None:
         _resolve_promote_api_key(args, supplier_context="lcsc")
 
 
-def test_handle_promote_stamps_supplier_context_column(tmp_path, capsys) -> None:
+def test_handle_promote_writes_canonical_inventory_columns(tmp_path, capsys) -> None:
     source = tmp_path / "jlc-export.csv"
     source.write_text(
-        '"JLC Part #","Description"\n"C2286","1uF 0603"\n',
+        '"Category","JLC Part #","MFR Part #","Footprint","Description"\n'
+        '"Capacitors","C2286","CC0603KRX7R9BB104","0603","0.1uF 50V X7R \u00b110%"\n',
         encoding="utf-8",
     )
+    # No --supplier / --jlc => implicit 'generic' context => no catalog
+    # enrichment is attempted, keeping the test fully offline.
     args = argparse.Namespace(
         source_inventory=str(source),
-        supplier=["lcsc"],
+        supplier=None,
         jlc=False,
+        api_key=None,
         output="-",
         force=False,
         verbose=False,
@@ -101,8 +105,36 @@ def test_handle_promote_stamps_supplier_context_column(tmp_path, capsys) -> None
     rows = list(reader)
 
     assert reader.fieldnames is not None
-    assert "SupplierContext" in reader.fieldnames
-    assert rows[0]["SupplierContext"] == "lcsc"
+    for column in (
+        "RowType",
+        "IPN",
+        "Category",
+        "Value",
+        "Package",
+        "Description",
+        "MFGPN",
+        "Supplier",
+        "SPN",
+        "Tolerance",
+        "Type",
+        "V",
+        "Capacitance",
+        "SupplierContext",
+    ):
+        assert column in reader.fieldnames, column
+
+    row = rows[0]
+    assert row["SupplierContext"] == "generic"
+    assert row["RowType"] == "ITEM"
+    assert row["Category"] == "CAP"
+    assert row["Package"] == "0603"
+    assert row["Value"]  # parser populated some EIA-style value
+    assert row["Capacitance"]
+    assert row["Tolerance"] == "10%"
+    assert row["Type"] == "X7R"
+    assert row["V"] == "50V"
+    assert row["MFGPN"] == "CC0603KRX7R9BB104"
+    assert row["SPN"] == "C2286"
 
 
 def test_handle_promote_fails_fast_on_supplier_overlap(tmp_path, capsys) -> None:
@@ -115,6 +147,7 @@ def test_handle_promote_fails_fast_on_supplier_overlap(tmp_path, capsys) -> None
         source_inventory=str(source),
         supplier=["lcsc", "mouser"],
         jlc=False,
+        api_key=None,
         output="-",
         force=False,
         verbose=False,

--- a/tests/unit/test_promote_cli.py
+++ b/tests/unit/test_promote_cli.py
@@ -1,0 +1,126 @@
+"""Unit tests for ``jbom promote`` command scaffolding."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+
+import pytest
+
+from jbom.cli.main import create_parser
+from jbom.cli.promote import (
+    _resolve_promote_api_key,
+    _resolve_promote_supplier_context,
+    handle_promote,
+)
+
+
+def test_promote_parser_accepts_positional_input() -> None:
+    parser = create_parser()
+    args = parser.parse_args(["promote", "supplier-export.csv"])
+
+    assert args.command == "promote"
+    assert args.source_inventory == "supplier-export.csv"
+
+
+def test_promote_parser_accepts_api_key_argument() -> None:
+    parser = create_parser()
+    args = parser.parse_args(
+        ["promote", "supplier-export.csv", "--api-key", "lcsc=KEY123"]
+    )
+
+    assert args.api_key == ["lcsc=KEY123"]
+
+
+def test_resolve_promote_supplier_context_defaults_to_generic() -> None:
+    args = argparse.Namespace(supplier=None, jlc=False)
+
+    assert _resolve_promote_supplier_context(args) == "generic"
+
+
+def test_resolve_promote_supplier_context_from_jlc_flag() -> None:
+    args = argparse.Namespace(supplier=None, jlc=True)
+
+    assert _resolve_promote_supplier_context(args) == "lcsc"
+
+
+def test_resolve_promote_supplier_context_rejects_jlc_plus_supplier() -> None:
+    args = argparse.Namespace(supplier=["lcsc"], jlc=True)
+
+    with pytest.raises(ValueError, match=r"tracked by #324"):
+        _resolve_promote_supplier_context(args)
+
+
+def test_resolve_promote_supplier_context_rejects_multiple_suppliers() -> None:
+    args = argparse.Namespace(supplier=["lcsc", "mouser"], jlc=False)
+
+    with pytest.raises(ValueError, match=r"tracked by #324"):
+        _resolve_promote_supplier_context(args)
+
+
+def test_resolve_promote_supplier_context_allows_duplicate_supplier_values() -> None:
+    args = argparse.Namespace(supplier=["lcsc", "LCSC", "lcsc"], jlc=False)
+
+    assert _resolve_promote_supplier_context(args) == "lcsc"
+
+
+def test_resolve_promote_api_key_accepts_matching_scoped_key() -> None:
+    args = argparse.Namespace(api_key=["lcsc=KEY123"])
+
+    assert _resolve_promote_api_key(args, supplier_context="lcsc") == "KEY123"
+
+
+def test_resolve_promote_api_key_rejects_mismatched_scoped_key() -> None:
+    args = argparse.Namespace(api_key=["mouser=KEY999"])
+
+    with pytest.raises(ValueError, match=r"not present in --supplier arguments"):
+        _resolve_promote_api_key(args, supplier_context="lcsc")
+
+
+def test_handle_promote_stamps_supplier_context_column(tmp_path, capsys) -> None:
+    source = tmp_path / "jlc-export.csv"
+    source.write_text(
+        '"JLC Part #","Description"\n"C2286","1uF 0603"\n',
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        source_inventory=str(source),
+        supplier=["lcsc"],
+        jlc=False,
+        output="-",
+        force=False,
+        verbose=False,
+    )
+
+    rc = handle_promote(args)
+    assert rc == 0
+
+    output_text = capsys.readouterr().out
+    reader = csv.DictReader(io.StringIO(output_text))
+    rows = list(reader)
+
+    assert reader.fieldnames is not None
+    assert "SupplierContext" in reader.fieldnames
+    assert rows[0]["SupplierContext"] == "lcsc"
+
+
+def test_handle_promote_fails_fast_on_supplier_overlap(tmp_path, capsys) -> None:
+    source = tmp_path / "jlc-export.csv"
+    source.write_text(
+        '"JLC Part #","Description"\n"C2286","1uF 0603"\n',
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        source_inventory=str(source),
+        supplier=["lcsc", "mouser"],
+        jlc=False,
+        output="-",
+        force=False,
+        verbose=False,
+    )
+
+    rc = handle_promote(args)
+
+    assert rc == 1
+    assert "tracked by #324" in capsys.readouterr().err

--- a/tests/unit/test_promote_workflow.py
+++ b/tests/unit/test_promote_workflow.py
@@ -1,0 +1,394 @@
+"""Unit tests for the promote subpackage (adapter / parser / identity / workflow)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from jbom.services.promote.description_parser import (
+    derive_category,
+    parse_description,
+)
+from jbom.services.promote.identity import build_ipn
+from jbom.services.promote.source_adapters import (
+    GenericCsvAdapter,
+    JlcpcbExportAdapter,
+    detect_source_format,
+    select_adapter,
+)
+from jbom.services.promote.workflow import (
+    CANONICAL_FIELDS,
+    PromotionResult,
+    promote_rows,
+)
+from jbom.services.search.inventory_search_service import (
+    InventorySearchCandidate,
+    InventorySearchRecord,
+)
+from jbom.services.search.models import SearchResult
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests
+# ---------------------------------------------------------------------------
+
+
+def test_detect_source_format_recognizes_jlc_headers() -> None:
+    headers = [
+        "Category",
+        "MFR Part #",
+        "Footprint",
+        "Description",
+        "JLCPCB Part #",
+        "JLCPCB Parts Qty",
+    ]
+    assert detect_source_format(headers) == "jlc"
+
+
+def test_detect_source_format_falls_back_to_generic() -> None:
+    headers = ["IPN", "Category", "Value", "Package"]
+    assert detect_source_format(headers) == "generic"
+
+
+def test_jlc_adapter_maps_canonical_fields() -> None:
+    adapter = JlcpcbExportAdapter()
+    seed = adapter.adapt(
+        {
+            "Category": "Capacitors",
+            "MFR Part #": "CC0603KRX7R9BB104",
+            "Footprint": "0603",
+            "Description": "0.1uF 50V X7R 10% 0603",
+            "JLCPCB Part #": "C2286",
+            "JLCPCB Parts Qty": "120",
+            "Unit Price($)": "0.01",
+        }
+    )
+    assert seed.spn == "C2286"
+    assert seed.mfgpn == "CC0603KRX7R9BB104"
+    assert seed.package == "0603"
+    assert seed.category_hint == "Capacitors"
+    assert seed.description == "0.1uF 50V X7R 10% 0603"
+    assert seed.extras == {
+        "JLCPCB Parts Qty": "120",
+        "Unit Price($)": "0.01",
+    }
+
+
+def test_generic_adapter_passthrough_with_extras() -> None:
+    adapter = GenericCsvAdapter()
+    seed = adapter.adapt(
+        {
+            "SPN": "ABC",
+            "MPN": "XYZ",
+            "Manufacturer": "ACME",
+            "Category": "Resistor",
+            "Package": "0603",
+            "Description": "10K 1% 0603",
+            "CustomCol": "kept",
+        }
+    )
+    assert seed.spn == "ABC"
+    assert seed.mfgpn == "XYZ"
+    assert seed.manufacturer == "ACME"
+    assert seed.package == "0603"
+    assert seed.category_hint == "Resistor"
+    assert seed.description == "10K 1% 0603"
+    assert seed.extras == {"CustomCol": "kept"}
+
+
+def test_select_adapter_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        select_adapter("nope")
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_capacitor_description() -> None:
+    parsed = parse_description(
+        "0.1uF 50V X7R ±10% 0603",
+        category_hint="Capacitors",
+        package_hint="0603",
+        mfgpn="CC0603KRX7R9BB104",
+    )
+    assert parsed.category == "CAP"
+    assert parsed.package == "0603"
+    assert parsed.tolerance == "10%"
+    assert parsed.voltage == "50V"
+    assert parsed.type == "X7R"
+    assert parsed.capacitance == pytest.approx(0.1e-6, rel=1e-3)
+    assert parsed.value
+
+
+def test_parse_resistor_description_supports_ohm_symbol() -> None:
+    parsed = parse_description(
+        "10kΩ 1% 0603 chip resistor",
+        category_hint="Resistors",
+        package_hint="0603",
+    )
+    assert parsed.category == "RES"
+    assert parsed.resistance == pytest.approx(10000.0, rel=1e-6)
+    assert parsed.tolerance == "1%"
+    assert parsed.package == "0603"
+    assert parsed.value
+
+
+def test_parse_inductor_description() -> None:
+    parsed = parse_description(
+        "10uH 5% 1210 shielded power inductor",
+        category_hint="Inductors",
+        package_hint="1210",
+    )
+    assert parsed.category == "IND"
+    assert parsed.inductance == pytest.approx(10e-6, rel=1e-6)
+    assert parsed.tolerance == "5%"
+    assert parsed.package == "1210"
+    assert parsed.value
+
+
+def test_parse_led_description() -> None:
+    parsed = parse_description(
+        "Red LED 620nm 100mcd 120° 0603",
+        category_hint="LEDs",
+        package_hint="0603",
+    )
+    assert parsed.category == "LED"
+    assert parsed.wavelength == "620nm"
+    assert parsed.mcd == "100mcd"
+    assert parsed.angle == "120°"
+    assert parsed.package == "0603"
+
+
+def test_derive_category_uses_hint_first() -> None:
+    assert derive_category(category_hint="Resistors") == "RES"
+    assert derive_category(category_hint="Diodes") == "DIO"
+
+
+def test_derive_category_falls_back_to_description() -> None:
+    assert derive_category(description="Schottky DIODE 30V") == "DIO"
+
+
+# ---------------------------------------------------------------------------
+# Identity policy tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_ipn_passive_capacitor() -> None:
+    parsed = parse_description(
+        "0.1uF 50V X7R 10% 0603",
+        category_hint="Capacitors",
+        package_hint="0603",
+    )
+    ipn = build_ipn(parsed)
+    assert ipn.startswith("CAP_")
+    assert "0603" in ipn
+    assert "X7R" in ipn
+
+
+def test_build_ipn_returns_empty_when_unsupported_category() -> None:
+    parsed = parse_description("AMS1117-3.3 LDO regulator SOT-223")
+    parsed.category = "IC"
+    assert build_ipn(parsed) == ""
+
+
+# ---------------------------------------------------------------------------
+# Workflow tests (with mocked enrichment)
+# ---------------------------------------------------------------------------
+
+
+def _fake_search_result(*, mpn: str, dpn: str) -> SearchResult:
+    return SearchResult(
+        manufacturer="YAGEO",
+        mpn=mpn,
+        description="0.1uF 50V X7R 10% 0603",
+        datasheet="https://example.com/datasheet.pdf",
+        distributor="lcsc",
+        distributor_part_number=dpn,
+        availability="In Stock",
+        price="0.01",
+        details_url="https://example.com/details",
+        raw_data={},
+    )
+
+
+def test_workflow_produces_canonical_columns_without_enrichment() -> None:
+    adapter = JlcpcbExportAdapter()
+    rows = [
+        {
+            "Category": "Capacitors",
+            "MFR Part #": "CC0603KRX7R9BB104",
+            "Footprint": "0603",
+            "Description": "0.1uF 50V X7R 10% 0603",
+            "JLCPCB Part #": "C2286",
+            "JLCPCB Parts Qty": "120",
+        }
+    ]
+    result: PromotionResult = promote_rows(
+        rows,
+        adapter=adapter,
+        supplier_context="lcsc",
+        supplier_label="LCSC",
+        search_service=None,
+    )
+    assert result.stats.rows_total == 1
+    assert result.stats.rows_parsed == 1
+    assert result.stats.rows_with_canonical_value == 1
+    assert result.stats.rows_enrichment_skipped == 1
+    canonical = result.rows[0].canonical
+    for column in (
+        "RowType",
+        "Category",
+        "Value",
+        "Package",
+        "Tolerance",
+        "Type",
+        "V",
+        "Capacitance",
+        "SupplierContext",
+    ):
+        assert column in CANONICAL_FIELDS, column
+        assert column in canonical, column
+    assert canonical["Category"] == "CAP"
+    assert canonical["Package"] == "0603"
+    assert canonical["Tolerance"] == "10%"
+    assert canonical["Type"] == "X7R"
+    assert canonical["V"] == "50V"
+    assert canonical["SPN"] == "C2286"
+    assert canonical["MFGPN"] == "CC0603KRX7R9BB104"
+    assert canonical["Supplier"] == "LCSC"
+    assert canonical["SupplierContext"] == "lcsc"
+    # Supplemental traceability columns retained after canonical block.
+    assert "JLCPCB Parts Qty" in result.fieldnames
+    assert result.fieldnames.index("RowType") < result.fieldnames.index(
+        "JLCPCB Parts Qty"
+    )
+
+
+def test_workflow_uses_mpn_lookup_when_available() -> None:
+    adapter = JlcpcbExportAdapter()
+    rows = [
+        {
+            "Category": "Capacitors",
+            "MFR Part #": "CC0603KRX7R9BB104",
+            "Footprint": "0603",
+            "Description": "0.1uF 50V X7R 10% 0603",
+            "JLCPCB Part #": "C2286",
+        }
+    ]
+    fake_provider = MagicMock()
+    fake_provider.lookup_by_mpn.return_value = _fake_search_result(
+        mpn="CC0603KRX7R9BB104",
+        dpn="C2286",
+    )
+    fake_service = SimpleNamespace(
+        _provider=fake_provider,
+        search=MagicMock(return_value=[]),
+    )
+
+    result = promote_rows(
+        rows,
+        adapter=adapter,
+        supplier_context="lcsc",
+        supplier_label="LCSC",
+        search_service=fake_service,
+    )
+    assert fake_provider.lookup_by_mpn.called
+    # Keyword search should not be called when MPN lookup wins.
+    assert not fake_service.search.called
+    canonical = result.rows[0].canonical
+    assert canonical["Manufacturer"] == "YAGEO"
+    assert canonical["Datasheet"] == "https://example.com/datasheet.pdf"
+    assert result.stats.rows_enriched_mpn == 1
+
+
+def test_workflow_falls_back_to_keyword_search() -> None:
+    adapter = JlcpcbExportAdapter()
+    rows = [
+        {
+            "Category": "Capacitors",
+            "MFR Part #": "CC0603KRX7R9BB104",
+            "Footprint": "0603",
+            "Description": "0.1uF 50V X7R 10% 0603",
+            "JLCPCB Part #": "C2286",
+        }
+    ]
+
+    candidate = InventorySearchCandidate(
+        result=_fake_search_result(mpn="CC0603KRX7R9BB104", dpn="C2286"),
+        match_score=99,
+    )
+    fake_provider = MagicMock()
+    fake_provider.lookup_by_mpn.return_value = None
+
+    class _FakeService:
+        _provider = fake_provider
+
+        def __init__(self) -> None:
+            self.search_calls = 0
+
+        def search(self, items):
+            self.search_calls += 1
+            return [
+                InventorySearchRecord(
+                    inventory_item=items[0],
+                    query="q",
+                    candidates=[candidate],
+                )
+            ]
+
+    fake_service = _FakeService()
+    result = promote_rows(
+        rows,
+        adapter=adapter,
+        supplier_context="lcsc",
+        supplier_label="LCSC",
+        search_service=fake_service,
+    )
+    assert fake_provider.lookup_by_mpn.called
+    assert fake_service.search_calls == 1
+    assert result.stats.rows_enriched_search == 1
+    canonical = result.rows[0].canonical
+    assert canonical["Manufacturer"] == "YAGEO"
+    assert canonical["Datasheet"] == "https://example.com/datasheet.pdf"
+
+
+def test_workflow_counts_misses_when_provider_has_nothing() -> None:
+    adapter = JlcpcbExportAdapter()
+    rows = [
+        {
+            "Category": "Capacitors",
+            "MFR Part #": "",
+            "Footprint": "0603",
+            "Description": "0.1uF 50V X7R 10% 0603",
+            "JLCPCB Part #": "C2286",
+        }
+    ]
+
+    fake_provider = MagicMock()
+    fake_provider.lookup_by_mpn.return_value = None
+    fake_service = SimpleNamespace(
+        _provider=fake_provider,
+        search=MagicMock(
+            return_value=[
+                InventorySearchRecord(
+                    inventory_item=MagicMock(),
+                    query="q",
+                    candidates=[],
+                )
+            ]
+        ),
+    )
+    result = promote_rows(
+        rows,
+        adapter=adapter,
+        supplier_context="lcsc",
+        supplier_label="LCSC",
+        search_service=fake_service,
+    )
+    assert result.stats.rows_enriched_mpn == 0
+    assert result.stats.rows_enriched_search == 0
+    assert result.stats.rows_enrichment_misses == 1


### PR DESCRIPTION
# `jbom promote`: canonical-inventory workflow, supplier-implied enrichment, and aligned supplier API-key semantics

Closes #323
Refs #324

## What this PR delivers

### 1) `jbom promote` rewritten as a real promotion workflow

Replaces the original stamp-only scaffold with a pipeline that converts a
supplier-export CSV into canonical jBOM inventory rows.

The workflow lives under `src/jbom/services/promote/` and is composed of:

- **Source adapter** (`source_adapters.py`) — `JlcpcbExportAdapter` and
  `GenericCsvAdapter`. Auto-detected from CSV headers. Emits a normalized
  `SourceSeed` (SPN, MFGPN, manufacturer, description, package, category
  hint, plus traceability extras).
- **Description / EM parser** (`description_parser.py`) — pure regex
  extractor for `Category`, `Value`, `Package`, `Tolerance`, dielectric
  `Type`, `V`/`A`/`W`, `Wavelength`/`mcd`/`Angle` (LEDs), and typed
  `Resistance`/`Capacitance`/`Inductance`. Carries provenance.
- **Identity policy** (`identity.py`) — deterministic IPN for passives and
  LEDs from the parsed identity.
- **Workflow** (`workflow.py`) — combines adapter + parser + identity, and
  optionally calls supplier enrichment (`InventorySearchService`,
  MPN-first lookup with keyword search fallback), then materializes the
  canonical row.

### 2) CLI shape: supplier-implies-enrichment, no override flags

- Removed `--source-format` (auto-detection is sufficient; any future
  override should be a named profile per ADR 0008).
- Removed `--no-enrich`. Catalog enrichment is implied by supplier context:
  `--supplier <id>` or `--jlc` engages the supplier provider; the implicit
  `generic` context carries no catalog and stays offline.

### 3) Shared supplier argument and API-key handling

- `src/jbom/cli/supplier_args.py` centralizes supplier normalization and
  API-key parsing/resolution, used by both `promote` and `inventory`.
- Supported `--api-key` shapes:
  - scoped: `--api-key SUPPLIER_ID=KEY`
  - single fallback: `--api-key KEY`
  - ordered pairing fallback: repeated unscoped keys zip to `--supplier`
    order when counts match.
- Fail-fast on ambiguous combinations (mixed scoped + unscoped, count
  mismatch, scoped supplier not present in `--supplier`).

### 4) Documentation refresh

- `docs/reference/cli.md` — updated `promote` synopsis + section to
  reflect the workflow, the implicit supplier-implies-search rule, and the
  canonical-output schema. Removed `--source-format` and `--no-enrich`.
- `docs/tutorials/inventory-workflows.md` — promote walk-through reflects
  the same rules; describes the offline/online dichotomy via the supplier
  flags themselves.
- **`docs/architecture/adr/0018-promote-scope-and-enrichment-model.md`** —
  records the three architecture decisions established during review
  (provider-attributes-first, source-export shapes as configuration,
  promote stays per-invoice). The PR comment containing the original plan
  is preserved as design history; the ADR is the durable record.

## Concrete validation against real SPCoast inventory data

Promoted `Parts Inventory on JLCPCB.csv` (55 rows) offline (no
`--supplier`/`--jlc`, implicit `generic` context) and compared against
the curated `SPCoast-INVENTORY.csv` by JLCPCB part number.

- **Original input vs promoted output**: columns 10 → 31. New canonical
  columns include `RowType`, `IPN`, `Category`, `Value`, `Package`,
  `Manufacturer`, `MFGPN`, `Supplier`, `SPN`, `Datasheet`, `Resistance`,
  `Capacitance`, `Inductance`, `Tolerance`, `Type`, `V`, `A`, `W`,
  `Wavelength`, `mcd`, `Angle`, `Priority`, `SupplierContext`. Supplemental
  source columns (qty/pricing) preserved after the canonical block for
  traceability.
- **Per-component coverage in promoted output**: `Package` 55/55, `MFGPN`
  55/55, `Supplier` 55/55, `SPN` 55/55, `V` 55/55, `SupplierContext`
  55/55, `Category` 50/55, `IPN` 43/55, `W` 32/55, `A` 28/55, `Value`
  28/55, `Tolerance` 29/55, `Resistance` 17/55, `Capacitance` 11/55,
  `Type` 9/55, LED-specific fields where present.
- **For the 48 rows matched to SPCoast by SPN**: parity or near-parity with
  the curated inventory on `Category`, `Package`, `Tolerance`, `V`,
  `MFGPN`, `Supplier`, `SPN`, `Resistance`, `Capacitance`. `Value`/`Type`
  still trail (parser is conservative on free-text descriptions; see
  followup #329).

## Architecture decisions

These are recorded in **ADR 0018**
(`docs/architecture/adr/0018-promote-scope-and-enrichment-model.md`):

- **D1** — Provider parametric attributes are the primary parameterized
  data source; description-regex parsing is a last-resort fallback.
  Realised by #329.
- **D2** — Source-export shapes are declarative configuration, not code.
  Realised by #327 (new `supplier.export:` stanza per ADR 0008).
- **D3** — `promote` is per-invoice; cross-supplier discovery and
  freshness/lifecycle/stock stamping belong to `jbom inventory`, not
  `promote`. Realised by #330 and #331.

The PR comment thread on this PR additionally preserves the original
rewrite plan for design-history context.

## Followup issues

| # | Title |
|---|---|
| #326 | Finish ADR 0008 migration: remove legacy `*.fab.yaml` / `*.supplier.yaml` / `*.defaults.yaml` code paths and doc remnants |
| #327 | Move promote source-export shapes into `supplier.export:` stanza; retire in-code adapter switch (realises ADR 0018 D2) |
| #328 | Lift promote-parser vocabularies (category synonyms, MLCC dielectrics, package tokens) into `defaults:` stanza |
| #329 | Invert promote enrichment: provider-attributes-first, description-regex-fallback (realises ADR 0018 D1) |
| #330 | `jbom inventory`: cross-supplier alternative discovery (realises ADR 0018 D3) |
| #331 | `jbom inventory`: freshness/lifecycle/stock stamping on canonical rows (realises ADR 0018 D3) |

## Tests and validation

- `PYTHONPATH=.../src python -m pytest tests/ -q`: **1441 passed**.
- `PYTHONPATH=.../src python -m behave --format progress`: **49 features,
  275 scenarios, 0 failed**.
- `pre-commit run`: clean (black, flake8, bandit, EOF/whitespace).
- New/updated promote unit and BDD tests:
  - `tests/unit/test_promote_cli.py`
  - `tests/unit/test_promote_workflow.py`
  - `features/promote/core.feature`

Conversation: https://app.warp.dev/conversation/b8a017e0-5cc0-4254-803e-6c797c3158ad

Co-Authored-By: Oz <oz-agent@warp.dev>
