### PR TITLE
feat(audit): read-only datasheet document-library hygiene checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Once the schematic is clean, verify your inventory covers every component:
 jbom audit MyProject/ --inventory inventory.csv
 ```
 
+If your inventory carries `Datasheet`/`Datasheet Name` columns for a shared datasheet document library, `jbom audit` also runs read-only naming/provenance hygiene checks against them, and can check file presence against a local library checkout:
+
+```bash
+jbom audit inventory.csv --datasheet-library ~/Dropbox/workspace/SPCoast-inventory
+```
+
 ### 3. Fill in part numbers for JLC's LCSC supplier
 
 An inventory file maps your generic schematic values to real parts from a supplier's catalog — in this case LCSC, which JLCPCB uses for sourcing. Open `inventory.csv` and fill in the **LCSC** column for each part you want JLCPCB to source. Set **Priority** to `1` on rows you want matched first.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,7 +14,7 @@ jbom — generate Bill of Materials, Placement Files, and Parts Lists from KiCad
 
 ```
 jbom [-q] [--version]
-jbom audit PATH [PATH ...] [--inventory CATALOG_CSV] [--supplier NAME] [--api-key KEY] [--requirements REQ_CSV] [-o REPORT_CSV] [--strict] [-v]
+jbom audit PATH [PATH ...] [--inventory CATALOG_CSV] [--supplier NAME] [--api-key KEY] [--requirements REQ_CSV] [--datasheet-library LIBRARY_DIR] [-o REPORT_CSV] [--strict] [-v]
 jbom annotate INPUT [--repairs REPORT_CSV] [--normalize] [--dry-run]
 jbom bom [PROJECT] [--inventory FILE ...] [-o OUTPUT] [BOM OPTIONS]
 jbom pos [PROJECT] [-o OUTPUT] [POS OPTIONS]
@@ -57,7 +57,7 @@ The BOM workflow keeps designs supplier-neutral: components carry generic values
 
 ```
 jbom audit PATH [PATH ...]  [--inventory CATALOG_CSV]  [--supplier NAME] [--api-key KEY]  [-o REPORT_CSV]  [--strict] [-v]
-jbom audit CAT.CSV [...]    [--requirements REQ_CSV]   [--supplier NAME] [--api-key KEY]  [-o REPORT_CSV]  [--strict] [-v]
+jbom audit CAT.CSV [...]    [--requirements REQ_CSV]   [--supplier NAME] [--api-key KEY]  [--datasheet-library LIBRARY_DIR]  [-o REPORT_CSV]  [--strict] [-v]
 ```
 
 Diagnoses field-quality issues and inventory coverage gaps. Mode is detected automatically from the positional arguments:
@@ -96,6 +96,20 @@ Diagnoses field-quality issues and inventory coverage gaps. Mode is detected aut
   - Existing PN matches the best search result → silent
   - Row has no supplier PN → skipped (no check)
 
+**Datasheet document-library hygiene checks (inventory mode, always)**
+: Read-only, offline lints against the shared `SPCoast-inventory` datasheet document library (`Datasheet` URL / `Datasheet Name` columns). These run automatically for every inventory-mode audit, with no flag required:
+  - `Datasheet` URL populated but `Datasheet Name` empty (dig-deeper backlog) → `DATASHEET_BACKLOG / INFO`
+  - No row sharing a `Datasheet Name` carries the canonical-source URL → `DATASHEET_PROVENANCE_MISSING / WARN`
+  - More than one row sharing a `Datasheet Name` carries a URL (violates the one-URL-per-Name rule) → `DATASHEET_PROVENANCE_CONFLICT / ERROR`
+  - Same `Datasheet Name` spelled with inconsistent casing across rows → `DATASHEET_NAME_CASE_MISMATCH / ERROR`
+  - Two distinct `Datasheet Name` values are suspiciously similar (possible spelling drift) → `DATASHEET_NAME_NEAR_COLLISION / WARN`
+  - `Manufacturer` (or a `Datasheet Name` token) diverges from the catalog's canonical spelling for that manufacturer/tech token → `DATASHEET_TOKEN_MISMATCH / WARN`
+
+**Datasheet library file-presence checks (inventory mode + `--datasheet-library`)**
+: When `--datasheet-library LIBRARY_DIR` is given, curated `Datasheet Name` values are additionally checked against the library checkout's `datasheets/` directory (case-insensitive filename match):
+  - A `Datasheet Name` has no matching `datasheets/<name>.pdf` → `DATASHEET_FILE_MISSING / ERROR`
+  - A PDF under `datasheets/` is not referenced by any Item's `Datasheet Name` → `DATASHEET_ORPHAN_FILE / WARN`
+
 ### Arguments
 
 **PATH** (one or more, required)
@@ -112,6 +126,9 @@ Diagnoses field-quality issues and inventory coverage gaps. Mode is detected aut
 
 **--requirements REQ_CSV**
 : Requirements CSV (output of `jbom inventory proj`) for a coverage check (inventory mode only).
+
+**--datasheet-library LIBRARY_DIR**
+: SPCoast-inventory checkout root (containing `datasheets/`) for datasheet document-library file-presence checks (inventory mode only; rejected in project mode). Enables `DATASHEET_FILE_MISSING` / `DATASHEET_ORPHAN_FILE` rows. The other datasheet-library hygiene checks (backlog, name/provenance lints, token normalization) always run in inventory mode regardless of this flag.
 
 **-o, --output REPORT_CSV**
 : Write the audit report to this file. If omitted, CSV is written to stdout.
@@ -157,6 +174,9 @@ jbom annotate ./my_project --repairs report.csv
 # 3. Audit catalog coverage against project requirements
 jbom inventory ./my_project -o requirements.csv
 jbom audit catalog.csv --requirements requirements.csv -o catalog_report.csv
+
+# 4. Audit the datasheet document library (offline hygiene + file presence)
+jbom audit catalog.csv --datasheet-library ~/Dropbox/workspace/SPCoast-inventory -o datasheet_report.csv
 ```
 
 ## ANNOTATE COMMAND

--- a/docs/reference/inventory-format.md
+++ b/docs/reference/inventory-format.md
@@ -118,7 +118,21 @@ user; jBOM exposes them to the BOM-generation pipeline by name.
   inventories should use `Supplier` + `SPN` instead.
 
 **Datasheet**
-: URL to the component datasheet PDF.
+: URL to the component datasheet PDF. When a curated `Datasheet Name` (below) is
+  shared by multiple rows, the one-URL-per-Name rule applies: exactly one of those
+  rows should carry the canonical-source URL (the row the library copy was actually
+  acquired from); the other member rows leave `Datasheet` blank. `jbom audit`
+  enforces this (`DATASHEET_PROVENANCE_MISSING` / `DATASHEET_PROVENANCE_CONFLICT`);
+  see [docs/reference/cli.md](cli.md#audit-command).
+
+**Datasheet Name**
+: Curated name of the document in the shared datasheet document library, resolving by
+  convention to `datasheets/<name>.pdf` (no path, no `.pdf` extension stored in the
+  cell). Presence of `Datasheet Name` is what marks an Item as curated; `Datasheet`
+  URL populated with `Datasheet Name` empty is the structural "dig-deeper" backlog.
+  `jbom audit` runs read-only naming, provenance, and (with `--datasheet-library`)
+  file-presence checks against this column; see
+  [docs/reference/cli.md](cli.md#audit-command).
 
 **Keywords**
 : Comma-separated search keywords. Not currently used in matching but available for

--- a/features/audit/datasheet_library.feature
+++ b/features/audit/datasheet_library.feature
@@ -1,0 +1,141 @@
+Feature: Audit datasheet document-library hygiene checks
+  As a hardware developer curating the shared SPCoast-inventory datasheet
+  document library
+  I want jbom audit to run read-only hygiene checks against the inventory's
+  Datasheet / Datasheet Name columns and the library's datasheets/ directory
+  So that I can catch naming, provenance, and file-presence problems before
+  they reach CI (jBOM#357)
+
+  # ──────────────────────────────────────────────────────────────
+  # Clean pass
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: A fully curated catalog produces no datasheet findings
+    Given a datasheet library directory "library" containing:
+      | Filename                                    |
+      | Resistor-ThickFilm-Yageo-RC0805-series.pdf  |
+    And an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Manufacturer | Datasheet                       | Datasheet Name                              |
+      | ITEM    | R1  | RES      | Yageo        | https://example.com/rc0805.pdf | Resistor-ThickFilm-Yageo-RC0805-series      |
+      | ITEM    | R2  | RES      | Yageo        |                                 | Resistor-ThickFilm-Yageo-RC0805-series      |
+    When I run "jbom audit catalog.csv --datasheet-library library"
+    Then the command should succeed
+    And the output should not contain "DATASHEET_"
+
+  # ──────────────────────────────────────────────────────────────
+  # Bullet 5: structural backlog (URL populated, Name empty)
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: DATASHEET_BACKLOG emitted for a URL-only row
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet                    | Datasheet Name |
+      | ITEM    | R1  | RES      | https://example.com/rc0805.pdf |                |
+    When I run "jbom audit catalog.csv"
+    Then the command should succeed
+    And the output should contain "DATASHEET_BACKLOG"
+    And the output should contain "R1"
+
+  # ──────────────────────────────────────────────────────────────
+  # Bullet 1: Name -> URL consistency (one-URL-per-Name provenance)
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: DATASHEET_PROVENANCE_MISSING emitted when no row in the group carries a URL
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet | Datasheet Name |
+      | ITEM    | R1  | RES      |           | shared-doc     |
+      | ITEM    | R2  | RES      |           | shared-doc     |
+    When I run "jbom audit catalog.csv"
+    Then the command should succeed
+    And the output should contain "DATASHEET_PROVENANCE_MISSING"
+    And the output should contain "shared-doc"
+
+  Scenario: DATASHEET_PROVENANCE_CONFLICT emitted when more than one row carries a URL
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet          | Datasheet Name |
+      | ITEM    | R1  | RES      | https://example.com/a.pdf | shared-doc     |
+      | ITEM    | R2  | RES      | https://example.com/b.pdf | shared-doc     |
+    When I run "jbom audit catalog.csv"
+    Then the command should fail
+    And the output should contain "DATASHEET_PROVENANCE_CONFLICT"
+
+  # ──────────────────────────────────────────────────────────────
+  # Bullet 2: case-insensitive uniqueness + near-collisions
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: DATASHEET_NAME_CASE_MISMATCH emitted for inconsistent casing of the same name
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet                  | Datasheet Name |
+      | ITEM    | R1  | RES      | https://example.com/a.pdf | Foo-Series     |
+      | ITEM    | R2  | RES      |                            | foo-series     |
+    When I run "jbom audit catalog.csv"
+    Then the command should fail
+    And the output should contain "DATASHEET_NAME_CASE_MISMATCH"
+
+  Scenario: DATASHEET_NAME_NEAR_COLLISION emitted for suspiciously similar names
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet                  | Datasheet Name                              |
+      | ITEM    | R1  | RES      | https://example.com/a.pdf | Resistor-ThickFilm-Uniroyal-0603WAJ-series  |
+      | ITEM    | R2  | RES      | https://example.com/b.pdf | Resistor-ThickFilm-Univoyal-0603WAJ-series  |
+    When I run "jbom audit catalog.csv"
+    Then the command should succeed
+    And the output should contain "DATASHEET_NAME_NEAR_COLLISION"
+
+  # ──────────────────────────────────────────────────────────────
+  # Bullet 3: file presence (requires --datasheet-library)
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: DATASHEET_FILE_MISSING emitted when a curated Name has no library PDF
+    Given a datasheet library directory "library" containing:
+      | Filename |
+    And an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet                  | Datasheet Name |
+      | ITEM    | R1  | RES      | https://example.com/a.pdf | missing-doc    |
+    When I run "jbom audit catalog.csv --datasheet-library library"
+    Then the command should fail
+    And the output should contain "DATASHEET_FILE_MISSING"
+    And the output should contain "R1"
+
+  Scenario: DATASHEET_ORPHAN_FILE emitted for a library PDF with no referencing Item
+    Given a datasheet library directory "library" containing:
+      | Filename        |
+      | orphan-doc.pdf   |
+    And an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet | Datasheet Name |
+      | ITEM    | R1  | RES      |           |                |
+    When I run "jbom audit catalog.csv --datasheet-library library"
+    Then the command should succeed
+    And the output should contain "DATASHEET_ORPHAN_FILE"
+    And the output should contain "orphan-doc"
+
+  Scenario: File-presence checks do not run without --datasheet-library
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Datasheet                  | Datasheet Name |
+      | ITEM    | R1  | RES      | https://example.com/a.pdf | missing-doc    |
+    When I run "jbom audit catalog.csv"
+    Then the command should succeed
+    And the output should not contain "DATASHEET_FILE_MISSING"
+    And the output should not contain "DATASHEET_ORPHAN_FILE"
+
+  Scenario: --datasheet-library is rejected in project mode
+    Given a schematic that contains:
+      | UUID    | Reference | Value | Footprint            | Package | LibID    |
+      | uuid-r1 | R1        | 10K   | Resistor_SMD:R_0603  | 0603    | Device:R |
+    When I run jbom command "audit . --datasheet-library library"
+    Then the command should fail
+    And the output should contain "only valid in inventory mode"
+
+  # ──────────────────────────────────────────────────────────────
+  # Bullet 4: manufacturer/tech token normalization
+  # ──────────────────────────────────────────────────────────────
+
+  Scenario: DATASHEET_TOKEN_MISMATCH emitted for manufacturer spelling drift
+    Given an inventory file "catalog.csv" that contains:
+      | RowType | IPN | Category | Manufacturer |
+      | ITEM    | R1  | RES      | Uniroyal     |
+      | ITEM    | R2  | RES      | Uniroyal     |
+      | ITEM    | R3  | RES      | UNI-ROYAL    |
+    When I run "jbom audit catalog.csv"
+    Then the command should succeed
+    And the output should contain "DATASHEET_TOKEN_MISMATCH"
+    And the output should contain "UNI-ROYAL"
+    And the output should contain "Uniroyal"

--- a/features/steps/datasheet_library_audit_steps.py
+++ b/features/steps/datasheet_library_audit_steps.py
@@ -1,0 +1,33 @@
+"""Step definitions for `jbom audit` datasheet document-library checks (jBOM#357).
+
+Fixture PDFs are minimal ``%PDF-`` byte stubs; the audit checks under test
+only care about filename presence/absence under ``<library>/datasheets/``,
+never file contents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from behave import given
+
+_PDF_FIXTURE_BYTES = b"%PDF-1.4\n%fixture datasheet for jBOM#357 BDD scenarios\n%%EOF"
+
+
+@given('a datasheet library directory "{rel_path}" containing:')
+def given_datasheet_library_directory(context, rel_path: str) -> None:
+    """Create ``<sandbox>/<rel_path>/datasheets/<Filename>`` fixture PDFs.
+
+    The table's ``Filename`` column may be empty (zero data rows) to create
+    an empty library (still exercising DATASHEET_FILE_MISSING checks).
+    """
+
+    datasheets_dir = Path(context.project_root) / rel_path / "datasheets"
+    datasheets_dir.mkdir(parents=True, exist_ok=True)
+
+    if context.table:
+        for row in context.table:
+            filename = row["Filename"].strip()
+            if not filename:
+                continue
+            (datasheets_dir / filename).write_bytes(_PDF_FIXTURE_BYTES)

--- a/src/jbom/cli/audit.py
+++ b/src/jbom/cli/audit.py
@@ -191,6 +191,20 @@ def register_command(subparsers: argparse._SubParsersAction) -> None:  # type: i
     )
 
     parser.add_argument(
+        "--datasheet-library",
+        metavar="LIBRARY_DIR",
+        type=Path,
+        default=None,
+        help=(
+            "SPCoast-inventory checkout root (containing datasheets/) for the "
+            "datasheet document-library file-presence checks (inventory mode "
+            "only; triggers DATASHEET_FILE_MISSING / DATASHEET_ORPHAN_FILE rows). "
+            "Other datasheet-library hygiene checks (backlog, name/provenance "
+            "lints, token normalization) always run in inventory mode."
+        ),
+    )
+
+    parser.add_argument(
         "-o",
         "--output",
         metavar="DEST",
@@ -274,6 +288,14 @@ def _run_project_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
         )
         return 1
 
+    if getattr(args, "datasheet_library", None) is not None:
+        print(
+            "Error: --datasheet-library is only valid in inventory mode "
+            "(positional arguments must be .csv files for inventory mode)",
+            file=sys.stderr,
+        )
+        return 1
+
     supplier_service, supplier_id = _build_supplier_service(args)
 
     service = AuditService()
@@ -313,6 +335,7 @@ def _run_inventory_mode(args: argparse.Namespace, inputs: list[Path]) -> int:
         requirements_path=getattr(args, "requirements", None),
         supplier_service=supplier_service,
         supplier_id=supplier_id,
+        library_dir=getattr(args, "datasheet_library", None),
     )
 
     _write_inventory_report(args, report)

--- a/src/jbom/services/audit_service.py
+++ b/src/jbom/services/audit_service.py
@@ -710,7 +710,15 @@ class AuditService:
         by_exact_name: dict[str, list[InventoryItem]],
         catalog_file: str,
     ) -> list[AuditRow]:
-        """Return provenance rows for the one-URL-per-Name rule (jBOM#348/#351)."""
+        """Return provenance rows for the one-URL-per-Name rule (jBOM#348/#351).
+
+        Note: *by_exact_name* groups by exact string, not case-folded. This
+        is intentional -- case variants of the same name are a distinct
+        defect (DATASHEET_NAME_CASE_MISMATCH, see
+        _check_datasheet_name_collisions) and are surfaced there rather than
+        silently merged into one provenance group here, which would risk
+        double-counting or masking findings across the two checks.
+        """
         rows: list[AuditRow] = []
         for name, members in by_exact_name.items():
             with_url = [m for m in members if (m.datasheet or "").strip()]

--- a/src/jbom/services/audit_service.py
+++ b/src/jbom/services/audit_service.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import csv
 import io
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -32,6 +33,16 @@ from jbom.common.field_taxonomy import (
 )
 from jbom.common.types import Component, InventoryItem
 from jbom.services.component_merge_service import ComponentMergeService
+from jbom.services.datasheet_library import (
+    datasheet_filename,
+    extract_name_tokens,
+    find_near_collisions,
+    get_datasheet_name,
+    group_case_insensitive_variants,
+    normalize_token as _normalize_manufacturer_token,
+    resolve_canonical_spellings,
+    scan_library_pdfs,
+)
 from jbom.services.inventory_reader import InventoryReader
 from jbom.services.project_component_collector import ProjectComponentCollector
 from jbom.services.schematic_reader import SchematicReader
@@ -87,6 +98,29 @@ class CheckType(str, Enum):
     STALE_PART = "STALE_PART"  # existing PN not found in fresh catalog search
     BETTER_AVAILABLE = "BETTER_AVAILABLE"  # fresh search found a different/better PN
     SPEC_MISMATCH = "SPEC_MISMATCH"  # reserved: supplier PN doesn't match item spec
+
+    # Datasheet document-library hygiene checks (jBOM#357). Read-only, offline;
+    # see jBOM#342 (map), #346/#348/#351 (lint decisions), #349 (audit surface).
+    DATASHEET_BACKLOG = "DATASHEET_BACKLOG"  # Datasheet URL populated, Name empty
+    DATASHEET_PROVENANCE_MISSING = (
+        "DATASHEET_PROVENANCE_MISSING"  # Name, no URL anywhere in group
+    )
+    DATASHEET_PROVENANCE_CONFLICT = (
+        "DATASHEET_PROVENANCE_CONFLICT"  # >1 URL row per Name
+    )
+    DATASHEET_NAME_CASE_MISMATCH = (
+        "DATASHEET_NAME_CASE_MISMATCH"  # inconsistent casing, same name
+    )
+    DATASHEET_NAME_NEAR_COLLISION = (
+        "DATASHEET_NAME_NEAR_COLLISION"  # suspiciously similar names
+    )
+    DATASHEET_FILE_MISSING = (
+        "DATASHEET_FILE_MISSING"  # Name has no datasheets/<name>.pdf
+    )
+    DATASHEET_ORPHAN_FILE = "DATASHEET_ORPHAN_FILE"  # PDF unreferenced by any Item
+    DATASHEET_TOKEN_MISMATCH = (
+        "DATASHEET_TOKEN_MISMATCH"  # manufacturer/tech spelling drift
+    )
 
 
 class Severity(str, Enum):
@@ -479,6 +513,7 @@ class AuditService:
         requirements_path: Optional[Path] = None,
         supplier_service: Optional[InventorySearchService] = None,
         supplier_id: str = "",
+        library_dir: Optional[Path] = None,
     ) -> AuditReport:
         """Audit inventory catalog(s) for coverage and quality.
 
@@ -491,6 +526,9 @@ class AuditService:
                 When provided, each COMPONENT requirement is also checked
                 against the supplier catalog.
             supplier_id: Display name for the supplier used in row descriptions.
+            library_dir: Optional path to the SPCoast-inventory checkout root
+                (containing ``datasheets/``). When provided, file-presence
+                datasheet-library checks (jBOM#357) also run.
 
         Returns:
             :class:`AuditReport` with all findings.
@@ -505,7 +543,17 @@ class AuditService:
             items, _ = reader.load()
             catalog_items.extend(i for i in items if i.row_type.upper() == "ITEM")
 
-        # No requirements and no supplier check? Nothing to do.
+        # Datasheet-library hygiene checks (jBOM#357) run unconditionally for
+        # any loaded catalog: they are read-only, offline, and need no flags
+        # beyond the catalog itself (file-presence checks additionally need
+        # library_dir; see _check_datasheet_library).
+        for datasheet_row in self._check_datasheet_library(
+            catalog_items, catalog_file_str, library_dir
+        ):
+            report.rows.append(datasheet_row)
+            _increment_counter(report, datasheet_row.severity)
+
+        # No requirements and no supplier check? Nothing further to do.
         if requirements_path is None and supplier_service is None:
             return report
 
@@ -579,6 +627,282 @@ class AuditService:
                 report.info_count += 1
 
         return report
+
+    # ------------------------------------------------------------------
+    # Private helpers — datasheet document-library hygiene (jBOM#357)
+    # ------------------------------------------------------------------
+
+    def _check_datasheet_library(
+        self,
+        catalog_items: list[InventoryItem],
+        catalog_file: str,
+        library_dir: Optional[Path],
+    ) -> list[AuditRow]:
+        """Run read-only datasheet document-library hygiene checks.
+
+        Implements the lints decided in jBOM#346 (naming/uniqueness/token
+        normalization), jBOM#348 (Name→URL schema linkage, amended by
+        jBOM#351's one-URL-per-Name provenance rule), and jBOM#351
+        (structural backlog framing). All checks are offline; file-presence
+        checks additionally require *library_dir*.
+
+        Args:
+            catalog_items: ITEM rows from the inventory catalog.
+            catalog_file: String path to the catalog file (used in rows).
+            library_dir: SPCoast-inventory checkout root, or ``None`` to
+                skip file-presence checks.
+
+        Returns:
+            List of :class:`AuditRow` findings, offline-first ordering.
+        """
+        rows: list[AuditRow] = []
+
+        by_exact_name: dict[str, list[InventoryItem]] = OrderedDict()
+        for item in catalog_items:
+            name = get_datasheet_name(item)
+            if name:
+                by_exact_name.setdefault(name, []).append(item)
+
+        rows.extend(self._check_datasheet_backlog(catalog_items, catalog_file))
+        rows.extend(self._check_datasheet_provenance(by_exact_name, catalog_file))
+        rows.extend(self._check_datasheet_name_collisions(by_exact_name, catalog_file))
+        if library_dir is not None:
+            rows.extend(
+                self._check_datasheet_file_presence(
+                    by_exact_name, catalog_file, library_dir
+                )
+            )
+        rows.extend(
+            self._check_datasheet_token_normalization(
+                catalog_items, by_exact_name, catalog_file
+            )
+        )
+
+        return rows
+
+    def _check_datasheet_backlog(
+        self, catalog_items: list[InventoryItem], catalog_file: str
+    ) -> list[AuditRow]:
+        """Return DATASHEET_BACKLOG rows: URL populated, Name empty (jBOM#348)."""
+        rows: list[AuditRow] = []
+        for item in catalog_items:
+            url = (item.datasheet or "").strip()
+            if url and not get_datasheet_name(item):
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_BACKLOG,
+                        severity=Severity.INFO,
+                        catalog_file=catalog_file,
+                        ipn=item.ipn,
+                        category=item.category or "",
+                        field="Datasheet Name",
+                        current_value=url,
+                        description=(
+                            f"IPN {item.ipn!r}: Datasheet URL populated but "
+                            "Datasheet Name is empty (dig-deeper backlog)."
+                        ),
+                    )
+                )
+        return rows
+
+    def _check_datasheet_provenance(
+        self,
+        by_exact_name: dict[str, list[InventoryItem]],
+        catalog_file: str,
+    ) -> list[AuditRow]:
+        """Return provenance rows for the one-URL-per-Name rule (jBOM#348/#351)."""
+        rows: list[AuditRow] = []
+        for name, members in by_exact_name.items():
+            with_url = [m for m in members if (m.datasheet or "").strip()]
+            if not with_url:
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_PROVENANCE_MISSING,
+                        severity=Severity.WARN,
+                        catalog_file=catalog_file,
+                        category=members[0].category or "",
+                        field="Datasheet Name",
+                        current_value=name,
+                        description=(
+                            f"Datasheet Name {name!r}: no row carries the "
+                            "canonical-source URL (provenance missing)."
+                        ),
+                    )
+                )
+            elif len(with_url) > 1:
+                ipns = ", ".join(m.ipn for m in with_url if m.ipn)
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_PROVENANCE_CONFLICT,
+                        severity=Severity.ERROR,
+                        catalog_file=catalog_file,
+                        category=members[0].category or "",
+                        field="Datasheet Name",
+                        current_value=name,
+                        description=(
+                            f"Datasheet Name {name!r}: {len(with_url)} rows "
+                            f"carry a Datasheet URL ({ipns}); the "
+                            "one-URL-per-Name rule allows exactly one."
+                        ),
+                    )
+                )
+        return rows
+
+    def _check_datasheet_name_collisions(
+        self,
+        by_exact_name: dict[str, list[InventoryItem]],
+        catalog_file: str,
+    ) -> list[AuditRow]:
+        """Return case-insensitive uniqueness and near-collision rows (jBOM#346)."""
+        rows: list[AuditRow] = []
+
+        for lowered, variants in group_case_insensitive_variants(
+            by_exact_name.keys()
+        ).items():
+            if len(variants) > 1:
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_NAME_CASE_MISMATCH,
+                        severity=Severity.ERROR,
+                        catalog_file=catalog_file,
+                        field="Datasheet Name",
+                        current_value=", ".join(sorted(variants)),
+                        description=(
+                            "Datasheet Name collides case-insensitively with "
+                            f"inconsistent casing: {sorted(variants)}."
+                        ),
+                    )
+                )
+
+        for name_a, name_b, ratio in find_near_collisions(by_exact_name.keys()):
+            rows.append(
+                AuditRow(
+                    check_type=CheckType.DATASHEET_NAME_NEAR_COLLISION,
+                    severity=Severity.WARN,
+                    catalog_file=catalog_file,
+                    field="Datasheet Name",
+                    current_value=name_a,
+                    suggested_value=name_b,
+                    description=(
+                        f"Datasheet Names {name_a!r} and {name_b!r} are "
+                        f"suspiciously similar ({ratio:.0%}); check for "
+                        "spelling drift."
+                    ),
+                )
+            )
+        return rows
+
+    def _check_datasheet_file_presence(
+        self,
+        by_exact_name: dict[str, list[InventoryItem]],
+        catalog_file: str,
+        library_dir: Path,
+    ) -> list[AuditRow]:
+        """Return file-presence rows against the library checkout (jBOM#348)."""
+        rows: list[AuditRow] = []
+        library_pdf_stems = scan_library_pdfs(library_dir)
+        library_pdf_stems_lower = {stem.lower() for stem in library_pdf_stems}
+        referenced_lower: set[str] = set()
+
+        for name, members in by_exact_name.items():
+            referenced_lower.add(name.lower())
+            if name.lower() not in library_pdf_stems_lower:
+                ipns = ", ".join(m.ipn for m in members if m.ipn)
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_FILE_MISSING,
+                        severity=Severity.ERROR,
+                        catalog_file=catalog_file,
+                        category=members[0].category or "",
+                        field="Datasheet Name",
+                        current_value=name,
+                        description=(
+                            f"Datasheet Name {name!r} (IPN(s): {ipns}) has no "
+                            f"matching {datasheet_filename(name)} under "
+                            f"{library_dir}/datasheets/."
+                        ),
+                    )
+                )
+
+        for stem in library_pdf_stems:
+            if stem.lower() not in referenced_lower:
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_ORPHAN_FILE,
+                        severity=Severity.WARN,
+                        catalog_file=catalog_file,
+                        field="Datasheet Name",
+                        current_value=stem,
+                        description=(
+                            f"datasheets/{stem}.pdf is not referenced by any "
+                            "Item's Datasheet Name."
+                        ),
+                    )
+                )
+        return rows
+
+    def _check_datasheet_token_normalization(
+        self,
+        catalog_items: list[InventoryItem],
+        by_exact_name: dict[str, list[InventoryItem]],
+        catalog_file: str,
+    ) -> list[AuditRow]:
+        """Return manufacturer/tech token spelling-drift rows (jBOM#346)."""
+        rows: list[AuditRow] = []
+        canonical = resolve_canonical_spellings(
+            item.manufacturer or "" for item in catalog_items
+        )
+
+        for item in catalog_items:
+            manufacturer = (item.manufacturer or "").strip()
+            if not manufacturer:
+                continue
+            canonical_spelling = canonical.get(
+                _normalize_manufacturer_token(manufacturer), ""
+            )
+            if canonical_spelling and canonical_spelling != manufacturer:
+                rows.append(
+                    AuditRow(
+                        check_type=CheckType.DATASHEET_TOKEN_MISMATCH,
+                        severity=Severity.WARN,
+                        catalog_file=catalog_file,
+                        ipn=item.ipn,
+                        category=item.category or "",
+                        field="Manufacturer",
+                        current_value=manufacturer,
+                        suggested_value=canonical_spelling,
+                        description=(
+                            f"IPN {item.ipn!r}: Manufacturer spelling "
+                            f"{manufacturer!r} diverges from canonical "
+                            f"spelling {canonical_spelling!r}."
+                        ),
+                    )
+                )
+
+        for name, members in by_exact_name.items():
+            for token in extract_name_tokens(name):
+                canonical_spelling = canonical.get(
+                    _normalize_manufacturer_token(token), ""
+                )
+                if canonical_spelling and canonical_spelling != token:
+                    rows.append(
+                        AuditRow(
+                            check_type=CheckType.DATASHEET_TOKEN_MISMATCH,
+                            severity=Severity.WARN,
+                            catalog_file=catalog_file,
+                            category=members[0].category or "",
+                            field="Datasheet Name",
+                            current_value=name,
+                            suggested_value=canonical_spelling,
+                            description=(
+                                f"Datasheet Name {name!r}: token {token!r} "
+                                "diverges from canonical manufacturer "
+                                f"spelling {canonical_spelling!r}."
+                            ),
+                        )
+                    )
+                    break  # one finding per name is enough signal
+        return rows
 
     # ------------------------------------------------------------------
     # Private helpers — supplier validation

--- a/src/jbom/services/datasheet_library.py
+++ b/src/jbom/services/datasheet_library.py
@@ -1,0 +1,127 @@
+"""Pure helpers for datasheet document-library hygiene checks (jBOM#357).
+
+These helpers back the read-only, offline lints ``jbom audit`` grows for the
+shared ``SPCoast-inventory`` datasheet document library (see jBOM#342).
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from collections import Counter, OrderedDict
+from pathlib import Path
+from typing import Iterable
+
+from jbom.common.types import InventoryItem
+
+DATASHEET_NAME_COLUMN = "Datasheet Name"
+DATASHEETS_SUBDIR = "datasheets"
+NAME_NEAR_COLLISION_RATIO = 0.90
+NAME_NEAR_COLLISION_MIN_LENGTH = 6
+
+
+def get_datasheet_name(item: InventoryItem) -> str:
+    """Return *item*'s curated ``Datasheet Name``, or ``""`` when absent."""
+
+    raw = item.raw_data or {}
+    return str(raw.get(DATASHEET_NAME_COLUMN, "") or "").strip()
+
+
+def normalize_token(text: str) -> str:
+    """Normalize a manufacturer/tech token for canonical-spelling comparison."""
+
+    return re.sub(r"[^A-Za-z0-9]+", "", text or "").upper()
+
+
+def resolve_canonical_spellings(values: Iterable[str]) -> dict[str, str]:
+    """Map each normalized token to its canonical most-common spelling."""
+
+    groups: OrderedDict[str, list[str]] = OrderedDict()
+    for value in values:
+        cleaned = str(value or "").strip()
+        if not cleaned:
+            continue
+        key = normalize_token(cleaned)
+        if not key:
+            continue
+        groups.setdefault(key, []).append(cleaned)
+
+    canonical: dict[str, str] = {}
+    for key, spellings in groups.items():
+        counts = Counter(spellings)
+        best_count = max(counts.values())
+        for spelling in spellings:
+            if counts[spelling] == best_count:
+                canonical[key] = spelling
+                break
+    return canonical
+
+
+def find_near_collisions(names: Iterable[str]) -> list[tuple[str, str, float]]:
+    """Return suspiciously similar, non-identical ``Datasheet Name`` pairs."""
+
+    unique = sorted({n for n in names if n})
+    pairs: list[tuple[str, str, float]] = []
+    for i, name_a in enumerate(unique):
+        for name_b in unique[i + 1 :]:
+            if name_a.lower() == name_b.lower():
+                continue
+            if (
+                len(name_a) < NAME_NEAR_COLLISION_MIN_LENGTH
+                or len(name_b) < NAME_NEAR_COLLISION_MIN_LENGTH
+            ):
+                continue
+            ratio = difflib.SequenceMatcher(
+                None, name_a.lower(), name_b.lower()
+            ).ratio()
+            if ratio >= NAME_NEAR_COLLISION_RATIO:
+                pairs.append((name_a, name_b, ratio))
+    return pairs
+
+
+def group_case_insensitive_variants(names: Iterable[str]) -> dict[str, set[str]]:
+    """Group Datasheet Names by lowercase form, revealing casing drift."""
+
+    groups: dict[str, set[str]] = {}
+    for name in names:
+        if not name:
+            continue
+        groups.setdefault(name.lower(), set()).add(name)
+    return groups
+
+
+def extract_name_tokens(name: str) -> list[str]:
+    """Split a curated Datasheet Name into its hyphen/underscore tokens."""
+
+    return [tok for tok in re.split(r"[-_]", name or "") if tok]
+
+
+def datasheet_filename(name: str) -> str:
+    """Return the library filename for a curated Datasheet Name."""
+
+    return f"{name}.pdf"
+
+
+def scan_library_pdfs(library_dir: Path) -> list[str]:
+    """Return sorted PDF filename stems found in ``<library_dir>/datasheets/``."""
+
+    datasheets_dir = Path(library_dir) / DATASHEETS_SUBDIR
+    if not datasheets_dir.is_dir():
+        return []
+    return sorted(p.stem for p in datasheets_dir.glob("*.pdf"))
+
+
+__all__ = [
+    "DATASHEET_NAME_COLUMN",
+    "DATASHEETS_SUBDIR",
+    "NAME_NEAR_COLLISION_RATIO",
+    "NAME_NEAR_COLLISION_MIN_LENGTH",
+    "get_datasheet_name",
+    "normalize_token",
+    "resolve_canonical_spellings",
+    "find_near_collisions",
+    "group_case_insensitive_variants",
+    "extract_name_tokens",
+    "datasheet_filename",
+    "scan_library_pdfs",
+]

--- a/tests/unit/test_audit_datasheet_library.py
+++ b/tests/unit/test_audit_datasheet_library.py
@@ -1,0 +1,315 @@
+"""Unit tests for AuditService datasheet document-library hygiene checks (jBOM#357)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from jbom.common.types import InventoryItem
+from jbom.services.audit_service import AuditService, CheckType
+from jbom.services.datasheet_library import DATASHEET_NAME_COLUMN
+
+
+def _make_item(
+    *,
+    ipn: str = "IPN1",
+    category: str = "RES",
+    manufacturer: str = "",
+    datasheet: str = "",
+    datasheet_name: str = "",
+) -> InventoryItem:
+    raw: dict[str, str] = {}
+    if datasheet_name:
+        raw[DATASHEET_NAME_COLUMN] = datasheet_name
+    return InventoryItem(
+        ipn=ipn,
+        keywords="",
+        category=category,
+        description="",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="",
+        voltage="",
+        amperage="",
+        wattage="",
+        manufacturer=manufacturer,
+        datasheet=datasheet,
+        row_type="ITEM",
+        raw_data=raw,
+    )
+
+
+def _audit_catalog(items: list[InventoryItem], *, library_dir: Path | None = None):
+    svc = AuditService()
+    with patch("jbom.services.audit_service.InventoryReader") as MockReader:
+        mock_reader = MagicMock()
+        mock_reader.load.return_value = (items, [])
+        MockReader.return_value = mock_reader
+        return svc.audit_inventory(
+            catalog_paths=[Path("catalog.csv")],
+            library_dir=library_dir,
+        )
+
+
+class TestCleanCatalogIsSilent:
+    def test_no_datasheet_rows_for_fully_curated_catalog(self, tmp_path: Path) -> None:
+        datasheets = tmp_path / "datasheets"
+        datasheets.mkdir()
+        # Naming convention (jBOM#346) uses Title-Case tokens matching the
+        # canonical manufacturer spelling, so this name's "Yageo" token
+        # matches the Manufacturer column exactly and stays silent.
+        (datasheets / "Resistor-ThickFilm-Yageo-RC0805-series.pdf").write_bytes(
+            b"%PDF-1.4\n"
+        )
+
+        items = [
+            _make_item(
+                ipn="R1",
+                manufacturer="Yageo",
+                datasheet="https://example.com/rc0805.pdf",
+                datasheet_name="Resistor-ThickFilm-Yageo-RC0805-series",
+            ),
+            _make_item(
+                ipn="R2",
+                manufacturer="Yageo",
+                datasheet_name="Resistor-ThickFilm-Yageo-RC0805-series",  # sibling: no URL (provenance elsewhere)
+            ),
+        ]
+        report = _audit_catalog(items, library_dir=tmp_path)
+        datasheet_rows = [
+            r for r in report.rows if r.check_type.startswith("DATASHEET_")
+        ]
+        assert datasheet_rows == []
+
+
+class TestBacklog:
+    def test_url_without_name_is_backlog(self) -> None:
+        items = [_make_item(ipn="R1", datasheet="https://example.com/x.pdf")]
+        report = _audit_catalog(items)
+        backlog = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_BACKLOG
+        ]
+        assert len(backlog) == 1
+        assert backlog[0].ipn == "R1"
+        assert backlog[0].severity == "INFO"
+
+    def test_no_backlog_when_url_and_name_present(self) -> None:
+        items = [
+            _make_item(
+                ipn="R1", datasheet="https://example.com/x.pdf", datasheet_name="x"
+            )
+        ]
+        report = _audit_catalog(items)
+        backlog = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_BACKLOG
+        ]
+        assert backlog == []
+
+
+class TestProvenance:
+    def test_missing_provenance_when_no_row_has_url(self) -> None:
+        items = [_make_item(ipn="R1", datasheet_name="shared-doc")]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type == CheckType.DATASHEET_PROVENANCE_MISSING
+        ]
+        assert len(rows) == 1
+        assert rows[0].current_value == "shared-doc"
+
+    def test_conflict_when_multiple_rows_carry_url(self) -> None:
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="shared-doc"),
+            _make_item(ipn="R2", datasheet="https://b", datasheet_name="shared-doc"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type == CheckType.DATASHEET_PROVENANCE_CONFLICT
+        ]
+        assert len(rows) == 1
+        assert rows[0].severity == "ERROR"
+        assert "R1" in rows[0].description and "R2" in rows[0].description
+
+    def test_no_finding_when_exactly_one_row_carries_url(self) -> None:
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="shared-doc"),
+            _make_item(ipn="R2", datasheet_name="shared-doc"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type
+            in (
+                CheckType.DATASHEET_PROVENANCE_MISSING,
+                CheckType.DATASHEET_PROVENANCE_CONFLICT,
+            )
+        ]
+        assert rows == []
+
+
+class TestNameCollisions:
+    def test_case_mismatch_flagged(self) -> None:
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="Foo-Series"),
+            _make_item(ipn="R2", datasheet_name="foo-series"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type == CheckType.DATASHEET_NAME_CASE_MISMATCH
+        ]
+        assert len(rows) == 1
+        assert rows[0].severity == "ERROR"
+
+    def test_near_collision_flagged(self) -> None:
+        items = [
+            _make_item(
+                ipn="R1",
+                datasheet="https://a",
+                datasheet_name="Resistor-ThickFilm-Uniroyal-0603WAJ",
+            ),
+            _make_item(
+                ipn="R2",
+                datasheet="https://b",
+                datasheet_name="Resistor-ThickFilm-Univoyal-0603WAJ",
+            ),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type == CheckType.DATASHEET_NAME_NEAR_COLLISION
+        ]
+        assert len(rows) == 1
+        assert rows[0].severity == "WARN"
+
+    def test_identical_names_not_flagged(self) -> None:
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="shared-doc"),
+            _make_item(ipn="R2", datasheet_name="shared-doc"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type
+            in (
+                CheckType.DATASHEET_NAME_CASE_MISMATCH,
+                CheckType.DATASHEET_NAME_NEAR_COLLISION,
+            )
+        ]
+        assert rows == []
+
+
+class TestFilePresence:
+    def test_missing_file_flagged_when_library_dir_given(self, tmp_path: Path) -> None:
+        (tmp_path / "datasheets").mkdir()
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="missing-doc")
+        ]
+        report = _audit_catalog(items, library_dir=tmp_path)
+        rows = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_FILE_MISSING
+        ]
+        assert len(rows) == 1
+        assert rows[0].severity == "ERROR"
+        assert "R1" in rows[0].description
+
+    def test_no_file_checks_without_library_dir(self) -> None:
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="missing-doc")
+        ]
+        report = _audit_catalog(items, library_dir=None)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type
+            in (CheckType.DATASHEET_FILE_MISSING, CheckType.DATASHEET_ORPHAN_FILE)
+        ]
+        assert rows == []
+
+    def test_orphan_pdf_flagged(self, tmp_path: Path) -> None:
+        datasheets = tmp_path / "datasheets"
+        datasheets.mkdir()
+        (datasheets / "orphan-doc.pdf").write_bytes(b"%PDF-1.4\n")
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="other-doc")
+        ]
+        # other-doc file also missing -> also produces DATASHEET_FILE_MISSING
+        report = _audit_catalog(items, library_dir=tmp_path)
+        orphan_rows = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_ORPHAN_FILE
+        ]
+        assert len(orphan_rows) == 1
+        assert orphan_rows[0].current_value == "orphan-doc"
+        assert orphan_rows[0].severity == "WARN"
+
+    def test_case_insensitive_file_match(self, tmp_path: Path) -> None:
+        datasheets = tmp_path / "datasheets"
+        datasheets.mkdir()
+        (datasheets / "Foo-Series.pdf").write_bytes(b"%PDF-1.4\n")
+        items = [
+            _make_item(ipn="R1", datasheet="https://a", datasheet_name="foo-series")
+        ]
+        report = _audit_catalog(items, library_dir=tmp_path)
+        rows = [
+            r
+            for r in report.rows
+            if r.check_type
+            in (CheckType.DATASHEET_FILE_MISSING, CheckType.DATASHEET_ORPHAN_FILE)
+        ]
+        assert rows == []
+
+
+class TestTokenNormalization:
+    def test_manufacturer_spelling_drift_flagged(self) -> None:
+        items = [
+            _make_item(ipn="R1", manufacturer="Uniroyal"),
+            _make_item(ipn="R2", manufacturer="Uniroyal"),
+            _make_item(ipn="R3", manufacturer="UNI-ROYAL"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_TOKEN_MISMATCH
+        ]
+        assert len(rows) == 1
+        assert rows[0].ipn == "R3"
+        assert rows[0].current_value == "UNI-ROYAL"
+        assert rows[0].suggested_value == "Uniroyal"
+
+    def test_consistent_manufacturer_spelling_silent(self) -> None:
+        items = [
+            _make_item(ipn="R1", manufacturer="Yageo"),
+            _make_item(ipn="R2", manufacturer="Yageo"),
+        ]
+        report = _audit_catalog(items)
+        rows = [
+            r for r in report.rows if r.check_type == CheckType.DATASHEET_TOKEN_MISMATCH
+        ]
+        assert rows == []
+
+    def test_datasheet_name_token_drift_flagged(self) -> None:
+        items = [
+            _make_item(ipn="R1", manufacturer="Uniroyal"),
+            _make_item(ipn="R2", manufacturer="Uniroyal"),
+            _make_item(
+                ipn="R3",
+                datasheet="https://a",
+                datasheet_name="Resistor-ThickFilm-UNIROYAL-0603WAJ-series",
+            ),
+        ]
+        report = _audit_catalog(items)
+        name_token_rows = [
+            r
+            for r in report.rows
+            if r.check_type == CheckType.DATASHEET_TOKEN_MISMATCH
+            and r.field == "Datasheet Name"
+        ]
+        assert len(name_token_rows) == 1
+        assert name_token_rows[0].suggested_value == "Uniroyal"

--- a/tests/unit/test_datasheet_library.py
+++ b/tests/unit/test_datasheet_library.py
@@ -1,0 +1,169 @@
+"""Unit tests for jbom.services.datasheet_library helpers (jBOM#357)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jbom.common.types import InventoryItem
+from jbom.services.datasheet_library import (
+    DATASHEET_NAME_COLUMN,
+    datasheet_filename,
+    extract_name_tokens,
+    find_near_collisions,
+    get_datasheet_name,
+    group_case_insensitive_variants,
+    normalize_token,
+    resolve_canonical_spellings,
+    scan_library_pdfs,
+)
+
+
+def _make_item(*, datasheet_name: str = "", **raw_extra: str) -> InventoryItem:
+    raw = dict(raw_extra)
+    if datasheet_name:
+        raw[DATASHEET_NAME_COLUMN] = datasheet_name
+    return InventoryItem(
+        ipn="IPN1",
+        keywords="",
+        category="RES",
+        description="",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="",
+        voltage="",
+        amperage="",
+        wattage="",
+        raw_data=raw,
+    )
+
+
+class TestGetDatasheetName:
+    def test_returns_stripped_name(self) -> None:
+        item = _make_item(datasheet_name="  foo-series  ")
+        assert get_datasheet_name(item) == "foo-series"
+
+    def test_returns_empty_when_absent(self) -> None:
+        item = _make_item()
+        assert get_datasheet_name(item) == ""
+
+    def test_returns_empty_when_raw_data_none(self) -> None:
+        item = InventoryItem(
+            ipn="X",
+            keywords="",
+            category="",
+            description="",
+            smd="",
+            value="",
+            type="",
+            tolerance="",
+            voltage="",
+            amperage="",
+            wattage="",
+            raw_data=None,
+        )
+        assert get_datasheet_name(item) == ""
+
+
+class TestNormalizeToken:
+    def test_strips_punctuation_and_uppercases(self) -> None:
+        # Non-ASCII qualifiers (e.g. the CJK aside in "UNI-ROYAL(\u539a\u58f0)") are
+        # stripped along with punctuation, so both spellings normalize to the
+        # same ASCII token and are recognized as the same manufacturer.
+        assert normalize_token("UNI-ROYAL(\u539a\u58f0)") == "UNIROYAL"
+        assert normalize_token("Uniroyal") == "UNIROYAL"
+
+    def test_empty_input(self) -> None:
+        assert normalize_token("") == ""
+        assert normalize_token(None) == ""  # type: ignore[arg-type]
+
+
+class TestResolveCanonicalSpellings:
+    def test_most_frequent_spelling_wins(self) -> None:
+        canonical = resolve_canonical_spellings(
+            ["Uniroyal", "Uniroyal", "UNI-ROYAL", "Uniroyal"]
+        )
+        assert canonical[normalize_token("Uniroyal")] == "Uniroyal"
+
+    def test_tie_break_is_first_seen(self) -> None:
+        canonical = resolve_canonical_spellings(["Yageo", "YAGEO"])
+        assert canonical[normalize_token("Yageo")] == "Yageo"
+
+    def test_ignores_blank_values(self) -> None:
+        canonical = resolve_canonical_spellings(["", "  ", "Vishay"])
+        assert canonical == {normalize_token("Vishay"): "Vishay"}
+
+    def test_distinct_manufacturers_do_not_collide(self) -> None:
+        canonical = resolve_canonical_spellings(["Yageo", "Vishay"])
+        assert canonical[normalize_token("Yageo")] == "Yageo"
+        assert canonical[normalize_token("Vishay")] == "Vishay"
+
+
+class TestFindNearCollisions:
+    def test_flags_similar_long_names(self) -> None:
+        pairs = find_near_collisions(
+            [
+                "Resistor-ThickFilm-Uniroyal-0603WAJ",
+                "Resistor-ThickFilm-Univoyal-0603WAJ",
+            ]
+        )
+        assert len(pairs) == 1
+        assert pairs[0][2] >= 0.90
+
+    def test_ignores_case_insensitive_duplicates(self) -> None:
+        pairs = find_near_collisions(["Foo-Series-Long", "foo-series-long"])
+        assert pairs == []
+
+    def test_ignores_short_names(self) -> None:
+        pairs = find_near_collisions(["ab", "ac"])
+        assert pairs == []
+
+    def test_distinct_names_not_flagged(self) -> None:
+        pairs = find_near_collisions(
+            ["Resistor-ThickFilm-Uniroyal-0603WAJ", "MOSFET-AO4443-PChannel-UMW"]
+        )
+        assert pairs == []
+
+
+class TestGroupCaseInsensitiveVariants:
+    def test_groups_by_lowercase(self) -> None:
+        groups = group_case_insensitive_variants(["Foo-Bar", "foo-bar", "Baz"])
+        assert groups["foo-bar"] == {"Foo-Bar", "foo-bar"}
+        assert groups["baz"] == {"Baz"}
+
+    def test_skips_empty_names(self) -> None:
+        groups = group_case_insensitive_variants(["", "Foo"])
+        assert "" not in groups
+        assert groups["foo"] == {"Foo"}
+
+
+class TestExtractNameTokens:
+    def test_splits_on_hyphen_and_underscore(self) -> None:
+        assert extract_name_tokens("Resistor-ThickFilm-Uniroyal-0603WAJ-series") == [
+            "Resistor",
+            "ThickFilm",
+            "Uniroyal",
+            "0603WAJ",
+            "series",
+        ]
+
+    def test_empty_name(self) -> None:
+        assert extract_name_tokens("") == []
+
+
+class TestDatasheetFilename:
+    def test_appends_pdf_extension(self) -> None:
+        assert datasheet_filename("foo-series") == "foo-series.pdf"
+
+
+class TestScanLibraryPdfs:
+    def test_returns_stems_sorted(self, tmp_path: Path) -> None:
+        datasheets = tmp_path / "datasheets"
+        datasheets.mkdir()
+        (datasheets / "b-series.pdf").write_bytes(b"%PDF-1.4\n")
+        (datasheets / "a-series.pdf").write_bytes(b"%PDF-1.4\n")
+        (datasheets / "not-a-pdf.txt").write_text("nope")
+        assert scan_library_pdfs(tmp_path) == ["a-series", "b-series"]
+
+    def test_missing_datasheets_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert scan_library_pdfs(tmp_path) == []


### PR DESCRIPTION
Closes #357

## Summary
Implements `jbom audit` inventory-mode datasheet document-library hygiene checks per the map (#342) and its lint decisions (#346, #348, #351) and audit surface decision (#349).

All checks are **read-only and offline** — no inventory writes.

## New checks
- **Name→URL consistency** (one-URL-per-Name provenance rule, #351 amendment to #348): `DATASHEET_PROVENANCE_MISSING` (WARN, no row carries the canonical URL) / `DATASHEET_PROVENANCE_CONFLICT` (ERROR, more than one row carries a URL)
- **Case-insensitive Datasheet Name uniqueness + near-collisions** (#346): `DATASHEET_NAME_CASE_MISMATCH` (ERROR, inconsistent casing of the same name) / `DATASHEET_NAME_NEAR_COLLISION` (WARN, suspiciously similar distinct names)
- **File presence** against the SPCoast-inventory checkout: `DATASHEET_FILE_MISSING` (ERROR) / `DATASHEET_ORPHAN_FILE` (WARN). Opt-in via a new `--datasheet-library LIBRARY_DIR` flag (inventory mode only), since it names a local checkout path.
- **Manufacturer/tech token normalization** shared with the inventory `Manufacturer` column (#346 point 5): `DATASHEET_TOKEN_MISMATCH` (WARN), applied both to the `Manufacturer` column and to `Datasheet Name` tokens.
- **Structural backlog report** (#348): `DATASHEET_BACKLOG` (INFO, `Datasheet` URL populated + `Datasheet Name` empty).

## CLI surface
`jbom audit <catalog.csv> [--datasheet-library LIBRARY_DIR]`

The non-file-presence checks run unconditionally whenever an inventory catalog is audited (no new flag needed, matching #349's "audit is the general validate/refine doorway" framing). File-presence checks additionally require `--datasheet-library`. `--datasheet-library` is rejected in project mode, matching the existing `--requirements`/`--inventory` mode-scoping pattern.

Exit codes follow the existing severity convention (ERROR fails; `--strict` also fails on WARN), so `jbom audit` is usable as a CI gate in SPCoast-inventory per the ticket's acceptance criteria.

## Design notes for reviewers
- New pure helper module `jbom.services.datasheet_library` (token normalization, near-collision detection via `difflib`, case-insensitive grouping, library PDF scanning) — no CLI/service imports, unit-testable in isolation.
- `AuditService._check_datasheet_library` and its per-lint private helpers are additive to `audit_service.py`; no existing behavior changed except that inventory-mode audits now always run these offline checks (previously, running `jbom audit catalog.csv` with no flags produced an empty report).
- `Datasheet Name` is read via `item.raw_data["Datasheet Name"]`, matching the existing convention established in `datasheet_staging.py` (#355) — no schema/dataclass field yet (that's #359's scope).
- CLI surface note for the sibling `--check-urls` ticket (#358, same command): this PR only adds `--datasheet-library`; no other flags, so there should be no overlap.

## Testing
- New unit tests: `tests/unit/test_datasheet_library.py` (pure helpers), `tests/unit/test_audit_datasheet_library.py` (AuditService integration).
- New behave feature: `features/audit/datasheet_library.feature` — clean pass + one scenario per violation class, plus a project-mode rejection scenario for `--datasheet-library`.
- Full suite green, re-verified from the worktree root exactly as documented:
  - `python -m pytest tests/ -q` → **1567 passed**
  - `python -m behave` → **53 features / 296 scenarios / 1960 steps passed, 0 failed** (1 unrelated feature/8 unrelated scenarios skipped via `-wip` tag filtering, none of them datasheet-related)
  - (An earlier PR description claimed 1110 pytest and a pre-existing `datasheet_staging.feature` failure; both were wrong — the 1110 figure came from accidentally running only `tests/unit` instead of `tests/`, and the feature failure did not reproduce on a clean full-suite run and was a one-off artifact of an ad hoc partial-path behave invocation, not a real defect.)

## Related
- Map: #342
- Lint decisions: #346, #348, #351
- Audit surface decision: #349
- Sibling wave-2 ticket on the same command: #358 (`--check-urls` recovery ladder)

Conversation: https://app.warp.dev/conversation/c8e8a4d8-8300-4fc5-8387-fa7adf39eb0a
Run: https://oz.warp.dev/runs/019f5dc4-83a5-74b0-9952-cb85f72d784c

