### PR TITLE
feat(inventory): always-on staging fetch for datasheet URLs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -341,6 +341,17 @@ Generates an initial inventory template from schematic components. The output is
 **-v, --verbose**
 : Show loading and processing diagnostics.
 
+### Datasheet staging fetch (side effect)
+
+When `--supplier` is given, every Item's Datasheet URL encountered during
+enrichment (freshly populated by a supplier candidate, or already present on
+the row) is fetched into a staging directory for later human review. This
+rides the same always-on staging fetch as `jbom search` -- see that
+command's "Datasheet staging fetch" note above for the full behavior
+(idempotency, PDF/HTML verification, fetch budget, profile-based
+configuration). Items that already have a `Datasheet Name` (already in the
+Library) are skipped for free, without a network call.
+
 ## PROMOTE COMMAND
 
 ```
@@ -485,8 +496,43 @@ Searches distributor catalogs for parts matching a keyword or part number.
   - Use `-o -` for CSV to stdout.
   - Otherwise, treat the value as a file path.
 
+**--inventory CATALOG_CSV**
+: Optional. Cross-reference results against an existing inventory catalog so
+  already-admitted Datasheet documents (rows with a populated `Datasheet
+  Name`) are never re-staged by the datasheet staging fetch (see below).
+
 **-F, --force, --Force**
 : Overwrite an existing output file.
+
+### Datasheet staging fetch (side effect, opt-in per machine)
+
+Whenever a search result carries a Datasheet URL, `jbom search` fetches it
+into a staging directory for later human review, in addition to printing
+results (jBOM#355). This is **inert by default**: `staging_dir` is a
+user-machine binding (it names a local SPCoast-inventory checkout) that the
+shipped profile never sets, so nothing changes for any invocation until you
+configure it once in your own `~/.jbom/common.jbom.yaml` -- see
+[`configuration.md`](configuration.md#datasheet_staging-sub-stanza-jbom355).
+Once configured:
+
+- Downloads land with a `.unverified` suffix until a `file(1)`-style content
+  check confirms the payload is a real PDF; verified files get a plain
+  `.pdf` suffix. HTML responses (a common supplier-side "document not
+  found" placeholder) stay flagged `.unverified` and print a warning to
+  stderr; they are never admitted automatically.
+- Idempotent: a URL already staged (verified or flagged) is never re-fetched.
+  When `--inventory` is given, a URL already admitted (`Datasheet Name`
+  populated on a matching row) is also skipped.
+- Bounded: one invocation attempts at most `datasheet_staging.max_fetches_per_run`
+  real fetches (shipped default 20) within `fetch_time_budget_seconds`
+  (shipped default 30). Once either limit is hit, remaining URLs are
+  skipped with a one-line stderr summary; the command still succeeds.
+- Never fails the command: fetch errors are reported as stderr warnings only.
+
+`jbom inventory --supplier` has the identical side effect for every Item's
+Datasheet URL encountered during supplier enrichment (see the INVENTORY
+COMMAND section above); it does not need `--inventory` for admitted-skip
+since it already operates on inventory Items directly.
 
 ## GERBERS COMMAND
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -166,6 +166,56 @@ Activate by setting:
 export JBOM_PROFILE_PATH=/shared/jbom
 ```
 
+### `datasheet_staging:` sub-stanza (jBOM#355)
+
+Governs the always-on staging fetch that rides `jbom search` and `jbom
+inventory --supplier`: whenever an Item's Datasheet URL is encountered, it
+is fetched into a gitignored `staging/` directory for later human review via
+`jbom inventory admit`. See `docs/reference/cli.md` for the full behavioral
+write-up (idempotency, `file(1)`-style PDF verification, HTML-impostor
+flagging).
+
+Key fields:
+
+- `staging_dir:` — target directory for staged downloads. This is a
+  **user-machine binding**: it names a local checkout of the
+  SPCoast-inventory repo, which lives at a different path on every
+  machine. The shipped `generic.jbom.yaml` deliberately never declares a
+  value for it (there is no sensible one to ship). **With no `staging_dir`
+  configured, the staging fetch is inert** — a silent no-op, not a warning
+  — so nothing changes for any invocation until a user opts in. Set it once
+  in your own `~/.jbom/common.jbom.yaml` (see example below) to enable
+  staging for every invocation on that machine.
+- `max_fetches_per_run:` — maximum number of real network fetches one
+  `jbom search` or `jbom inventory --supplier` invocation will attempt.
+  Shipped in `generic.jbom.yaml` (currently `20`), since this is a generic,
+  non-machine-specific tuning knob.
+- `fetch_time_budget_seconds:` — wall-clock budget for real fetches in one
+  invocation. Shipped in `generic.jbom.yaml` (currently `30`). Once either
+  limit is hit, remaining Datasheet URLs are skipped for that run with a
+  one-line stderr summary; nothing else about the command fails.
+
+> **Overriding `max_fetches_per_run`/`fetch_time_budget_seconds`**: because
+> the builtin `generic.jbom.yaml` declares concrete values for these two
+> keys, a `common.jbom.yaml` override of them is clobbered by the builtin
+> (the named-profile chain always wins over the `common.jbom.yaml` chain
+> during merge for any key both declare — the same behavior every other
+> `generic.jbom.yaml`-declared default has, e.g. `domain_defaults`).
+> Override them the same way you would any other `generic.jbom.yaml` value:
+> via a project- or user-level `.jbom/generic.jbom.yaml` that shadows the
+> builtin file. `staging_dir` has no such caveat, since the builtin never
+> declares it.
+
+### Example: enable staging for every invocation on this machine
+
+Place in `~/.jbom/common.jbom.yaml`:
+
+```yaml
+defaults:
+  datasheet_staging:
+    staging_dir: "/Users/you/checkouts/SPCoast-inventory/staging"
+```
+
 ## `presets:` stanza
 
 Named field-set collections shared across profiles. Consumed wherever preset

--- a/features/environment.py
+++ b/features/environment.py
@@ -46,6 +46,14 @@ def before_scenario(context, scenario):
     context.sandbox_root = tmp
     context.project_root = tmp
 
+    # Sandboxed HOME for CLI subprocesses (see common_steps.step_run_command).
+    # Every scenario gets an isolated $HOME so profile resolution can never
+    # fall through to the developer's real ~/.jbom/ -- e.g. a real
+    # datasheet_staging.staging_dir binding must never leak into a test run.
+    fake_home = tmp / "_home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    context.fake_home = fake_home
+
 
 def after_scenario(context, scenario):
     """Clean up the per-scenario temp workspace."""

--- a/features/inventory/datasheet_staging.feature
+++ b/features/inventory/datasheet_staging.feature
@@ -32,6 +32,21 @@ Feature: Always-on datasheet staging fetch
     And the staging directory contains a flagged unverified file for "https://example.com/docs/lm358-missing.pdf"
     And the output should contain "HTML impostor"
 
+  Scenario: jbom search skips staging for an already-admitted document
+    Given a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn    | stock_quantity | price | datasheet                                    |
+      | S25807         | Texas Inst   | LM358D | 500            | 0.20  | https://example.com/docs/lm358-admitted.pdf  |
+    And the datasheet URL "https://example.com/docs/lm358-admitted.pdf" resolves to a PDF
+    And an inventory file "library.csv" that contains:
+      | IPN      | Category | Value  | Description | Package | Datasheet                                    | Datasheet Name |
+      | IC_LM358 | IC       | LM358D | Dual Op-Amp  | SOIC-8  | https://example.com/docs/lm358-admitted.pdf  | LM358-series   |
+    When I run jbom command "search LM358 --supplier generic --inventory library.csv"
+    Then the command should succeed
+    And the staging directory does not contain a file for "https://example.com/docs/lm358-admitted.pdf"
+
   Scenario: jbom inventory --supplier stages a verified PDF datasheet
     Given a supplier profile that contains:
       | key | value   |
@@ -61,3 +76,19 @@ Feature: Always-on datasheet staging fetch
     When I run jbom command "inventory --supplier generic -o result.csv"
     Then the command should succeed
     And the staging directory contains a flagged unverified file for "https://example.com/docs/rc0603-missing.pdf"
+
+  Scenario: fetch budget stops further staging attempts with a summary warning
+    Given the datasheet staging fetch budget is 1 fetch per run
+    And a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn    | stock_quantity | price | datasheet                              |
+      | S30001         | Texas Inst   | LM358D | 500            | 0.20  | https://example.com/docs/budget-a.pdf  |
+      | S30002         | Texas Inst   | LM358D | 400            | 0.25  | https://example.com/docs/budget-b.pdf  |
+    And the datasheet URL "https://example.com/docs/budget-a.pdf" resolves to a PDF
+    And the datasheet URL "https://example.com/docs/budget-b.pdf" resolves to a PDF
+    When I run jbom command "search LM358 --supplier generic"
+    Then the command should succeed
+    And the staging directory contains exactly 1 staged file
+    And the output should contain "budget exceeded"

--- a/features/inventory/datasheet_staging.feature
+++ b/features/inventory/datasheet_staging.feature
@@ -1,0 +1,63 @@
+Feature: Always-on datasheet staging fetch
+  As a hardware developer
+  I want jbom search / jbom inventory --supplier to stage Datasheet URLs
+  So that candidate documents are collected for later human review without
+  ever writing to the inventory or hitting real network endpoints in tests
+
+  Background:
+    Given a staging directory
+
+  Scenario: jbom search stages a verified PDF datasheet
+    Given a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn    | stock_quantity | price | datasheet                                  |
+      | S25804         | Texas Inst   | LM358D | 500            | 0.20  | https://example.com/docs/lm358-series.pdf  |
+    And the datasheet URL "https://example.com/docs/lm358-series.pdf" resolves to a PDF
+    When I run jbom command "search LM358 --supplier generic"
+    Then the command should succeed
+    And the staging directory contains a verified PDF for "https://example.com/docs/lm358-series.pdf"
+
+  Scenario: jbom search flags an HTML impostor datasheet
+    Given a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn    | stock_quantity | price | datasheet                                   |
+      | S25805         | Texas Inst   | LM358D | 500            | 0.20  | https://example.com/docs/lm358-missing.pdf  |
+    And the datasheet URL "https://example.com/docs/lm358-missing.pdf" resolves to HTML
+    When I run jbom command "search LM358 --supplier generic"
+    Then the command should succeed
+    And the staging directory contains a flagged unverified file for "https://example.com/docs/lm358-missing.pdf"
+    And the output should contain "HTML impostor"
+
+  Scenario: jbom inventory --supplier stages a verified PDF datasheet
+    Given a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price | datasheet                                    |
+      | S25804         | Yageo        | RC0603FR-0710KL | 500            | 0.01  | https://example.com/docs/rc0603-series.pdf   |
+    And the datasheet URL "https://example.com/docs/rc0603-series.pdf" resolves to a PDF
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic -o result.csv"
+    Then the command should succeed
+    And the staging directory contains a verified PDF for "https://example.com/docs/rc0603-series.pdf"
+
+  Scenario: jbom inventory --supplier flags an HTML impostor datasheet
+    Given a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn             | stock_quantity | price | datasheet                                     |
+      | S25806         | Yageo        | RC0603FR-0710KL | 500            | 0.01  | https://example.com/docs/rc0603-missing.pdf   |
+    And the datasheet URL "https://example.com/docs/rc0603-missing.pdf" resolves to HTML
+    And a schematic that contains:
+      | Reference | Value | Footprint   | LibID    |
+      | R1        | 10K   | R_0603_1608 | Device:R |
+    When I run jbom command "inventory --supplier generic -o result.csv"
+    Then the command should succeed
+    And the staging directory contains a flagged unverified file for "https://example.com/docs/rc0603-missing.pdf"

--- a/features/inventory/datasheet_staging_hermeticity.feature
+++ b/features/inventory/datasheet_staging_hermeticity.feature
@@ -1,0 +1,20 @@
+Feature: Datasheet staging hermeticity guard
+  As a jBOM maintainer
+  I want the test suite to prove that a real $HOME profile can never leak
+  into a jbom CLI subprocess run by the test harness
+  So that a maintainer's own datasheet_staging.staging_dir binding on their
+  development machine can never cause a test to touch real network
+  endpoints or write into a real curated staging directory
+
+  Scenario: a poisoned real HOME profile never leaks into a jbom subprocess
+    Given a poisoned "real" HOME profile with a datasheet staging_dir binding
+    And a supplier profile that contains:
+      | key | value   |
+      | id  | generic |
+    And a supplier catalog that contains:
+      | distributor_pn | manufacturer | mpn    | stock_quantity | price | datasheet                                   |
+      | S40001         | Texas Inst   | LM358D | 500            | 0.20  | https://example.com/docs/poison-guard.pdf   |
+    And the datasheet URL "https://example.com/docs/poison-guard.pdf" resolves to a PDF
+    When I run jbom command "search LM358 --supplier generic"
+    Then the command should succeed
+    And the poisoned staging directory was never written to

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -139,6 +139,15 @@ def step_run_command(context, command):
     env["JBOM_QUIET"] = "1"
     if getattr(context, "trace", False):
         env["JBOM_BEHAVE_TRACE"] = "1"
+
+    # Hermeticity: force every CLI subprocess to resolve profiles against
+    # this scenario's sandboxed $HOME (features/environment.py), never the
+    # real developer/CI $HOME, and never a real $JBOM_PROFILE_PATH inherited
+    # from the outer shell. A scenario that wants org-level profile search
+    # path behavior sets JBOM_PROFILE_PATH explicitly via its own steps.
+    env["HOME"] = str(getattr(context, "fake_home", context.sandbox_root))
+    env.pop("JBOM_PROFILE_PATH", None)
+
     # Apply mock tool overrides (e.g. PATH prefix for mock kicad-cli).
     # Set by 'Given mock kicad-cli is available' and similar steps.
     env.update(getattr(context, "mock_env", {}))

--- a/features/steps/datasheet_staging_steps.py
+++ b/features/steps/datasheet_staging_steps.py
@@ -1,8 +1,18 @@
 """Step definitions for the always-on datasheet staging fetch (jBOM#355).
 
+Configuration (staging directory, fetch budget, and the test-only fixture
+manifest) is written to this scenario's sandboxed ``.jbom/common.jbom.yaml``
+profile -- the same ``defaults:`` stanza mechanism every other jBOM setting
+uses (see ``docs/reference/configuration.md``) -- rather than environment
+variables. ``common.jbom.yaml`` is used (instead of ``generic.jbom.yaml``)
+because the supplier-profile steps in ``project_centric_steps.py`` overwrite
+``.jbom/generic.jbom.yaml`` wholesale; ``common.jbom.yaml`` merges
+cumulatively underneath every named profile, so the two step families never
+collide.
+
 Network access is never exercised in these scenarios: the CLI runs as a
-subprocess (see ``features/steps/common_steps.py``), and
-``JBOM_DATASHEET_FETCH_FIXTURES`` redirects ``default_fetch`` to read
+subprocess (see ``features/steps/common_steps.py``), and the
+``fetch_fixtures_manifest`` profile key redirects ``default_fetch`` to read
 response bytes from local fixture files written by these steps instead of
 making real HTTP requests (see ``jbom.services.datasheet_staging``).
 """
@@ -10,9 +20,10 @@ making real HTTP requests (see ``jbom.services.datasheet_staging``).
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
+from typing import Any
 
+import yaml
 from behave import given, then
 
 _PDF_FIXTURE_BYTES = b"%PDF-1.4\n%fixture datasheet for jBOM#355 BDD scenarios\n%%EOF"
@@ -22,27 +33,50 @@ _HTML_FIXTURE_BYTES = (
 )
 
 
-def _staging_dir(context) -> Path:
-    staging_dir = getattr(context, "staging_dir", None)
-    assert staging_dir is not None, "Use 'Given a staging directory' first"
-    return staging_dir
+def _common_profile_path(context) -> Path:
+    jbom_dir = Path(context.sandbox_root) / ".jbom"
+    jbom_dir.mkdir(parents=True, exist_ok=True)
+    return jbom_dir / "common.jbom.yaml"
+
+
+def _read_common_profile(context) -> dict[str, Any]:
+    path = _common_profile_path(context)
+    if not path.is_file():
+        return {}
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _write_common_profile(context, data: dict[str, Any]) -> None:
+    _common_profile_path(context).write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def _set_datasheet_staging_value(context, key: str, value: Any) -> None:
+    """Merge one ``defaults.datasheet_staging.<key>`` value into common.jbom.yaml."""
+
+    data = _read_common_profile(context)
+    defaults_stanza = data.get("defaults")
+    if not isinstance(defaults_stanza, dict):
+        defaults_stanza = {}
+    staging_cfg = defaults_stanza.get("datasheet_staging")
+    if not isinstance(staging_cfg, dict):
+        staging_cfg = {}
+    staging_cfg[key] = value
+    defaults_stanza["datasheet_staging"] = staging_cfg
+    data["defaults"] = defaults_stanza
+    _write_common_profile(context, data)
 
 
 def _fixture_manifest_path(context) -> Path:
-    """Return this scenario's fixture manifest path, creating it if needed.
-
-    Deliberately keyed off ``context.sandbox_root`` (recreated per scenario
-    by ``features/environment.py``) rather than cached on ``context`` --
-    ``context`` itself is reused across scenarios within a feature run, so a
-    cached path would go stale once the previous scenario's sandbox is torn
-    down.
-    """
+    """Return this scenario's fixture manifest path, creating it if needed."""
 
     manifest_path = Path(context.sandbox_root) / "_datasheet_fixtures.json"
     if not manifest_path.is_file():
         manifest_path.write_text("{}", encoding="utf-8")
-        os.environ["JBOM_DATASHEET_FETCH_FIXTURES"] = str(manifest_path)
-        context.add_cleanup(os.environ.pop, "JBOM_DATASHEET_FETCH_FIXTURES", None)
+        _set_datasheet_staging_value(
+            context, "fetch_fixtures_manifest", str(manifest_path)
+        )
     return manifest_path
 
 
@@ -59,14 +93,39 @@ def _register_fixture(context, url: str, content: bytes) -> None:
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
 
+def _staging_dir(context) -> Path:
+    staging_dir = getattr(context, "staging_dir", None)
+    assert staging_dir is not None, "Use 'Given a staging directory' first"
+    return staging_dir
+
+
 @given("a staging directory")
 def given_a_staging_directory(context) -> None:
-    """Create an isolated staging directory and point JBOM_STAGING_DIR at it."""
+    """Configure datasheet_staging.staging_dir to an isolated sandbox path.
+
+    Also mirrors generic.jbom.yaml's shipped fetch-budget defaults
+    (max_fetches_per_run=20, fetch_time_budget_seconds=30): scenarios in
+    this feature also write a supplier profile to the sandbox's own
+    ``.jbom/generic.jbom.yaml`` (see ``project_centric_steps.py``), which
+    shadows the builtin generic profile entirely -- including the
+    datasheet_staging budget values it declares -- so this step supplies
+    working defaults directly rather than relying on the (shadowed)
+    builtin.
+    """
 
     staging_dir = Path(context.sandbox_root) / "staging"
     context.staging_dir = staging_dir
-    os.environ["JBOM_STAGING_DIR"] = str(staging_dir)
-    context.add_cleanup(os.environ.pop, "JBOM_STAGING_DIR", None)
+    _set_datasheet_staging_value(context, "staging_dir", str(staging_dir))
+    _set_datasheet_staging_value(context, "max_fetches_per_run", 20)
+    _set_datasheet_staging_value(context, "fetch_time_budget_seconds", 30)
+
+
+@given("the datasheet staging fetch budget is {count:d} fetch per run")
+@given("the datasheet staging fetch budget is {count:d} fetches per run")
+def given_the_datasheet_staging_fetch_budget(context, count: int) -> None:
+    """Configure datasheet_staging.max_fetches_per_run."""
+
+    _set_datasheet_staging_value(context, "max_fetches_per_run", count)
 
 
 @given('the datasheet URL "{url}" resolves to a PDF')
@@ -121,3 +180,17 @@ def then_staging_dir_does_not_contain_file(context, url: str) -> None:
         f"Expected no staged file for {url!r}, found: "
         f"{[p for p in (verified_path, unverified_path) if p.exists()]}"
     )
+
+
+@then("the staging directory contains exactly {count:d} staged file")
+@then("the staging directory contains exactly {count:d} staged files")
+def then_staging_dir_contains_exactly_n_staged_files(context, count: int) -> None:
+    staging_dir = _staging_dir(context)
+    staged = (
+        list(staging_dir.glob("*.pdf")) + list(staging_dir.glob("*.unverified"))
+        if staging_dir.is_dir()
+        else []
+    )
+    assert (
+        len(staged) == count
+    ), f"Expected exactly {count} staged file(s), found {len(staged)}: {staged}"

--- a/features/steps/datasheet_staging_steps.py
+++ b/features/steps/datasheet_staging_steps.py
@@ -1,0 +1,123 @@
+"""Step definitions for the always-on datasheet staging fetch (jBOM#355).
+
+Network access is never exercised in these scenarios: the CLI runs as a
+subprocess (see ``features/steps/common_steps.py``), and
+``JBOM_DATASHEET_FETCH_FIXTURES`` redirects ``default_fetch`` to read
+response bytes from local fixture files written by these steps instead of
+making real HTTP requests (see ``jbom.services.datasheet_staging``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from behave import given, then
+
+_PDF_FIXTURE_BYTES = b"%PDF-1.4\n%fixture datasheet for jBOM#355 BDD scenarios\n%%EOF"
+_HTML_FIXTURE_BYTES = (
+    b"<!DOCTYPE html><html><head><title>404</title></head>"
+    b"<body>Not Found</body></html>"
+)
+
+
+def _staging_dir(context) -> Path:
+    staging_dir = getattr(context, "staging_dir", None)
+    assert staging_dir is not None, "Use 'Given a staging directory' first"
+    return staging_dir
+
+
+def _fixture_manifest_path(context) -> Path:
+    """Return this scenario's fixture manifest path, creating it if needed.
+
+    Deliberately keyed off ``context.sandbox_root`` (recreated per scenario
+    by ``features/environment.py``) rather than cached on ``context`` --
+    ``context`` itself is reused across scenarios within a feature run, so a
+    cached path would go stale once the previous scenario's sandbox is torn
+    down.
+    """
+
+    manifest_path = Path(context.sandbox_root) / "_datasheet_fixtures.json"
+    if not manifest_path.is_file():
+        manifest_path.write_text("{}", encoding="utf-8")
+        os.environ["JBOM_DATASHEET_FETCH_FIXTURES"] = str(manifest_path)
+        context.add_cleanup(os.environ.pop, "JBOM_DATASHEET_FETCH_FIXTURES", None)
+    return manifest_path
+
+
+def _register_fixture(context, url: str, content: bytes) -> None:
+    manifest_path = _fixture_manifest_path(context)
+    fixtures_dir = Path(context.sandbox_root) / "_datasheet_fixture_files"
+    fixtures_dir.mkdir(parents=True, exist_ok=True)
+
+    fixture_file = fixtures_dir / f"fixture-{len(list(fixtures_dir.glob('*')))}.bin"
+    fixture_file.write_bytes(content)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest[url] = str(fixture_file)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+@given("a staging directory")
+def given_a_staging_directory(context) -> None:
+    """Create an isolated staging directory and point JBOM_STAGING_DIR at it."""
+
+    staging_dir = Path(context.sandbox_root) / "staging"
+    context.staging_dir = staging_dir
+    os.environ["JBOM_STAGING_DIR"] = str(staging_dir)
+    context.add_cleanup(os.environ.pop, "JBOM_STAGING_DIR", None)
+
+
+@given('the datasheet URL "{url}" resolves to a PDF')
+def given_datasheet_url_resolves_to_pdf(context, url: str) -> None:
+    """Register a fixture so fetching *url* returns verified PDF bytes."""
+
+    _register_fixture(context, url, _PDF_FIXTURE_BYTES)
+
+
+@given('the datasheet URL "{url}" resolves to HTML')
+def given_datasheet_url_resolves_to_html(context, url: str) -> None:
+    """Register a fixture so fetching *url* returns HTML-impostor bytes."""
+
+    _register_fixture(context, url, _HTML_FIXTURE_BYTES)
+
+
+@then('the staging directory contains a verified PDF for "{url}"')
+def then_staging_dir_contains_verified_pdf(context, url: str) -> None:
+    from jbom.services.datasheet_staging import staged_filename_for_url
+
+    stem = staged_filename_for_url(url)
+    staged_path = _staging_dir(context) / f"{stem}.pdf"
+    assert staged_path.is_file(), (
+        f"Expected verified PDF at {staged_path}; "
+        f"staging dir contents: {list(_staging_dir(context).glob('*'))}"
+    )
+    assert staged_path.read_bytes().startswith(b"%PDF-")
+
+
+@then('the staging directory contains a flagged unverified file for "{url}"')
+def then_staging_dir_contains_flagged_unverified(context, url: str) -> None:
+    from jbom.services.datasheet_staging import staged_filename_for_url
+
+    stem = staged_filename_for_url(url)
+    staged_path = _staging_dir(context) / f"{stem}.unverified"
+    assert staged_path.is_file(), (
+        f"Expected flagged .unverified file at {staged_path}; "
+        f"staging dir contents: {list(_staging_dir(context).glob('*'))}"
+    )
+    assert not staged_path.read_bytes().startswith(b"%PDF-")
+
+
+@then('the staging directory does not contain a file for "{url}"')
+def then_staging_dir_does_not_contain_file(context, url: str) -> None:
+    from jbom.services.datasheet_staging import staged_filename_for_url
+
+    stem = staged_filename_for_url(url)
+    staging_dir = _staging_dir(context)
+    verified_path = staging_dir / f"{stem}.pdf"
+    unverified_path = staging_dir / f"{stem}.unverified"
+    assert not verified_path.exists() and not unverified_path.exists(), (
+        f"Expected no staged file for {url!r}, found: "
+        f"{[p for p in (verified_path, unverified_path) if p.exists()]}"
+    )

--- a/features/steps/datasheet_staging_steps.py
+++ b/features/steps/datasheet_staging_steps.py
@@ -20,6 +20,7 @@ making real HTTP requests (see ``jbom.services.datasheet_staging``).
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -194,3 +195,69 @@ def then_staging_dir_contains_exactly_n_staged_files(context, count: int) -> Non
     assert (
         len(staged) == count
     ), f"Expected exactly {count} staged file(s), found {len(staged)}: {staged}"
+
+
+@given('a poisoned "real" HOME profile with a datasheet staging_dir binding')
+def given_a_poisoned_real_home_profile(context) -> None:
+    """Simulate a maintainer's real $HOME already binding a staging_dir.
+
+    Writes a ``.jbom/common.jbom.yaml`` under a directory standing in for
+    "the developer's actual home directory" (never the harness's own
+    sandboxed ``context.fake_home``), and points the *current test
+    process's* ``HOME`` env var at it -- mirroring exactly what a real
+    maintainer's shell environment looks like once they've configured
+    datasheet staging for their own invocations.
+
+    The assertion this proves: ``common_steps.step_run_command`` must
+    override ``HOME`` for the CLI subprocess regardless of what ``HOME``
+    happens to be in the *outer* (test-harness) process, so this poisoned
+    binding never resolves inside the subprocess under test.
+    """
+
+    poisoned_home = Path(context.sandbox_root) / "_poisoned_real_home"
+    poison_target = Path(context.sandbox_root) / "_poison_target"
+    context.poison_target = poison_target
+
+    jbom_dir = poisoned_home / ".jbom"
+    jbom_dir.mkdir(parents=True, exist_ok=True)
+    (jbom_dir / "common.jbom.yaml").write_text(
+        yaml.safe_dump(
+            {"defaults": {"datasheet_staging": {"staging_dir": str(poison_target)}}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    # Also supply working fetch-budget values via the (safe, sandboxed) cwd
+    # tier -- the supplier-profile steps this scenario also uses shadow the
+    # builtin generic.jbom.yaml wholesale (see given_a_staging_directory's
+    # docstring), which would otherwise leave max_fetches_per_run at its
+    # Python-level "unconfigured" fallback of 0 and mask the very leak this
+    # scenario exists to catch (a zero budget skips every real fetch
+    # attempt regardless of which staging_dir would have been used).
+    _set_datasheet_staging_value(context, "max_fetches_per_run", 20)
+    _set_datasheet_staging_value(context, "fetch_time_budget_seconds", 30)
+
+    previous_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(poisoned_home)
+
+    def _restore_home() -> None:
+        if previous_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = previous_home
+
+    context.add_cleanup(_restore_home)
+
+
+@then("the poisoned staging directory was never written to")
+def then_poisoned_staging_directory_untouched(context) -> None:
+    poison_target = getattr(context, "poison_target", None)
+    assert (
+        poison_target is not None
+    ), "Use 'Given a poisoned \"real\" HOME profile ...' first"
+    assert not poison_target.exists(), (
+        f"Poisoned real-HOME staging_dir leaked into the CLI subprocess: "
+        f"{poison_target} was created with contents "
+        f"{list(poison_target.glob('*')) if poison_target.exists() else []}"
+    )

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -809,7 +809,7 @@ def _table_to_supplier_results(context, *, supplier_id: str) -> list[dict[str, A
             "distributor": supplier_id,
             "distributor_part_number": r.get("distributor_pn", ""),
             "description": r.get("description", ""),
-            "datasheet": "",
+            "datasheet": r.get("datasheet", ""),
             "availability": f"{r.get('stock_quantity', '0')} In Stock",
             "price": r.get("price", ""),
             "details_url": "",

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -30,6 +30,7 @@ from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.common.types import Component, InventoryItem
 from jbom.common.options import GeneratorOptions
 from jbom.cli.formatting import print_inventory_table
+from jbom.services.datasheet_staging import resolve_staging_dir, stage_datasheet_url
 from jbom.services.inventory_reader import InventoryReader
 from jbom.common.component_filters import apply_component_filters
 from jbom.services.project_file_resolver import ProjectFileResolver
@@ -682,7 +683,7 @@ def _enrich_items_with_suppliers(
 
     if len(supplier_services) == 1:
         service, supplier_config, supplier_id = supplier_services[0]
-        return _enrich_items_with_supplier(
+        enriched_items, enriched_field_names = _enrich_items_with_supplier(
             items,
             field_names,
             service,
@@ -691,6 +692,8 @@ def _enrich_items_with_suppliers(
             limit=limit,
             verbose=verbose,
         )
+        _stage_datasheets_for_items(enriched_items, verbose=verbose)
+        return enriched_items, enriched_field_names
 
     candidate_limit = max(1, int(limit))
     base_items = list(items)
@@ -763,9 +766,9 @@ def _enrich_items_with_suppliers(
     if priority_assigned and "Priority" not in working_field_names:
         working_field_names = list(working_field_names) + ["Priority"]
 
-    if not added_items:
-        return base_items, working_field_names
-    return base_items + added_items, working_field_names
+    final_items = base_items if not added_items else base_items + added_items
+    _stage_datasheets_for_items(final_items, verbose=verbose)
+    return final_items, working_field_names
 
 
 def _enrich_items_with_supplier(
@@ -929,6 +932,37 @@ def _apply_supplier_candidate_to_item(
         item.manufacturer = candidate.manufacturer
     if not (item.mfgpn or "").strip() and candidate.mpn:
         item.mfgpn = candidate.mpn
+    if not (item.datasheet or "").strip() and getattr(candidate, "datasheet", ""):
+        item.datasheet = candidate.datasheet
+        item.raw_data["Datasheet"] = candidate.datasheet
+
+
+def _stage_datasheets_for_items(
+    items: "list[InventoryItem]", *, verbose: bool = False
+) -> None:
+    """Always-on staging fetch (jBOM#355): stage every encountered Datasheet URL.
+
+    Rides the already-networked ``jbom inventory --supplier`` flow. Covers
+    both items whose Datasheet URL was just populated by supplier
+    enrichment and items that already carried one before enrichment ran.
+    Already-admitted items (``Datasheet Name`` populated) and already-staged
+    URLs are skipped idempotently by :func:`stage_datasheet_url`. Fetch and
+    staging failures never fail the inventory command; they are reported to
+    stderr as warnings only.
+    """
+
+    staging_dir = resolve_staging_dir()
+    for item in items:
+        url = (item.datasheet or "").strip()
+        if not url:
+            continue
+        outcome = stage_datasheet_url(url, item=item, staging_dir=staging_dir)
+        if outcome.status == "flagged":
+            print(f"Warning: {outcome.message}", file=sys.stderr)
+        elif outcome.status == "fetch-error":
+            print(f"Warning: {outcome.message}", file=sys.stderr)
+        elif verbose and outcome.status == "verified":
+            print(f"  {outcome.message}", file=sys.stderr)
 
 
 def _handle_generate_inventory(input_path: str, args: argparse.Namespace) -> int:

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -30,7 +30,7 @@ from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.common.types import Component, InventoryItem
 from jbom.common.options import GeneratorOptions
 from jbom.cli.formatting import print_inventory_table
-from jbom.services.datasheet_staging import resolve_staging_dir, stage_datasheet_url
+from jbom.services.datasheet_staging import stage_datasheet_urls
 from jbom.services.inventory_reader import InventoryReader
 from jbom.common.component_filters import apply_component_filters
 from jbom.services.project_file_resolver import ProjectFileResolver
@@ -946,23 +946,31 @@ def _stage_datasheets_for_items(
     both items whose Datasheet URL was just populated by supplier
     enrichment and items that already carried one before enrichment ran.
     Already-admitted items (``Datasheet Name`` populated) and already-staged
-    URLs are skipped idempotently by :func:`stage_datasheet_url`. Fetch and
-    staging failures never fail the inventory command; they are reported to
-    stderr as warnings only.
+    URLs are skipped idempotently, for free, by
+    :func:`~jbom.services.datasheet_staging.stage_datasheet_urls`. Real
+    fetch attempts are bounded by the active profile's
+    ``datasheet_staging.max_fetches_per_run`` /
+    ``fetch_time_budget_seconds``, so a large inventory run never stalls on
+    a long tail of slow downloads. Fetch/staging failures and a
+    budget-exceeded summary never fail the inventory command; they are
+    reported to stderr as warnings only.
     """
 
-    staging_dir = resolve_staging_dir()
-    for item in items:
-        url = (item.datasheet or "").strip()
-        if not url:
-            continue
-        outcome = stage_datasheet_url(url, item=item, staging_dir=staging_dir)
-        if outcome.status == "flagged":
-            print(f"Warning: {outcome.message}", file=sys.stderr)
-        elif outcome.status == "fetch-error":
+    entries = [
+        (item.datasheet, item) for item in items if (item.datasheet or "").strip()
+    ]
+    if not entries:
+        return
+
+    batch = stage_datasheet_urls(entries)
+    for outcome in batch.outcomes:
+        if outcome.status in ("flagged", "fetch-error"):
             print(f"Warning: {outcome.message}", file=sys.stderr)
         elif verbose and outcome.status == "verified":
             print(f"  {outcome.message}", file=sys.stderr)
+    summary = batch.summary_message()
+    if summary:
+        print(f"Warning: {summary}", file=sys.stderr)
 
 
 def _handle_generate_inventory(input_path: str, args: argparse.Namespace) -> int:

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -22,6 +22,7 @@ from jbom.cli.output import (
 from jbom.config.defaults import get_defaults
 from jbom.config.providers import get_provider, list_searchable_suppliers
 from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
+from jbom.services.datasheet_staging import resolve_staging_dir, stage_datasheet_url
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.diagnostics import (
     SearchPipelineDiagnostics,
@@ -346,6 +347,8 @@ def handle_search(
     if bool(getattr(args, "debug", False)):
         _print_search_debug_diagnostics(diagnostics)
 
+    _stage_result_datasheets(results)
+
     force = bool(getattr(args, "force", False))
     return _output_results(
         results,
@@ -403,6 +406,28 @@ def _run_adaptive_search_pipeline(
             break
         fetch_limit = next_fetch_limit
     return best_results, best_diagnostics
+
+
+def _stage_result_datasheets(results: list[SearchResult]) -> None:
+    """Always-on staging fetch (jBOM#355): stage any Datasheet URL encountered.
+
+    Rides the already-networked ``jbom search`` flow. No inventory context is
+    available here, so admission (``Datasheet Name``) skips never apply --
+    only already-staged skips, verified-PDF writes, and HTML-impostor flags.
+    Fetch/staging failures never fail the search command; they are reported
+    to stderr as warnings only.
+    """
+
+    staging_dir = resolve_staging_dir()
+    for result in results:
+        url = (result.datasheet or "").strip()
+        if not url:
+            continue
+        outcome = stage_datasheet_url(url, staging_dir=staging_dir)
+        if outcome.status == "flagged":
+            print(f"Warning: {outcome.message}", file=sys.stderr)
+        elif outcome.status == "fetch-error":
+            print(f"Warning: {outcome.message}", file=sys.stderr)
 
 
 def _apply_result_pipeline(

--- a/src/jbom/cli/search.py
+++ b/src/jbom/cli/search.py
@@ -19,10 +19,11 @@ from jbom.cli.output import (
     open_output_text_file,
     resolve_output_destination,
 )
+from jbom.common.types import InventoryItem
 from jbom.config.defaults import get_defaults
 from jbom.config.providers import get_provider, list_searchable_suppliers
 from jbom.config.suppliers import load_supplier, resolve_supplier_by_id
-from jbom.services.datasheet_staging import resolve_staging_dir, stage_datasheet_url
+from jbom.services.datasheet_staging import is_admitted, stage_datasheet_urls
 from jbom.services.search.cache import DiskSearchCache, InMemorySearchCache, SearchCache
 from jbom.services.search.diagnostics import (
     SearchPipelineDiagnostics,
@@ -303,6 +304,14 @@ def register_command(subparsers) -> None:
         "--output",
         help="Output destination: omit for console, use 'console' for table, '-' for CSV to stdout, or a file path",
     )
+    parser.add_argument(
+        "--inventory",
+        help=(
+            "Optional inventory CSV to cross-reference for already-admitted "
+            "Datasheet URLs (Datasheet Name populated); admitted documents "
+            "are never re-staged by the always-on staging fetch (jBOM#355)."
+        ),
+    )
     add_force_argument(parser)
 
     parser.set_defaults(handler=handle_search)
@@ -347,7 +356,8 @@ def handle_search(
     if bool(getattr(args, "debug", False)):
         _print_search_debug_diagnostics(diagnostics)
 
-    _stage_result_datasheets(results)
+    admitted_by_url = _load_admitted_datasheet_lookup(getattr(args, "inventory", None))
+    _stage_result_datasheets(results, admitted_by_url)
 
     force = bool(getattr(args, "force", False))
     return _output_results(
@@ -408,26 +418,72 @@ def _run_adaptive_search_pipeline(
     return best_results, best_diagnostics
 
 
-def _stage_result_datasheets(results: list[SearchResult]) -> None:
-    """Always-on staging fetch (jBOM#355): stage any Datasheet URL encountered.
+def _load_admitted_datasheet_lookup(
+    inventory_path: str | None,
+) -> dict[str, InventoryItem]:
+    """Load an optional ``--inventory`` CSV and index admitted Datasheet URLs.
 
-    Rides the already-networked ``jbom search`` flow. No inventory context is
-    available here, so admission (``Datasheet Name``) skips never apply --
-    only already-staged skips, verified-PDF writes, and HTML-impostor flags.
-    Fetch/staging failures never fail the search command; they are reported
-    to stderr as warnings only.
+    Returns a ``{Datasheet URL: InventoryItem}`` map for rows that already
+    have a ``Datasheet Name`` (i.e. the document is in the Library). Used so
+    ``jbom search`` can honor the admitted-skip rule even though it has no
+    other inventory context of its own.
     """
 
-    staging_dir = resolve_staging_dir()
-    for result in results:
-        url = (result.datasheet or "").strip()
-        if not url:
-            continue
-        outcome = stage_datasheet_url(url, staging_dir=staging_dir)
-        if outcome.status == "flagged":
+    if not inventory_path:
+        return {}
+
+    from pathlib import Path as _Path
+
+    from jbom.services.inventory_reader import InventoryReader
+
+    try:
+        items, _fields = InventoryReader(_Path(inventory_path)).load()
+    except Exception as exc:
+        print(
+            f"Warning: could not load --inventory {inventory_path!r} for "
+            f"datasheet admission check: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+
+    lookup: dict[str, InventoryItem] = {}
+    for item in items:
+        url = (item.datasheet or "").strip()
+        if url and is_admitted(item):
+            lookup[url] = item
+    return lookup
+
+
+def _stage_result_datasheets(
+    results: list[SearchResult],
+    admitted_by_url: dict[str, InventoryItem] | None = None,
+) -> None:
+    """Always-on staging fetch (jBOM#355): stage any Datasheet URL encountered.
+
+    Rides the already-networked ``jbom search`` flow. When ``--inventory`` was
+    given, results whose Datasheet URL matches an admitted Item (see
+    :func:`_load_admitted_datasheet_lookup`) are skipped for free -- never
+    re-fetched, never counted against the fetch budget. Fetch/staging
+    failures and a budget-exceeded summary are reported to stderr as
+    warnings only; they never fail the search command.
+    """
+
+    admitted_by_url = admitted_by_url or {}
+    entries = [
+        (result.datasheet, admitted_by_url.get((result.datasheet or "").strip()))
+        for result in results
+        if (result.datasheet or "").strip()
+    ]
+    if not entries:
+        return
+
+    batch = stage_datasheet_urls(entries)
+    for outcome in batch.outcomes:
+        if outcome.status in ("flagged", "fetch-error"):
             print(f"Warning: {outcome.message}", file=sys.stderr)
-        elif outcome.status == "fetch-error":
-            print(f"Warning: {outcome.message}", file=sys.stderr)
+    summary = batch.summary_message()
+    if summary:
+        print(f"Warning: {summary}", file=sys.stderr)
 
 
 def _apply_result_pipeline(

--- a/src/jbom/config/defaults.py
+++ b/src/jbom/config/defaults.py
@@ -211,6 +211,55 @@ class DefaultsSearchConfig(BaseModel):
         return tuple(dict.fromkeys(normalized).keys())
 
 
+class DatasheetStagingConfig(BaseModel):
+    """Defaults profile ``datasheet_staging:`` stanza (jBOM#355).
+
+    Governs the always-on staging fetch that rides ``jbom search`` and
+    ``jbom inventory --supplier``. See ``docs/reference/configuration.md``
+    for the full write-up.
+
+    Per jBOM convention, business-meaningful defaults are declared in the
+    ``generic.jbom.yaml`` profile (``max_fetches_per_run``,
+    ``fetch_time_budget_seconds``), not hardcoded here -- the Python-level
+    fallbacks below are structurally neutral ("unconfigured"), reachable
+    only if profile loading fails entirely. ``staging_dir`` is a
+    user-machine binding (it names a local SPCoast-inventory checkout) and
+    is deliberately never declared in the shipped ``generic.jbom.yaml``;
+    users set it in their own ``~/.jbom/common.jbom.yaml``.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    staging_dir: str = ""
+    max_fetches_per_run: int = 0
+    fetch_time_budget_seconds: float = 0.0
+    # Test-only escape hatch: when non-empty, default_fetch() resolves URLs
+    # against a local ``{url: file_path}`` JSON manifest instead of the
+    # network. Never set this in a production profile.
+    fetch_fixtures_manifest: str = ""
+
+    @field_validator("staging_dir", "fetch_fixtures_manifest", mode="before")
+    @classmethod
+    def _normalize_optional_path_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @field_validator("max_fetches_per_run", mode="before")
+    @classmethod
+    def _validate_max_fetches_per_run(cls, value: Any) -> int:
+        if value is None:
+            return 0
+        return max(0, int(value))
+
+    @field_validator("fetch_time_budget_seconds", mode="before")
+    @classmethod
+    def _validate_fetch_time_budget_seconds(cls, value: Any) -> float:
+        if value is None:
+            return 0.0
+        return max(0.0, float(value))
+
+
 class DefaultsConfig(BaseModel):
     """Loaded defaults profile."""
 
@@ -229,6 +278,9 @@ class DefaultsConfig(BaseModel):
         default_factory=InventorySchemaConfig.default
     )
     search: DefaultsSearchConfig = Field(default_factory=DefaultsSearchConfig)
+    datasheet_staging: DatasheetStagingConfig = Field(
+        default_factory=DatasheetStagingConfig
+    )
     search_excluded_categories: frozenset[str] = Field(default_factory=frozenset)
     component_id_fields: dict[str, frozenset[str]] = Field(default_factory=dict)
     field_precedence_policy: dict[str, tuple[str, ...]] = Field(default_factory=dict)
@@ -413,6 +465,20 @@ class DefaultsConfig(BaseModel):
             return DefaultsSearchConfig()
         return DefaultsSearchConfig.model_validate(value)
 
+    @field_validator("datasheet_staging", mode="before")
+    @classmethod
+    def _parse_datasheet_staging_config(cls, value: Any) -> DatasheetStagingConfig:
+        if value is None:
+            return DatasheetStagingConfig()
+        if isinstance(value, DatasheetStagingConfig):
+            return value
+        if not isinstance(value, dict):
+            log.warning(
+                "datasheet_staging must be a mapping; found %r", type(value).__name__
+            )
+            return DatasheetStagingConfig()
+        return DatasheetStagingConfig.model_validate(value)
+
     @field_validator("search_excluded_categories", mode="before")
     @classmethod
     def _normalize_search_excluded_categories(cls, value: Any) -> frozenset[str]:
@@ -544,6 +610,11 @@ class DefaultsConfig(BaseModel):
 
         return dict(self.field_precedence_policy)
 
+    def get_datasheet_staging_config(self) -> DatasheetStagingConfig:
+        """Return the datasheet staging fetch config (jBOM#355)."""
+
+        return self.datasheet_staging
+
 
 def load_defaults(name: str, *, cwd: Path | None = None) -> DefaultsConfig:
     """Load a named defaults profile from the search path."""
@@ -655,6 +726,7 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
 
 
 __all__ = [
+    "DatasheetStagingConfig",
     "DefaultsConfig",
     "EnrichmentCategoryConfig",
     "FieldSynonymConfig",

--- a/src/jbom/config/profiles/generic.jbom.yaml
+++ b/src/jbom/config/profiles/generic.jbom.yaml
@@ -367,6 +367,22 @@ defaults:
       fabricator_part_number: __resolved_fabricator_part_number__
 
   # ---------------------------------------------------------------------------
+  # Datasheet staging fetch (jBOM#355): always-on staging fetch that rides
+  # `jbom search` / `jbom inventory --supplier`, bounded so an invocation
+  # never stalls on a long tail of slow/hanging downloads. Once either limit
+  # is hit, remaining Datasheet URLs are skipped for that run with a
+  # one-line stderr summary; nothing else about the command fails.
+  #
+  # staging_dir is deliberately NOT declared here: it names a user-machine
+  # SPCoast-inventory checkout, so it is a user binding set in the user's
+  # own ~/.jbom/common.jbom.yaml, not a value the shipped generic profile
+  # can know. With no staging_dir configured, staging is inert (a no-op).
+  # ---------------------------------------------------------------------------
+  datasheet_staging:
+    max_fetches_per_run: 20
+    fetch_time_budget_seconds: 30
+
+  # ---------------------------------------------------------------------------
   # Default CLI search output fields (used when supplier profile has no override).
   # ---------------------------------------------------------------------------
   search:

--- a/src/jbom/services/datasheet_staging.py
+++ b/src/jbom/services/datasheet_staging.py
@@ -1,0 +1,290 @@
+"""Staging fetch for datasheet documents (jBOM#355).
+
+Implements the fetch half of the datasheet-document acquisition lifecycle
+decided in jBOM#349: an always-on staging fetch that rides the already
+networked ``jbom search`` / ``jbom inventory --supplier`` flows.
+
+Staging conventions (glossary owned by SPCoast-inventory's CONTEXT.md;
+imported terms: Staging, Intake, Admission, Library, Document, Datasheet
+Name, Never-Rename):
+
+* Staging is a gitignored ``staging/`` directory inside the SPCoast-inventory
+  checkout. Downloads land here with a ``.unverified`` suffix until a
+  ``file(1)``-style content check confirms the payload is a real PDF.
+  Verified PDFs are written with a plain ``.pdf`` suffix.
+* HTML impostors keep the ``.unverified`` suffix and are flagged with a
+  warning; per jBOM#345 HTML is never admitted, so this module never
+  promotes an unverified file automatically.
+* Filenames are derived deterministically from the Datasheet URL
+  (:func:`staged_filename_for_url`), so re-fetching the same URL always
+  resolves to the same staged file (idempotency).
+* This module never writes to the inventory. Admission into the Library's
+  ``datasheets/`` directory is the separate ``jbom inventory admit`` gate
+  (jBOM#356), which depends on the staging layout documented here but is
+  out of scope for this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlparse
+
+from jbom.common.types import InventoryItem
+
+log = logging.getLogger(__name__)
+
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - exercised only when requests is absent
+    requests = None  # type: ignore
+
+UNVERIFIED_SUFFIX = ".unverified"
+VERIFIED_SUFFIX = ".pdf"
+
+_DATASHEET_NAME_COLUMN = "Datasheet Name"
+_ENV_STAGING_DIR = "JBOM_STAGING_DIR"
+_ENV_INVENTORY_ROOT = "JBOM_INVENTORY_ROOT"
+_DEFAULT_INVENTORY_ROOT = Path.home() / "Dropbox" / "KiCad" / "SPCoast-inventory"
+
+# Test seam only: when set, default_fetch() reads response bytes from a local
+# JSON manifest (``{url: local_file_path}``) instead of making a real network
+# request. Used exclusively by BDD scenarios that exercise the CLI as a
+# subprocess (features/steps/datasheet_staging_steps.py); never read by
+# production code paths unless a developer explicitly sets it.
+_ENV_FETCH_FIXTURES = "JBOM_DATASHEET_FETCH_FIXTURES"
+
+_PDF_MAGIC = b"%PDF-"
+_PDF_MAGIC_SEARCH_WINDOW = 1024
+_HTML_MARKERS = (b"<!doctype html", b"<html", b"<head", b"<body")
+_HTML_SNIFF_WINDOW = 2048
+
+
+def resolve_staging_dir(explicit: Path | str | None = None) -> Path:
+    """Resolve the staging directory using a documented precedence order.
+
+    Precedence (highest first):
+
+    1. *explicit* -- an explicit override passed by the caller.
+    2. ``JBOM_STAGING_DIR`` environment variable -- a direct path to the
+       staging directory itself.
+    3. ``JBOM_INVENTORY_ROOT`` environment variable -- path to the
+       SPCoast-inventory checkout; staging directory is ``<root>/staging``.
+    4. A sensible, non-hardcoded-username default:
+       ``~/Dropbox/KiCad/SPCoast-inventory/staging``.
+
+    Args:
+        explicit: Optional caller-supplied override.
+
+    Returns:
+        Resolved path to the staging directory. The directory is not
+        created here; callers create it lazily on first write.
+    """
+
+    if explicit:
+        return Path(explicit)
+
+    env_staging_dir = os.environ.get(_ENV_STAGING_DIR, "").strip()
+    if env_staging_dir:
+        return Path(env_staging_dir)
+
+    env_inventory_root = os.environ.get(_ENV_INVENTORY_ROOT, "").strip()
+    if env_inventory_root:
+        return Path(env_inventory_root) / "staging"
+
+    return _DEFAULT_INVENTORY_ROOT / "staging"
+
+
+def looks_like_pdf(content: bytes) -> bool:
+    """Return True when *content* starts with a PDF signature.
+
+    Mirrors ``file(1)``'s PDF detection: the ``%PDF-`` magic bytes must
+    appear within the document header window.
+    """
+
+    return _PDF_MAGIC in content[:_PDF_MAGIC_SEARCH_WINDOW]
+
+
+def looks_like_html(content: bytes) -> bool:
+    """Return True when *content* looks like an HTML document."""
+
+    head = content[:_HTML_SNIFF_WINDOW].lower()
+    return any(marker in head for marker in _HTML_MARKERS)
+
+
+def staged_filename_for_url(url: str) -> str:
+    """Derive a stable staging filename stem (no suffix) for a Datasheet URL."""
+
+    parsed = urlparse(url)
+    basename = Path(parsed.path).name or "datasheet"
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", basename)
+    stem = re.sub(r"\.(pdf|html?|php|aspx?)$", "", stem, flags=re.IGNORECASE)
+    stem = stem.strip("._-") or "datasheet"
+    digest = hashlib.sha256(url.strip().encode("utf-8")).hexdigest()[:10]
+    return f"{stem}-{digest}"
+
+
+def is_admitted(item: InventoryItem | None) -> bool:
+    """Return True when *item* already has a populated ``Datasheet Name``."""
+
+    if item is None:
+        return False
+    raw = item.raw_data or {}
+    return bool(str(raw.get(_DATASHEET_NAME_COLUMN, "")).strip())
+
+
+def find_existing_staged_path(staging_dir: Path, stem: str) -> Path | None:
+    """Return the existing staged file for *stem*, verified or unverified."""
+
+    verified_path = staging_dir / f"{stem}{VERIFIED_SUFFIX}"
+    if verified_path.exists():
+        return verified_path
+    unverified_path = staging_dir / f"{stem}{UNVERIFIED_SUFFIX}"
+    if unverified_path.exists():
+        return unverified_path
+    return None
+
+
+@dataclass(frozen=True)
+class StagingOutcome:
+    """Result of one :func:`stage_datasheet_url` call.
+
+    Attributes:
+        status: One of ``"skip-empty-url"``, ``"admitted-skip"``,
+            ``"staged-skip"``, ``"verified"``, ``"flagged"``, or
+            ``"fetch-error"``.
+        path: The staged file path, when one exists.
+        message: Human-readable summary, suitable for verbose/warning output.
+    """
+
+    status: str
+    path: Path | None = None
+    message: str = ""
+
+
+def default_fetch(url: str, *, timeout: float = 20.0) -> bytes:
+    """Fetch *url* over the network and return the raw response body.
+
+    When ``JBOM_DATASHEET_FETCH_FIXTURES`` is set (a test-only seam), reads
+    response bytes from the local file mapped to *url* in that JSON manifest
+    instead of making a real network request.
+    """
+
+    fixtures_path = os.environ.get(_ENV_FETCH_FIXTURES, "").strip()
+    if fixtures_path:
+        return _fetch_from_fixture_manifest(url, Path(fixtures_path))
+
+    if requests is None:  # pragma: no cover - exercised only without requests
+        raise RuntimeError(
+            "Datasheet staging fetch requires the 'requests' package. "
+            "Install it with: pip install requests"
+        )
+    response = requests.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.content
+
+
+def _fetch_from_fixture_manifest(url: str, manifest_path: Path) -> bytes:
+    """Resolve *url* to local fixture bytes via a ``{url: file_path}`` manifest."""
+
+    import json
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    file_path = manifest.get(url)
+    if not file_path:
+        raise RuntimeError(
+            f"No fixture registered for datasheet URL {url!r} in {manifest_path}"
+        )
+    return Path(file_path).read_bytes()
+
+
+def stage_datasheet_url(
+    url: str,
+    *,
+    item: InventoryItem | None = None,
+    staging_dir: Path,
+    fetch: Callable[[str], bytes] = default_fetch,
+) -> StagingOutcome:
+    """Idempotently stage one Datasheet URL.
+
+    Args:
+        url: The Item's Datasheet URL, as encountered by ``jbom search`` or
+            ``jbom inventory --supplier``.
+        item: Optional owning :class:`InventoryItem`, used only to check
+            :func:`is_admitted` (already-in-Library skip).
+        staging_dir: Resolved staging directory (see
+            :func:`resolve_staging_dir`).
+        fetch: Injectable network fetch callable, ``url -> bytes``.
+
+    Returns:
+        A :class:`StagingOutcome` describing what happened.
+    """
+
+    url = (url or "").strip()
+    if not url:
+        return StagingOutcome(
+            status="skip-empty-url", message="No Datasheet URL to stage."
+        )
+
+    if is_admitted(item):
+        return StagingOutcome(
+            status="admitted-skip",
+            message=f"Item already admitted (Datasheet Name present); skipping {url!r}.",
+        )
+
+    stem = staged_filename_for_url(url)
+    existing = find_existing_staged_path(staging_dir, stem)
+    if existing is not None:
+        return StagingOutcome(
+            status="staged-skip",
+            path=existing,
+            message=f"Already staged: {existing.name}",
+        )
+
+    try:
+        content = fetch(url)
+    except Exception as exc:
+        return StagingOutcome(
+            status="fetch-error", message=f"Failed to fetch {url!r}: {exc}"
+        )
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    if looks_like_pdf(content):
+        verified_path = staging_dir / f"{stem}{VERIFIED_SUFFIX}"
+        verified_path.write_bytes(content)
+        return StagingOutcome(
+            status="verified",
+            path=verified_path,
+            message=f"Staged verified PDF: {verified_path.name}",
+        )
+
+    unverified_path = staging_dir / f"{stem}{UNVERIFIED_SUFFIX}"
+    unverified_path.write_bytes(content)
+    reason = "HTML impostor" if looks_like_html(content) else "unrecognized content"
+    warning = (
+        f"Datasheet URL did not resolve to a PDF ({reason}): "
+        f"{url} -> {unverified_path.name}"
+    )
+    log.warning(warning)
+    return StagingOutcome(status="flagged", path=unverified_path, message=warning)
+
+
+__all__ = [
+    "UNVERIFIED_SUFFIX",
+    "VERIFIED_SUFFIX",
+    "StagingOutcome",
+    "default_fetch",
+    "find_existing_staged_path",
+    "is_admitted",
+    "looks_like_html",
+    "looks_like_pdf",
+    "resolve_staging_dir",
+    "stage_datasheet_url",
+    "staged_filename_for_url",
+]

--- a/src/jbom/services/datasheet_staging.py
+++ b/src/jbom/services/datasheet_staging.py
@@ -22,20 +22,28 @@ Name, Never-Rename):
   ``datasheets/`` directory is the separate ``jbom inventory admit`` gate
   (jBOM#356), which depends on the staging layout documented here but is
   out of scope for this module.
+
+Configuration is sourced entirely from jBOM's ``defaults:`` profile stanza
+(see ``datasheet_staging:`` in ``docs/reference/configuration.md``) rather
+than ad hoc environment variables, so staging directory / fetch-budget
+overrides follow the same ``.jbom/`` profile-hierarchy precedence as every
+other jBOM setting.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
-import os
 import re
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterable, Optional
 from urllib.parse import urlparse
 
 from jbom.common.types import InventoryItem
+from jbom.config.defaults import DefaultsConfig, get_defaults
 
 log = logging.getLogger(__name__)
 
@@ -48,16 +56,6 @@ UNVERIFIED_SUFFIX = ".unverified"
 VERIFIED_SUFFIX = ".pdf"
 
 _DATASHEET_NAME_COLUMN = "Datasheet Name"
-_ENV_STAGING_DIR = "JBOM_STAGING_DIR"
-_ENV_INVENTORY_ROOT = "JBOM_INVENTORY_ROOT"
-_DEFAULT_INVENTORY_ROOT = Path.home() / "Dropbox" / "KiCad" / "SPCoast-inventory"
-
-# Test seam only: when set, default_fetch() reads response bytes from a local
-# JSON manifest (``{url: local_file_path}``) instead of making a real network
-# request. Used exclusively by BDD scenarios that exercise the CLI as a
-# subprocess (features/steps/datasheet_staging_steps.py); never read by
-# production code paths unless a developer explicitly sets it.
-_ENV_FETCH_FIXTURES = "JBOM_DATASHEET_FETCH_FIXTURES"
 
 _PDF_MAGIC = b"%PDF-"
 _PDF_MAGIC_SEARCH_WINDOW = 1024
@@ -65,39 +63,52 @@ _HTML_MARKERS = (b"<!doctype html", b"<html", b"<head", b"<body")
 _HTML_SNIFF_WINDOW = 2048
 
 
-def resolve_staging_dir(explicit: Path | str | None = None) -> Path:
-    """Resolve the staging directory using a documented precedence order.
+def resolve_staging_dir(
+    explicit: Path | str | None = None,
+    *,
+    cwd: Path | None = None,
+    defaults: DefaultsConfig | None = None,
+) -> Path | None:
+    """Resolve the staging directory via the profile system.
 
     Precedence (highest first):
 
     1. *explicit* -- an explicit override passed by the caller.
-    2. ``JBOM_STAGING_DIR`` environment variable -- a direct path to the
-       staging directory itself.
-    3. ``JBOM_INVENTORY_ROOT`` environment variable -- path to the
-       SPCoast-inventory checkout; staging directory is ``<root>/staging``.
-    4. A sensible, non-hardcoded-username default:
-       ``~/Dropbox/KiCad/SPCoast-inventory/staging``.
+    2. ``defaults:.datasheet_staging.staging_dir`` from the active jBOM
+       profile (project ``.jbom/`` overrides > ``common.jbom.yaml`` >
+       ``$JBOM_PROFILE_PATH`` > ``~/.jbom/`` > built-in), the same
+       resolution order used by every other jBOM configuration value.
+
+    The staging directory is a user-machine binding (it names a checkout of
+    the SPCoast-inventory repo, which lives at a different path per
+    machine), so there is deliberately no code-level fallback path: when
+    neither of the above is set, this returns ``None`` and staging is
+    inert. A user enables it once, for every invocation, by declaring
+    ``defaults.datasheet_staging.staging_dir`` in their own
+    ``~/.jbom/common.jbom.yaml``.
 
     Args:
         explicit: Optional caller-supplied override.
+        cwd: Working directory used for project-local profile search. Passed
+            straight through to :func:`jbom.config.defaults.get_defaults`.
+        defaults: Optional pre-loaded :class:`DefaultsConfig`, to avoid
+            reloading the profile when the caller already has one.
 
     Returns:
-        Resolved path to the staging directory. The directory is not
-        created here; callers create it lazily on first write.
+        Resolved path to the staging directory, or ``None`` when staging is
+        not configured. The directory is not created here; callers create
+        it lazily on first write.
     """
 
     if explicit:
         return Path(explicit)
 
-    env_staging_dir = os.environ.get(_ENV_STAGING_DIR, "").strip()
-    if env_staging_dir:
-        return Path(env_staging_dir)
+    cfg = defaults if defaults is not None else get_defaults(cwd=cwd)
+    configured = cfg.get_datasheet_staging_config().staging_dir
+    if configured:
+        return Path(configured).expanduser()
 
-    env_inventory_root = os.environ.get(_ENV_INVENTORY_ROOT, "").strip()
-    if env_inventory_root:
-        return Path(env_inventory_root) / "staging"
-
-    return _DEFAULT_INVENTORY_ROOT / "staging"
+    return None
 
 
 def looks_like_pdf(content: bytes) -> bool:
@@ -155,9 +166,9 @@ class StagingOutcome:
     """Result of one :func:`stage_datasheet_url` call.
 
     Attributes:
-        status: One of ``"skip-empty-url"``, ``"admitted-skip"``,
-            ``"staged-skip"``, ``"verified"``, ``"flagged"``, or
-            ``"fetch-error"``.
+        status: One of ``"inactive"``, ``"skip-empty-url"``,
+            ``"admitted-skip"``, ``"staged-skip"``, ``"verified"``,
+            ``"flagged"``, ``"fetch-error"``, or ``"budget-skip"``.
         path: The staged file path, when one exists.
         message: Human-readable summary, suitable for verbose/warning output.
     """
@@ -168,16 +179,7 @@ class StagingOutcome:
 
 
 def default_fetch(url: str, *, timeout: float = 20.0) -> bytes:
-    """Fetch *url* over the network and return the raw response body.
-
-    When ``JBOM_DATASHEET_FETCH_FIXTURES`` is set (a test-only seam), reads
-    response bytes from the local file mapped to *url* in that JSON manifest
-    instead of making a real network request.
-    """
-
-    fixtures_path = os.environ.get(_ENV_FETCH_FIXTURES, "").strip()
-    if fixtures_path:
-        return _fetch_from_fixture_manifest(url, Path(fixtures_path))
+    """Fetch *url* over the network and return the raw response body."""
 
     if requests is None:  # pragma: no cover - exercised only without requests
         raise RuntimeError(
@@ -189,10 +191,31 @@ def default_fetch(url: str, *, timeout: float = 20.0) -> bytes:
     return response.content
 
 
+def _resolve_fetch(fetch_fixtures_manifest: str) -> Callable[[str], bytes]:
+    """Return the effective fetch callable for a staging batch.
+
+    When *fetch_fixtures_manifest* is set (test-only; see
+    ``DatasheetStagingConfig.fetch_fixtures_manifest``), URLs are resolved
+    against that local JSON manifest instead of the network. Otherwise the
+    current module-level :func:`default_fetch` is used -- looked up by name
+    at call time (not bound at import time) so tests can monkeypatch
+    ``jbom.services.datasheet_staging.default_fetch`` directly.
+    """
+
+    manifest = (fetch_fixtures_manifest or "").strip()
+    if not manifest:
+        return default_fetch
+
+    manifest_path = Path(manifest)
+
+    def _fixture_fetch(url: str) -> bytes:
+        return _fetch_from_fixture_manifest(url, manifest_path)
+
+    return _fixture_fetch
+
+
 def _fetch_from_fixture_manifest(url: str, manifest_path: Path) -> bytes:
     """Resolve *url* to local fixture bytes via a ``{url: file_path}`` manifest."""
-
-    import json
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     file_path = manifest.get(url)
@@ -207,8 +230,9 @@ def stage_datasheet_url(
     url: str,
     *,
     item: InventoryItem | None = None,
-    staging_dir: Path,
-    fetch: Callable[[str], bytes] = default_fetch,
+    staging_dir: Path | None,
+    fetch: Optional[Callable[[str], bytes]] = None,
+    fetch_fixtures_manifest: str = "",
 ) -> StagingOutcome:
     """Idempotently stage one Datasheet URL.
 
@@ -218,12 +242,27 @@ def stage_datasheet_url(
         item: Optional owning :class:`InventoryItem`, used only to check
             :func:`is_admitted` (already-in-Library skip).
         staging_dir: Resolved staging directory (see
-            :func:`resolve_staging_dir`).
-        fetch: Injectable network fetch callable, ``url -> bytes``.
+            :func:`resolve_staging_dir`), or ``None`` when staging is not
+            configured -- in which case this is a silent no-op.
+        fetch: Injectable network fetch callable, ``url -> bytes``. When
+            omitted, resolved from *fetch_fixtures_manifest* (falling back to
+            :func:`default_fetch`).
+        fetch_fixtures_manifest: Test-only fixture-manifest path; ignored
+            when *fetch* is provided explicitly.
 
     Returns:
         A :class:`StagingOutcome` describing what happened.
     """
+
+    if staging_dir is None:
+        log.debug(
+            "Datasheet staging inactive (no datasheet_staging.staging_dir "
+            "configured); skipping %r.",
+            url,
+        )
+        return StagingOutcome(
+            status="inactive", message="Datasheet staging is not configured."
+        )
 
     url = (url or "").strip()
     if not url:
@@ -246,8 +285,12 @@ def stage_datasheet_url(
             message=f"Already staged: {existing.name}",
         )
 
+    resolved_fetch = (
+        fetch if fetch is not None else _resolve_fetch(fetch_fixtures_manifest)
+    )
+
     try:
-        content = fetch(url)
+        content = resolved_fetch(url)
     except Exception as exc:
         return StagingOutcome(
             status="fetch-error", message=f"Failed to fetch {url!r}: {exc}"
@@ -275,9 +318,130 @@ def stage_datasheet_url(
     return StagingOutcome(status="flagged", path=unverified_path, message=warning)
 
 
+@dataclass(frozen=True)
+class StagingBatchResult:
+    """Outcome of one :func:`stage_datasheet_urls` batch run.
+
+    Attributes:
+        outcomes: One :class:`StagingOutcome` per URL that was evaluated
+            (admitted/staged skips included; budget-skipped entries are
+            *not* included here, see ``skipped_for_budget``).
+        attempted: Number of URLs that required an actual network fetch
+            attempt (excludes free admitted/staged skips).
+        budget_exceeded: True when ``max_fetches_per_run`` or
+            ``fetch_time_budget_seconds`` was hit before all entries were
+            processed.
+        skipped_for_budget: Number of entries left unprocessed because the
+            budget was exceeded.
+    """
+
+    outcomes: list[StagingOutcome] = field(default_factory=list)
+    attempted: int = 0
+    budget_exceeded: bool = False
+    skipped_for_budget: int = 0
+
+    def summary_message(self) -> str:
+        """Return a one-line human-readable summary for CLI output."""
+
+        if not self.budget_exceeded:
+            return ""
+        return (
+            "Datasheet staging budget exceeded "
+            f"(attempted={self.attempted}); skipped {self.skipped_for_budget} "
+            "remaining URL(s) this run."
+        )
+
+
+def stage_datasheet_urls(
+    entries: Iterable[tuple[str, Optional[InventoryItem]]],
+    *,
+    cwd: Path | None = None,
+    defaults: DefaultsConfig | None = None,
+) -> StagingBatchResult:
+    """Stage a batch of ``(url, item)`` pairs, honoring the fetch budget.
+
+    This is the shared orchestration used by both ``jbom search`` and
+    ``jbom inventory --supplier``: it resolves the staging directory and
+    fetch behavior once from the active profile (see
+    :class:`~jbom.config.defaults.DatasheetStagingConfig`), then stages each
+    entry via :func:`stage_datasheet_url`, stopping early -- without failing
+    the surrounding command -- once ``max_fetches_per_run`` or
+    ``fetch_time_budget_seconds`` is exceeded. Admitted/already-staged
+    entries are always processed (they never touch the network), so the
+    budget only governs real fetch attempts.
+
+    Args:
+        entries: Iterable of ``(datasheet_url, inventory_item_or_none)``.
+        cwd: Working directory for profile resolution.
+        defaults: Optional pre-loaded :class:`DefaultsConfig`.
+
+    Returns:
+        A :class:`StagingBatchResult` summarizing what happened.
+    """
+
+    cfg = defaults if defaults is not None else get_defaults(cwd=cwd)
+    staging_cfg = cfg.get_datasheet_staging_config()
+    staging_dir = resolve_staging_dir(defaults=cfg)
+    if staging_dir is None:
+        # Staging is a user-machine opt-in (datasheet_staging.staging_dir is
+        # unset). Inert: no fetches, no filesystem writes, no per-URL log
+        # noise -- just a single debug-level note.
+        log.debug(
+            "Datasheet staging inactive (no datasheet_staging.staging_dir "
+            "configured); skipping this batch."
+        )
+        return StagingBatchResult()
+
+    fetch = _resolve_fetch(staging_cfg.fetch_fixtures_manifest)
+    max_fetches = staging_cfg.max_fetches_per_run
+    time_budget = staging_cfg.fetch_time_budget_seconds
+
+    outcomes: list[StagingOutcome] = []
+    attempted = 0
+    skipped_for_budget = 0
+    budget_exceeded = False
+    start = time.monotonic()
+
+    for url, item in entries:
+        normalized_url = (url or "").strip()
+        if not normalized_url:
+            continue
+
+        if budget_exceeded:
+            skipped_for_budget += 1
+            continue
+
+        stem = staged_filename_for_url(normalized_url)
+        free = is_admitted(item) or (
+            find_existing_staged_path(staging_dir, stem) is not None
+        )
+        if not free:
+            over_count = attempted >= max_fetches
+            over_time = (time.monotonic() - start) >= time_budget
+            if over_count or over_time:
+                budget_exceeded = True
+                skipped_for_budget += 1
+                continue
+            attempted += 1
+
+        outcomes.append(
+            stage_datasheet_url(
+                normalized_url, item=item, staging_dir=staging_dir, fetch=fetch
+            )
+        )
+
+    return StagingBatchResult(
+        outcomes=outcomes,
+        attempted=attempted,
+        budget_exceeded=budget_exceeded,
+        skipped_for_budget=skipped_for_budget,
+    )
+
+
 __all__ = [
     "UNVERIFIED_SUFFIX",
     "VERIFIED_SUFFIX",
+    "StagingBatchResult",
     "StagingOutcome",
     "default_fetch",
     "find_existing_staged_path",
@@ -286,5 +450,6 @@ __all__ = [
     "looks_like_pdf",
     "resolve_staging_dir",
     "stage_datasheet_url",
+    "stage_datasheet_urls",
     "staged_filename_for_url",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 _SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 if str(_SRC_DIR) not in sys.path:
@@ -19,6 +21,36 @@ if str(_SRC_DIR) not in sys.path:
 
 _TESTS_DIR = Path(__file__).resolve().parent
 _FIXTURES_DIR = _TESTS_DIR / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_datasheet_staging(monkeypatch: pytest.MonkeyPatch):
+    """Prevent any test from touching real network.
+
+    jBOM#355's always-on staging fetch rides ``jbom search`` / ``jbom
+    inventory --supplier``, but is inert by design unless a
+    ``datasheet_staging.staging_dir`` is explicitly configured (there is no
+    code-level fallback path -- see ``jbom.services.datasheet_staging``).
+    So the only residual risk is a test that configures a staging_dir
+    without also injecting a fake fetch: this fixture makes
+    :func:`jbom.services.datasheet_staging.default_fetch` raise immediately
+    instead of making a real HTTP request in that case, so a forgotten
+    fixture/mock fails loudly and fast rather than silently reaching out.
+
+    Individual tests that want to exercise real staging behavior inject
+    their own ``fetch`` callable or ``fetch_fixtures_manifest``, which take
+    precedence over this fixture.
+    """
+
+    import jbom.services.datasheet_staging as datasheet_staging
+
+    def _forbidden_fetch(url: str, *, timeout: float = 20.0) -> bytes:
+        raise RuntimeError(
+            f"Real network fetch attempted in tests (url={url!r}); inject a "
+            "fake `fetch` callable or configure fetch_fixtures_manifest instead."
+        )
+
+    monkeypatch.setattr(datasheet_staging, "default_fetch", _forbidden_fetch)
 
 
 def load_mouser_fixture(name: str) -> dict[str, Any]:

--- a/tests/services/search/test_search_cli.py
+++ b/tests/services/search/test_search_cli.py
@@ -15,7 +15,10 @@ def _sr(**kw) -> SearchResult:
         manufacturer="Yageo",
         mpn="RC0603FR-0710KL",
         description="RES 10K",
-        datasheet="http://example",
+        # Deliberately empty: a non-empty Datasheet URL would trigger the
+        # jBOM#355 always-on staging fetch, which would attempt a real
+        # network request unless explicitly under test for that behavior.
+        datasheet="",
         distributor="mouser",
         distributor_part_number="123-ABC",
         availability="6,609 In Stock",

--- a/tests/unit/test_datasheet_staging.py
+++ b/tests/unit/test_datasheet_staging.py
@@ -1,6 +1,8 @@
 """Unit tests for jbom.services.datasheet_staging (jBOM#355).
 
-All fetches are injected fakes; no real network access is ever performed.
+All fetches are injected fakes; no real network access is ever performed
+(and the autouse ``_hermetic_datasheet_staging`` fixture in ``tests/conftest.py``
+would raise loudly if one slipped through).
 """
 
 from __future__ import annotations
@@ -8,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from jbom.common.types import InventoryItem
+from jbom.config.defaults import DefaultsConfig
 from jbom.services.datasheet_staging import (
     find_existing_staged_path,
     is_admitted,
@@ -15,6 +18,7 @@ from jbom.services.datasheet_staging import (
     looks_like_pdf,
     resolve_staging_dir,
     stage_datasheet_url,
+    stage_datasheet_urls,
     staged_filename_for_url,
 )
 
@@ -37,6 +41,35 @@ def _make_item(*, datasheet_name: str = "") -> InventoryItem:
         amperage="",
         wattage="",
         raw_data={"Datasheet Name": datasheet_name} if datasheet_name else {},
+    )
+
+
+def _defaults_with_staging_dir(staging_dir: Path) -> DefaultsConfig:
+    # max_fetches_per_run / fetch_time_budget_seconds mirror generic.jbom.yaml's
+    # shipped values: DatasheetStagingConfig's own Python-level defaults are
+    # deliberately 0/0.0 ("unconfigured"), per jBOM's no-hardcoded-defaults-in-
+    # code convention -- real values always come from the profile.
+    return DefaultsConfig.model_validate(
+        {
+            "datasheet_staging": {
+                "staging_dir": str(staging_dir),
+                "max_fetches_per_run": 20,
+                "fetch_time_budget_seconds": 30.0,
+            }
+        }
+    )
+
+
+def _defaults_with_budget(
+    *, max_fetches_per_run: int = 20, fetch_time_budget_seconds: float = 30.0
+) -> DefaultsConfig:
+    return DefaultsConfig.model_validate(
+        {
+            "datasheet_staging": {
+                "max_fetches_per_run": max_fetches_per_run,
+                "fetch_time_budget_seconds": fetch_time_budget_seconds,
+            }
+        }
     )
 
 
@@ -111,34 +144,31 @@ class TestIsAdmitted:
 
 
 class TestResolveStagingDir:
-    def test_explicit_override_wins(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("JBOM_STAGING_DIR", str(tmp_path / "env-staging"))
-        monkeypatch.setenv("JBOM_INVENTORY_ROOT", str(tmp_path / "env-root"))
+    def test_explicit_override_wins(self, tmp_path: Path) -> None:
+        cfg = _defaults_with_staging_dir(tmp_path / "profile-staging")
         explicit = tmp_path / "explicit"
-        assert resolve_staging_dir(explicit) == explicit
+        assert resolve_staging_dir(explicit, defaults=cfg) == explicit
 
-    def test_staging_dir_env_var_used_when_no_explicit(
+    def test_profile_configured_staging_dir_is_honored(self, tmp_path: Path) -> None:
+        configured = tmp_path / "profile-staging"
+        cfg = _defaults_with_staging_dir(configured)
+        assert resolve_staging_dir(defaults=cfg) == configured
+
+    def test_profile_staging_dir_supports_tilde_expansion(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        staging_dir = tmp_path / "env-staging"
-        monkeypatch.setenv("JBOM_STAGING_DIR", str(staging_dir))
-        monkeypatch.delenv("JBOM_INVENTORY_ROOT", raising=False)
-        assert resolve_staging_dir() == staging_dir
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = DefaultsConfig.model_validate(
+            {"datasheet_staging": {"staging_dir": "~/my-staging"}}
+        )
+        assert resolve_staging_dir(defaults=cfg) == tmp_path / "my-staging"
 
-    def test_inventory_root_env_var_appends_staging(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
-        root = tmp_path / "SPCoast-inventory"
-        monkeypatch.delenv("JBOM_STAGING_DIR", raising=False)
-        monkeypatch.setenv("JBOM_INVENTORY_ROOT", str(root))
-        assert resolve_staging_dir() == root / "staging"
-
-    def test_default_when_nothing_configured(self, monkeypatch) -> None:
-        monkeypatch.delenv("JBOM_STAGING_DIR", raising=False)
-        monkeypatch.delenv("JBOM_INVENTORY_ROOT", raising=False)
-        result = resolve_staging_dir()
-        assert result.name == "staging"
-        assert "SPCoast-inventory" in result.parts
+    def test_returns_none_when_unconfigured(self) -> None:
+        # staging_dir is a user-machine binding (names a local
+        # SPCoast-inventory checkout); there is deliberately no code-level
+        # fallback path, so an unconfigured profile means "inactive".
+        cfg = DefaultsConfig.model_validate({})
+        assert resolve_staging_dir(defaults=cfg) is None
 
 
 class TestFindExistingStagedPath:
@@ -165,6 +195,14 @@ class TestFindExistingStagedPath:
 
 
 class TestStageDatasheetUrl:
+    def test_inactive_when_staging_dir_is_none(self) -> None:
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=None,
+            fetch=_unused_fetch,
+        )
+        assert outcome.status == "inactive"
+
     def test_empty_url_is_skipped(self, tmp_path: Path) -> None:
         outcome = stage_datasheet_url("", staging_dir=tmp_path, fetch=_unused_fetch)
         assert outcome.status == "skip-empty-url"
@@ -292,6 +330,170 @@ class TestStageDatasheetUrl:
 
         assert outcome.status == "verified"
         assert staging_dir.is_dir()
+
+    def test_fixture_manifest_resolves_bytes_without_a_fetch_callable(
+        self, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "fixture.pdf"
+        pdf_file.write_bytes(_PDF_BYTES)
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(
+            '{"https://example.com/docs/lm358.pdf": "%s"}' % pdf_file, encoding="utf-8"
+        )
+
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=tmp_path / "staging",
+            fetch_fixtures_manifest=str(manifest_path),
+        )
+
+        assert outcome.status == "verified"
+
+
+class TestStageDatasheetUrls:
+    def test_inert_when_staging_dir_unconfigured(self) -> None:
+        cfg = DefaultsConfig.model_validate({})
+        entries = [("https://example.com/docs/a.pdf", None)]
+
+        result = stage_datasheet_urls(entries, defaults=cfg)
+
+        assert result.outcomes == []
+        assert result.attempted == 0
+        assert result.budget_exceeded is False
+
+    def test_stages_multiple_entries(self, tmp_path: Path) -> None:
+        cfg = _defaults_with_staging_dir(tmp_path)
+        entries = [
+            ("https://example.com/docs/a.pdf", None),
+            ("https://example.com/docs/b.pdf", None),
+        ]
+
+        # Real calls require monkeypatching default_fetch (module-level),
+        # which the autouse hermetic fixture forbids by default -- so patch
+        # it locally for this test.
+        import jbom.services.datasheet_staging as _mod
+
+        original = _mod.default_fetch
+        try:
+            _mod.default_fetch = lambda url, **_: _PDF_BYTES
+            result = stage_datasheet_urls(entries, defaults=cfg)
+        finally:
+            _mod.default_fetch = original
+
+        assert len(result.outcomes) == 2
+        assert all(o.status == "verified" for o in result.outcomes)
+        assert result.attempted == 2
+        assert result.budget_exceeded is False
+        assert result.summary_message() == ""
+
+    def test_empty_and_admitted_entries_are_free(self, tmp_path: Path) -> None:
+        cfg = _defaults_with_staging_dir(tmp_path)
+        admitted_item = _make_item(datasheet_name="LM358-series")
+        entries = [
+            ("", None),
+            ("https://example.com/docs/admitted.pdf", admitted_item),
+        ]
+
+        result = stage_datasheet_urls(entries, defaults=cfg)
+
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].status == "admitted-skip"
+        assert result.attempted == 0
+        assert result.budget_exceeded is False
+
+    def test_max_fetches_per_run_caps_real_fetch_attempts(self, tmp_path: Path) -> None:
+        cfg = _defaults_with_budget(
+            max_fetches_per_run=1, fetch_time_budget_seconds=30.0
+        )
+        # Redirect staging_dir onto tmp_path via a second profile merge.
+        cfg = DefaultsConfig.model_validate(
+            {
+                "datasheet_staging": {
+                    "staging_dir": str(tmp_path),
+                    "max_fetches_per_run": 1,
+                    "fetch_time_budget_seconds": 30.0,
+                }
+            }
+        )
+        entries = [
+            ("https://example.com/docs/a.pdf", None),
+            ("https://example.com/docs/b.pdf", None),
+            ("https://example.com/docs/c.pdf", None),
+        ]
+
+        import jbom.services.datasheet_staging as _mod
+
+        original = _mod.default_fetch
+        try:
+            _mod.default_fetch = lambda url, **_: _PDF_BYTES
+            result = stage_datasheet_urls(entries, defaults=cfg)
+        finally:
+            _mod.default_fetch = original
+
+        assert result.attempted == 1
+        assert result.budget_exceeded is True
+        assert result.skipped_for_budget == 2
+        assert len(result.outcomes) == 1
+        assert "budget exceeded" in result.summary_message()
+
+    def test_zero_time_budget_blocks_all_real_fetches(self, tmp_path: Path) -> None:
+        cfg = DefaultsConfig.model_validate(
+            {
+                "datasheet_staging": {
+                    "staging_dir": str(tmp_path),
+                    "max_fetches_per_run": 20,
+                    "fetch_time_budget_seconds": 0.0,
+                }
+            }
+        )
+        entries = [("https://example.com/docs/a.pdf", None)]
+
+        import jbom.services.datasheet_staging as _mod
+
+        original = _mod.default_fetch
+        try:
+            _mod.default_fetch = lambda url, **_: _PDF_BYTES
+            result = stage_datasheet_urls(entries, defaults=cfg)
+        finally:
+            _mod.default_fetch = original
+
+        assert result.attempted == 0
+        assert result.budget_exceeded is True
+        assert result.skipped_for_budget == 1
+
+    def test_free_entries_do_not_count_against_budget(self, tmp_path: Path) -> None:
+        cfg = DefaultsConfig.model_validate(
+            {
+                "datasheet_staging": {
+                    "staging_dir": str(tmp_path),
+                    "max_fetches_per_run": 1,
+                    "fetch_time_budget_seconds": 30.0,
+                }
+            }
+        )
+        admitted_item = _make_item(datasheet_name="LM358-series")
+        entries = [
+            ("https://example.com/docs/admitted-1.pdf", admitted_item),
+            ("https://example.com/docs/admitted-2.pdf", admitted_item),
+            ("https://example.com/docs/real.pdf", None),
+        ]
+
+        import jbom.services.datasheet_staging as _mod
+
+        original = _mod.default_fetch
+        try:
+            _mod.default_fetch = lambda url, **_: _PDF_BYTES
+            result = stage_datasheet_urls(entries, defaults=cfg)
+        finally:
+            _mod.default_fetch = original
+
+        assert result.attempted == 1
+        assert result.budget_exceeded is False
+        assert [o.status for o in result.outcomes] == [
+            "admitted-skip",
+            "admitted-skip",
+            "verified",
+        ]
 
 
 def _unused_fetch(url: str) -> bytes:  # pragma: no cover - defensive guard

--- a/tests/unit/test_datasheet_staging.py
+++ b/tests/unit/test_datasheet_staging.py
@@ -1,0 +1,298 @@
+"""Unit tests for jbom.services.datasheet_staging (jBOM#355).
+
+All fetches are injected fakes; no real network access is ever performed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jbom.common.types import InventoryItem
+from jbom.services.datasheet_staging import (
+    find_existing_staged_path,
+    is_admitted,
+    looks_like_html,
+    looks_like_pdf,
+    resolve_staging_dir,
+    stage_datasheet_url,
+    staged_filename_for_url,
+)
+
+_PDF_BYTES = b"%PDF-1.4\n%...rest of a minimal pdf...\n%%EOF"
+_HTML_BYTES = b"<!DOCTYPE html><html><head></head><body>Not found</body></html>"
+_JUNK_BYTES = b"this is neither a pdf nor html"
+
+
+def _make_item(*, datasheet_name: str = "") -> InventoryItem:
+    return InventoryItem(
+        ipn="RES_10K_0603",
+        keywords="",
+        category="RES",
+        description="",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="",
+        voltage="",
+        amperage="",
+        wattage="",
+        raw_data={"Datasheet Name": datasheet_name} if datasheet_name else {},
+    )
+
+
+class TestLooksLikePdf:
+    def test_true_for_pdf_magic_at_start(self) -> None:
+        assert looks_like_pdf(_PDF_BYTES) is True
+
+    def test_true_for_pdf_magic_with_small_prefix(self) -> None:
+        # Some PDFs have a small amount of leading junk before %PDF-.
+        assert looks_like_pdf(b"\xef\xbb\xbf" + _PDF_BYTES) is True
+
+    def test_false_for_html(self) -> None:
+        assert looks_like_pdf(_HTML_BYTES) is False
+
+    def test_false_for_empty_content(self) -> None:
+        assert looks_like_pdf(b"") is False
+
+    def test_false_for_unrelated_binary(self) -> None:
+        assert looks_like_pdf(_JUNK_BYTES) is False
+
+
+class TestLooksLikeHtml:
+    def test_true_for_doctype_html(self) -> None:
+        assert looks_like_html(_HTML_BYTES) is True
+
+    def test_true_for_bare_html_tag(self) -> None:
+        assert looks_like_html(b"<html><body>hi</body></html>") is True
+
+    def test_false_for_pdf(self) -> None:
+        assert looks_like_html(_PDF_BYTES) is False
+
+    def test_false_for_unrelated_binary(self) -> None:
+        assert looks_like_html(_JUNK_BYTES) is False
+
+
+class TestStagedFilenameForUrl:
+    def test_stable_for_same_url(self) -> None:
+        url = "https://example.com/docs/LM358.pdf"
+        assert staged_filename_for_url(url) == staged_filename_for_url(url)
+
+    def test_different_urls_with_same_basename_do_not_collide(self) -> None:
+        stem_a = staged_filename_for_url("https://supplier-a.com/ds/datasheet.pdf")
+        stem_b = staged_filename_for_url("https://supplier-b.com/ds/datasheet.pdf")
+        assert stem_a != stem_b
+
+    def test_uses_sanitized_basename_as_prefix(self) -> None:
+        stem = staged_filename_for_url("https://example.com/docs/LM358.pdf")
+        assert stem.startswith("LM358-")
+
+    def test_falls_back_to_generic_stem_for_url_without_path(self) -> None:
+        stem = staged_filename_for_url("https://example.com")
+        assert stem.startswith("datasheet-")
+
+    def test_sanitizes_unsafe_characters(self) -> None:
+        stem = staged_filename_for_url("https://example.com/a b?c=d.pdf")
+        prefix = stem.rsplit("-", 1)[0]
+        assert all(ch.isalnum() or ch in "._-" for ch in prefix)
+
+
+class TestIsAdmitted:
+    def test_false_when_item_is_none(self) -> None:
+        assert is_admitted(None) is False
+
+    def test_false_when_datasheet_name_absent(self) -> None:
+        assert is_admitted(_make_item()) is False
+
+    def test_false_when_datasheet_name_blank(self) -> None:
+        assert is_admitted(_make_item(datasheet_name="   ")) is False
+
+    def test_true_when_datasheet_name_present(self) -> None:
+        assert is_admitted(_make_item(datasheet_name="LM358-series")) is True
+
+
+class TestResolveStagingDir:
+    def test_explicit_override_wins(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("JBOM_STAGING_DIR", str(tmp_path / "env-staging"))
+        monkeypatch.setenv("JBOM_INVENTORY_ROOT", str(tmp_path / "env-root"))
+        explicit = tmp_path / "explicit"
+        assert resolve_staging_dir(explicit) == explicit
+
+    def test_staging_dir_env_var_used_when_no_explicit(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        staging_dir = tmp_path / "env-staging"
+        monkeypatch.setenv("JBOM_STAGING_DIR", str(staging_dir))
+        monkeypatch.delenv("JBOM_INVENTORY_ROOT", raising=False)
+        assert resolve_staging_dir() == staging_dir
+
+    def test_inventory_root_env_var_appends_staging(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        root = tmp_path / "SPCoast-inventory"
+        monkeypatch.delenv("JBOM_STAGING_DIR", raising=False)
+        monkeypatch.setenv("JBOM_INVENTORY_ROOT", str(root))
+        assert resolve_staging_dir() == root / "staging"
+
+    def test_default_when_nothing_configured(self, monkeypatch) -> None:
+        monkeypatch.delenv("JBOM_STAGING_DIR", raising=False)
+        monkeypatch.delenv("JBOM_INVENTORY_ROOT", raising=False)
+        result = resolve_staging_dir()
+        assert result.name == "staging"
+        assert "SPCoast-inventory" in result.parts
+
+
+class TestFindExistingStagedPath:
+    def test_returns_none_when_nothing_staged(self, tmp_path: Path) -> None:
+        assert find_existing_staged_path(tmp_path, "stem-abc") is None
+
+    def test_returns_verified_path_when_present(self, tmp_path: Path) -> None:
+        verified = tmp_path / "stem-abc.pdf"
+        verified.write_bytes(_PDF_BYTES)
+        assert find_existing_staged_path(tmp_path, "stem-abc") == verified
+
+    def test_returns_unverified_path_when_only_that_exists(
+        self, tmp_path: Path
+    ) -> None:
+        unverified = tmp_path / "stem-abc.unverified"
+        unverified.write_bytes(_HTML_BYTES)
+        assert find_existing_staged_path(tmp_path, "stem-abc") == unverified
+
+    def test_prefers_verified_over_unverified(self, tmp_path: Path) -> None:
+        verified = tmp_path / "stem-abc.pdf"
+        verified.write_bytes(_PDF_BYTES)
+        (tmp_path / "stem-abc.unverified").write_bytes(_HTML_BYTES)
+        assert find_existing_staged_path(tmp_path, "stem-abc") == verified
+
+
+class TestStageDatasheetUrl:
+    def test_empty_url_is_skipped(self, tmp_path: Path) -> None:
+        outcome = stage_datasheet_url("", staging_dir=tmp_path, fetch=_unused_fetch)
+        assert outcome.status == "skip-empty-url"
+        assert outcome.path is None
+
+    def test_admitted_item_is_skipped_without_fetching(self, tmp_path: Path) -> None:
+        item = _make_item(datasheet_name="LM358-series")
+        calls: list[str] = []
+
+        def _tracking_fetch(url: str) -> bytes:
+            calls.append(url)
+            return _PDF_BYTES
+
+        outcome = stage_datasheet_url(
+            "https://example.com/lm358.pdf",
+            item=item,
+            staging_dir=tmp_path,
+            fetch=_tracking_fetch,
+        )
+
+        assert outcome.status == "admitted-skip"
+        assert calls == []
+        assert list(tmp_path.glob("*")) == []
+
+    def test_verified_pdf_is_written_with_pdf_suffix(self, tmp_path: Path) -> None:
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=tmp_path,
+            fetch=lambda url: _PDF_BYTES,
+        )
+
+        assert outcome.status == "verified"
+        assert outcome.path is not None
+        assert outcome.path.suffix == ".pdf"
+        assert outcome.path.read_bytes() == _PDF_BYTES
+
+    def test_html_response_is_flagged_and_kept_unverified(self, tmp_path: Path) -> None:
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=tmp_path,
+            fetch=lambda url: _HTML_BYTES,
+        )
+
+        assert outcome.status == "flagged"
+        assert outcome.path is not None
+        assert outcome.path.name.endswith(".unverified")
+        assert outcome.path.read_bytes() == _HTML_BYTES
+        assert "HTML impostor" in outcome.message
+
+    def test_non_pdf_non_html_response_is_flagged_as_unrecognized(
+        self, tmp_path: Path
+    ) -> None:
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=tmp_path,
+            fetch=lambda url: _JUNK_BYTES,
+        )
+
+        assert outcome.status == "flagged"
+        assert "unrecognized content" in outcome.message
+
+    def test_already_verified_staged_file_is_not_refetched(
+        self, tmp_path: Path
+    ) -> None:
+        url = "https://example.com/docs/lm358.pdf"
+        first = stage_datasheet_url(
+            url, staging_dir=tmp_path, fetch=lambda u: _PDF_BYTES
+        )
+        assert first.status == "verified"
+
+        calls: list[str] = []
+
+        def _tracking_fetch(u: str) -> bytes:
+            calls.append(u)
+            return _PDF_BYTES
+
+        second = stage_datasheet_url(url, staging_dir=tmp_path, fetch=_tracking_fetch)
+
+        assert second.status == "staged-skip"
+        assert calls == []
+
+    def test_already_flagged_unverified_file_is_not_refetched(
+        self, tmp_path: Path
+    ) -> None:
+        url = "https://example.com/docs/lm358.pdf"
+        first = stage_datasheet_url(
+            url, staging_dir=tmp_path, fetch=lambda u: _HTML_BYTES
+        )
+        assert first.status == "flagged"
+
+        calls: list[str] = []
+
+        def _tracking_fetch(u: str) -> bytes:
+            calls.append(u)
+            return _HTML_BYTES
+
+        second = stage_datasheet_url(url, staging_dir=tmp_path, fetch=_tracking_fetch)
+
+        assert second.status == "staged-skip"
+        assert calls == []
+
+    def test_fetch_error_is_reported_without_raising(self, tmp_path: Path) -> None:
+        def _boom(url: str) -> bytes:
+            raise RuntimeError("connection reset")
+
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=tmp_path,
+            fetch=_boom,
+        )
+
+        assert outcome.status == "fetch-error"
+        assert "connection reset" in outcome.message
+        assert list(tmp_path.glob("*")) == []
+
+    def test_staging_dir_is_created_on_first_write(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "nested" / "staging"
+        assert not staging_dir.exists()
+
+        outcome = stage_datasheet_url(
+            "https://example.com/docs/lm358.pdf",
+            staging_dir=staging_dir,
+            fetch=lambda url: _PDF_BYTES,
+        )
+
+        assert outcome.status == "verified"
+        assert staging_dir.is_dir()
+
+
+def _unused_fetch(url: str) -> bytes:  # pragma: no cover - defensive guard
+    raise AssertionError(f"fetch should not have been called for {url!r}")

--- a/tests/unit/test_defaults_config.py
+++ b/tests/unit/test_defaults_config.py
@@ -27,6 +27,7 @@ from jbom.config.defaults import (
     load_defaults,
     set_active_defaults_profile,
 )
+from jbom.config.unified import clear_unified_loader_caches
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +168,88 @@ def test_generic_profile_has_inventory_schema_contract() -> None:
         schema.enrichment_bindings["fabricator_part_number"]
         == "__resolved_fabricator_part_number__"
     )
+
+
+# ---------------------------------------------------------------------------
+# datasheet_staging: stanza (jBOM#355)
+# ---------------------------------------------------------------------------
+
+
+def test_generic_profile_has_datasheet_staging_defaults() -> None:
+    cfg = load_defaults("generic")
+    staging_cfg = cfg.get_datasheet_staging_config()
+    assert staging_cfg.staging_dir == ""
+    assert staging_cfg.max_fetches_per_run == 20
+    assert staging_cfg.fetch_time_budget_seconds == 30.0
+    assert staging_cfg.fetch_fixtures_manifest == ""
+
+
+def test_home_common_jbom_yaml_can_bind_staging_dir(tmp_path: Path) -> None:
+    """``staging_dir`` is a user-machine binding: the shipped generic profile
+    never declares it, so a user's ``~/.jbom/common.jbom.yaml`` (modeled
+    here via a project-cwd ``common.jbom.yaml`` for test simplicity) can set
+    it without being clobbered by the builtin profile.
+    """
+
+    jbom_dir = tmp_path / ".jbom"
+    _write_yaml(
+        jbom_dir / "common.jbom.yaml",
+        {"defaults": {"datasheet_staging": {"staging_dir": "/custom/staging"}}},
+    )
+
+    cfg = get_defaults(cwd=tmp_path)
+    staging_cfg = cfg.get_datasheet_staging_config()
+    assert staging_cfg.staging_dir == "/custom/staging"
+    # Generic, non-machine-specific values still come from the builtin profile.
+    assert staging_cfg.max_fetches_per_run == 20
+    assert staging_cfg.fetch_time_budget_seconds == 30.0
+
+
+def test_project_generic_jbom_yaml_override_wins_over_common(
+    tmp_path: Path,
+) -> None:
+    jbom_dir = tmp_path / ".jbom"
+    _write_yaml(
+        jbom_dir / "common.jbom.yaml",
+        {"defaults": {"datasheet_staging": {"staging_dir": "/from/common"}}},
+    )
+    _write_yaml(
+        jbom_dir / "generic.jbom.yaml",
+        {"defaults": {"datasheet_staging": {"staging_dir": "/from/project"}}},
+    )
+
+    cfg = get_defaults(cwd=tmp_path)
+    assert cfg.get_datasheet_staging_config().staging_dir == "/from/project"
+
+
+def test_max_fetches_per_run_override_requires_a_named_profile_shadow(
+    tmp_path: Path,
+) -> None:
+    """``max_fetches_per_run`` is declared with a concrete value in the
+    builtin ``generic.jbom.yaml``, so -- consistent with every other key the
+    builtin declares (e.g. ``domain_defaults``) -- a ``common.jbom.yaml``
+    override of it is clobbered by the builtin; overriding it requires
+    shadowing the named profile itself (a project ``.jbom/generic.jbom.yaml``
+    that declares the same key), the same pattern used for other generic.
+    jbom.yaml-declared values throughout this codebase.
+    """
+
+    jbom_dir = tmp_path / ".jbom"
+    _write_yaml(
+        jbom_dir / "common.jbom.yaml",
+        {"defaults": {"datasheet_staging": {"max_fetches_per_run": 5}}},
+    )
+
+    cfg = get_defaults(cwd=tmp_path)
+    assert cfg.get_datasheet_staging_config().max_fetches_per_run == 20
+
+    _write_yaml(
+        jbom_dir / "generic.jbom.yaml",
+        {"defaults": {"datasheet_staging": {"max_fetches_per_run": 5}}},
+    )
+    clear_unified_loader_caches()
+    cfg = get_defaults(cwd=tmp_path)
+    assert cfg.get_datasheet_staging_config().max_fetches_per_run == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_inventory_supplier_flag.py
+++ b/tests/unit/test_inventory_supplier_flag.py
@@ -79,13 +79,17 @@ def _make_item(
 
 
 def _make_result(
-    *, pn: str = "S25804", mfr: str = "Yageo", mpn: str = "RC0603"
+    *,
+    pn: str = "S25804",
+    mfr: str = "Yageo",
+    mpn: str = "RC0603",
+    datasheet: str = "",
 ) -> SearchResult:
     return SearchResult(
         manufacturer=mfr,
         mpn=mpn,
         description="RES 10K 1% 0603",
-        datasheet="",
+        datasheet=datasheet,
         distributor="generic",
         distributor_part_number=pn,
         availability="500 In Stock",
@@ -97,10 +101,11 @@ def _make_result(
 
 
 def _candidate(
-    pn: str = "S25804", mfr: str = "Yageo", mpn: str = "RC0603"
+    pn: str = "S25804", mfr: str = "Yageo", mpn: str = "RC0603", datasheet: str = ""
 ) -> InventorySearchCandidate:
     return InventorySearchCandidate(
-        result=_make_result(pn=pn, mfr=mfr, mpn=mpn), match_score=80
+        result=_make_result(pn=pn, mfr=mfr, mpn=mpn, datasheet=datasheet),
+        match_score=80,
     )
 
 
@@ -319,6 +324,36 @@ class TestEnrichSuccessful:
         items_out, _ = _enrich([item], ["IPN"], service, filter_returns=[item])
 
         assert items_out[0].mfgpn == "RC0402FR-07100KL"
+
+    def test_datasheet_backfilled_when_blank(self) -> None:
+        item = _make_item()
+        record = InventorySearchRecord(
+            inventory_item=item,
+            query="10K",
+            candidates=[
+                _candidate("S25804", datasheet="https://example.com/lm358.pdf")
+            ],
+        )
+        service = _mock_service([record])
+        items_out, _ = _enrich([item], ["IPN"], service, filter_returns=[item])
+
+        assert items_out[0].datasheet == "https://example.com/lm358.pdf"
+        assert items_out[0].raw_data.get("Datasheet") == "https://example.com/lm358.pdf"
+
+    def test_datasheet_not_overwritten_when_present(self) -> None:
+        item = _make_item()
+        item.datasheet = "https://example.com/original.pdf"
+        record = InventorySearchRecord(
+            inventory_item=item,
+            query="10K",
+            candidates=[
+                _candidate("S25804", datasheet="https://example.com/candidate.pdf")
+            ],
+        )
+        service = _mock_service([record])
+        items_out, _ = _enrich([item], ["IPN"], service, filter_returns=[item])
+
+        assert items_out[0].datasheet == "https://example.com/original.pdf"
 
     def test_limit_gt_one_emits_ranked_alternatives(self) -> None:
         item = _make_item()


### PR DESCRIPTION
## Summary

Implements the always-on staging fetch decided in jBOM#349: whenever `jbom search` or `jbom inventory --supplier` encounters an Item's Datasheet URL, it is fetched into a `staging/` directory. Downloads land with a `.unverified` suffix until a `file(1)`-style content check confirms the payload is a real PDF; verified PDFs get a plain `.pdf` suffix. HTML impostors keep the `.unverified` suffix and are flagged with a warning (per jBOM#345, HTML is never admitted). The fetch is idempotent: already-staged URLs and already-admitted items (`Datasheet Name` populated) are skipped without a network call. No inventory writes occur anywhere in this change — admission into `datasheets/` remains the separate `jbom inventory admit` gate (jBOM#356), which depends on this staging layout and coordinates on the same `datasheet_staging.staging_dir` profile key.

### Configuration contract (see jBOM#355's amended "Configuration contract" section)

Staging is configured entirely through jBOM's `defaults:` profile stanza (`datasheet_staging:`) — no environment variables, no repo/path defaults in code or `generic.jbom.yaml`:

- **`staging_dir`** is a *user-specified repo binding*, resolved exclusively via the profile hierarchy. The shipped `generic.jbom.yaml` never declares a value for it, and there is no code-level fallback path. **With no `staging_dir` configured, the staging fetch is inert** (a silent no-op) until a user sets it in their own `~/.jbom/common.jbom.yaml`.
- **`max_fetches_per_run`** / **`fetch_time_budget_seconds`** are generic, non-machine-specific tuning knobs shipped with concrete values (`20` / `30`) in `generic.jbom.yaml`, per jBOM's convention that profile-declared defaults — not hardcoded Python values — are the source of truth. Once either limit is hit, remaining Datasheet URLs are skipped for that run with a one-line stderr summary; nothing else about the command fails.

See `docs/reference/configuration.md` (`datasheet_staging:` sub-stanza) and `docs/reference/cli.md` (search/inventory command sections) for the full write-up.

### What changed

- New `jbom.services.datasheet_staging` module: `resolve_staging_dir` (profile-based, returns `None` when unconfigured), `looks_like_pdf`/`looks_like_html` (magic-byte/content sniffing), `staged_filename_for_url` (stable, collision-resistant filename derivation), `is_admitted`, `stage_datasheet_url` / `stage_datasheet_urls` (idempotent, budget-aware orchestration), and `default_fetch` (lazy `requests` import, mirroring the existing pattern in `suppliers/lcsc/api.py`).
- `config/defaults.py`: new `DatasheetStagingConfig` schema + `DefaultsConfig.get_datasheet_staging_config()`.
- `cli/search.py`: every result with a Datasheet URL is staged (when configured); new optional `--inventory CATALOG_CSV` argument cross-references admitted documents so `jbom search` honors admitted-skip even though it has no other inventory context of its own.
- `cli/inventory.py`: `_apply_supplier_candidate_to_item` now also propagates `candidate.result.datasheet` onto `item.datasheet` when the item doesn't already carry one; `_stage_datasheets_for_items` uses the new budget-aware batch orchestration.
- `features/steps/project_centric_steps.py`: the supplier-catalog fixture table now passes through a `datasheet` column.
- Test-only fixture-manifest seam (`fetch_fixtures_manifest`, a `datasheet_staging` config key) lets BDD scenarios exercising the CLI as a subprocess redirect fetches to local files instead of the network; Backgrounds provision sandboxed staging dirs via a scenario-local `common.jbom.yaml`.
- `tests/conftest.py`: autouse hermetic guard makes any real network fetch attempt raise immediately.

## Validation

- `pytest tests/` — 1527 passed
- `python -m behave --format progress` — 50 features passed, 281 scenarios passed, 1880 steps passed, 0 failed, 8 skipped (pre-existing skips, unrelated)
- `pre-commit` — all hooks passed (trailing whitespace, EOF, merge conflicts, debugger imports, mixed line endings, black, flake8, bandit)

Closes #355
