### PR TITLE
fix: correct license metadata to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,5 +145,5 @@ Regenerate baseline-vs-candidate parity delta evidence:
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
 
-**License**: AGPLv3 — See LICENSE file for full terms.
+**License**: MIT — See LICENSE file for full terms.
 Author: John Plocher

--- a/docs/design/contributing.md
+++ b/docs/design/contributing.md
@@ -197,6 +197,6 @@ user-visible behavior, BDD scenarios.
 ## Contributor Agreement
 
 By contributing to jBOM, you agree that your contributions will be
-licensed under the AGPLv3 license. Contributions of all kinds are
+licensed under the MIT license. Contributions of all kinds are
 welcome — bug fixes, features, documentation, tests, and feedback. Be
 respectful and professional.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "jbom"
 version = "7.3.0"
 description = "Intelligent KiCad Bill of Materials generator with inventory matching"
 readme = "README.md"
-license = "AGPL-3.0-only"
+license = "MIT"
 authors = [{name = "John Plocher", email = "John.Plocher@gmail.com"}]
 keywords = ["kicad", "bom", "bill-of-materials", "pcb", "electronics", "inventory"]
 classifiers = [


### PR DESCRIPTION
## Summary

Corrects stale AGPL-3.0 license declarations to MIT. The `LICENSE` file has always been MIT (copyright John Plocher); an early automated change incorrectly set AGPL in package metadata and docs without asking. The KiCad plugin `metadata.json` already correctly said MIT.

Closes #334

## Changes

- `pyproject.toml` — `license = "AGPL-3.0-only"` → `license = "MIT"` (this is the field published to PyPI; the next semantic-release corrects the public package metadata)
- `README.md` — License line now agrees with the LICENSE file it points to
- `docs/design/contributing.md` — contributor agreement now references MIT

Not changed: `src/jbom.egg-info/PKG-INFO` is a build artifact regenerated from pyproject at build time.

## Validation

- `pre-commit` — all hooks pass
- `pytest tests/` — **1472 passed** (18.45s)
- `behave --format progress` — **49 features passed, 0 failed, 1 skipped; 275 scenarios passed, 0 failed, 8 skipped**

## Follow-up (outside this repo)

- kproj `docs/phase1/jbom-reuse-map.md` built its vendoring-risk analysis on the AGPL assumption; an erratum note will be added there separately.

## Merge recommendation

Rebase-merge per repo convention. Semantic-release will treat `fix:` as a patch bump and publish corrected metadata to PyPI.
