### PR TITLE
ci(release): auto-build PCM archive and attach stable-name asset on release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     concurrency: release
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - uses: actions/checkout@v4
@@ -37,11 +40,97 @@ jobs:
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
         semantic-release version
+
+    - name: Detect whether a release was cut
+      # semantic-release version may no-op when no relevant commits landed.
+      # Presence of dist/ artifacts is the reliable signal that a new
+      # version was tagged and built; use that to gate every subsequent
+      # release-only step (PyPI publish, PCM build, asset upload, metadata
+      # sync commit).
+      id: release
+      run: |
+        if [ -n "$(ls -A dist 2>/dev/null || true)" ]; then
+          version=$(python -c "import re,sys; m=re.search(r'^version *= *\"([^\"]+)\"', open('pyproject.toml').read(), re.MULTILINE); sys.stdout.write(m.group(1))")
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Detected new release v${version}"
+        else
+          echo "released=false" >> "$GITHUB_OUTPUT"
+          echo "No new release; skipping publish and asset attach steps."
+        fi
+
     - name: Publish to PyPI
-      if: ${{ hashFiles('dist/*') != '' }}
+      if: steps.release.outputs.released == 'true'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         pip install twine
-        twine upload dist/*
+        # Upload only the wheel + sdist to PyPI. The PCM zip we're about to
+        # build must NOT be uploaded here — PyPI would reject it. It is
+        # built after this step and attached to the GitHub Release only.
+        twine upload dist/*.whl dist/*.tar.gz
+
+    - name: Install vendored runtime dependencies for PCM build
+      if: steps.release.outputs.released == 'true'
+      # The PCM archive vendors these pure-Python packages from the build
+      # host's site-packages. They must be present for the archive to be
+      # complete; skipping this step yields a silently-broken archive.
+      run: pip install -r scripts/_vendor_requirements.txt
+
+    - name: Build PCM archive and sync metadata.json
+      if: steps.release.outputs.released == 'true'
+      # --update-metadata performs the two-phase manifest sync:
+      # (1) bump versions[0].version and download_url before the archive
+      # is staged, (2) patch download_sha256/install_size/download_size
+      # after zipping. See scripts/build_pcm_package.py._update_metadata.
+      run: |
+        python scripts/build_pcm_package.py --update-metadata
+        # Stable-name copy so
+        # https://github.com/plocher/jBOM/releases/latest/download/jbom-pcm.zip
+        # resolves to the newest release archive without manual maintenance.
+        cp "dist/jbom-pcm-${{ steps.release.outputs.version }}.zip" \
+           dist/jbom-pcm.zip
+
+    - name: Attach release assets
+      if: steps.release.outputs.released == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # --clobber makes this step idempotent if the workflow is re-run
+      # against the same tag (e.g. after a transient upload failure).
+      run: |
+        version="${{ steps.release.outputs.version }}"
+        tag="${{ steps.release.outputs.tag }}"
+        gh release upload "${tag}" \
+          "dist/jbom-pcm-${version}.zip" \
+          "dist/jbom-pcm.zip" \
+          --clobber
+        shopt -s nullglob
+        pypi_artifacts=(dist/*.whl dist/*.tar.gz)
+        if [ ${#pypi_artifacts[@]} -gt 0 ]; then
+          gh release upload "${tag}" "${pypi_artifacts[@]}" --clobber
+        fi
+
+    - name: Sync metadata.json back to main
+      if: steps.release.outputs.released == 'true'
+      # metadata.json now reflects the just-released version + sha256. Push
+      # the change back so the PCM manifest at
+      # https://raw.githubusercontent.com/plocher/jBOM/main/metadata.json
+      # stays authoritative for consumers reading the manifest directly.
+      # The `[skip ci]` marker prevents this commit from re-triggering the
+      # release workflow.
+      run: |
+        if git diff --quiet metadata.json; then
+          echo "metadata.json unchanged; nothing to commit."
+          exit 0
+        fi
+        version="${{ steps.release.outputs.version }}"
+        git add metadata.json
+        git commit \
+          -m "chore(release): sync metadata.json for v${version} [skip ci]" \
+          -m "" \
+          -m "Refs #338" \
+          -m "" \
+          -m "Co-Authored-By: Oz <oz-agent@warp.dev>"
+        git push origin HEAD:main

--- a/release-management/README.md
+++ b/release-management/README.md
@@ -129,23 +129,69 @@ follow-up commit from cascading into another release run. See
   overwrite `versions[0]` regardless of prior content; drift is
   self-healing.
 
-## Portability notes
+## Portability and the shared-process principle
 
-The PCM archive contract described here is specific to jBOM, but the
-mechanics are reusable by sibling KiCad-plugin projects (e.g. `kproj`)
-that follow the same conventions:
+Sibling repositories must not evolve arbitrarily different release
+processes. The **shape** of the release chain — feature-branch →
+conventional commits → PR → merge to `main` →
+`semantic-release version` → release-detected gate → PyPI publish →
+attach wheel + sdist to VCS release → (optional domain-specific asset
+steps) → (optional `[skip ci]` sync commit) — is normative across the
+family. Cosmetic differences (step names, gate mechanism, commit
+vocabulary, tag scheme, config layout) between sibling workflows are
+treated as bugs, not stylistic choices.
+
+Divergence is allowed only where a real domain requirement makes it
+necessary. Currently one such divergence exists:
+
+**PCM packaging applies to jBOM only, because jBOM ships a KiCad
+ActionPlugin distributed through KiCad's Plugin and Content Manager.**
+Sibling projects that do not ship a KiCad plugin (e.g. `kproj`, which
+is a pure-Python app) do not need any of the PCM machinery, and their
+release chains should stop at "attach wheel + sdist to VCS release."
+The jBOM-specific steps are:
+
+- PCM archive build (`scripts/build_pcm_package.py`) and its
+  `_vendor_requirements.txt` install step.
+- Stable-name `jbom-pcm.zip` copy and the two-phase
+  `metadata.json` sync (version + URL pre-stage, sha256 + sizes
+  post-zip).
+- The `[skip ci]` `metadata.json` sync commit back to `main`.
+
+Everything else in the chain is generic and every sibling should keep
+it byte-for-byte compatible with jBOM's implementation:
+
+- Release-detected gate that reads the freshly-bumped version from
+  `pyproject.toml` and gates every release-only step on
+  `steps.release.outputs.released == 'true'`.
+- `twine upload dist/*.whl dist/*.tar.gz` (never a bare `dist/*` —
+  keeps room for non-PyPI artifacts alongside).
+- `gh release upload <tag> ... --clobber` for the wheel + sdist mirror
+  attach, so the VCS release is a complete audit trail of what shipped.
+- Semantic-release configuration shape: `version_toml` +
+  `version_variables`, `branch = "main"`, `exclude_commit_patterns`
+  filtering `chore` / `ci` / `docs` / `style` / `test` out of the
+  changelog, `upload_to_vcs_release = true`, `upload_to_pypi = true`.
+- Conventional-commit vocabulary: `fix` → patch, `feat` → minor,
+  breaking change → major, plus non-release types listed above.
+- Feature-branch naming (`feature/issue-N-...` / `fix/issue-N-...`)
+  and the co-author trailer requirement.
+
+When either project's release chain needs to evolve, evaluate the
+change against the sibling. If the change is generic (release
+mechanics), apply it to both. If the change is domain-specific,
+document the divergence and its justification in this section —
+silent divergence is the antipattern this section exists to prevent.
+
+Mechanical reuse notes for the PCM builder itself (in case any future
+sibling ever does ship a KiCad plugin):
 
 - `metadata.json` at the repo root, with `resources.homepage` pointing
-  at the project's GitHub URL.
-- `scripts/build_pcm_package.py` (or an equivalent vendored copy)
-  accepting the same `--update-metadata` flag and its
-  `archive_name_template` argument.
-- Semantic-release-driven `vX.Y.Z` tagging.
-
-`_update_metadata` in the builder derives the `download_url` owner /
-repo from `resources.homepage`, so the same code produces correct URLs
-for any repo following the shape. The archive filename template is a
-parameter, so `kproj-pcm-{version}.zip` is a one-line change.
+  at the project's GitHub URL (`_update_metadata` derives the
+  `owner/repo` in `download_url` from this field, so no per-repo code
+  changes are needed).
+- `_update_metadata`'s `archive_name_template` argument makes the
+  archive filename a one-line customization.
 
 ## Related documents
 

--- a/release-management/README.md
+++ b/release-management/README.md
@@ -1,0 +1,158 @@
+# Release-Artifact Naming Contract
+
+This document is the source of truth for what artifacts every jBOM release
+attaches and where consumers can find them. The release automation in
+[`.github/workflows/semantic-release.yml`](../.github/workflows/semantic-release.yml)
+and the PCM archive builder in
+[`scripts/build_pcm_package.py`](../scripts/build_pcm_package.py) must
+uphold this contract on every release.
+
+## Release tag naming
+
+Semantic-release cuts every release with a plain `vX.Y.Z` tag (e.g.
+`v7.4.0`). There is no separate PCM tag prefix — the same tag anchors
+the PyPI publish and the PCM archive. Historic `pcm-vX.Y.Z` tags are
+retained but no longer produced.
+
+## Attached assets
+
+Every release produced by the automation attaches four files:
+
+| Asset | Purpose | Consumer |
+|---|---|---|
+| `jbom-pcm-<VERSION>.zip` | Canonical, versioned PCM archive | KiCad PCM (via download_url in `metadata.json`) |
+| `jbom-pcm.zip` | Byte-identical copy of the versioned archive under a stable filename | End-users installing via `releases/latest/download/jbom-pcm.zip` |
+| `jbom-<VERSION>-py3-none-any.whl` | PyPI wheel, mirror-attached to VCS release | Developers auditing a specific release's shipped bits |
+| `jbom-<VERSION>.tar.gz` | PyPI sdist, mirror-attached to VCS release | Same |
+
+The two PCM archives (`jbom-pcm-<VERSION>.zip` and `jbom-pcm.zip`) are
+byte-identical. The stable-name copy exists so that
+`https://github.com/plocher/jBOM/releases/latest/download/jbom-pcm.zip`
+resolves to the newest release without any per-release maintenance —
+GitHub resolves the `releases/latest/download/<asset>` URL to whatever
+asset of that name is attached to the newest published release.
+
+## Manifest file
+
+`metadata.json` at the repo root is the KiCad PCM manifest for jBOM.
+Its `versions[0]` entry is rewritten on every release with:
+
+- `version` — matching the release version
+- `download_url` —
+  `https://github.com/plocher/jBOM/releases/download/v<VERSION>/jbom-pcm-<VERSION>.zip`
+  (versioned; PCM requires this)
+- `download_sha256` — SHA-256 of the built PCM archive
+- `install_size` — uncompressed installed size in bytes
+- `download_size` — compressed archive size in bytes
+
+Consumers reading the manifest directly should fetch it from
+`https://raw.githubusercontent.com/plocher/jBOM/main/metadata.json`.
+The release workflow commits the updated manifest back to `main` after
+attaching the release assets so this URL stays authoritative.
+
+A copy of `metadata.json` also ships inside every PCM archive at the
+archive root. That in-archive copy carries the correct version and
+download_url but placeholder hash/size fields, because the hash is
+computed over the archive itself. KiCad reads the authoritative hash
+from the manifest, not from inside the archive.
+
+## Consumer URLs
+
+End-user install (via KiCad PCM):
+
+```
+https://github.com/plocher/jBOM/releases/latest/download/jbom-pcm.zip
+```
+
+Versioned direct download (for reproducible builds, audits, manifest
+references):
+
+```
+https://github.com/plocher/jBOM/releases/download/vX.Y.Z/jbom-pcm-X.Y.Z.zip
+```
+
+Manifest (for third-party PCM registries, mirrors, or CI checks):
+
+```
+https://raw.githubusercontent.com/plocher/jBOM/main/metadata.json
+```
+
+## Automation pipeline
+
+The pipeline lives in a single job in
+[`.github/workflows/semantic-release.yml`](../.github/workflows/semantic-release.yml).
+It fires on every push to `main` and runs these steps in order (all
+release-only steps are gated on `dist/` being non-empty after
+`semantic-release version`, which is the reliable signal that a new
+version was actually cut):
+
+1. `semantic-release version` — determines the next version from
+   Conventional Commits, updates `pyproject.toml` + `src/jbom/__init__.py`,
+   regenerates `CHANGELOG.md`, tags, and pushes.
+2. **Detect release** — inspects `dist/` and reads the new version from
+   `pyproject.toml` for use by later steps.
+3. **Publish to PyPI** — twine-uploads only `dist/*.whl` and
+   `dist/*.tar.gz`. The PCM archive is intentionally excluded from PyPI.
+4. **Install vendored runtime deps** — `pip install -r scripts/_vendor_requirements.txt`
+   so the PCM builder can find pure-Python packages via `importlib.util.find_spec`.
+5. **Build PCM archive and sync `metadata.json`** — runs
+   `python scripts/build_pcm_package.py --update-metadata`, which (a)
+   bumps `versions[0].version` and `download_url` before the archive is
+   staged so the archived manifest carries the new version, and (b)
+   patches `download_sha256` / `install_size` / `download_size` into the
+   repo-root manifest after zipping. A stable-name copy is made with
+   `cp dist/jbom-pcm-<VERSION>.zip dist/jbom-pcm.zip`.
+6. **Attach release assets** — `gh release upload` with `--clobber`
+   attaches the versioned PCM archive, the stable-name copy, and the
+   PyPI wheel + sdist to the `vX.Y.Z` release. `--clobber` makes the
+   step idempotent for workflow re-runs.
+7. **Sync `metadata.json` back to `main`** — commits the patched
+   manifest with `[skip ci]` in the subject line so the push does not
+   re-trigger the release workflow. Skipped when `metadata.json` did
+   not change (safety net).
+
+The `[skip ci]` marker is honored by GitHub Actions and prevents the
+follow-up commit from cascading into another release run. See
+[GitHub docs on skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs).
+
+## Failure modes and recovery
+
+- **Workflow fails after PyPI publish, before asset attach.** PyPI is
+  irrevocable, so a subsequent manual invocation must skip that step.
+  Rerun the workflow with the release-only steps and let `--clobber`
+  overwrite any partial uploads.
+- **`metadata.json` sync push race.** If another commit lands on `main`
+  between the workflow's fetch and its `git push`, the push fails.
+  Re-run the workflow — the second attempt refreshes and re-computes,
+  and `--clobber` makes the asset attach idempotent.
+- **`metadata.json` has drifted manually.** The next release will
+  overwrite `versions[0]` regardless of prior content; drift is
+  self-healing.
+
+## Portability notes
+
+The PCM archive contract described here is specific to jBOM, but the
+mechanics are reusable by sibling KiCad-plugin projects (e.g. `kproj`)
+that follow the same conventions:
+
+- `metadata.json` at the repo root, with `resources.homepage` pointing
+  at the project's GitHub URL.
+- `scripts/build_pcm_package.py` (or an equivalent vendored copy)
+  accepting the same `--update-metadata` flag and its
+  `archive_name_template` argument.
+- Semantic-release-driven `vX.Y.Z` tagging.
+
+`_update_metadata` in the builder derives the `download_url` owner /
+repo from `resources.homepage`, so the same code produces correct URLs
+for any repo following the shape. The archive filename template is a
+parameter, so `kproj-pcm-{version}.zip` is a one-line change.
+
+## Related documents
+
+- [`release-management/WARP.md`](WARP.md) — semantic-release
+  operational guidance, secrets, and pre-commit rules.
+- [`release-management/version-management.md`](version-management.md) —
+  version-file layout and the single-source-of-truth rule.
+- [`release-management/github-secrets-setup.md`](github-secrets-setup.md)
+  — required secrets (`GITHUB_TOKEN`, `PYPI_API_TOKEN`).
+- Root [`README.md`](../README.md) — end-user PCM install instructions.

--- a/scripts/build_pcm_package.py
+++ b/scripts/build_pcm_package.py
@@ -49,9 +49,14 @@ Flags
 --output-dir DIR
     Directory where the zip is written (default: ``dist/``).
 --update-metadata
-    After building, patch ``metadata.json`` in the repo root with the computed
-    ``download_sha256``, ``install_size``, and ``download_size`` for the
-    current version.  Useful when preparing a release.
+    Synchronize ``metadata.json`` in the repo root with the current build.
+    This flag now performs a two-phase update: before the archive is staged,
+    ``versions[0].version`` and ``download_url`` are rewritten to match the
+    current build version and the ``vX.Y.Z`` release-tag pattern (so the
+    archived copy of ``metadata.json`` also carries the new version). After
+    the zip is built, ``download_sha256``, ``install_size``, and
+    ``download_size`` are patched in with the final values.
+    Used by the release workflow to keep the PCM manifest authoritative.
 --skip-binary-fetch
     Do not call ``pip download`` for compiled deps; only vendor the build
     host's local pydantic_core.  Useful for offline CI smoke tests and for
@@ -72,6 +77,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -442,24 +448,131 @@ def _read_version() -> str:
     raise RuntimeError(f"Cannot read __version__ from {init_py}")
 
 
+# Default PCM archive-name template. Sibling projects (e.g. kproj) reuse
+# this script by passing their own ``archive_name_template`` when they
+# call ``_update_metadata`` from their own workflow.
+_DEFAULT_ARCHIVE_NAME_TEMPLATE = "jbom-pcm-{version}.zip"
+
+# GitHub homepage → (owner, repo) parser. Trailing slash tolerated;
+# ``.git`` suffix tolerated in case a repo URL was accidentally used.
+_GITHUB_HOMEPAGE_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+def _parse_github_homepage(homepage: str) -> tuple[str, str]:
+    """Return ``(owner, repo)`` parsed from a GitHub homepage URL.
+
+    Raises ``RuntimeError`` when the URL does not match the expected shape;
+    the release-artifact contract in ``release-management/README.md``
+    depends on this URL being derivable so we surface the misconfiguration
+    instead of silently emitting a broken download_url.
+    """
+    match = _GITHUB_HOMEPAGE_RE.match(homepage.strip())
+    if match is None:
+        raise RuntimeError(
+            f"resources.homepage {homepage!r} is not a github.com/<owner>/<repo> URL; "
+            "cannot derive download_url. Fix metadata.json.resources.homepage."
+        )
+    return match.group("owner"), match.group("repo")
+
+
+def _build_download_url(homepage: str, version: str, archive_name_template: str) -> str:
+    """Return the canonical ``download_url`` for a ``vX.Y.Z`` release tag."""
+    owner, repo = _parse_github_homepage(homepage)
+    archive_name = archive_name_template.format(version=version)
+    return (
+        f"https://github.com/{owner}/{repo}/releases/download/"
+        f"v{version}/{archive_name}"
+    )
+
+
+def _default_version_entry(version: str) -> dict:
+    """Return a schema-shaped ``versions[]`` entry with placeholder hash/sizes."""
+    return {
+        "version": version,
+        "status": "stable",
+        "kicad_version": "9.0",
+        "kicad_version_max": "",
+        "download_url": "",
+        "download_sha256": "",
+        "install_size": 0,
+        "download_size": 0,
+    }
+
+
 def _update_metadata(
     version: str,
-    sha256: str,
-    install_size: int,
-    download_size: int,
+    *,
+    sha256: str | None = None,
+    install_size: int | None = None,
+    download_size: int | None = None,
+    metadata_path: Path | None = None,
+    archive_name_template: str = _DEFAULT_ARCHIVE_NAME_TEMPLATE,
 ) -> None:
-    """Patch the repo-root metadata.json with computed release values."""
-    data = json.loads(_METADATA_SRC.read_text(encoding="utf-8"))
-    for v in data.get("versions", []):
-        if v.get("version") == version:
-            v["download_sha256"] = sha256
-            v["install_size"] = install_size
-            v["download_size"] = download_size
-    _METADATA_SRC.write_text(
+    """Synchronize ``metadata.json`` with the current build.
+
+    Always rewrites ``versions[0].version`` and ``download_url`` so the PCM
+    manifest tracks the release currently being built. When ``sha256`` /
+    ``install_size`` / ``download_size`` are supplied, they are written in
+    the same pass. When they are omitted (the pre-archive-staging call),
+    the hash and size fields are reset to placeholders so the archived
+    copy of metadata.json never advertises a stale hash.
+
+    Args:
+        version: The release version (e.g. ``"7.4.0"``).
+        sha256: Optional lowercase hex SHA-256 of the built archive.
+        install_size: Optional uncompressed installed size in bytes.
+        download_size: Optional compressed archive size in bytes.
+        metadata_path: Path to the metadata.json to patch. Defaults to the
+            repo-root manifest. Overridable for tests and for sibling
+            projects that vendor this script.
+        archive_name_template: Format string for the archive filename; must
+            contain ``{version}``. Defaults to ``jbom-pcm-{version}.zip``.
+
+    Regression guard for #338: earlier revisions only patched sha256/sizes
+    on a ``versions[]`` entry whose ``version`` already matched the build,
+    so once semantic-release bumped past the pinned version the manifest
+    silently stopped updating. The new behavior always bumps the entry.
+    """
+    if metadata_path is None:
+        metadata_path = _METADATA_SRC
+
+    data = json.loads(metadata_path.read_text(encoding="utf-8"))
+    homepage = data.get("resources", {}).get("homepage", "")
+    download_url = _build_download_url(homepage, version, archive_name_template)
+
+    versions = data.setdefault("versions", [])
+    if not versions:
+        entry = _default_version_entry(version)
+        versions.append(entry)
+    else:
+        entry = versions[0]
+
+    entry["version"] = version
+    entry["download_url"] = download_url
+
+    if sha256 is not None:
+        entry["download_sha256"] = sha256
+    else:
+        entry["download_sha256"] = ""
+    if install_size is not None:
+        entry["install_size"] = install_size
+    else:
+        entry["install_size"] = 0
+    if download_size is not None:
+        entry["download_size"] = download_size
+    else:
+        entry["download_size"] = 0
+
+    metadata_path.write_text(
         json.dumps(data, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    print(f"  updated metadata.json with sha256={sha256[:16]}…")
+    if sha256:
+        print(f"  updated {metadata_path.name}: v{version} " f"sha256={sha256[:16]}…")
+    else:
+        print(f"  updated {metadata_path.name}: v{version} (hash pending)")
 
 
 # ---------------------------------------------------------------------------
@@ -558,6 +671,13 @@ def build(
         # ------------------------------------------------------------------
         # 4. metadata.json → archive root
         # ------------------------------------------------------------------
+        # Pre-stage version+URL sync: ensures the metadata.json that ships
+        # inside the archive carries the version being built (hash/sizes are
+        # placeholders here and are patched into the repo-root manifest in a
+        # second call after zipping — KiCad reads the authoritative manifest
+        # from the release URL, not from inside the archive).
+        if update_metadata:
+            _update_metadata(version)
         print("  copying metadata.json…")
         shutil.copy2(_METADATA_SRC, stage / "metadata.json")
 
@@ -585,7 +705,12 @@ def build(
         print(f"  download: {download_size:,} bytes (compressed)")
 
         if update_metadata:
-            _update_metadata(version, sha256, install_size, download_size)
+            _update_metadata(
+                version,
+                sha256=sha256,
+                install_size=install_size,
+                download_size=download_size,
+            )
 
         return output_zip
 

--- a/tests/unit/test_build_pcm_package.py
+++ b/tests/unit/test_build_pcm_package.py
@@ -1,19 +1,20 @@
-"""Integration smoke tests for ``scripts/build_pcm_package.py``.
+"""Tests for ``scripts/build_pcm_package.py``.
 
-These tests exercise the build script with ``--skip-binary-fetch`` so they
-run without network access.  They verify the resulting archive layout
-matches expectations:
+Two groups of coverage live here:
 
-* ``plugins/__init__.py`` and the rest of the plugin adapter are present.
-* ``plugins/jbom/`` contains the vendored core (no ``plugin/`` subdir).
-* Pure-Python deps live at ``plugins/<name>/`` (e.g. ``plugins/pydantic/``).
-* The compiled-deps layout exists at ``plugins/_vendor/pydantic_core/<tag>/``.
-* ``metadata.json`` is present at the archive root.
+* Integration smoke tests that exercise the build script with
+  ``--skip-binary-fetch`` so they run without network access. They verify
+  the resulting archive layout matches expectations.
+* Unit tests for ``_update_metadata`` — the metadata.json sync logic that
+  bumps ``versions[0].version`` and rebuilds ``download_url`` from the
+  release tag pattern on every build. These tests use a scratch metadata
+  file so they don't mutate the real repo-root ``metadata.json``.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import zipfile
 from pathlib import Path
@@ -134,3 +135,244 @@ def test_skip_binary_fetch_build_produces_expected_layout(
     # ActionPlugin toolbar icons (light/dark) bundled with plugin sources
     assert "plugins/assets/icons/pcb-fabrication-tool-light-24.png" in names
     assert "plugins/assets/icons/pcb-fabrication-tool-dark-24.png" in names
+
+
+# ---------------------------------------------------------------------------
+# _update_metadata: metadata.json version + download_url sync
+# ---------------------------------------------------------------------------
+
+
+def _write_metadata(
+    path: Path,
+    *,
+    versions: list[dict] | None = None,
+    homepage: str = "https://github.com/plocher/jBOM",
+) -> None:
+    """Write a minimal PCM-shaped metadata.json to *path*."""
+    data = {
+        "$schema": "https://go.kicad.org/pcm/schemas/v1",
+        "name": "jBOM Fabrication",
+        "identifier": "com.spcoast.jbom",
+        "type": "plugin",
+        "license": "MIT",
+        "resources": {"homepage": homepage},
+        "versions": versions if versions is not None else [],
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_metadata(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_update_metadata_overwrites_stale_version_entry(
+    tmp_path: Path, build_module
+) -> None:
+    """A stale versions[0] entry gets its version and download_url rebuilt.
+
+    Regression guard for #338: previously ``_update_metadata`` only patched
+    sha256/sizes on a *matching-version* entry, so once semantic-release
+    bumped past the pinned version the manifest silently stopped updating.
+    """
+    meta = tmp_path / "metadata.json"
+    _write_metadata(
+        meta,
+        versions=[
+            {
+                "version": "6.53.0",
+                "status": "stable",
+                "kicad_version": "9.0",
+                "kicad_version_max": "",
+                "download_url": (
+                    "https://github.com/plocher/jBOM/releases/download/"
+                    "pcm-v6.53.0/jbom-pcm-6.53.0.zip"
+                ),
+                "download_sha256": "deadbeef",
+                "install_size": 111,
+                "download_size": 222,
+            }
+        ],
+    )
+
+    build_module._update_metadata(
+        "7.4.0",
+        sha256="a" * 64,
+        install_size=1000,
+        download_size=500,
+        metadata_path=meta,
+    )
+
+    entry = _read_metadata(meta)["versions"][0]
+    assert entry["version"] == "7.4.0"
+    assert entry["download_url"] == (
+        "https://github.com/plocher/jBOM/releases/download/" "v7.4.0/jbom-pcm-7.4.0.zip"
+    )
+    assert entry["download_sha256"] == "a" * 64
+    assert entry["install_size"] == 1000
+    assert entry["download_size"] == 500
+
+
+def test_update_metadata_creates_entry_when_versions_empty(
+    tmp_path: Path, build_module
+) -> None:
+    """An empty ``versions`` list is populated with a full new-release entry."""
+    meta = tmp_path / "metadata.json"
+    _write_metadata(meta, versions=[])
+
+    build_module._update_metadata(
+        "7.4.0",
+        sha256="b" * 64,
+        install_size=42,
+        download_size=21,
+        metadata_path=meta,
+    )
+
+    versions = _read_metadata(meta)["versions"]
+    assert len(versions) == 1
+    assert versions[0]["version"] == "7.4.0"
+    assert versions[0]["download_url"].endswith("/v7.4.0/jbom-pcm-7.4.0.zip")
+    assert versions[0]["download_sha256"] == "b" * 64
+    assert versions[0]["install_size"] == 42
+    assert versions[0]["download_size"] == 21
+    # Sane defaults for schema-required fields.
+    assert "status" in versions[0]
+    assert "kicad_version" in versions[0]
+
+
+def test_update_metadata_preserves_schema_fields_on_bump(
+    tmp_path: Path, build_module
+) -> None:
+    """``status``, ``kicad_version``, ``kicad_version_max`` are preserved."""
+    meta = tmp_path / "metadata.json"
+    _write_metadata(
+        meta,
+        versions=[
+            {
+                "version": "6.53.0",
+                "status": "testing",
+                "kicad_version": "9.0",
+                "kicad_version_max": "9.99",
+                "download_url": "stale",
+                "download_sha256": "",
+                "install_size": 0,
+                "download_size": 0,
+            }
+        ],
+    )
+
+    build_module._update_metadata(
+        "7.4.0",
+        sha256="c" * 64,
+        install_size=1,
+        download_size=1,
+        metadata_path=meta,
+    )
+
+    entry = _read_metadata(meta)["versions"][0]
+    assert entry["status"] == "testing"
+    assert entry["kicad_version"] == "9.0"
+    assert entry["kicad_version_max"] == "9.99"
+
+
+def test_update_metadata_matching_version_still_patches_sha256(
+    tmp_path: Path, build_module
+) -> None:
+    """Backward-compat: matching version entries still get sha256/sizes patched."""
+    meta = tmp_path / "metadata.json"
+    _write_metadata(
+        meta,
+        versions=[
+            {
+                "version": "7.4.0",
+                "status": "stable",
+                "kicad_version": "9.0",
+                "kicad_version_max": "",
+                "download_url": (
+                    "https://github.com/plocher/jBOM/releases/download/"
+                    "v7.4.0/jbom-pcm-7.4.0.zip"
+                ),
+                "download_sha256": "",
+                "install_size": 0,
+                "download_size": 0,
+            }
+        ],
+    )
+
+    build_module._update_metadata(
+        "7.4.0",
+        sha256="d" * 64,
+        install_size=999,
+        download_size=333,
+        metadata_path=meta,
+    )
+
+    entry = _read_metadata(meta)["versions"][0]
+    assert entry["version"] == "7.4.0"
+    assert entry["download_sha256"] == "d" * 64
+    assert entry["install_size"] == 999
+    assert entry["download_size"] == 333
+
+
+def test_update_metadata_derives_owner_repo_from_homepage(
+    tmp_path: Path, build_module
+) -> None:
+    """``download_url`` is derived from ``resources.homepage``.
+
+    This portability guarantee is what lets sibling projects (e.g. kproj)
+    reuse this script by simply pointing their ``resources.homepage`` at
+    their own GitHub repo.
+    """
+    meta = tmp_path / "metadata.json"
+    _write_metadata(meta, homepage="https://github.com/example-org/kproj")
+
+    build_module._update_metadata(
+        "1.2.3",
+        sha256="e" * 64,
+        install_size=1,
+        download_size=1,
+        metadata_path=meta,
+        archive_name_template="kproj-pcm-{version}.zip",
+    )
+
+    entry = _read_metadata(meta)["versions"][0]
+    assert entry["download_url"] == (
+        "https://github.com/example-org/kproj/releases/download/"
+        "v1.2.3/kproj-pcm-1.2.3.zip"
+    )
+
+
+def test_update_metadata_accepts_version_only_call(
+    tmp_path: Path, build_module
+) -> None:
+    """Called with only ``version=``, the entry is rewritten with placeholder hash/sizes.
+
+    Used by the workflow's two-phase update: (1) bump version+URL before
+    the archive is staged so the archived ``metadata.json`` carries the
+    new version, then (2) after zipping, patch sha256/sizes.
+    """
+    meta = tmp_path / "metadata.json"
+    _write_metadata(
+        meta,
+        versions=[
+            {
+                "version": "6.53.0",
+                "status": "stable",
+                "kicad_version": "9.0",
+                "kicad_version_max": "",
+                "download_url": "stale",
+                "download_sha256": "deadbeef",
+                "install_size": 111,
+                "download_size": 222,
+            }
+        ],
+    )
+
+    build_module._update_metadata("7.4.0", metadata_path=meta)
+
+    entry = _read_metadata(meta)["versions"][0]
+    assert entry["version"] == "7.4.0"
+    assert entry["download_url"].endswith("/v7.4.0/jbom-pcm-7.4.0.zip")
+    # Hash/sizes reset — they are re-populated by the post-zip second call.
+    assert entry["download_sha256"] == ""
+    assert entry["install_size"] == 0
+    assert entry["download_size"] == 0


### PR DESCRIPTION
Closes #338.

## Summary

Automates the PCM release-artifact contract described in the new
`release-management/README.md`. After semantic-release cuts a `vX.Y.Z`
tag, the workflow now:

1. Publishes the wheel + sdist to PyPI (existing).
2. Installs pinned vendored deps and builds `dist/jbom-pcm-<VERSION>.zip`.
3. Copies it to `dist/jbom-pcm.zip` so
   `releases/latest/download/jbom-pcm.zip` resolves without maintenance.
4. Attaches PCM (versioned + stable-name) plus wheel + sdist to the VCS
   Release with `gh release upload --clobber`.
5. Commits the updated `metadata.json` back to `main` with `[skip ci]`.

Latest release `v7.3.2` currently has zero assets attached; the next
release cut under this workflow will restore all four canonical assets.

## Key design decisions (agreed with maintainer up-front)

1. **In-place workflow extension** rather than a companion workflow —
   avoids the well-known GitHub gotcha where `release: published`
   events triggered by `GITHUB_TOKEN` don't fire follow-on workflows.
2. **Extended `--update-metadata`** to always overwrite `versions[0]`
   with the current build's version and rebuild `download_url` from
   the `vX.Y.Z` tag pattern. Previously this flag silently no-oped
   after any semantic-release bump because it only patched matching
   version entries. Manifest was stuck at 6.53.0 as a result.
3. **`[skip ci]` sync commit** so `metadata.json` at the raw content
   URL stays authoritative without cascading another release run.
4. **Opportunistic scope** — attach wheel + sdist to the VCS release
   too, restoring parity with typical Python-project releases (they
   were previously PyPI-only).

## Portability

`_update_metadata` derives owner/repo from `resources.homepage` and
takes an `archive_name_template` argument, so the same script is
reusable by the sibling `kproj` project. That port is parked as a
follow-up after this lands.

## Validation

All jBOM validation gates run clean on this branch:

- `PYTHONPATH=src python -m pytest tests/` — **1478 passed** (nine of
  those are for `_update_metadata`: six new, three pre-existing).
- `PYTHONPATH=src python -m behave --format progress` — **49
  features, 275 scenarios passed, 0 failed, 8 skipped** (2m 53s).
- `pre-commit` — clean on all four changed files after black
  reformat + iterative re-stage.

The workflow YAML itself cannot be exercised locally (it needs a real
GitHub Release), but:

- YAML syntax validated with `yaml.safe_load`.
- The version-extraction one-liner was validated locally against the
  current `pyproject.toml` (returns `7.3.2`).
- The archive-build path is exercised by the existing
  `test_skip_binary_fetch_build_produces_expected_layout` smoke test,
  which still passes.

## Files touched

- `scripts/build_pcm_package.py` — restructured `_update_metadata` for
  two-phase sync; added `_parse_github_homepage`,
  `_build_download_url`, `_default_version_entry` helpers.
- `tests/unit/test_build_pcm_package.py` — six new unit tests.
- `.github/workflows/semantic-release.yml` — four new steps after
  `semantic-release version`, all gated on release-detected flag.
- `release-management/README.md` — new file, release-artifact naming
  contract.

## Follow-up (not part of this PR)

- Apply the same automation pattern to the peer `kproj` project. Will
  be tracked as a separate issue in that repo once this lands.

## Conversation

- Warp conversation: https://app.warp.dev/conversation/25f5f302-f25d-440c-bf03-aca63e4ab6bf

Co-Authored-By: Oz <oz-agent@warp.dev>
