### PR TITLE
ci(release): bump release-workflow runner to Python 3.10 to match declared floor

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -26,7 +26,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        # Match jBOM's declared floor (``requires-python = ">=3.10"``) so
+        # the release build catches accidental 3.11+ usage before it
+        # reaches users on the minimum supported version. Runner version
+        # is discipline-neutral for the built artifact (pure-Python
+        # wheel + sdist). See release-management/README.md#portability-and-the-shared-process-principle.
+        python-version: "3.10"
 
     - name: Install python-semantic-release
       run: |

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,50 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+How the `/wayfinder` skill expresses maps, tickets, blocking, and the frontier in this repo. (This tracker lacks `gh`-accessible native issue dependencies, so blocking uses the body convention below.)
+
+### Labels
+
+- The **map** is a GitHub issue labelled `wayfinder:map`.
+- Each **ticket** is a GitHub issue labelled `wayfinder:<type>`, one of: `wayfinder:research`, `wayfinder:prototype`, `wayfinder:grilling`, `wayfinder:task`.
+
+(All five labels already exist in this repo.)
+
+### Parent / child
+
+A ticket declares its map with a first-line body reference:
+
+```
+Map: #<map-number>
+```
+
+List a map's children: `gh issue list --state all --search "Map: #<map-number> in:body" --json number,title,state,labels,assignees`
+
+### Blocking
+
+A ticket declares its blockers with a body line (comma/space separated issue refs):
+
+```
+Blocked by: #<n>, #<m>
+```
+
+A ticket is **unblocked** when every issue it lists as `Blocked by:` is closed. Update the body line (`gh issue edit <number> --body ...`) if edges change; do not track blocking in comments.
+
+### Frontier
+
+The frontier = open children of the map that are **unblocked** and **unclaimed**. Compute it by listing the map's open children, then filtering out any whose `Blocked by:` references an open issue and any with an assignee.
+
+### Claiming
+
+A session claims a ticket by assigning it before any work: `gh issue edit <number> --add-assignee @me`. An open, unassigned ticket is unclaimed.
+
+### Resolving
+
+Post the answer as a resolution comment and close in one step: `gh issue close <number> --comment "Resolution: ..."`. Then append a one-line entry to the map's `## Decisions so far` section (`gh issue edit <map-number> --body ...`), linking the closed ticket by title.
+
+### Assets
+
+Link assets (research summaries, prototypes) from the ticket — as URLs or repo paths in the resolution comment — rather than pasting their content into the issue body.


### PR DESCRIPTION
Closes #340.

## Change

One-line workflow edit in `.github/workflows/semantic-release.yml`: `python-version: "3.11"` → `"3.10"`, with an inline comment referencing the shared-process contract in `release-management/README.md`.

Added /wayfinder skill details to agent instructions

## Rationale

jBOM's `pyproject.toml` declares `requires-python = ">=3.10"` and classifies 3.10, 3.11, and 3.12 as supported, but the release workflow was pinned to 3.11 — the last remaining floor-alignment drift after the peer work in [plocher/kproj#28](https://github.com/plocher/kproj/pull/28). Per the "match-the-floor" discipline codified in the [Portability and Shared-Process section](https://github.com/plocher/jBOM/blob/main/release-management/README.md#portability-and-the-shared-process-principle) of `release-management/README.md`, building on the declared floor catches accidental 3.11+ usage before it reaches users on the minimum supported version.

The kproj peer work is the concrete precedent: dropping its own workflow to 3.10 surfaced two real 3.11-only stdlib APIs (`typing.Self`, `datetime.UTC`) that its declared-3.10 users would have hit at runtime.

## Behavior-neutral

Runner version has no effect on the built artifact for pure-Python wheel/sdist projects (`py3-none-any` wheels are identical across 3.10, 3.11, 3.12). The PCM archive build, `metadata.json` sync, and release-attach steps are unaffected — no downstream code change required.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` — YAML still parses cleanly.
- `pre-commit run --files .github/workflows/semantic-release.yml` — clean.
- Cannot exercise `actions/setup-python@v5` locally, but 3.10 is a supported version and semantic-release + build + twine + gh CLI all work identically on 3.10 vs 3.11.

## Verification on next release

- Actions log will show `Set up Python` step using 3.10.
- Release assets should still land as usual (`jbom-<VERSION>-py3-none-any.whl`, `jbom-<VERSION>.tar.gz`, `jbom-pcm-<VERSION>.zip`, `jbom-pcm.zip`) — the workflow's business logic didn't change.

## References

- kproj PR that established the discipline: https://github.com/plocher/kproj/pull/28
- kproj tracking issue: https://github.com/plocher/kproj/issues/27
- Shared-process contract: https://github.com/plocher/jBOM/blob/main/release-management/README.md

## Conversation

- Warp conversation: https://app.warp.dev/conversation/25f5f302-f25d-440c-bf03-aca63e4ab6bf

Co-Authored-By: Oz <oz-agent@warp.dev>
