### PR TITLE
docs: ready-for-agent model guidance; fix: harden post_merge_cleanup

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -9,3 +9,12 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 - `wontfix` -> `wontfix` (will not be actioned)
 
 When a skill mentions a role (for example "apply the AFK-ready triage label"), use the corresponding label string from this mapping.
+
+## Model guidance for `ready-for-agent` issues
+
+When applying `ready-for-agent`, add a `Suggested model:` line to the issue body when the choice matters. Default to cost-effective models — a fully-specified ticket needs execution, not deep reasoning. Reserve high-reasoning / high-cost models for issues that genuinely require them (novel design work, subtle cross-cutting refactors, specialized domain knowledge), and justify the spend in the suggestion.
+
+Examples:
+
+- `Suggested model: cost-effective tier — well-specified plumbing; acceptance criteria are mechanical.`
+- `Suggested model: high-reasoning tier — cross-service refactor with subtle rollback semantics.`

--- a/scripts/post_merge_cleanup.py
+++ b/scripts/post_merge_cleanup.py
@@ -19,9 +19,14 @@ RFE behavior:
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
+
+#: Upper bound for git operations that touch the network (fetch, push).
+#: Generous enough for slow links; prevents indefinite silent stalls.
+GIT_NETWORK_TIMEOUT_SECONDS = 120.0
 
 
 @dataclass(frozen=True)
@@ -74,15 +79,39 @@ class CleanupOutcome:
 
 
 def run_git(
-    args: list[str], *, capture_output: bool = True
+    args: list[str], *, capture_output: bool = True, timeout: float | None = None
 ) -> subprocess.CompletedProcess[str]:
-    """Run a git command and return the completed process without raising."""
-    return subprocess.run(
-        ["git", "--no-pager", *args],
-        check=False,
-        text=True,
-        capture_output=capture_output,
-    )
+    """Run a git command and return the completed process without raising.
+
+    Hardened against silent hangs (#364):
+    - stdin is redirected to DEVNULL so git can never block on hidden prompts
+      (prompt text would otherwise be swallowed by the captured stderr)
+    - GIT_TERMINAL_PROMPT=0 and ssh BatchMode make git fail fast instead of
+      prompting for credentials/passphrases/host keys
+    - an optional timeout bounds network operations; expiry is converted to
+      a failed CompletedProcess rather than an exception
+    """
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
+    cmd = ["git", "--no-pager", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            capture_output=capture_output,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=124,
+            stdout="",
+            stderr=f"git {' '.join(args)} timed out after {timeout}s",
+        )
 
 
 def git_ref_exists(ref: str) -> bool:
@@ -108,7 +137,7 @@ def fetch_and_prune(remote: str, *, dry_run: bool, verbose: bool) -> int:
             print(f"[dry-run] git --no-pager {' '.join(cmd)}")
         return 0
 
-    result = run_git(cmd, capture_output=True)
+    result = run_git(cmd, capture_output=True, timeout=GIT_NETWORK_TIMEOUT_SECONDS)
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
         print(f"Error: failed to fetch/prune {remote}: {stderr}", file=sys.stderr)
@@ -219,7 +248,7 @@ def delete_remote_branch(
             print(f"[dry-run] git --no-pager {' '.join(cmd)}")
         return 0
 
-    result = run_git(cmd, capture_output=True)
+    result = run_git(cmd, capture_output=True, timeout=GIT_NETWORK_TIMEOUT_SECONDS)
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
         print(

--- a/tests/test_post_merge_cleanup.py
+++ b/tests/test_post_merge_cleanup.py
@@ -1,0 +1,138 @@
+"""Unit tests for scripts/post_merge_cleanup.py subprocess hardening (#364).
+
+Covers the anti-hang guarantees of ``run_git``:
+- stdin is redirected to DEVNULL so git can never block on hidden prompts
+- interactive prompting is disabled via GIT_TERMINAL_PROMPT / ssh BatchMode
+- network operations (fetch/prune, remote delete) pass a timeout
+- a timeout expiry is converted into a failed result, not an exception
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "post_merge_cleanup.py"
+
+
+@pytest.fixture(scope="module")
+def cleanup_module() -> ModuleType:
+    """Load scripts/post_merge_cleanup.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("post_merge_cleanup", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    """Build a benign CompletedProcess for mocking subprocess.run."""
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout="", stderr=""
+    )
+
+
+class TestRunGitHardening:
+    """run_git must be immune to interactive prompts and silent stalls."""
+
+    def test_stdin_redirected_to_devnull(self, cleanup_module: ModuleType) -> None:
+        """git subprocesses must not inherit the TTY on stdin."""
+        with mock.patch("subprocess.run", return_value=_completed()) as run_mock:
+            cleanup_module.run_git(["status"])
+        assert run_mock.call_args.kwargs["stdin"] == subprocess.DEVNULL
+
+    def test_terminal_prompts_disabled(self, cleanup_module: ModuleType) -> None:
+        """Child env must set GIT_TERMINAL_PROMPT=0 and ssh BatchMode."""
+        with mock.patch("subprocess.run", return_value=_completed()) as run_mock:
+            cleanup_module.run_git(["status"])
+        env = run_mock.call_args.kwargs["env"]
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
+
+    def test_existing_git_ssh_command_respected(
+        self, cleanup_module: ModuleType
+    ) -> None:
+        """A caller-provided GIT_SSH_COMMAND must not be overridden."""
+        with mock.patch.dict(os.environ, {"GIT_SSH_COMMAND": "custom-ssh -i key"}):
+            with mock.patch("subprocess.run", return_value=_completed()) as run_mock:
+                cleanup_module.run_git(["status"])
+        env = run_mock.call_args.kwargs["env"]
+        assert env["GIT_SSH_COMMAND"] == "custom-ssh -i key"
+
+    def test_timeout_forwarded_to_subprocess(self, cleanup_module: ModuleType) -> None:
+        """An explicit timeout must reach subprocess.run."""
+        with mock.patch("subprocess.run", return_value=_completed()) as run_mock:
+            cleanup_module.run_git(["push"], timeout=42.0)
+        assert run_mock.call_args.kwargs["timeout"] == 42.0
+
+    def test_timeout_expiry_becomes_failed_result(
+        self, cleanup_module: ModuleType
+    ) -> None:
+        """TimeoutExpired must surface as a failed result with a clear error."""
+        with mock.patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["git", "push"], timeout=5.0),
+        ):
+            result = cleanup_module.run_git(["push"], timeout=5.0)
+        assert result.returncode != 0
+        assert "timed out" in result.stderr
+
+
+class TestNetworkOperationTimeouts:
+    """Network-facing helpers must bound their git calls with a timeout."""
+
+    def test_fetch_and_prune_uses_network_timeout(
+        self, cleanup_module: ModuleType
+    ) -> None:
+        """fetch --prune must pass the module network timeout."""
+        with mock.patch.object(
+            cleanup_module, "run_git", return_value=_completed()
+        ) as run_git_mock:
+            code = cleanup_module.fetch_and_prune(
+                "origin", dry_run=False, verbose=False
+            )
+        assert code == 0
+        assert (
+            run_git_mock.call_args.kwargs["timeout"]
+            == cleanup_module.GIT_NETWORK_TIMEOUT_SECONDS
+        )
+
+    def test_delete_remote_branch_uses_network_timeout(
+        self, cleanup_module: ModuleType
+    ) -> None:
+        """push --delete must pass the module network timeout."""
+        with mock.patch.object(
+            cleanup_module, "run_git", return_value=_completed()
+        ) as run_git_mock:
+            code = cleanup_module.delete_remote_branch(
+                "origin", "feature/x", dry_run=False, verbose=False
+            )
+        assert code == 0
+        assert (
+            run_git_mock.call_args.kwargs["timeout"]
+            == cleanup_module.GIT_NETWORK_TIMEOUT_SECONDS
+        )
+
+    def test_timed_out_remote_delete_reports_error(
+        self, cleanup_module: ModuleType
+    ) -> None:
+        """A timed-out remote delete must return a non-zero code, not hang."""
+        timed_out = subprocess.CompletedProcess(
+            args=["git"], returncode=124, stdout="", stderr="timed out after 5.0s"
+        )
+        with mock.patch.object(cleanup_module, "run_git", return_value=timed_out):
+            code = cleanup_module.delete_remote_branch(
+                "origin", "feature/x", dry_run=False, verbose=False
+            )
+        assert code != 0


### PR DESCRIPTION
## Summary

Two small changes:

1. **docs (#362)**: Adds a "Model guidance for `ready-for-agent` issues" section to `docs/agents/triage-labels.md`, codifying the convention of including a `Suggested model:` line in agent-ready issue bodies — defaulting to cost-effective models, with high-reasoning tiers reserved for issues that justify the spend. Matching sections are on the open PR branches for kproj (plocher/kproj#33) and SPCoast-inventory (plocher/SPCoast-inventory#3).

2. **fix (#364)**: Hardens `scripts/post_merge_cleanup.py` against silent hangs: `run_git` now redirects stdin to DEVNULL, disables interactive git/ssh prompts (`GIT_TERMINAL_PROMPT=0`, ssh `BatchMode=yes` — caller-provided `GIT_SSH_COMMAND` is respected), and bounds the network operations (`fetch --prune`, `push --delete`) with a 120s timeout that surfaces as a failed result instead of an indefinite stall. TDD'd with 8 new unit tests in `tests/test_post_merge_cleanup.py`.

Closes #362
Closes #364

## Validation

- pytest: 1486 passed (includes 8 new post_merge_cleanup tests)
- behave: 49 features / 275 scenarios passed, 0 failed
- pre-commit: clean
- smoke: `python scripts/post_merge_cleanup.py --dry-run --verbose` behaves as before
