### PR TITLE
feat(metadata): complete KiCad text-variable ingestion (#332)

### DIFF
--- a/src/jbom/application/pcb_project_loader.py
+++ b/src/jbom/application/pcb_project_loader.py
@@ -26,9 +26,10 @@ right tool for catching them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Sequence
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
 
 from jbom.common.options import GeneratorOptions
 from jbom.common.pcb_types import BoardModel
@@ -43,7 +44,10 @@ from jbom.services.project_file_resolver import (
     ProjectFileResolver,
     ResolvedInput,
 )
+from jbom.services.project_variables_reader import read_text_variables
 from jbom.services.schematic_reader import SchematicReader
+
+_EMPTY_TEXT_VARIABLES: Mapping[str, str] = MappingProxyType({})
 
 
 @dataclass(frozen=True)
@@ -55,12 +59,23 @@ class ResolvedPcbProject:
     (typically the ``Note: <artifact> requires a PCB file\u2026 / found
     matching PCB\u2026 / Using PCB\u2026`` trio when the user input pointed at
     something other than a PCB).
+
+    ``text_variables`` carries the ``${VAR}`` substitution map read from
+    the project's ``.kicad_pro``.  Empty when the project file does not
+    declare any (the modal case) or when the resolver could not safely
+    read it; absence is intentional and emits no diagnostic.  Title-block
+    fields (title / rev / date / company / COMMENT N) are NOT included
+    here — those are per-file and read independently by the SCH and PCB
+    readers.
     """
 
     resolved_input: ResolvedInput
     pcb_path: Path
     project_context: ProjectContext
     diagnostics: tuple[Diagnostic, ...] = ()
+    text_variables: Mapping[str, str] = field(
+        default_factory=lambda: _EMPTY_TEXT_VARIABLES
+    )
 
 
 def resolve_pcb_input(
@@ -130,7 +145,26 @@ def resolve_pcb_input(
         pcb_path=resolved.resolved_path,
         project_context=resolved.project_context,
         diagnostics=tuple(diagnostics),
+        text_variables=_load_text_variables(resolved.project_context),
     )
+
+
+def _load_text_variables(project_context: ProjectContext) -> Mapping[str, str]:
+    """Read ``text_variables`` from the project's ``.kicad_pro``, defensively.
+
+    Resolution succeeds even when ``text_variables`` cannot be read — the
+    map is enrichment data, not a precondition.  Missing files, missing
+    keys, malformed JSON, or test doubles without a ``project_file``
+    attribute all fall back to an empty read-only map without emitting a
+    diagnostic.
+    """
+    project_file = getattr(project_context, "project_file", None)
+    if not isinstance(project_file, Path) or not project_file.exists():
+        return _EMPTY_TEXT_VARIABLES
+    try:
+        return read_text_variables(project_file).variables
+    except (FileNotFoundError, ValueError):
+        return _EMPTY_TEXT_VARIABLES
 
 
 def load_board(pcb_path: Path) -> BoardModel:

--- a/src/jbom/common/types.py
+++ b/src/jbom/common/types.py
@@ -1,7 +1,7 @@
 """Data classes for jBOM components and inventory items."""
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Dict, Literal, Optional
+from typing import Dict, Literal, Mapping, Optional
 from pathlib import Path
 
 
@@ -45,13 +45,29 @@ class TitleBlockMetadata:
     section with project metadata including title, revision, date, company, etc.
     This dataclass represents the common extracted metadata from either source.
 
-    All fields default to empty string; callers must handle absent data gracefully.
+    All scalar fields default to empty string; ``comments`` defaults to an
+    empty mapping. Callers must handle absent data gracefully.
+
+    KiCad supports nine user-defined comment fields (``${COMMENT1}`` through
+    ``${COMMENT9}``) inside the ``(title_block ...)`` stanza. They are
+    surfaced here verbatim via :attr:`comments`, keyed by the 1-based KiCad
+    index. Two distinct cases are preserved:
+
+    * Comment *missing* from the file → key absent from :attr:`comments`.
+    * Comment present but *empty* (``(comment 2 "")``) → key present with
+      an empty-string value.
+
+    The schematic and PCB title blocks each populate :class:`TitleBlockMetadata`
+    independently. jBOM never merges or reconciles values across files;
+    cross-file divergence is a consumer concern (KiCad itself permits
+    independent edits after initial sync).
     """
 
     title: str = ""
     revision: str = ""
     date: str = ""  # issue_date from title block (YYYY-MM-DD or designer-formatted)
     company: str = ""  # company / organisation field from title block
+    comments: Mapping[int, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/jbom/services/pcb_reader.py
+++ b/src/jbom/services/pcb_reader.py
@@ -176,7 +176,15 @@ class DefaultKiCadReaderService(KiCadReaderService):
                 board.kicad_version = item[1]
 
     def _extract_title_block_metadata(self, sexp) -> TitleBlockMetadata:
-        """Extract title block metadata from a KiCad PCB S-expression tree."""
+        """Extract title block metadata from a KiCad PCB S-expression tree.
+
+        Populates ``title``, ``revision``, ``date``, ``company``, and the
+        per-file ``comments`` map (``${COMMENT1}``..``${COMMENT9}``).  Values
+        are reported verbatim; missing comments are absent from the map and
+        empty-string comments are preserved as empty strings.  This reader
+        never merges or reconciles with the schematic's title block; cross-
+        file divergence is a consumer concern.
+        """
         from sexpdata import Symbol
 
         if not isinstance(sexp, list) or len(sexp) < 2:
@@ -186,6 +194,7 @@ class DefaultKiCadReaderService(KiCadReaderService):
         revision = ""
         date = ""
         company = ""
+        comments: dict[int, str] = {}
         for item in sexp[1:]:
             if not (
                 isinstance(item, list) and item and item[0] == Symbol("title_block")
@@ -193,25 +202,38 @@ class DefaultKiCadReaderService(KiCadReaderService):
                 continue
 
             for title_block_item in item[1:]:
+                if not (isinstance(title_block_item, list) and title_block_item):
+                    continue
+
+                tag = title_block_item[0]
+                if tag == Symbol("comment") and len(title_block_item) >= 3:
+                    idx = title_block_item[1]
+                    text = title_block_item[2]
+                    if isinstance(idx, int) and isinstance(text, str) and 1 <= idx <= 9:
+                        comments[idx] = text
+                    continue
+
                 if not (
-                    isinstance(title_block_item, list)
-                    and len(title_block_item) >= 2
-                    and isinstance(title_block_item[1], str)
+                    len(title_block_item) >= 2 and isinstance(title_block_item[1], str)
                 ):
                     continue
 
-                if title_block_item[0] == Symbol("title"):
+                if tag == Symbol("title"):
                     title = title_block_item[1]
-                elif title_block_item[0] == Symbol("rev"):
+                elif tag == Symbol("rev"):
                     revision = title_block_item[1]
-                elif title_block_item[0] == Symbol("date"):
+                elif tag == Symbol("date"):
                     date = title_block_item[1]
-                elif title_block_item[0] == Symbol("company"):
+                elif tag == Symbol("company"):
                     company = title_block_item[1]
             break
 
         return TitleBlockMetadata(
-            title=title, revision=revision, date=date, company=company
+            title=title,
+            revision=revision,
+            date=date,
+            company=company,
+            comments=comments,
         )
 
     def _parse_footprint_node(self, node) -> Optional[PcbComponent]:

--- a/src/jbom/services/project_variables_reader.py
+++ b/src/jbom/services/project_variables_reader.py
@@ -1,0 +1,102 @@
+"""Read ``text_variables`` from a KiCad ``.kicad_pro`` project file.
+
+``.kicad_pro`` is JSON.  Among other things, it may carry a
+``text_variables`` mapping that KiCad expands as ``${VAR_NAME}`` inside
+title-block fields, schematic/PCB text, sheet titles, and friends.  This
+module exposes that mapping as a typed jBOM artifact so consumers
+(notably ``jbom.application.pcb_project_loader.ResolvedPcbProject`` and
+downstream tools such as ``kproj``) no longer have to JSON-parse the
+project file directly.
+
+Per issue #332: *missing* ``text_variables`` is the modal case for
+hand-edited or legacy projects, and is NOT a diagnostic \u2014 the artifact
+just carries an empty map.  Bad inputs (missing file, wrong extension,
+malformed JSON) raise so the caller can decide how to react.
+
+The schematic and PCB title blocks are NOT consulted here; those are
+read independently by :class:`jbom.services.schematic_reader.SchematicReader`
+and :class:`jbom.services.pcb_reader.DefaultKiCadReaderService`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+__all__ = [
+    "ProjectTextVariables",
+    "read_text_variables",
+]
+
+
+@dataclass(frozen=True)
+class ProjectTextVariables:
+    """Typed view of the ``text_variables`` map from a ``.kicad_pro`` file.
+
+    Attributes:
+        variables:    Read-only mapping of variable name to value, both
+                      strings.  Empty when the project file does not
+                      declare ``text_variables`` or declares it as ``{}``
+                      / ``null``.
+        source_path:  The ``.kicad_pro`` path that was read.
+    """
+
+    variables: Mapping[str, str]
+    source_path: Path
+
+
+def _coerce_text_variables(raw: object) -> Mapping[str, str]:
+    """Coerce a raw JSON ``text_variables`` value into a read-only ``str``\u2192``str`` map.
+
+    Per the KiCad project schema, ``text_variables`` is a JSON object of
+    string-to-string entries.  In the wild we still accept and skip
+    non-string values defensively rather than crashing on a hand-edited
+    project file; absence remains the modal case and is reported as an
+    empty map.
+    """
+    if not isinstance(raw, dict):
+        return MappingProxyType({})
+    coerced: dict[str, str] = {}
+    for key, value in raw.items():
+        if isinstance(key, str) and isinstance(value, str):
+            coerced[key] = value
+    return MappingProxyType(coerced)
+
+
+def read_text_variables(project_file: Path) -> ProjectTextVariables:
+    """Read ``text_variables`` from a ``.kicad_pro`` JSON project file.
+
+    Args:
+        project_file: Path to the KiCad project file (``*.kicad_pro``).
+
+    Returns:
+        A :class:`ProjectTextVariables` artifact.  When the project file
+        does not declare ``text_variables``, the artifact carries an
+        empty map; absence is intentional and emits no diagnostic.
+
+    Raises:
+        FileNotFoundError: When *project_file* does not exist.
+        ValueError:        When *project_file* has the wrong suffix or
+                           cannot be parsed as JSON.
+    """
+    if not project_file.exists():
+        raise FileNotFoundError(f"Project file not found: {project_file}")
+    if project_file.suffix.lower() != ".kicad_pro":
+        raise ValueError(
+            f"Expected .kicad_pro file, got: {project_file.suffix or '<none>'}"
+        )
+    try:
+        payload = json.loads(project_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Failed to parse project file as JSON: {project_file}: {exc}"
+        ) from exc
+
+    raw = payload.get("text_variables") if isinstance(payload, dict) else None
+    return ProjectTextVariables(
+        variables=_coerce_text_variables(raw),
+        source_path=project_file,
+    )

--- a/src/jbom/services/schematic_reader.py
+++ b/src/jbom/services/schematic_reader.py
@@ -170,7 +170,15 @@ class SchematicReader:
         return True
 
     def _extract_title_block_metadata(self, sexp) -> TitleBlockMetadata:
-        """Extract title block metadata from a KiCad schematic S-expression tree."""
+        """Extract title block metadata from a KiCad schematic S-expression tree.
+
+        Populates ``title``, ``revision``, ``date``, ``company``, and the
+        per-file ``comments`` map (``${COMMENT1}``..``${COMMENT9}``).  Values
+        are reported verbatim; missing comments are absent from the map and
+        empty-string comments are preserved as empty strings.  This reader
+        never merges or reconciles with the PCB's title block; cross-file
+        divergence is a consumer concern.
+        """
         from sexpdata import Symbol
 
         if not isinstance(sexp, list) or len(sexp) < 2:
@@ -180,6 +188,7 @@ class SchematicReader:
         revision = ""
         date = ""
         company = ""
+        comments: dict[int, str] = {}
         for item in sexp[1:]:
             if not (
                 isinstance(item, list) and item and item[0] == Symbol("title_block")
@@ -187,23 +196,36 @@ class SchematicReader:
                 continue
 
             for title_block_item in item[1:]:
+                if not (isinstance(title_block_item, list) and title_block_item):
+                    continue
+
+                tag = title_block_item[0]
+                if tag == Symbol("comment") and len(title_block_item) >= 3:
+                    idx = title_block_item[1]
+                    text = title_block_item[2]
+                    if isinstance(idx, int) and isinstance(text, str) and 1 <= idx <= 9:
+                        comments[idx] = text
+                    continue
+
                 if not (
-                    isinstance(title_block_item, list)
-                    and len(title_block_item) >= 2
-                    and isinstance(title_block_item[1], str)
+                    len(title_block_item) >= 2 and isinstance(title_block_item[1], str)
                 ):
                     continue
 
-                if title_block_item[0] == Symbol("title"):
+                if tag == Symbol("title"):
                     title = title_block_item[1]
-                elif title_block_item[0] == Symbol("rev"):
+                elif tag == Symbol("rev"):
                     revision = title_block_item[1]
-                elif title_block_item[0] == Symbol("date"):
+                elif tag == Symbol("date"):
                     date = title_block_item[1]
-                elif title_block_item[0] == Symbol("company"):
+                elif tag == Symbol("company"):
                     company = title_block_item[1]
             break
 
         return TitleBlockMetadata(
-            title=title, revision=revision, date=date, company=company
+            title=title,
+            revision=revision,
+            date=date,
+            company=company,
+            comments=comments,
         )

--- a/tests/application/test_pcb_project_loader.py
+++ b/tests/application/test_pcb_project_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -91,6 +92,9 @@ def test_resolve_pcb_input_emits_no_diagnostics_when_input_is_pcb(
     assert result.pcb_path == pcb_path
     assert result.diagnostics == ()
     assert fake_resolver.resolve_for_wrong_file_type_calls == 0
+    # text_variables defaults to an empty map when the fake project context
+    # carries no .kicad_pro path.
+    assert dict(result.text_variables) == {}
 
 
 def test_resolve_pcb_input_emits_diagnostic_trio_when_input_is_schematic(
@@ -153,6 +157,99 @@ def test_resolve_pcb_input_raises_when_no_project_context(
     )
     with pytest.raises(ValueError, match="No project context available"):
         loader.resolve_pcb_input(str(tmp_path), artifact_name="BOM")
+
+
+# ---------------------------------------------------------------------------
+# resolve_pcb_input: text_variables ingestion (#332)
+# ---------------------------------------------------------------------------
+
+
+class _ProjectContextWithFile:
+    """Stand-in ProjectContext that exposes a real ``.kicad_pro`` path."""
+
+    def __init__(self, project_file: Path) -> None:
+        self.project_file = project_file
+        self.project_base_name = project_file.stem
+        self.project_directory = project_file.parent
+
+    @staticmethod
+    def get_hierarchical_schematic_files() -> list[Path]:
+        return []
+
+
+def _write_kicad_pro(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_resolve_pcb_input_carries_text_variables_when_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``ResolvedPcbProject.text_variables`` mirrors the ``.kicad_pro`` map."""
+    project_file = tmp_path / "demo.kicad_pro"
+    _write_kicad_pro(
+        project_file,
+        {"text_variables": {"DESIGNER": "JP", "STATUS": "released"}},
+    )
+    pcb_path = tmp_path / "demo.kicad_pcb"
+    pcb_path.write_text("(kicad_pcb)", encoding="utf-8")
+    fake_resolver = _FakeResolver(
+        starts_as_pcb=True,
+        starting_path=pcb_path,
+        pcb_path=pcb_path,
+        project_context=_ProjectContextWithFile(project_file),
+    )
+    monkeypatch.setattr(loader, "ProjectFileResolver", lambda **_kwargs: fake_resolver)
+
+    result = loader.resolve_pcb_input(str(pcb_path), artifact_name="BOM")
+    assert dict(result.text_variables) == {
+        "DESIGNER": "JP",
+        "STATUS": "released",
+    }
+
+
+def test_resolve_pcb_input_text_variables_empty_when_absent_from_pro(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``.kicad_pro`` without ``text_variables`` yields an empty map."""
+    project_file = tmp_path / "demo.kicad_pro"
+    _write_kicad_pro(project_file, {"meta": {"version": 1}})
+    pcb_path = tmp_path / "demo.kicad_pcb"
+    pcb_path.write_text("(kicad_pcb)", encoding="utf-8")
+    fake_resolver = _FakeResolver(
+        starts_as_pcb=True,
+        starting_path=pcb_path,
+        pcb_path=pcb_path,
+        project_context=_ProjectContextWithFile(project_file),
+    )
+    monkeypatch.setattr(loader, "ProjectFileResolver", lambda **_kwargs: fake_resolver)
+
+    result = loader.resolve_pcb_input(str(pcb_path), artifact_name="BOM")
+    assert dict(result.text_variables) == {}
+
+
+def test_resolve_pcb_input_swallows_unreadable_kicad_pro(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A malformed ``.kicad_pro`` must not poison the resolution path.
+
+    Reading text_variables is enrichment data, not a precondition of
+    PCB resolution. Errors there silently fall back to an empty map so
+    the caller can still produce BOM/POS/Gerber artifacts.
+    """
+    project_file = tmp_path / "demo.kicad_pro"
+    project_file.write_text("{not-json", encoding="utf-8")
+    pcb_path = tmp_path / "demo.kicad_pcb"
+    pcb_path.write_text("(kicad_pcb)", encoding="utf-8")
+    fake_resolver = _FakeResolver(
+        starts_as_pcb=True,
+        starting_path=pcb_path,
+        pcb_path=pcb_path,
+        project_context=_ProjectContextWithFile(project_file),
+    )
+    monkeypatch.setattr(loader, "ProjectFileResolver", lambda **_kwargs: fake_resolver)
+
+    result = loader.resolve_pcb_input(str(pcb_path), artifact_name="BOM")
+    assert dict(result.text_variables) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/readers/test_schematic_reader.py
+++ b/tests/services/readers/test_schematic_reader.py
@@ -4,8 +4,10 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+from sexpdata import Symbol
+
 from jbom.services.schematic_reader import SchematicReader
-from jbom.common.types import Component
+from jbom.common.types import Component, TitleBlockMetadata
 
 
 class TestSchematicReader:
@@ -146,3 +148,125 @@ class TestSchematicReader:
             dnp=False,
         )
         assert reader._should_include_component(hash_component) is True
+
+
+# ---------------------------------------------------------------------------
+# Title-block metadata: COMMENT 1..9 parsing (#332)
+# ---------------------------------------------------------------------------
+
+
+def _sch_sexp_with_title_block(title_block_items: list[object]) -> list[object]:
+    """Build a minimal ``(kicad_sch ... (title_block ...))`` tree for tests."""
+    return [
+        Symbol("kicad_sch"),
+        [Symbol("version"), "20240108"],
+        [Symbol("title_block"), *title_block_items],
+    ]
+
+
+def _comment(index: int, text: str) -> list[object]:
+    return [Symbol("comment"), index, text]
+
+
+class TestSchematicTitleBlockComments:
+    """SchematicReader._extract_title_block_metadata parses comment N=1..9."""
+
+    def test_scalar_fields_still_extracted(self) -> None:
+        reader = SchematicReader()
+        sexp = _sch_sexp_with_title_block(
+            [
+                [Symbol("title"), "MySch"],
+                [Symbol("rev"), "A"],
+                [Symbol("date"), "2026-05-09"],
+                [Symbol("company"), "Acme"],
+            ]
+        )
+        metadata = reader._extract_title_block_metadata(sexp)
+        assert isinstance(metadata, TitleBlockMetadata)
+        assert metadata.title == "MySch"
+        assert metadata.revision == "A"
+        assert metadata.date == "2026-05-09"
+        assert metadata.company == "Acme"
+        assert dict(metadata.comments) == {}
+
+    def test_populates_all_nine_comments(self) -> None:
+        reader = SchematicReader()
+        sexp = _sch_sexp_with_title_block(
+            [_comment(n, f"sch-comment-{n}") for n in range(1, 10)]
+        )
+        metadata = reader._extract_title_block_metadata(sexp)
+        for n in range(1, 10):
+            assert metadata.comments[n] == f"sch-comment-{n}"
+
+    def test_missing_comments_absent_from_map(self) -> None:
+        reader = SchematicReader()
+        sexp = _sch_sexp_with_title_block([[Symbol("title"), "MySch"]])
+        metadata = reader._extract_title_block_metadata(sexp)
+        assert dict(metadata.comments) == {}
+
+    def test_empty_comment_value_preserved(self) -> None:
+        reader = SchematicReader()
+        sexp = _sch_sexp_with_title_block([_comment(2, "")])
+        metadata = reader._extract_title_block_metadata(sexp)
+        assert 2 in metadata.comments
+        assert metadata.comments[2] == ""
+
+    def test_mixed_presence_preserved(self) -> None:
+        reader = SchematicReader()
+        sexp = _sch_sexp_with_title_block(
+            [
+                _comment(1, "designer"),
+                _comment(9, "released"),
+            ]
+        )
+        metadata = reader._extract_title_block_metadata(sexp)
+        assert metadata.comments == {1: "designer", 9: "released"}
+
+
+class TestReaderIndependence:
+    """The schematic and PCB readers do not merge or reconcile values.
+
+    Divergent SCH/PCB title-block content must be reported as-is by each
+    reader; reconciliation policy is a consumer concern (KiCad itself
+    permits independent edits once the schematic→PCB sync has happened).
+    """
+
+    def test_sch_and_pcb_readers_report_independent_comments(self) -> None:
+        from jbom.services.pcb_reader import DefaultKiCadReaderService
+
+        sch_reader = SchematicReader()
+        pcb_reader = DefaultKiCadReaderService()
+
+        sch_sexp = _sch_sexp_with_title_block(
+            [
+                [Symbol("title"), "sch-title"],
+                [Symbol("rev"), "A"],
+                _comment(1, "sch-designer"),
+                _comment(9, "sch-status"),
+            ]
+        )
+        pcb_sexp = [
+            Symbol("kicad_pcb"),
+            [Symbol("version"), "20240108"],
+            [
+                Symbol("title_block"),
+                [Symbol("title"), "pcb-title"],
+                [Symbol("rev"), "A1"],
+                _comment(1, "pcb-designer"),
+                _comment(9, "pcb-status"),
+            ],
+        ]
+
+        sch_meta = sch_reader._extract_title_block_metadata(sch_sexp)
+        pcb_meta = pcb_reader._extract_title_block_metadata(pcb_sexp)
+
+        # Each reader reports its own file's values; divergent scalars and
+        # comments are *not* merged across files.
+        assert sch_meta.title == "sch-title"
+        assert pcb_meta.title == "pcb-title"
+        assert sch_meta.revision == "A"
+        assert pcb_meta.revision == "A1"
+        assert sch_meta.comments[1] == "sch-designer"
+        assert pcb_meta.comments[1] == "pcb-designer"
+        assert sch_meta.comments[9] == "sch-status"
+        assert pcb_meta.comments[9] == "pcb-status"

--- a/tests/unit/test_pcb_reader.py
+++ b/tests/unit/test_pcb_reader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from sexpdata import Symbol
 
+from jbom.common.types import TitleBlockMetadata
 from jbom.services.pcb_reader import DefaultKiCadReaderService
 
 
@@ -91,3 +92,91 @@ def test_parse_footprint_node_preserves_canonical_fpid_over_schematic_footprint_
     assert parsed.footprint_name == "VendorLib:0805-CAP"
     # The schematic-side hint is preserved alongside it for diagnostics.
     assert parsed.attributes["schematic_footprint"] == "Capacitor_SMD:C_0805_2012Metric"
+
+
+# ---------------------------------------------------------------------------
+# Title-block metadata: COMMENT 1..9 parsing (#332)
+# ---------------------------------------------------------------------------
+
+
+def _pcb_sexp_with_title_block(title_block_items: list[object]) -> list[object]:
+    """Build a minimal ``(kicad_pcb ... (title_block ...))`` tree for tests."""
+    return [
+        Symbol("kicad_pcb"),
+        [Symbol("version"), "20240108"],
+        [Symbol("title_block"), *title_block_items],
+    ]
+
+
+def _comment(index: int, text: str) -> list[object]:
+    return [Symbol("comment"), index, text]
+
+
+def test_pcb_title_block_extracts_scalar_fields() -> None:
+    """Existing scalar fields keep working alongside the new comments map."""
+    reader = DefaultKiCadReaderService()
+    sexp = _pcb_sexp_with_title_block(
+        [
+            [Symbol("title"), "MyBoard"],
+            [Symbol("rev"), "1.0"],
+            [Symbol("date"), "2026-05-09"],
+            [Symbol("company"), "Acme"],
+        ]
+    )
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert metadata.title == "MyBoard"
+    assert metadata.revision == "1.0"
+    assert metadata.date == "2026-05-09"
+    assert metadata.company == "Acme"
+    assert dict(metadata.comments) == {}
+
+
+def test_pcb_title_block_populates_all_nine_comments() -> None:
+    """COMMENT 1..9 each surface verbatim under :attr:`comments`."""
+    reader = DefaultKiCadReaderService()
+    sexp = _pcb_sexp_with_title_block(
+        [_comment(n, f"pcb-comment-{n}") for n in range(1, 10)]
+    )
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert isinstance(metadata, TitleBlockMetadata)
+    for n in range(1, 10):
+        assert metadata.comments[n] == f"pcb-comment-{n}"
+
+
+def test_pcb_title_block_missing_comments_are_absent() -> None:
+    """A title block without any comments yields an empty comments map."""
+    reader = DefaultKiCadReaderService()
+    sexp = _pcb_sexp_with_title_block([[Symbol("title"), "MyBoard"]])
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert dict(metadata.comments) == {}
+
+
+def test_pcb_title_block_empty_comment_value_preserved() -> None:
+    """``(comment 2 "")`` keeps the key with an empty-string value."""
+    reader = DefaultKiCadReaderService()
+    sexp = _pcb_sexp_with_title_block([_comment(2, "")])
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert 2 in metadata.comments
+    assert metadata.comments[2] == ""
+
+
+def test_pcb_title_block_mixed_presence_preserved() -> None:
+    """Mixed-presence layouts keep the populated indices verbatim and omit the rest."""
+    reader = DefaultKiCadReaderService()
+    sexp = _pcb_sexp_with_title_block(
+        [
+            _comment(1, "designer"),
+            _comment(9, "released"),
+        ]
+    )
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert metadata.comments == {1: "designer", 9: "released"}
+
+
+def test_pcb_title_block_preserves_raw_comment_strings() -> None:
+    """Raw values are stored verbatim, including whitespace."""
+    reader = DefaultKiCadReaderService()
+    raw = "  spaced  with\ttabs  "
+    sexp = _pcb_sexp_with_title_block([_comment(3, raw)])
+    metadata = reader._extract_title_block_metadata(sexp)
+    assert metadata.comments[3] == raw

--- a/tests/unit/test_project_variables_reader.py
+++ b/tests/unit/test_project_variables_reader.py
@@ -1,0 +1,122 @@
+"""Unit tests for :mod:`jbom.services.project_variables_reader`.
+
+Pins down ``.kicad_pro`` ``text_variables`` ingestion behaviour added in
+issue #332:
+
+* When the project file declares a ``text_variables`` map, its entries
+  surface verbatim through :class:`ProjectTextVariables`.
+* When ``text_variables`` is absent (the modal case for legacy or
+  hand-edited projects), the artifact carries an empty map \u2014 *not* a
+  diagnostic.  Absence is normal.
+* Bad inputs (missing file, wrong extension, malformed JSON) raise on
+  ingest so the resolver path can decide how to react.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jbom.services.project_variables_reader import (
+    ProjectTextVariables,
+    read_text_variables,
+)
+
+
+def _write_project_file(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestReadTextVariablesPresent:
+    """``.kicad_pro`` with a populated ``text_variables`` map."""
+
+    def test_returns_text_variables_verbatim(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(
+            project,
+            {
+                "meta": {"filename": "demo.kicad_pro", "version": 1},
+                "text_variables": {
+                    "DESIGNER": "John Plocher",
+                    "STATUS": "released",
+                },
+            },
+        )
+        result = read_text_variables(project)
+        assert isinstance(result, ProjectTextVariables)
+        assert dict(result.variables) == {
+            "DESIGNER": "John Plocher",
+            "STATUS": "released",
+        }
+        assert result.source_path == project
+
+    def test_preserves_raw_values(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        raw = "  spaced  with\ttabs  "
+        _write_project_file(project, {"text_variables": {"NOTE": raw}})
+        result = read_text_variables(project)
+        assert result.variables["NOTE"] == raw
+
+
+class TestReadTextVariablesAbsent:
+    """Missing or empty ``text_variables`` is the modal case \u2014 no diagnostic."""
+
+    def test_missing_text_variables_key_yields_empty_map(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(project, {"meta": {"version": 1}})
+        result = read_text_variables(project)
+        assert dict(result.variables) == {}
+        assert result.source_path == project
+
+    def test_empty_text_variables_object_yields_empty_map(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(project, {"text_variables": {}})
+        result = read_text_variables(project)
+        assert dict(result.variables) == {}
+
+    def test_text_variables_set_to_null_yields_empty_map(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(project, {"text_variables": None})
+        result = read_text_variables(project)
+        assert dict(result.variables) == {}
+
+
+class TestReadTextVariablesErrors:
+    """Bad inputs surface as exceptions so callers can decide policy."""
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            read_text_variables(tmp_path / "nope.kicad_pro")
+
+    def test_wrong_extension_raises_value_error(self, tmp_path: Path) -> None:
+        bogus = tmp_path / "demo.txt"
+        bogus.write_text("{}", encoding="utf-8")
+        with pytest.raises(ValueError, match=r"\.kicad_pro"):
+            read_text_variables(bogus)
+
+    def test_malformed_json_raises_value_error(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        project.write_text("{not-json", encoding="utf-8")
+        with pytest.raises(ValueError):
+            read_text_variables(project)
+
+
+class TestProjectTextVariablesDataclass:
+    """The artifact is a frozen dataclass with a read-only variables map.\"\"\" """
+
+    def test_is_frozen(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(project, {"text_variables": {"A": "1"}})
+        artifact = read_text_variables(project)
+        with pytest.raises(AttributeError):
+            artifact.source_path = tmp_path  # type: ignore[misc]
+
+    def test_variables_mapping_is_read_only(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo.kicad_pro"
+        _write_project_file(project, {"text_variables": {"A": "1"}})
+        artifact = read_text_variables(project)
+        with pytest.raises(TypeError):
+            artifact.variables["B"] = "2"  # type: ignore[index]

--- a/tests/unit/test_title_block_metadata.py
+++ b/tests/unit/test_title_block_metadata.py
@@ -1,0 +1,64 @@
+"""Unit tests for :class:`jbom.common.types.TitleBlockMetadata`.
+
+These tests pin down the per-file comment behaviour added in #332:
+
+* ``comments`` is a ``Mapping[int, str]`` keyed by the KiCad comment
+  index (1..9).
+* The map is built so that *missing* comments are absent from the map
+  (consumers see ``meta.comments.get(N)`` → ``None``), while *empty*
+  comments are present with an empty-string value.  The distinction is
+  load-bearing for downstream tooling that wants to tell "no field" from
+  "field deliberately blanked".
+* The dataclass remains frozen / immutable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jbom.common.types import TitleBlockMetadata
+
+
+class TestTitleBlockMetadataDefaults:
+    """Defaults preserve the existing public API."""
+
+    def test_default_construction_has_empty_comments(self) -> None:
+        meta = TitleBlockMetadata()
+        assert meta.title == ""
+        assert meta.revision == ""
+        assert meta.date == ""
+        assert meta.company == ""
+        assert dict(meta.comments) == {}
+
+    def test_dataclass_is_frozen(self) -> None:
+        meta = TitleBlockMetadata()
+        with pytest.raises(AttributeError):
+            meta.title = "changed"  # type: ignore[misc]
+
+
+class TestTitleBlockMetadataComments:
+    """``comments`` is keyed by int and preserves raw values verbatim."""
+
+    def test_comments_populated_for_all_nine_indices(self) -> None:
+        comments = {n: f"c{n}" for n in range(1, 10)}
+        meta = TitleBlockMetadata(comments=comments)
+        for n in range(1, 10):
+            assert meta.comments[n] == f"c{n}"
+
+    def test_missing_comment_indices_are_absent_from_map(self) -> None:
+        meta = TitleBlockMetadata(comments={1: "designer", 9: "released"})
+        assert meta.comments.get(1) == "designer"
+        assert meta.comments.get(9) == "released"
+        # The missing indices are absent (not empty-string).
+        for n in (2, 3, 4, 5, 6, 7, 8):
+            assert n not in meta.comments
+
+    def test_empty_string_comment_is_present_and_empty(self) -> None:
+        meta = TitleBlockMetadata(comments={2: ""})
+        assert 2 in meta.comments
+        assert meta.comments[2] == ""
+
+    def test_raw_string_content_is_preserved_verbatim(self) -> None:
+        raw = "  spaced  with\ttabs\nand newlines  "
+        meta = TitleBlockMetadata(comments={3: raw})
+        assert meta.comments[3] == raw


### PR DESCRIPTION
Closes #332.

## Summary

Completes KiCad text-variable ingestion in jBOM:

1. **Title-block `COMMENT 1..9`** is now surfaced by both readers.
   `TitleBlockMetadata` carries a frozen `comments: Mapping[int, str]`
   populated independently by `DefaultKiCadReaderService` (PCB side) and
   `SchematicReader` (schematic side). jBOM does **not** merge or
   reconcile across `.kicad_sch` and `.kicad_pcb` — divergent values are
   reported as they appear in each file.
2. **`.kicad_pro` `text_variables`** is now a typed artifact
   (`jbom.services.project_variables_reader.ProjectTextVariables`) and
   is also exposed on `ResolvedPcbProject.text_variables` for the
   project-loader path. Missing key → empty map (no diagnostic, per the
   acceptance criteria).

Together these replace kproj's local fallback walker
(`jbom.common.sexp_parser` + stdlib `json`).

## Design notes

- `TitleBlockMetadata.comments` uses `Mapping[int, str]` keyed by the
  KiCad 1-based index. *Missing* comments are absent from the map;
  *empty* comments (`(comment 2 "")`) are present with empty-string
  values, so consumers can distinguish "no field" from "field
  deliberately blanked".
- `ProjectTextVariables.variables` is wrapped in `MappingProxyType` so
  callers cannot mutate it.
- `ResolvedPcbProject.text_variables` reads `.kicad_pro` defensively:
  malformed JSON, missing files, or test doubles without a `project_file`
  attribute fall back to an empty read-only map. Title-block content is
  deliberately **not** mixed in here — those are per-file and read
  through the SCH/PCB readers.
- Naming-asymmetry sidecar (`DefaultKiCadReaderService` vs
  `SchematicReader`): left as-is for this PR. The readers are used by
  several call sites and a rename felt larger than the issue's scope.
  Flagging for a separate refactor issue per the issue's guidance.

## Tests

- `tests/unit/test_title_block_metadata.py` — new, pins down the
  dataclass shape.
- `tests/unit/test_pcb_reader.py` — extends with COMMENT 1..9 parsing
  cases (all-nine, missing, empty, mixed, raw-string preservation).
- `tests/services/readers/test_schematic_reader.py` — extends with the
  same comment cases plus a `TestReaderIndependence` block that
  exercises the divergent-values-not-merged guarantee.
- `tests/unit/test_project_variables_reader.py` — new, covers present /
  absent / null / malformed JSON / wrong extension / read-only map.
- `tests/application/test_pcb_project_loader.py` — extends
  `ResolvedPcbProject` coverage with text_variables present, absent,
  and unreadable-`.kicad_pro` fallback cases.

Full pytest suite: **1472 passed** (was 1441 baseline).
Full behave suite: **49 features / 275 scenarios passed, 0 failed, 1
feature / 8 scenarios skipped** (matches main baseline).
Pre-commit hooks (trailing whitespace, EOL, black, flake8, bandit):
clean across all five commits.

## Commits

- `4a1aece` feat(types): expose KiCad title-block COMMENT fields on
  TitleBlockMetadata
- `d87a600` feat(pcb-reader): parse title-block comment 1..9 fields
- `d9b6fae` feat(schematic-reader): parse title-block comment 1..9 fields
- `53414d3` feat(project-variables): expose .kicad_pro text_variables as
  typed artifact
- `bbbeeac` feat(pcb-project-loader): carry .kicad_pro text_variables on
  ResolvedPcbProject

## Artifacts

- Warp run: https://oz.warp.dev/runs/019f159d-36ee-745b-a0cf-2be9781fc2a3
- Conversation: https://app.warp.dev/conversation/28e2c158-88b3-42e8-ac29-1a9573c3e0a4
