### PR TITLE
feat(inventory): add jbom inventory admit datasheet library gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ To find LCSC part numbers:
 
 > **Coming soon**: `jbom inventory MyProject/ --supplier lcsc --limit 3 -o inventory.csv` will search and populate part numbers automatically.
 
+> **Curating a shared datasheet library?** Datasheet URLs encountered by `jbom search` / `jbom inventory --supplier` are automatically staged for review once you configure `datasheet_staging.staging_dir` in your own `~/.jbom/common.jbom.yaml`. `jbom inventory admit` is the gate that turns staged PDFs into a reviewed, named library: it proposes a manifest (curated name, matching inventory rows), you edit it, then `--apply` moves accepted PDFs into `datasheets/<name>.pdf` and hands back a paste-file for the `Datasheet Name` column. See [docs/reference/cli.md](docs/reference/cli.md#admit-subcommand-jbom-inventory-admit).
+
 ### 4. Generate fabrication files
 
 Use `jbom fab` for a one-shot run that writes everything to a `production/` folder:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,8 @@ jbom pos [PROJECT] [-o OUTPUT] [POS OPTIONS]
 jbom gerbers [PROJECT] [-o OUTPUT_DIR] [--fabricator NAME] [--no-drill] [--netlist] [--dry-run]
 jbom fab [PROJECT] [-o OUTPUT_ROOT] [--fabricator NAME] [--skip-bom] [--skip-pos] [--skip-gerbers] [--debug] [--dry-run]
 jbom inventory [PROJECT] [-o OUTPUT] [--supplier SUPPLIER_ID ...] [--api-key KEY_OR_SUPPLIER_KEY ...] [INVENTORY OPTIONS]
+jbom inventory admit [--inventory CATALOG_CSV ...] [--manifest PATH] [--staging-dir PATH] [--library-dir PATH]
+jbom inventory admit --apply [--manifest PATH] [-o PASTE_CSV] [-F] [-v]
 jbom promote SOURCE_INVENTORY [--supplier SUPPLIER_ID ...] [--api-key KEY_OR_SUPPLIER_KEY ...] [--jlc] [-o OUTPUT] [-F] [-v]
 jbom parts [PROJECT] [-o OUTPUT] [PARTS OPTIONS]
 jbom search QUERY [SEARCH OPTIONS]
@@ -431,6 +433,123 @@ command's "Datasheet staging fetch" note above for the full behavior
 (idempotency, PDF/HTML verification, fetch budget, profile-based
 configuration). Items that already have a `Datasheet Name` (already in the
 Library) are skipped for free, without a network call.
+
+### ADMIT SUBCOMMAND (`jbom inventory admit`)
+
+```
+jbom inventory admit [--inventory CATALOG_CSV ...] [--manifest PATH] [--staging-dir PATH] [--library-dir PATH]
+jbom inventory admit --apply [--manifest PATH] [-o PASTE_CSV] [-F] [-v]
+```
+
+The sole gate into the datasheet document library (jBOM#356): a two-phase
+**propose → human edit → apply** workflow. Datasheet documents never enter
+the library any other way -- neither the staging fetch (`jbom search` /
+`jbom inventory --supplier`, above) nor any other command writes into
+`datasheets/`.
+
+The staging directory comes exclusively from the
+`datasheet_staging.staging_dir` profile key (see
+[`configuration.md`](configuration.md#datasheet_staging-sub-stanza-jbom355)) --
+the same user-machine binding the staging fetch uses. There is no fallback
+path and no environment variable: when it is unconfigured, `admit` reports
+an error and there is nothing to admit. `--staging-dir` overrides it for one
+invocation; `--library-dir` overrides the library's `datasheets/` directory,
+which otherwise defaults to a `datasheets` sibling of the staging directory
+(i.e. `<staging_dir>/../datasheets`, matching the SPCoast-inventory layout).
+
+#### Propose (default mode)
+
+Scans the staging directory for verified PDFs (`.pdf`; `.unverified` files
+are never proposed) and matches each one back to the inventory backlog --
+rows with a populated `Datasheet` URL but no `Datasheet Name` yet, loaded
+from `--inventory CATALOG_CSV` (repeatable, required for propose). Items
+sharing one Datasheet URL (family members, e.g. several resistor rows
+that only differ by tolerance/value) are grouped into a single manifest
+candidate. Writes a manifest CSV (default `admit-manifest.csv` inside the
+staging directory; override with `--manifest PATH`) with one row per
+staged file:
+
+| Column | Meaning |
+| --- | --- |
+| `Action` | `ADMIT` (accept) or `SKIP` (leave staged). Propose defaults this based on `Disposition`; edit it before `--apply`. |
+| `ProposedName` | Curated `Datasheet Name` (no path, no extension) — the library filename stem. A best-effort heuristic derived from `Category`/`Manufacturer`/`MFGPN` (family candidates get a `-series` suffix). **Always review and correct before `--apply`.** |
+| `Disposition` | `new` (fresh candidate, `Action=ADMIT`), `dupe-of` (byte-identical to an already-published document, `Action=ADMIT`, idempotent), `collision` (name already published under different content, `Action=SKIP` — resolve by hand), or `unresolvable` (no matching backlog row, `Action=SKIP`). |
+| `DupeOf` | For `dupe-of` rows, the existing published name. |
+| `StagedFile` | Filename of the verified PDF within the staging directory. |
+| `SourceURL` | The Datasheet URL this file was staged from. |
+| `MemberIPNs` | Semicolon-separated IPNs of every backlog Item sharing `SourceURL` — the Items this admission will name. |
+
+**--inventory CATALOG_CSV**
+: Inventory catalog(s) to resolve the backlog against. Required for propose mode; repeatable.
+
+**--manifest PATH**
+: Manifest CSV path. Written by propose; read by `--apply`. Default: `admit-manifest.csv` inside the staging directory.
+
+**--staging-dir PATH**
+: Override the configured staging directory for this invocation.
+
+**--library-dir PATH**
+: Override the library's `datasheets/` directory.
+
+**-F, --force, --Force**
+: Overwrite an existing manifest file.
+
+#### Apply (`--apply`)
+
+Reads the (human-edited) manifest and, for every `Action=ADMIT` row, moves
+its staged PDF into `datasheets/<ProposedName>.pdf` and writes one
+full-sheet `Datasheet Name` paste-file row (`IPN`, `Datasheet Name`) per
+member IPN — ready for the human to paste into the canonical inventory at
+the matching rows. jBOM never writes to the inventory itself (per the
+human-sole-writer ruling); the paste-file is a proposal, not a write.
+Output defaults to stdout CSV; use `-o PATH` for a file, or `-o console`
+for a table.
+
+**Never-rename guard**: before moving anything, each `ADMIT` row is checked
+against the library. A `ProposedName` that collides (case-insensitively —
+library filesystems are case-insensitive) with an already-published
+document of *different* content is refused; a published document's name
+and content are never silently overwritten or renamed. Re-admitting
+byte-identical content under its own published name is a no-op, not a
+violation. `ProposedName` is also validated as a bare filename stem —
+path separators, `.`/`..` components, and absolute paths are refused
+outright, so a manifest can never write outside `datasheets/`.
+
+**Row-by-row commit semantics**: rows commit independently, in manifest
+order. A row refused by either guard is skipped without affecting any
+other row in the same `--apply` run — rows admitted earlier or later in
+the same batch are never rolled back or blocked by one refused row. Refused
+rows print an `Error:` line to stderr identifying the row and reason, and
+the command exits `1` if any row was refused, even though other rows in
+the same run succeeded.
+
+**--apply**
+: Switch to apply mode (reads `--manifest` instead of writing it).
+
+**-o, --output PASTE_CSV**
+: Paste-file output destination. Default: CSV to stdout. `-o console` prints a table; otherwise treat the value as a file path.
+
+**-v, --verbose**
+: Print one line per admitted/already-admitted row to stderr.
+
+### Exit codes (admit)
+
+- `0` — propose: manifest written (or nothing to propose); apply: every `ADMIT` row processed without a guard refusal.
+- `1` — propose: no staging directory configured, missing/invalid `--inventory`, or manifest already exists without `--force`; apply: manifest not found, or one or more rows refused by a guard.
+
+### Example workflow
+
+```sh
+# 1. Propose: scan staging, write a manifest for review
+jbom inventory admit --inventory library.csv --manifest admit-manifest.csv
+
+# 2. Edit admit-manifest.csv by hand: correct ProposedName, set Action=ADMIT/SKIP
+
+# 3. Apply: move accepted PDFs into datasheets/, write the paste-file proposal
+jbom inventory admit --apply --manifest admit-manifest.csv -o datasheet-names.csv
+
+# 4. Paste datasheet-names.csv's Datasheet Name column into library.csv by hand
+```
 
 ## PROMOTE COMMAND
 

--- a/docs/reference/inventory-format.md
+++ b/docs/reference/inventory-format.md
@@ -118,21 +118,31 @@ user; jBOM exposes them to the BOM-generation pipeline by name.
   inventories should use `Supplier` + `SPN` instead.
 
 **Datasheet**
-: URL to the component datasheet PDF. When a curated `Datasheet Name` (below) is
-  shared by multiple rows, the one-URL-per-Name rule applies: exactly one of those
-  rows should carry the canonical-source URL (the row the library copy was actually
-  acquired from); the other member rows leave `Datasheet` blank. `jbom audit`
-  enforces this (`DATASHEET_PROVENANCE_MISSING` / `DATASHEET_PROVENANCE_CONFLICT`);
-  see [docs/reference/cli.md](cli.md#audit-command).
+: URL to the component datasheet PDF. Once a document is admitted to the
+  library, this cell records the canonical source URL the library copy was
+  actually acquired from -- a provenance trail, not a live-link guarantee.
+  When a curated `Datasheet Name` (below) is shared by multiple rows (a
+  family of parts with one document), the one-URL-per-Name rule applies:
+  exactly one of those rows carries the canonical-source URL; the other
+  member rows leave `Datasheet` blank. `jbom audit` enforces this
+  (`DATASHEET_PROVENANCE_MISSING` / `DATASHEET_PROVENANCE_CONFLICT`); see
+  [docs/reference/cli.md](cli.md#audit-command).
 
 **Datasheet Name**
-: Curated name of the document in the shared datasheet document library, resolving by
-  convention to `datasheets/<name>.pdf` (no path, no `.pdf` extension stored in the
-  cell). Presence of `Datasheet Name` is what marks an Item as curated; `Datasheet`
-  URL populated with `Datasheet Name` empty is the structural "dig-deeper" backlog.
-  `jbom audit` runs read-only naming, provenance, and (with `--datasheet-library`)
-  file-presence checks against this column; see
-  [docs/reference/cli.md](cli.md#audit-command).
+: Curated name of the item's datasheet document in the shared datasheet
+  document library, resolving by convention to `datasheets/<name>.pdf` (no
+  path, no `.pdf` extension stored in the cell). Presence of `Datasheet
+  Name` is what marks an Item as curated; `Datasheet` URL populated with
+  `Datasheet Name` empty is the structural "dig-deeper" backlog.
+  `jbom audit` runs read-only naming, provenance, and (with
+  `--datasheet-library`) file-presence checks against this column; see
+  [docs/reference/cli.md](cli.md#audit-command). This cell is never
+  populated by jBOM directly: `jbom inventory admit` (see
+  [docs/reference/cli.md](cli.md#admit-subcommand-jbom-inventory-admit)) is
+  the sole gate into the library, and its `--apply` phase only ever
+  *proposes* the value via a full-sheet paste-file the human pastes into
+  this column by hand -- consistent with jBOM's human-sole-writer rule for
+  the canonical inventory file.
 
 **Keywords**
 : Comma-separated search keywords. Not currently used in matching but available for

--- a/features/inventory/inventory_admit.feature
+++ b/features/inventory/inventory_admit.feature
@@ -38,6 +38,20 @@ Feature: Datasheet library admission gate (jbom inventory admit)
     And the output should contain "Never-rename"
     And the published document "IC-TI-LM358D" still has its original content
 
+  Scenario: apply refuses a path-traversal ProposedName and writes nothing outside the library
+    Given an inventory file "library.csv" that contains:
+      | IPN      | Category | Value  | Description | Package | Manufacturer | MFGPN  | Datasheet                           | Datasheet Name |
+      | IC_LM358 | IC       | LM358D | Dual Op-Amp  | SOIC-8  | TI           | LM358D | https://example.com/docs/lm358.pdf  |                |
+    And the staging directory already has a verified PDF staged for "https://example.com/docs/lm358.pdf"
+    When I run jbom command "inventory admit --inventory library.csv --manifest manifest.csv"
+    Then the command should succeed
+    When I edit the manifest "manifest.csv" to set ProposedName "../../evil" for staged file matching "https://example.com/docs/lm358.pdf"
+    And I run jbom command "inventory admit --apply --manifest manifest.csv -o paste.csv"
+    Then the command should fail
+    And the output should contain "ProposedName"
+    And nothing named "evil.pdf" exists outside the library directory
+    And the library contains exactly 0 published documents
+
   Scenario: one family document names every member Item
     Given an inventory file "library.csv" that contains:
       | IPN      | Category | Value | Description       | Package | Manufacturer | MFGPN          | Datasheet                                    | Datasheet Name |

--- a/features/inventory/inventory_admit.feature
+++ b/features/inventory/inventory_admit.feature
@@ -1,0 +1,60 @@
+Feature: Datasheet library admission gate (jbom inventory admit)
+  As a hardware developer curating the SPCoast-inventory datasheet library
+  I want jbom inventory admit to propose a manifest from staged PDFs, let me
+  edit it, and then apply it into the library
+  So that documents only enter the library through one reviewed gate and a
+  published document name is never silently renamed or overwritten
+
+  Background:
+    Given a staging directory
+
+  Scenario: propose and apply admit a single new document
+    Given an inventory file "library.csv" that contains:
+      | IPN      | Category | Value  | Description | Package | Manufacturer | MFGPN  | Datasheet                           | Datasheet Name |
+      | IC_LM358 | IC       | LM358D | Dual Op-Amp  | SOIC-8  | TI           | LM358D | https://example.com/docs/lm358.pdf  |                |
+    And the staging directory already has a verified PDF staged for "https://example.com/docs/lm358.pdf"
+    When I run jbom command "inventory admit --inventory library.csv --manifest manifest.csv"
+    Then the command should succeed
+    And the file "manifest.csv" contains "ADMIT"
+    And the file "manifest.csv" contains "IC_LM358"
+    When I run jbom command "inventory admit --apply --manifest manifest.csv -o paste.csv"
+    Then the command should succeed
+    And the library contains a published document named "IC-TI-LM358D"
+    And the file "paste.csv" contains "IC_LM358"
+    And the file "paste.csv" contains "IC-TI-LM358D"
+
+  Scenario: apply refuses to rename or overwrite an already-published document
+    Given an inventory file "library.csv" that contains:
+      | IPN      | Category | Value  | Description | Package | Manufacturer | MFGPN  | Datasheet                           | Datasheet Name |
+      | IC_LM358 | IC       | LM358D | Dual Op-Amp  | SOIC-8  | TI           | LM358D | https://example.com/docs/lm358.pdf  |                |
+    And the staging directory already has a verified PDF staged for "https://example.com/docs/lm358.pdf"
+    And the library already contains "IC-TI-LM358D" published with different content
+    When I run jbom command "inventory admit --inventory library.csv --manifest manifest.csv"
+    Then the command should succeed
+    And the file "manifest.csv" contains "collision"
+    When I edit the manifest "manifest.csv" to set Action "ADMIT" for staged file matching "https://example.com/docs/lm358.pdf"
+    And I run jbom command "inventory admit --apply --manifest manifest.csv -o paste.csv"
+    Then the command should fail
+    And the output should contain "Never-rename"
+    And the published document "IC-TI-LM358D" still has its original content
+
+  Scenario: one family document names every member Item
+    Given an inventory file "library.csv" that contains:
+      | IPN      | Category | Value | Description       | Package | Manufacturer | MFGPN          | Datasheet                                    | Datasheet Name |
+      | RES_0331 | RES      | 10K   | Thick Film Resistor | 0603    | Uniroyal     | 0603WAJ0331T5E | https://example.com/docs/0603waj-series.pdf  |                |
+      | RES_0332 | RES      | 22K   | Thick Film Resistor | 0603    | Uniroyal     | 0603WAJ0332T5E | https://example.com/docs/0603waj-series.pdf  |                |
+      | RES_0333 | RES      | 33K   | Thick Film Resistor | 0603    | Uniroyal     | 0603WAJ0333T5E | https://example.com/docs/0603waj-series.pdf  |                |
+    And the staging directory already has a verified PDF staged for "https://example.com/docs/0603waj-series.pdf"
+    When I run jbom command "inventory admit --inventory library.csv --manifest manifest.csv"
+    Then the command should succeed
+    And the file "manifest.csv" contains exactly 1 admit candidate row
+    And the file "manifest.csv" contains "RES_0331"
+    And the file "manifest.csv" contains "RES_0332"
+    And the file "manifest.csv" contains "RES_0333"
+    When I run jbom command "inventory admit --apply --manifest manifest.csv -o paste.csv"
+    Then the command should succeed
+    And the library contains exactly 1 published document
+    And the file "paste.csv" contains exactly 3 data rows
+    And the file "paste.csv" contains "RES_0331"
+    And the file "paste.csv" contains "RES_0332"
+    And the file "paste.csv" contains "RES_0333"

--- a/features/steps/inventory_admit_steps.py
+++ b/features/steps/inventory_admit_steps.py
@@ -103,6 +103,30 @@ def then_manifest_contains_exactly_n_rows(context, filename: str, count: int) ->
     ), f"Expected exactly {count} manifest row(s), got {len(rows)}: {rows}"
 
 
+def _edit_manifest_column_for_url(
+    context, filename: str, column: str, value: str, url: str
+) -> None:
+    """Shared implementation: rewrite one manifest cell for the row matching *url*."""
+
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    matched = False
+    for row in rows:
+        if row.get("SourceURL", "") == url:
+            row[column] = value
+            matched = True
+    assert matched, f"No manifest row found with SourceURL={url!r} in {filename}"
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 @when(
     'I edit the manifest "{filename}" to set Action "{action}" for staged file '
     'matching "{url}"'
@@ -117,20 +141,62 @@ def when_edit_manifest_action_for_url(
     collision, to exercise the never-rename guard at apply time.
     """
 
-    path = context.project_root / filename
-    with path.open("r", encoding="utf-8", newline="") as handle:
-        reader = csv.DictReader(handle)
-        fieldnames = reader.fieldnames or []
-        rows = list(reader)
+    _edit_manifest_column_for_url(context, filename, "Action", action, url)
 
-    matched = False
-    for row in rows:
-        if row.get("SourceURL", "") == url:
-            row["Action"] = action
-            matched = True
-    assert matched, f"No manifest row found with SourceURL={url!r} in {filename}"
 
-    with path.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(rows)
+@when(
+    'I edit the manifest "{filename}" to set ProposedName "{name}" for staged file '
+    'matching "{url}"'
+)
+def when_edit_manifest_proposed_name_for_url(
+    context, filename: str, name: str, url: str
+) -> None:
+    """Simulate a human typing an unsafe ProposedName into the manifest.
+
+    Exercises the apply-time path-traversal guard: a crafted name like
+    ``"../../evil"`` must be refused, never trusted as a bare filename
+    stem.
+    """
+
+    _edit_manifest_column_for_url(context, filename, "ProposedName", name, url)
+
+
+@then('nothing named "{filename}" exists outside the library directory')
+def then_nothing_named_exists_outside_library(context, filename: str) -> None:
+    """Assert a crafted ProposedName never wrote a file outside datasheets/.
+
+    Checks both inside the sandbox tree (the whole scenario workspace) and
+    several levels above the sandbox root -- a ``"../../evil"`` style
+    traversal from the library directory (a fixed two levels under the
+    sandbox root: ``<sandbox>/staging/../datasheets``) would land outside
+    the sandbox tree entirely, so scanning only inside the sandbox would
+    not catch a real escape. This is the belt-and-braces proof that a
+    path-traversal ProposedName was refused, not merely refused-with-a-
+    caveat.
+    """
+
+    sandbox_root = Path(context.sandbox_root)
+    library_dir = _library_dir(context)
+
+    for path in sandbox_root.rglob(filename):
+        assert library_dir in path.parents or path.parent == library_dir, (
+            f"Found {path} outside the library directory ({library_dir}) -- "
+            "a path-traversal ProposedName was not refused."
+        )
+
+    # Also scan a few levels above the sandbox root -- where a "../../evil"
+    # style traversal rooted at <sandbox>/datasheets would actually resolve
+    # to (outside the sandbox tree, and outside anywhere rglob above would
+    # ever look).
+    probe_dir = sandbox_root
+    for _ in range(5):
+        probe_dir = probe_dir.parent
+        candidate = probe_dir / filename
+        assert not candidate.exists(), (
+            f"Found {candidate} outside the sandbox and library directory -- "
+            "a path-traversal ProposedName was not refused."
+        )
+
+    # Also confirm it did not land inside the library either (this filename
+    # was never a legitimate ProposedName in these scenarios).
+    assert not (library_dir / filename).exists()

--- a/features/steps/inventory_admit_steps.py
+++ b/features/steps/inventory_admit_steps.py
@@ -1,0 +1,136 @@
+"""Step definitions for the datasheet library admission gate (jBOM#356).
+
+Reuses the hermetic staging-directory setup from
+``datasheet_staging_steps.py`` (``Given a staging directory`` -- sandboxed
+``datasheet_staging.staging_dir`` binding written to this scenario's own
+``.jbom/common.jbom.yaml``; never a real developer/CI ``$HOME``). These
+steps place already-verified PDFs directly into the staging directory
+(admit consumes staged content -- it does not fetch), and inspect the
+library's ``datasheets/`` directory, which the CLI defaults to a sibling
+of the staging directory.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from behave import given, then, when
+
+_PDF_HEADER = b"%PDF-1.4\n"
+_PDF_FOOTER = b"\n%%EOF"
+
+
+def _pdf_bytes_for(url: str) -> bytes:
+    """Deterministic verified-PDF content derived from *url*.
+
+    Same URL always yields the same bytes, so re-staging (dupe-of) and
+    distinct URLs (never byte-identical) both behave predictably in tests.
+    """
+
+    return _PDF_HEADER + f"%fixture datasheet for {url}".encode("utf-8") + _PDF_FOOTER
+
+
+def _staging_dir(context) -> Path:
+    staging_dir = getattr(context, "staging_dir", None)
+    assert staging_dir is not None, "Use 'Given a staging directory' first"
+    return staging_dir
+
+
+def _library_dir(context) -> Path:
+    return _staging_dir(context).parent / "datasheets"
+
+
+@given('the staging directory already has a verified PDF staged for "{url}"')
+def given_staged_verified_pdf_for_url(context, url: str) -> None:
+    """Place a verified PDF directly into staging (admit does not fetch)."""
+
+    from jbom.services.datasheet_staging import staged_filename_for_url
+
+    staging_dir = _staging_dir(context)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    stem = staged_filename_for_url(url)
+    (staging_dir / f"{stem}.pdf").write_bytes(_pdf_bytes_for(url))
+
+
+@given('the library already contains "{name}" published with different content')
+def given_library_contains_published_with_different_content(context, name: str) -> None:
+    """Pre-populate the library with a published document under *name*."""
+
+    library_dir = _library_dir(context)
+    library_dir.mkdir(parents=True, exist_ok=True)
+    (library_dir / f"{name}.pdf").write_bytes(
+        _PDF_HEADER + b"%an already-published, unrelated document" + _PDF_FOOTER
+    )
+
+
+@then('the library contains a published document named "{name}"')
+def then_library_contains_published_document(context, name: str) -> None:
+    published = _library_dir(context) / f"{name}.pdf"
+    assert published.is_file(), (
+        f"Expected published document at {published}; "
+        f"library contents: {list(_library_dir(context).glob('*')) if _library_dir(context).is_dir() else []}"
+    )
+
+
+@then("the library contains exactly {count:d} published document")
+@then("the library contains exactly {count:d} published documents")
+def then_library_contains_exactly_n_documents(context, count: int) -> None:
+    library_dir = _library_dir(context)
+    published = list(library_dir.glob("*.pdf")) if library_dir.is_dir() else []
+    assert (
+        len(published) == count
+    ), f"Expected exactly {count} published document(s), found {len(published)}: {published}"
+
+
+@then('the published document "{name}" still has its original content')
+def then_published_document_unchanged(context, name: str) -> None:
+    published = _library_dir(context) / f"{name}.pdf"
+    assert published.is_file(), f"Expected {published} to still exist"
+    assert published.read_bytes() == (
+        _PDF_HEADER + b"%an already-published, unrelated document" + _PDF_FOOTER
+    ), "Published document content changed -- never-rename guard failed to protect it"
+
+
+@then('the file "{filename}" contains exactly {count:d} admit candidate row')
+@then('the file "{filename}" contains exactly {count:d} admit candidate rows')
+def then_manifest_contains_exactly_n_rows(context, filename: str, count: int) -> None:
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert (
+        len(rows) == count
+    ), f"Expected exactly {count} manifest row(s), got {len(rows)}: {rows}"
+
+
+@when(
+    'I edit the manifest "{filename}" to set Action "{action}" for staged file '
+    'matching "{url}"'
+)
+def when_edit_manifest_action_for_url(
+    context, filename: str, action: str, url: str
+) -> None:
+    """Simulate a human editing the manifest before --apply.
+
+    Finds the row whose ``SourceURL`` matches *url* and rewrites its
+    ``Action`` cell -- e.g. accepting a candidate that propose flagged as a
+    collision, to exercise the never-rename guard at apply time.
+    """
+
+    path = context.project_root / filename
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+
+    matched = False
+    for row in rows:
+        if row.get("SourceURL", "") == url:
+            row["Action"] = action
+            matched = True
+    assert matched, f"No manifest row found with SourceURL={url!r} in {filename}"
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -30,7 +30,14 @@ from jbom.common.value_parsing import farad_to_eia, henry_to_eia, ohms_to_eia
 from jbom.common.types import Component, InventoryItem
 from jbom.common.options import GeneratorOptions
 from jbom.cli.formatting import print_inventory_table
-from jbom.services.datasheet_staging import stage_datasheet_urls
+from jbom.services.datasheet_staging import resolve_staging_dir, stage_datasheet_urls
+from jbom.services.inventory_admit import (
+    apply_admit_manifest,
+    propose_admit_manifest,
+    read_admit_manifest,
+    write_admit_manifest,
+    write_paste_file,
+)
 from jbom.services.inventory_reader import InventoryReader
 from jbom.common.component_filters import apply_component_filters
 from jbom.services.project_file_resolver import ProjectFileResolver
@@ -211,7 +218,60 @@ def register_command(subparsers) -> None:
         ),
     )
 
+    # 'jbom inventory admit' -- the datasheet library admission gate (jBOM#356).
+    # Dispatched by first-positional-token detection (see handle_inventory),
+    # matching this codebase's existing mode-detection convention (cf.
+    # jbom audit's project/inventory mode split) rather than nested argparse
+    # subparsers, which don't compose cleanly with the '*' input positional
+    # already registered above.
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        dest="admit_apply",
+        help=(
+            "[admit] Apply a (human-edited) admit manifest: move accepted "
+            "PDFs into the library and emit the Datasheet Name paste-file."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        dest="admit_manifest",
+        help=(
+            "[admit] Manifest CSV path: written by propose mode, read by "
+            "--apply. Defaults to 'admit-manifest.csv' inside the staging "
+            "directory."
+        ),
+    )
+    parser.add_argument(
+        "--staging-dir",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        dest="admit_staging_dir",
+        help=(
+            "[admit] Override the configured datasheet_staging.staging_dir "
+            "for this invocation."
+        ),
+    )
+    parser.add_argument(
+        "--library-dir",
+        metavar="PATH",
+        type=Path,
+        default=None,
+        dest="admit_library_dir",
+        help=(
+            "[admit] Library 'datasheets/' directory. Defaults to a "
+            "'datasheets' sibling of the staging directory."
+        ),
+    )
+
     parser.set_defaults(handler=handle_inventory)
+
+
+_ADMIT_SUBCOMMAND = "admit"
 
 
 def handle_inventory(args: argparse.Namespace) -> int:
@@ -220,6 +280,9 @@ def handle_inventory(args: argparse.Namespace) -> int:
         # Normalise input: None or empty list -> ["."] (current directory)
         raw_inputs: list[str] = args.input or ["."]
 
+        if raw_inputs[0] == _ADMIT_SUBCOMMAND:
+            return _handle_inventory_admit(raw_inputs[1:], args)
+
         if len(raw_inputs) > 1:
             return _handle_batch_inventory(raw_inputs, args)
         # Single-project: delegate to the existing handler unchanged
@@ -227,6 +290,161 @@ def handle_inventory(args: argparse.Namespace) -> int:
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+
+
+def _handle_inventory_admit(
+    extra_positionals: list[str], args: argparse.Namespace
+) -> int:
+    """Handle 'jbom inventory admit' -- the datasheet library admission gate (jBOM#356).
+
+    Propose mode (default) scans the configured staging directory and
+    writes a proposal manifest for human review. ``--apply`` reads a
+    (human-edited) manifest, moves accepted PDFs into the library, and
+    emits the full-sheet ``Datasheet Name`` paste-file proposal.
+    """
+    if extra_positionals:
+        print(
+            "Error: 'jbom inventory admit' does not accept extra positional "
+            f"arguments yet: {extra_positionals!r}. Edit the manifest and "
+            "re-run with --apply.",
+            file=sys.stderr,
+        )
+        return 1
+
+    staging_dir = args.admit_staging_dir or resolve_staging_dir()
+    if staging_dir is None:
+        print(
+            "Error: no staging directory configured "
+            "(datasheet_staging.staging_dir); nothing to admit. Set it in "
+            "~/.jbom/common.jbom.yaml (see jBOM#355).",
+            file=sys.stderr,
+        )
+        return 1
+
+    library_dir = args.admit_library_dir or (staging_dir.parent / "datasheets")
+    manifest_path = args.admit_manifest or (staging_dir / "admit-manifest.csv")
+
+    if args.admit_apply:
+        return _apply_inventory_admit(manifest_path, staging_dir, library_dir, args)
+
+    return _propose_inventory_admit(staging_dir, library_dir, manifest_path, args)
+
+
+def _propose_inventory_admit(
+    staging_dir: Path,
+    library_dir: Path,
+    manifest_path: Path,
+    args: argparse.Namespace,
+) -> int:
+    """Scan the staging directory and write the proposed admit manifest CSV."""
+    inventory_files = args.inventory_files or []
+    if not inventory_files:
+        print(
+            "Error: 'jbom inventory admit' requires --inventory <catalog.csv> "
+            "(repeatable) to resolve staged files against the backlog "
+            "(rows with a Datasheet URL but no Datasheet Name).",
+            file=sys.stderr,
+        )
+        return 1
+
+    for inventory_file in inventory_files:
+        if not inventory_file.exists():
+            print(f"Error: Inventory file not found: {inventory_file}", file=sys.stderr)
+            return 1
+
+    inventory_items, _ = InventoryReader(inventory_files).load()
+
+    rows = propose_admit_manifest(
+        staging_dir=staging_dir,
+        library_dir=library_dir,
+        inventory_items=inventory_items,
+    )
+
+    if not rows:
+        print("No verified staged files found; nothing to propose.", file=sys.stderr)
+        return 0
+
+    refused = (
+        f"Error: Manifest file '{manifest_path}' already exists. "
+        "Use --force to overwrite."
+    )
+    try:
+        with open_output_text_file(
+            manifest_path, force=args.force, refused_message=refused
+        ) as handle:
+            write_admit_manifest(rows, handle)
+    except OutputRefusedError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row.disposition] = counts.get(row.disposition, 0) + 1
+    counts_summary = ", ".join(
+        f"{count} {disposition}" for disposition, count in sorted(counts.items())
+    )
+    print(
+        f"Proposed admit manifest written to {manifest_path} "
+        f"({len(rows)} candidate(s): {counts_summary}). "
+        "Edit Action/ProposedName then re-run with --apply."
+    )
+    return 0
+
+
+def _apply_inventory_admit(
+    manifest_path: Path,
+    staging_dir: Path,
+    library_dir: Path,
+    args: argparse.Namespace,
+) -> int:
+    """Read a (human-edited) manifest and apply the admit gate."""
+    if not manifest_path.exists():
+        print(f"Error: Manifest file not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    with manifest_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = read_admit_manifest(handle)
+
+    result = apply_admit_manifest(
+        rows, staging_dir=staging_dir, library_dir=library_dir
+    )
+
+    for outcome in result.outcomes:
+        if outcome.status == "refused-never-rename":
+            print(f"Error: {outcome.message}", file=sys.stderr)
+        elif args.verbose and outcome.status in ("admitted", "already-admitted"):
+            print(f"  {outcome.message}", file=sys.stderr)
+
+    dest = resolve_output_destination(
+        args.output, default_destination=OutputDestination(OutputKind.STDOUT)
+    )
+    if dest.kind in (OutputKind.CONSOLE, OutputKind.STDOUT):
+        write_paste_file(result.paste_rows, sys.stdout)
+    else:
+        if not dest.path:
+            raise ValueError(
+                "Internal error: file output selected but no path provided"
+            )
+        refused = (
+            f"Error: Output file '{dest.path}' already exists. "
+            "Use --force to overwrite."
+        )
+        try:
+            with open_output_text_file(
+                dest.path, force=args.force, refused_message=refused
+            ) as handle:
+                write_paste_file(result.paste_rows, handle)
+        except OutputRefusedError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+    print(
+        f"Admit complete: {result.admitted_count} admitted, "
+        f"{result.refused_count} refused (never-rename), "
+        f"{len(result.paste_rows)} paste-file row(s).",
+        file=sys.stderr,
+    )
+    return 1 if result.refused_count else 0
 
 
 def _load_components_from_path(

--- a/src/jbom/cli/inventory.py
+++ b/src/jbom/cli/inventory.py
@@ -397,7 +397,14 @@ def _apply_inventory_admit(
     library_dir: Path,
     args: argparse.Namespace,
 ) -> int:
-    """Read a (human-edited) manifest and apply the admit gate."""
+    """Read a (human-edited) manifest and apply the admit gate.
+
+    Rows commit independently and in manifest order: a row refused by the
+    invalid-name or never-rename guard is skipped without affecting any
+    other row in the same manifest -- rows admitted earlier or later in
+    the same ``--apply`` run are never rolled back or blocked by one
+    refused row.
+    """
     if not manifest_path.exists():
         print(f"Error: Manifest file not found: {manifest_path}", file=sys.stderr)
         return 1
@@ -410,7 +417,7 @@ def _apply_inventory_admit(
     )
 
     for outcome in result.outcomes:
-        if outcome.status == "refused-never-rename":
+        if outcome.status.startswith("refused-"):
             print(f"Error: {outcome.message}", file=sys.stderr)
         elif args.verbose and outcome.status in ("admitted", "already-admitted"):
             print(f"  {outcome.message}", file=sys.stderr)
@@ -440,7 +447,7 @@ def _apply_inventory_admit(
 
     print(
         f"Admit complete: {result.admitted_count} admitted, "
-        f"{result.refused_count} refused (never-rename), "
+        f"{result.refused_count} refused (never-rename/invalid-name), "
         f"{len(result.paste_rows)} paste-file row(s).",
         file=sys.stderr,
     )

--- a/src/jbom/services/inventory_admit.py
+++ b/src/jbom/services/inventory_admit.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import re
+import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, TextIO
@@ -167,7 +168,9 @@ class AdmitApplyOutcome:
         row: The manifest row this outcome corresponds to.
         status: ``"admitted"``, ``"skipped"``, ``"already-admitted"``
             (idempotent no-op; byte-identical content already at the
-            target name), or ``"refused-never-rename"``.
+            target name), ``"refused-never-rename"``, or
+            ``"refused-invalid-name"`` (unsafe ``ProposedName``, e.g. a path
+            traversal attempt).
         message: Human-readable detail, suitable for CLI warning output.
     """
 
@@ -202,11 +205,55 @@ class AdmitApplyResult:
 
     @property
     def refused_count(self) -> int:
-        """Number of rows refused by the never-rename guard."""
+        """Number of rows refused (never-rename guard or invalid-name guard)."""
 
         return sum(
-            1 for outcome in self.outcomes if outcome.status == "refused-never-rename"
+            1 for outcome in self.outcomes if outcome.status.startswith("refused-")
         )
+
+
+def _normalize_name(name: str) -> str:
+    """NFC-normalize and strip a proposed/published name for safe comparison.
+
+    The manifest is human-edited free text; normalizing to NFC before any
+    comparison or filesystem use prevents unicode-variant spellings (NFC vs
+    NFD encodings of the same visible characters) from slipping past the
+    case-insensitive uniqueness invariant (jBOM#346).
+    """
+
+    return unicodedata.normalize("NFC", str(name or "").strip())
+
+
+def invalid_proposed_name_reason(
+    proposed_name: str, *, library_dir: Path
+) -> str | None:
+    """Return a reason string when *proposed_name* is unsafe to use as a
+    library filename stem, or ``None`` when it is safe.
+
+    The admit manifest is human-edited free text, so a crafted
+    ``ProposedName`` (e.g. ``"../../evil"`` or an absolute path) must never
+    be trusted as a bare filename stem -- doing so would let a manifest
+    write outside the library directory. Rejects path separators, ``.``/
+    ``..`` components, and absolute paths outright, then (belt-and-braces)
+    verifies the fully resolved target still lands directly inside
+    *library_dir*.
+    """
+
+    name = _normalize_name(proposed_name)
+    if not name:
+        return "ProposedName is empty"
+    if "/" in name or "\\" in name or "\x00" in name:
+        return f"ProposedName contains a path separator: {proposed_name!r}"
+    if name in (".", ".."):
+        return f"ProposedName is a path traversal component: {proposed_name!r}"
+    if Path(name).is_absolute():
+        return f"ProposedName is an absolute path: {proposed_name!r}"
+
+    resolved_library_dir = library_dir.resolve()
+    resolved_target = (library_dir / f"{name}.pdf").resolve()
+    if resolved_target.parent != resolved_library_dir:
+        return f"ProposedName escapes the library directory: {proposed_name!r}"
+    return None
 
 
 def _sanitize_name_token(value: str) -> str:
@@ -294,13 +341,19 @@ def _sha256_of_file(path: Path) -> str:
 
 
 def _library_name_index(library_dir: Path) -> dict[str, Path]:
-    """Return a case-insensitive index of published names -> file paths."""
+    """Return a case-insensitive index of published names -> file paths.
+
+    Keys are NFC-normalized and lower-cased, so lookups are both
+    unicode-normalization-insensitive and OS-independent case-insensitive
+    (never relying on the host filesystem's own case sensitivity, which
+    varies between macOS/Windows and Linux).
+    """
 
     if not library_dir.is_dir():
         return {}
     index: dict[str, Path] = {}
     for candidate in library_dir.glob("*.pdf"):
-        index[candidate.stem.lower()] = candidate
+        index[_normalize_name(candidate.stem).lower()] = candidate
     return index
 
 
@@ -319,7 +372,7 @@ def never_rename_violation(
     """
 
     index = _library_name_index(library_dir)
-    existing = index.get(proposed_name.strip().lower())
+    existing = index.get(_normalize_name(proposed_name).lower())
     if existing is None:
         return None
     if _sha256_of_file(existing) == _sha256_of_file(staged_path):
@@ -414,7 +467,7 @@ def propose_admit_manifest(
         )
 
         index = _library_name_index(library_dir)
-        existing = index.get(proposed_name.lower())
+        existing = index.get(_normalize_name(proposed_name).lower())
         if existing is not None and _sha256_of_file(existing) == _sha256_of_file(
             staged_path
         ):
@@ -484,12 +537,14 @@ def apply_admit_manifest(
 ) -> AdmitApplyResult:
     """Apply a human-edited manifest: move accepted PDFs into the library.
 
-    Only rows with ``Action == "ADMIT"`` are processed. Each admitted row's
-    never-rename status is checked before any filesystem mutation for that
-    row; a violation refuses that row without moving its file (no partial
-    mutation). Successfully admitted rows contribute one paste-file entry
-    per member IPN, all carrying the row's proposed name (family docs name
-    every member the same way).
+    Only rows with ``Action == "ADMIT"`` are processed. Rows commit
+    independently and in manifest order: each row's safety checks (invalid
+    name, then never-rename) run before any filesystem mutation *for that
+    row*, and a refusal skips only that row -- it never aborts or rolls
+    back rows already admitted earlier in the same batch. Successfully
+    admitted rows contribute one paste-file entry per member IPN, all
+    carrying the row's proposed name (family docs name every member the
+    same way).
 
     Args:
         rows: Manifest rows, typically from :func:`read_admit_manifest`.
@@ -515,13 +570,31 @@ def apply_admit_manifest(
             )
             continue
 
-        proposed_name = row.proposed_name.strip()
+        proposed_name = _normalize_name(row.proposed_name)
         if not proposed_name:
             outcomes.append(
                 AdmitApplyOutcome(
                     row=row,
                     status="skipped",
                     message="ADMIT row has no ProposedName; skipped.",
+                )
+            )
+            continue
+
+        # Path-safety guard runs first and unconditionally: the manifest is
+        # human-edited free text, so a crafted ProposedName must never reach
+        # a filesystem write, regardless of whether the staged file exists.
+        invalid_reason = invalid_proposed_name_reason(
+            proposed_name, library_dir=library_dir
+        )
+        if invalid_reason is not None:
+            outcomes.append(
+                AdmitApplyOutcome(
+                    row=row,
+                    status="refused-invalid-name",
+                    message=(
+                        f"Refusing to admit {row.staged_file!r}: {invalid_reason}"
+                    ),
                 )
             )
             continue
@@ -558,14 +631,21 @@ def apply_admit_manifest(
             )
             continue
 
-        target_path = library_dir / f"{proposed_name}.pdf"
-        if target_path.exists():
+        # OS-independent idempotent-reuse check: look up the target name in
+        # the same case-insensitive/NFC-normalized index never_rename_
+        # violation already consulted (never_rename_violation having passed
+        # means either no match, or a byte-identical match) rather than
+        # target_path.exists(), which only detects a case-variant match on
+        # filesystems that happen to be case-insensitive (e.g. macOS).
+        existing = _library_name_index(library_dir).get(proposed_name.lower())
+        if existing is not None:
             # Idempotent re-admission of byte-identical content: no move
             # needed, but still contributes paste rows.
             status = "already-admitted"
-            message = f"{proposed_name}.pdf already published; no changes made."
+            message = f"{existing.name} already published; no changes made."
         else:
             library_dir.mkdir(parents=True, exist_ok=True)
+            target_path = library_dir / f"{proposed_name}.pdf"
             staged_path.replace(target_path)
             status = "admitted"
             message = f"Admitted {row.staged_file!r} as {proposed_name}.pdf"
@@ -604,6 +684,7 @@ __all__ = [
     "AdmitApplyResult",
     "AdmitManifestRow",
     "apply_admit_manifest",
+    "invalid_proposed_name_reason",
     "never_rename_violation",
     "propose_admit_manifest",
     "propose_document_name",

--- a/src/jbom/services/inventory_admit.py
+++ b/src/jbom/services/inventory_admit.py
@@ -1,0 +1,613 @@
+"""Admission gate for the datasheet document library (jBOM#356).
+
+Implements the second half of the datasheet-document acquisition lifecycle
+decided in jBOM#349 (the first half -- always-on staging fetch -- lives in
+:mod:`jbom.services.datasheet_staging`, jBOM#355). ``jbom inventory admit``
+is the *sole* gate into the library:
+
+* **Propose** (:func:`propose_admit_manifest`) scans the configured staging
+  directory for verified PDFs, matches each one back to the inventory
+  "backlog" (rows with a populated ``Datasheet`` URL but no ``Datasheet
+  Name`` yet -- see jBOM#348), and proposes a curated document name. Rows
+  sharing one URL (family members) are grouped into a single manifest row.
+* A human edits the resulting manifest CSV -- names, family grouping,
+  and per-row ``Action`` (``ADMIT`` to accept, ``SKIP`` to leave staged).
+* **Apply** (:func:`apply_admit_manifest`) moves accepted PDFs into
+  ``datasheets/<name>.pdf`` and emits a full-sheet paste-file proposal for
+  the ``Datasheet Name`` column (per jBOM#356's acceptance text). Per the
+  jBOM#347/#348 human-sole-writer ruling, this module never writes to the
+  inventory itself -- only to the staging/library directories and to the
+  paste-file it hands back to the human.
+
+Never-rename protection (jBOM#346/#347): a proposed name that collides
+(case-insensitively, since macOS/Dropbox filesystems are case-insensitive)
+with an *already-published* library document of different content is
+refused outright -- admit never silently renames or overwrites a published
+document. Re-admitting byte-identical content under its own published name
+is treated as an idempotent no-op, not a violation.
+
+Name proposal is a best-effort heuristic derived from inventory columns
+only (``Category``, ``Manufacturer``, ``MFGPN``) -- it does not read PDF
+content (technology/function tokens like "ThickFilm" or "Schottky" require
+opening the datasheet, which is out of scope for automated tooling; see the
+``bom-datasheets`` skill for the full POC convention). The human is always
+expected to review and correct the proposed name in the manifest before
+``--apply``.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, TextIO
+
+from jbom.common.types import InventoryItem
+from jbom.services.datasheet_staging import (
+    VERIFIED_SUFFIX,
+    is_admitted,
+    staged_filename_for_url,
+)
+
+_DATASHEET_URL_COLUMN = "Datasheet"
+_DATASHEET_NAME_COLUMN = "Datasheet Name"
+
+# Manifest CSV schema (human-editable; round-tripped by propose -> apply).
+MANIFEST_COLUMNS: tuple[str, ...] = (
+    "Action",
+    "ProposedName",
+    "Disposition",
+    "DupeOf",
+    "StagedFile",
+    "SourceURL",
+    "MemberIPNs",
+)
+
+ACTION_ADMIT = "ADMIT"
+ACTION_SKIP = "SKIP"
+
+DISPOSITION_NEW = "new"
+DISPOSITION_DUPE_OF = "dupe-of"
+DISPOSITION_COLLISION = "collision"
+DISPOSITION_UNRESOLVABLE = "unresolvable"
+
+_MEMBER_IPN_SEPARATOR = ";"
+_CLASS_TOKEN_BY_CATEGORY: dict[str, str] = {
+    "RES": "Resistor",
+    "CAP": "Capacitor",
+    "IND": "Inductor",
+    "IC": "IC",
+    "LED": "LED",
+    "DIODE": "Diode",
+    "MOSFET": "MOSFET",
+    "TRANSISTOR": "Transistor",
+    "CONNECTOR": "Connector",
+    "CRYSTAL": "Crystal",
+    "SWITCH": "Switch",
+    "FUSE": "Fuse",
+}
+
+
+@dataclass(frozen=True)
+class AdmitManifestRow:
+    """One row of the human-editable admit manifest.
+
+    Attributes:
+        action: ``"ADMIT"`` to accept this row at apply time, ``"SKIP"`` to
+            leave it staged (default for anything that needs human
+            attention: collisions and unresolvable candidates).
+        proposed_name: Curated ``Datasheet Name`` (no path, no extension).
+            Human-editable; the value used verbatim as the library filename
+            stem at apply time.
+        disposition: One of ``"new"``, ``"dupe-of"``, ``"collision"``, or
+            ``"unresolvable"`` -- see module docstring.
+        dupe_of: When ``disposition == "dupe-of"``, the existing published
+            name this staged file is byte-identical to.
+        staged_file: Filename (not full path) of the verified PDF within
+            the staging directory.
+        source_url: The Datasheet URL this staged file was fetched from.
+        member_ipns: IPNs of inventory Items sharing *source_url* that lack
+            a ``Datasheet Name`` -- the "target Item rows" this admission
+            will name. Family docs (jBOM#346) have more than one.
+    """
+
+    action: str
+    proposed_name: str
+    disposition: str
+    dupe_of: str
+    staged_file: str
+    source_url: str
+    member_ipns: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_csv_row(self) -> dict[str, str]:
+        """Render this row as a CSV dict matching :data:`MANIFEST_COLUMNS`."""
+
+        return {
+            "Action": self.action,
+            "ProposedName": self.proposed_name,
+            "Disposition": self.disposition,
+            "DupeOf": self.dupe_of,
+            "StagedFile": self.staged_file,
+            "SourceURL": self.source_url,
+            "MemberIPNs": _MEMBER_IPN_SEPARATOR.join(self.member_ipns),
+        }
+
+    @classmethod
+    def from_csv_row(cls, row: dict[str, str]) -> "AdmitManifestRow":
+        """Parse one CSV dict (as read back from an edited manifest) into a row."""
+
+        member_ipns_raw = str(row.get("MemberIPNs", "") or "").strip()
+        member_ipns = (
+            tuple(
+                token.strip()
+                for token in member_ipns_raw.split(_MEMBER_IPN_SEPARATOR)
+                if token.strip()
+            )
+            if member_ipns_raw
+            else tuple()
+        )
+        return cls(
+            action=str(row.get("Action", "") or "").strip().upper(),
+            proposed_name=str(row.get("ProposedName", "") or "").strip(),
+            disposition=str(row.get("Disposition", "") or "").strip(),
+            dupe_of=str(row.get("DupeOf", "") or "").strip(),
+            staged_file=str(row.get("StagedFile", "") or "").strip(),
+            source_url=str(row.get("SourceURL", "") or "").strip(),
+            member_ipns=member_ipns,
+        )
+
+
+@dataclass(frozen=True)
+class AdmitApplyOutcome:
+    """Per-row result of one :func:`apply_admit_manifest` row.
+
+    Attributes:
+        row: The manifest row this outcome corresponds to.
+        status: ``"admitted"``, ``"skipped"``, ``"already-admitted"``
+            (idempotent no-op; byte-identical content already at the
+            target name), or ``"refused-never-rename"``.
+        message: Human-readable detail, suitable for CLI warning output.
+    """
+
+    row: AdmitManifestRow
+    status: str
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class AdmitApplyResult:
+    """Aggregate outcome of one :func:`apply_admit_manifest` run.
+
+    Attributes:
+        outcomes: One :class:`AdmitApplyOutcome` per processed manifest row.
+        paste_rows: Ordered ``(ipn, proposed_name)`` pairs for the full-sheet
+            ``Datasheet Name`` paste-file -- one pair per admitted member
+            Item (family docs contribute one pair per member).
+    """
+
+    outcomes: list[AdmitApplyOutcome] = field(default_factory=list)
+    paste_rows: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def admitted_count(self) -> int:
+        """Number of rows successfully admitted (including idempotent no-ops)."""
+
+        return sum(
+            1
+            for outcome in self.outcomes
+            if outcome.status in ("admitted", "already-admitted")
+        )
+
+    @property
+    def refused_count(self) -> int:
+        """Number of rows refused by the never-rename guard."""
+
+        return sum(
+            1 for outcome in self.outcomes if outcome.status == "refused-never-rename"
+        )
+
+
+def _sanitize_name_token(value: str) -> str:
+    """Sanitize one name-component token to filesystem/manifest-safe text."""
+
+    token = re.sub(r"[^A-Za-z0-9]+", "-", str(value or "").strip())
+    return token.strip("-")
+
+
+def _class_token_for_category(category: str) -> str:
+    """Return a human-legible class token for a jBOM inventory category."""
+
+    normalized = str(category or "").strip().upper()
+    return _CLASS_TOKEN_BY_CATEGORY.get(normalized, normalized.title() or "Part")
+
+
+def _common_alnum_prefix(values: Iterable[str]) -> str:
+    """Return the longest common leading substring shared by all *values*."""
+
+    items = [str(v or "").strip() for v in values if str(v or "").strip()]
+    if not items:
+        return ""
+    prefix = items[0]
+    for item in items[1:]:
+        limit = min(len(prefix), len(item))
+        i = 0
+        while i < limit and prefix[i] == item[i]:
+            i += 1
+        prefix = prefix[:i]
+        if not prefix:
+            return ""
+    return prefix
+
+
+def propose_document_name(
+    *,
+    category: str,
+    manufacturer: str,
+    mfgpn_candidates: Iterable[str],
+) -> str:
+    """Propose a best-effort curated ``Datasheet Name`` for one candidate.
+
+    Follows the bom-datasheets POC convention's token order
+    (``<Class>-<Manufacturer>-<MPN>``) without the technology/function
+    tokens that require reading the datasheet itself. When more than one
+    MFGPN is supplied (a family candidate), a shared prefix of at least 3
+    characters is truncated and suffixed with ``-series`` (jBOM#346); when no
+    shared prefix exists, the first MFGPN is used verbatim -- the human is
+    expected to correct this in the manifest.
+
+    Args:
+        category: Inventory ``Category`` value (e.g. ``"RES"``).
+        manufacturer: Inventory ``Manufacturer`` value.
+        mfgpn_candidates: MFGPN values of every member Item sharing this
+            candidate's source URL.
+
+    Returns:
+        A proposed name, e.g. ``"Resistor-Uniroyal-0603WAJ-series"``.
+    """
+
+    class_token = _class_token_for_category(category)
+    manufacturer_token = _sanitize_name_token(manufacturer) or "Unknown"
+
+    candidates = [
+        str(v or "").strip() for v in mfgpn_candidates if str(v or "").strip()
+    ]
+    if not candidates:
+        mpn_token = "unknown"
+    elif len(candidates) == 1:
+        mpn_token = _sanitize_name_token(candidates[0]) or "unknown"
+    else:
+        common_prefix = _common_alnum_prefix(candidates).rstrip("-_")
+        if len(common_prefix) >= 3:
+            mpn_token = f"{_sanitize_name_token(common_prefix)}-series"
+        else:
+            mpn_token = _sanitize_name_token(candidates[0]) or "unknown"
+
+    return f"{class_token}-{manufacturer_token}-{mpn_token}"
+
+
+def _sha256_of_file(path: Path) -> str:
+    """Return the sha256 hex digest of a file's contents."""
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _library_name_index(library_dir: Path) -> dict[str, Path]:
+    """Return a case-insensitive index of published names -> file paths."""
+
+    if not library_dir.is_dir():
+        return {}
+    index: dict[str, Path] = {}
+    for candidate in library_dir.glob("*.pdf"):
+        index[candidate.stem.lower()] = candidate
+    return index
+
+
+def never_rename_violation(
+    *,
+    proposed_name: str,
+    staged_path: Path,
+    library_dir: Path,
+) -> str | None:
+    """Return the colliding published filename stem, or ``None`` if safe.
+
+    A violation exists when *proposed_name* matches (case-insensitively) an
+    already-published document in *library_dir* whose content differs from
+    *staged_path*. Re-admitting byte-identical content under its own
+    published name is not a violation (idempotent no-op).
+    """
+
+    index = _library_name_index(library_dir)
+    existing = index.get(proposed_name.strip().lower())
+    if existing is None:
+        return None
+    if _sha256_of_file(existing) == _sha256_of_file(staged_path):
+        return None
+    return existing.stem
+
+
+def _backlog_by_url(
+    inventory_items: Iterable[InventoryItem],
+) -> dict[str, list[InventoryItem]]:
+    """Group inventory Items lacking a ``Datasheet Name`` by their URL.
+
+    Mirrors the jBOM#348 structural backlog signal (``Datasheet`` URL
+    populated, ``Datasheet Name`` empty) already used by
+    :mod:`jbom.services.datasheet_staging`.
+    """
+
+    backlog: dict[str, list[InventoryItem]] = {}
+    for item in inventory_items:
+        if is_admitted(item):
+            continue
+        url = str(item.datasheet or "").strip()
+        if not url:
+            continue
+        backlog.setdefault(url, []).append(item)
+    return backlog
+
+
+def propose_admit_manifest(
+    *,
+    staging_dir: Path,
+    library_dir: Path,
+    inventory_items: Iterable[InventoryItem],
+) -> list[AdmitManifestRow]:
+    """Scan *staging_dir* and build a proposed admit manifest.
+
+    Args:
+        staging_dir: Resolved staging directory (jBOM#355); only verified
+            (``.pdf`` suffix) files are considered -- unverified/flagged
+            files are never proposed for admission.
+        library_dir: The library's ``datasheets/`` directory (may not exist
+            yet; only read for collision/dupe detection).
+        inventory_items: Loaded inventory rows, used to build the backlog
+            (URL -> member Items) and to derive proposed names.
+
+    Returns:
+        One :class:`AdmitManifestRow` per verified staged file, ordered by
+        filename for determinism.
+    """
+
+    backlog = _backlog_by_url(inventory_items)
+    # Precompute the staged stem for every backlog URL once, so each staged
+    # file can be resolved back to its URL without re-deriving per file.
+    stem_to_url: dict[str, str] = {
+        staged_filename_for_url(url): url for url in backlog.keys()
+    }
+
+    rows: list[AdmitManifestRow] = []
+    if not staging_dir.is_dir():
+        return rows
+
+    staged_files = sorted(
+        p for p in staging_dir.glob(f"*{VERIFIED_SUFFIX}") if p.is_file()
+    )
+    for staged_path in staged_files:
+        stem = staged_path.stem
+        url = stem_to_url.get(stem, "")
+        members = backlog.get(url, []) if url else []
+        member_ipns = tuple(
+            (m.ipn or "").strip() for m in members if (m.ipn or "").strip()
+        )
+
+        if not url or not members:
+            rows.append(
+                AdmitManifestRow(
+                    action=ACTION_SKIP,
+                    proposed_name="",
+                    disposition=DISPOSITION_UNRESOLVABLE,
+                    dupe_of="",
+                    staged_file=staged_path.name,
+                    source_url=url,
+                    member_ipns=member_ipns,
+                )
+            )
+            continue
+
+        category = members[0].category
+        manufacturer = members[0].manufacturer
+        mfgpns = [m.mfgpn for m in members]
+        proposed_name = propose_document_name(
+            category=category, manufacturer=manufacturer, mfgpn_candidates=mfgpns
+        )
+
+        index = _library_name_index(library_dir)
+        existing = index.get(proposed_name.lower())
+        if existing is not None and _sha256_of_file(existing) == _sha256_of_file(
+            staged_path
+        ):
+            rows.append(
+                AdmitManifestRow(
+                    action=ACTION_ADMIT,
+                    proposed_name=existing.stem,
+                    disposition=DISPOSITION_DUPE_OF,
+                    dupe_of=existing.stem,
+                    staged_file=staged_path.name,
+                    source_url=url,
+                    member_ipns=member_ipns,
+                )
+            )
+            continue
+
+        if existing is not None:
+            rows.append(
+                AdmitManifestRow(
+                    action=ACTION_SKIP,
+                    proposed_name=proposed_name,
+                    disposition=DISPOSITION_COLLISION,
+                    dupe_of="",
+                    staged_file=staged_path.name,
+                    source_url=url,
+                    member_ipns=member_ipns,
+                )
+            )
+            continue
+
+        rows.append(
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name=proposed_name,
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file=staged_path.name,
+                source_url=url,
+                member_ipns=member_ipns,
+            )
+        )
+
+    return rows
+
+
+def write_admit_manifest(rows: Iterable[AdmitManifestRow], out: TextIO) -> None:
+    """Write manifest rows as CSV to *out*."""
+
+    writer = csv.DictWriter(out, fieldnames=list(MANIFEST_COLUMNS))
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row.to_csv_row())
+
+
+def read_admit_manifest(handle: TextIO) -> list[AdmitManifestRow]:
+    """Read a (possibly human-edited) manifest CSV from *handle*."""
+
+    reader = csv.DictReader(handle)
+    return [AdmitManifestRow.from_csv_row(row) for row in reader]
+
+
+def apply_admit_manifest(
+    rows: Iterable[AdmitManifestRow],
+    *,
+    staging_dir: Path,
+    library_dir: Path,
+) -> AdmitApplyResult:
+    """Apply a human-edited manifest: move accepted PDFs into the library.
+
+    Only rows with ``Action == "ADMIT"`` are processed. Each admitted row's
+    never-rename status is checked before any filesystem mutation for that
+    row; a violation refuses that row without moving its file (no partial
+    mutation). Successfully admitted rows contribute one paste-file entry
+    per member IPN, all carrying the row's proposed name (family docs name
+    every member the same way).
+
+    Args:
+        rows: Manifest rows, typically from :func:`read_admit_manifest`.
+        staging_dir: Directory containing the staged (verified) PDFs.
+        library_dir: The library's ``datasheets/`` directory; created if
+            needed only when a row is actually admitted.
+
+    Returns:
+        Aggregate :class:`AdmitApplyResult`.
+    """
+
+    outcomes: list[AdmitApplyOutcome] = []
+    paste_rows: list[tuple[str, str]] = []
+
+    for row in rows:
+        if row.action.strip().upper() != ACTION_ADMIT:
+            outcomes.append(
+                AdmitApplyOutcome(
+                    row=row,
+                    status="skipped",
+                    message=f"Action={row.action or '(blank)'}",
+                )
+            )
+            continue
+
+        proposed_name = row.proposed_name.strip()
+        if not proposed_name:
+            outcomes.append(
+                AdmitApplyOutcome(
+                    row=row,
+                    status="skipped",
+                    message="ADMIT row has no ProposedName; skipped.",
+                )
+            )
+            continue
+
+        staged_path = staging_dir / row.staged_file
+        if not staged_path.is_file():
+            outcomes.append(
+                AdmitApplyOutcome(
+                    row=row,
+                    status="skipped",
+                    message=f"Staged file not found: {staged_path}",
+                )
+            )
+            continue
+
+        violation = never_rename_violation(
+            proposed_name=proposed_name,
+            staged_path=staged_path,
+            library_dir=library_dir,
+        )
+        if violation is not None:
+            outcomes.append(
+                AdmitApplyOutcome(
+                    row=row,
+                    status="refused-never-rename",
+                    message=(
+                        f"Refusing to admit {row.staged_file!r} as "
+                        f"{proposed_name!r}: a published document named "
+                        f"{violation!r} already exists with different "
+                        "content. Never-rename protection: choose a "
+                        "different name or resolve the collision by hand."
+                    ),
+                )
+            )
+            continue
+
+        target_path = library_dir / f"{proposed_name}.pdf"
+        if target_path.exists():
+            # Idempotent re-admission of byte-identical content: no move
+            # needed, but still contributes paste rows.
+            status = "already-admitted"
+            message = f"{proposed_name}.pdf already published; no changes made."
+        else:
+            library_dir.mkdir(parents=True, exist_ok=True)
+            staged_path.replace(target_path)
+            status = "admitted"
+            message = f"Admitted {row.staged_file!r} as {proposed_name}.pdf"
+
+        outcomes.append(AdmitApplyOutcome(row=row, status=status, message=message))
+        for ipn in row.member_ipns:
+            paste_rows.append((ipn, proposed_name))
+
+    return AdmitApplyResult(outcomes=outcomes, paste_rows=paste_rows)
+
+
+def write_paste_file(paste_rows: Iterable[tuple[str, str]], out: TextIO) -> None:
+    """Write the full-sheet ``Datasheet Name`` paste-file proposal.
+
+    One row per admitted member Item (``IPN``, ``Datasheet Name``), ready
+    for a human to paste the ``Datasheet Name`` column values into the
+    canonical inventory at the matching IPN rows. jBOM never writes to the
+    inventory directly (jBOM#347/#348).
+    """
+
+    writer = csv.DictWriter(out, fieldnames=["IPN", _DATASHEET_NAME_COLUMN])
+    writer.writeheader()
+    for ipn, name in paste_rows:
+        writer.writerow({"IPN": ipn, _DATASHEET_NAME_COLUMN: name})
+
+
+__all__ = [
+    "ACTION_ADMIT",
+    "ACTION_SKIP",
+    "DISPOSITION_COLLISION",
+    "DISPOSITION_DUPE_OF",
+    "DISPOSITION_NEW",
+    "DISPOSITION_UNRESOLVABLE",
+    "MANIFEST_COLUMNS",
+    "AdmitApplyOutcome",
+    "AdmitApplyResult",
+    "AdmitManifestRow",
+    "apply_admit_manifest",
+    "never_rename_violation",
+    "propose_admit_manifest",
+    "propose_document_name",
+    "read_admit_manifest",
+    "write_admit_manifest",
+    "write_paste_file",
+]

--- a/tests/unit/test_inventory_admit.py
+++ b/tests/unit/test_inventory_admit.py
@@ -15,6 +15,7 @@ from jbom.services.inventory_admit import (
     DISPOSITION_UNRESOLVABLE,
     AdmitManifestRow,
     apply_admit_manifest,
+    invalid_proposed_name_reason,
     never_rename_violation,
     propose_admit_manifest,
     propose_document_name,
@@ -154,6 +155,46 @@ class TestNeverRenameViolation:
         )
 
 
+class TestInvalidProposedNameReason:
+    def test_none_for_safe_name(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        assert (
+            invalid_proposed_name_reason("IC-TI-LM358D", library_dir=library_dir)
+            is None
+        )
+
+    def test_rejects_relative_path_traversal(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("../../evil", library_dir=library_dir)
+        assert reason is not None
+        assert "path separator" in reason
+
+    def test_rejects_nested_subdirectory(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("sub/evil", library_dir=library_dir)
+        assert reason is not None
+
+    def test_rejects_backslash_traversal(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("..\\evil", library_dir=library_dir)
+        assert reason is not None
+
+    def test_rejects_absolute_path(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("/etc/passwd", library_dir=library_dir)
+        assert reason is not None
+
+    def test_rejects_bare_dot_dot(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("..", library_dir=library_dir)
+        assert reason is not None
+
+    def test_rejects_empty_name(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        reason = invalid_proposed_name_reason("   ", library_dir=library_dir)
+        assert reason is not None
+
+
 class TestManifestCsvRoundTrip:
     def test_round_trips_all_fields(self) -> None:
         rows = [
@@ -204,6 +245,35 @@ class TestManifestCsvRoundTrip:
         assert parsed[0].action == "ADMIT"
         assert parsed[0].proposed_name == "Human-Renamed-Doc"
         assert parsed[0].member_ipns == ("RES_A", "RES_B")
+
+    def test_missing_optional_columns_default_to_empty(self) -> None:
+        """A hand-trimmed manifest missing DupeOf/MemberIPNs must still parse."""
+        buf = io.StringIO(
+            "Action,ProposedName,Disposition,StagedFile,SourceURL\n"
+            "ADMIT,Minimal-Doc,new,stem-min.pdf,https://x/min.pdf\n"
+        )
+        parsed = read_admit_manifest(buf)
+        assert parsed[0].proposed_name == "Minimal-Doc"
+        assert parsed[0].dupe_of == ""
+        assert parsed[0].member_ipns == ()
+
+    def test_duplicate_staged_file_rows_are_preserved_independently(self) -> None:
+        """The manifest is a flat CSV with no uniqueness constraint on
+        StagedFile/SourceURL -- a human accidentally duplicating a row (e.g.
+        via spreadsheet copy-paste) must round-trip both rows unchanged;
+        de-duplication is not this module's job. (apply_admit_manifest
+        processes each row independently, so a duplicate simply re-attempts
+        the same admission -- the second attempt becomes an idempotent
+        no-op once the first succeeds.)
+        """
+        buf = io.StringIO(
+            "Action,ProposedName,Disposition,DupeOf,StagedFile,SourceURL,MemberIPNs\n"
+            "ADMIT,Dup-Doc,new,,stem-dup.pdf,https://x/dup.pdf,IC_A\n"
+            "ADMIT,Dup-Doc,new,,stem-dup.pdf,https://x/dup.pdf,IC_A\n"
+        )
+        parsed = read_admit_manifest(buf)
+        assert len(parsed) == 2
+        assert parsed[0] == parsed[1]
 
 
 class TestProposeAdmitManifest:
@@ -578,6 +648,213 @@ class TestApplyAdmitManifest:
         assert result.outcomes[0].status == "skipped"
         assert result.admitted_count == 0
         assert result.refused_count == 0
+
+    def test_path_traversal_proposed_name_is_refused_and_writes_nothing_outside_library(
+        self, tmp_path: Path
+    ) -> None:
+        """A crafted ProposedName in a human-edited manifest must never
+        escape the library directory (reviewer-demonstrated live escape on
+        PR#373: ``proposed_name="../../evil"``).
+        """
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "library" / "datasheets"
+        library_dir.mkdir(parents=True)
+        (staging_dir / "stem-evil.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="../../evil",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-evil.pdf",
+                source_url="https://example.com/evil.pdf",
+                member_ipns=("IC_EVIL",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.outcomes[0].status == "refused-invalid-name"
+        assert result.refused_count == 1
+        assert result.admitted_count == 0
+        assert result.paste_rows == []
+        # The staged file must still be exactly where it was -- no move, no
+        # write anywhere, including outside the library directory tree.
+        assert (staging_dir / "stem-evil.pdf").read_bytes() == _PDF_BYTES_A
+        assert not (tmp_path / "library" / "evil.pdf").exists()
+        assert not (tmp_path / "evil.pdf").exists()
+        assert list(library_dir.glob("*.pdf")) == []
+
+    def test_absolute_path_proposed_name_is_refused(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        outside_target = tmp_path / "outside-target.pdf"
+        (staging_dir / "stem-abs.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name=str(outside_target.with_suffix("")),
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-abs.pdf",
+                source_url="https://example.com/abs.pdf",
+                member_ipns=("IC_ABS",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.outcomes[0].status == "refused-invalid-name"
+        assert not outside_target.exists()
+
+    def test_unicode_variant_name_is_treated_as_the_same_published_document(
+        self, tmp_path: Path
+    ) -> None:
+        """NFC vs NFD encodings of the same visible name must not bypass
+        the case-insensitive uniqueness invariant (jBOM#346)."""
+        import unicodedata
+
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+
+        nfc_name = unicodedata.normalize("NFC", "Cafe\u0301-Doc")  # "Café-Doc" (NFC)
+        nfd_name = unicodedata.normalize("NFD", nfc_name)  # same text, NFD encoding
+        assert nfc_name != nfd_name  # sanity: genuinely different byte sequences
+
+        (library_dir / f"{nfc_name}.pdf").write_bytes(_PDF_BYTES_A)
+        (staging_dir / "stem-variant.pdf").write_bytes(_PDF_BYTES_B)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name=nfd_name,
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-variant.pdf",
+                source_url="https://example.com/variant.pdf",
+                member_ipns=("IC_VARIANT",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        # Different content under the "same" (unicode-normalized) name is a
+        # never-rename violation, not a fresh admission.
+        assert result.outcomes[0].status == "refused-never-rename"
+
+    def test_case_variant_reuse_is_idempotent_without_relying_on_filesystem_case_sensitivity(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-admitting identical content under a different-case spelling of
+        an existing published name must be detected via the case-insensitive
+        index, not ``Path.exists()`` (which only "works" on filesystems that
+        happen to be case-insensitive, e.g. macOS/Windows -- not Linux)."""
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (library_dir / "Existing-Doc.pdf").write_bytes(_PDF_BYTES_A)
+        (staging_dir / "stem-case.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="existing-doc",  # case-variant spelling
+                disposition=DISPOSITION_DUPE_OF,
+                dupe_of="Existing-Doc",
+                staged_file="stem-case.pdf",
+                source_url="https://example.com/case.pdf",
+                member_ipns=("IC_CASE",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.outcomes[0].status == "already-admitted"
+        # Exactly one published file exists -- no case-variant duplicate was
+        # created, regardless of host filesystem case sensitivity.
+        assert [p.name for p in library_dir.glob("*.pdf")] == ["Existing-Doc.pdf"]
+
+
+class TestApplyAdmitManifestPartialBatch:
+    def test_one_refused_row_does_not_block_other_rows_in_the_same_batch(
+        self, tmp_path: Path
+    ) -> None:
+        """Row-by-row commit semantics: rows are independent within one
+        ``--apply`` run -- a refusal on one row must not prevent, roll back,
+        or otherwise affect any other row in the same manifest."""
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (library_dir / "Published-Name.pdf").write_bytes(_PDF_BYTES_A)
+
+        (staging_dir / "stem-good-1.pdf").write_bytes(_PDF_BYTES_A)
+        (staging_dir / "stem-bad.pdf").write_bytes(_PDF_BYTES_B)
+        (staging_dir / "stem-good-2.pdf").write_bytes(b"%PDF-1.4\n%datasheet C\n%%EOF")
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="IC-First-Doc",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-good-1.pdf",
+                source_url="https://example.com/first.pdf",
+                member_ipns=("IC_FIRST",),
+            ),
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                # Collides with a published doc of different content --
+                # must be refused without affecting the other two rows.
+                proposed_name="Published-Name",
+                disposition=DISPOSITION_COLLISION,
+                dupe_of="",
+                staged_file="stem-bad.pdf",
+                source_url="https://example.com/bad.pdf",
+                member_ipns=("IC_BAD",),
+            ),
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="IC-Third-Doc",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-good-2.pdf",
+                source_url="https://example.com/third.pdf",
+                member_ipns=("IC_THIRD",),
+            ),
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.admitted_count == 2
+        assert result.refused_count == 1
+        assert (library_dir / "IC-First-Doc.pdf").is_file()
+        assert (library_dir / "IC-Third-Doc.pdf").is_file()
+        # The refused row's staged file is untouched and never landed under
+        # the colliding published name.
+        assert (staging_dir / "stem-bad.pdf").read_bytes() == _PDF_BYTES_B
+        assert (library_dir / "Published-Name.pdf").read_bytes() == _PDF_BYTES_A
+        assert set(result.paste_rows) == {
+            ("IC_FIRST", "IC-First-Doc"),
+            ("IC_THIRD", "IC-Third-Doc"),
+        }
 
 
 class TestWritePasteFile:

--- a/tests/unit/test_inventory_admit.py
+++ b/tests/unit/test_inventory_admit.py
@@ -1,0 +1,596 @@
+"""Unit tests for jbom.services.inventory_admit (jBOM#356)."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from jbom.common.types import InventoryItem
+from jbom.services.inventory_admit import (
+    ACTION_ADMIT,
+    ACTION_SKIP,
+    DISPOSITION_COLLISION,
+    DISPOSITION_DUPE_OF,
+    DISPOSITION_NEW,
+    DISPOSITION_UNRESOLVABLE,
+    AdmitManifestRow,
+    apply_admit_manifest,
+    never_rename_violation,
+    propose_admit_manifest,
+    propose_document_name,
+    read_admit_manifest,
+    write_admit_manifest,
+    write_paste_file,
+)
+
+_PDF_BYTES_A = b"%PDF-1.4\n%datasheet A\n%%EOF"
+_PDF_BYTES_B = b"%PDF-1.4\n%datasheet B (different content)\n%%EOF"
+
+
+def _item(
+    *,
+    ipn: str,
+    category: str = "RES",
+    manufacturer: str = "Uniroyal",
+    mfgpn: str = "0603WAJ0331T5E",
+    datasheet: str = "",
+    datasheet_name: str = "",
+) -> InventoryItem:
+    raw_data = {}
+    if datasheet_name:
+        raw_data["Datasheet Name"] = datasheet_name
+    return InventoryItem(
+        ipn=ipn,
+        keywords="",
+        category=category,
+        description="",
+        smd="",
+        value="10K",
+        type="",
+        tolerance="",
+        voltage="",
+        amperage="",
+        wattage="",
+        manufacturer=manufacturer,
+        mfgpn=mfgpn,
+        datasheet=datasheet,
+        raw_data=raw_data,
+    )
+
+
+class TestProposeDocumentName:
+    def test_single_mpn_uses_verbatim_token(self) -> None:
+        name = propose_document_name(
+            category="RES", manufacturer="Uniroyal", mfgpn_candidates=["0603WAJ0331T5E"]
+        )
+        assert name == "Resistor-Uniroyal-0603WAJ0331T5E"
+
+    def test_family_candidates_truncate_to_common_prefix_with_series_suffix(
+        self,
+    ) -> None:
+        name = propose_document_name(
+            category="RES",
+            manufacturer="Uniroyal",
+            mfgpn_candidates=["0603WAJ0331T5E", "0603WAJ0332T5E", "0603WAJ0333T5E"],
+        )
+        assert name == "Resistor-Uniroyal-0603WAJ033-series"
+
+    def test_no_common_prefix_falls_back_to_first_candidate(self) -> None:
+        name = propose_document_name(
+            category="IC", manufacturer="TI", mfgpn_candidates=["LM358D", "NE555P"]
+        )
+        assert name == "IC-TI-LM358D"
+
+    def test_unknown_category_is_title_cased(self) -> None:
+        name = propose_document_name(
+            category="WIDGET", manufacturer="Acme", mfgpn_candidates=["W-1"]
+        )
+        assert name.startswith("Widget-Acme-")
+
+    def test_sanitizes_unsafe_characters_in_tokens(self) -> None:
+        name = propose_document_name(
+            category="CAP",
+            manufacturer="UNI-ROYAL(厚声)",
+            mfgpn_candidates=["CC0603KPX7R8BB103"],
+        )
+        assert all(ch.isalnum() or ch == "-" for ch in name)
+
+
+class TestNeverRenameViolation:
+    def test_returns_none_when_no_existing_file(self, tmp_path: Path) -> None:
+        staged = tmp_path / "staged.pdf"
+        staged.write_bytes(_PDF_BYTES_A)
+        library_dir = tmp_path / "datasheets"
+        assert (
+            never_rename_violation(
+                proposed_name="New-Doc", staged_path=staged, library_dir=library_dir
+            )
+            is None
+        )
+
+    def test_returns_none_when_content_is_byte_identical(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (library_dir / "Existing-Doc.pdf").write_bytes(_PDF_BYTES_A)
+        staged = tmp_path / "staged.pdf"
+        staged.write_bytes(_PDF_BYTES_A)
+        assert (
+            never_rename_violation(
+                proposed_name="Existing-Doc",
+                staged_path=staged,
+                library_dir=library_dir,
+            )
+            is None
+        )
+
+    def test_returns_existing_stem_when_content_differs(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (library_dir / "Existing-Doc.pdf").write_bytes(_PDF_BYTES_A)
+        staged = tmp_path / "staged.pdf"
+        staged.write_bytes(_PDF_BYTES_B)
+        assert (
+            never_rename_violation(
+                proposed_name="Existing-Doc",
+                staged_path=staged,
+                library_dir=library_dir,
+            )
+            == "Existing-Doc"
+        )
+
+    def test_collision_is_case_insensitive(self, tmp_path: Path) -> None:
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (library_dir / "Existing-Doc.pdf").write_bytes(_PDF_BYTES_A)
+        staged = tmp_path / "staged.pdf"
+        staged.write_bytes(_PDF_BYTES_B)
+        assert (
+            never_rename_violation(
+                proposed_name="existing-doc",
+                staged_path=staged,
+                library_dir=library_dir,
+            )
+            == "Existing-Doc"
+        )
+
+
+class TestManifestCsvRoundTrip:
+    def test_round_trips_all_fields(self) -> None:
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="Resistor-Uniroyal-0603WAJ-series",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-abc123.pdf",
+                source_url="https://example.com/ds.pdf",
+                member_ipns=("RES_A", "RES_B", "RES_C"),
+            )
+        ]
+        buf = io.StringIO()
+        write_admit_manifest(rows, buf)
+        buf.seek(0)
+        parsed = read_admit_manifest(buf)
+
+        assert len(parsed) == 1
+        assert parsed[0] == rows[0]
+
+    def test_round_trips_empty_member_ipns(self) -> None:
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_SKIP,
+                proposed_name="",
+                disposition=DISPOSITION_UNRESOLVABLE,
+                dupe_of="",
+                staged_file="orphan-xyz.pdf",
+                source_url="",
+                member_ipns=(),
+            )
+        ]
+        buf = io.StringIO()
+        write_admit_manifest(rows, buf)
+        buf.seek(0)
+        parsed = read_admit_manifest(buf)
+
+        assert parsed[0].member_ipns == ()
+
+    def test_human_edits_survive_round_trip(self) -> None:
+        """A human editing Action/ProposedName in the CSV is what apply reads back."""
+        buf = io.StringIO(
+            "Action,ProposedName,Disposition,DupeOf,StagedFile,SourceURL,MemberIPNs\n"
+            "ADMIT,Human-Renamed-Doc,new,,stem-abc.pdf,https://x/y.pdf,RES_A;RES_B\n"
+        )
+        parsed = read_admit_manifest(buf)
+        assert parsed[0].action == "ADMIT"
+        assert parsed[0].proposed_name == "Human-Renamed-Doc"
+        assert parsed[0].member_ipns == ("RES_A", "RES_B")
+
+
+class TestProposeAdmitManifest:
+    def test_returns_empty_list_when_staging_dir_missing(self, tmp_path: Path) -> None:
+        rows = propose_admit_manifest(
+            staging_dir=tmp_path / "does-not-exist",
+            library_dir=tmp_path / "datasheets",
+            inventory_items=[],
+        )
+        assert rows == []
+
+    def test_single_item_candidate_is_disposition_new(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        from jbom.services.datasheet_staging import staged_filename_for_url
+
+        url = "https://example.com/docs/lm358.pdf"
+        stem = staged_filename_for_url(url)
+        (staging_dir / f"{stem}.pdf").write_bytes(_PDF_BYTES_A)
+
+        items = [
+            _item(
+                ipn="IC_LM358",
+                category="IC",
+                manufacturer="TI",
+                mfgpn="LM358D",
+                datasheet=url,
+            )
+        ]
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir,
+            library_dir=tmp_path / "datasheets",
+            inventory_items=items,
+        )
+
+        assert len(rows) == 1
+        assert rows[0].disposition == DISPOSITION_NEW
+        assert rows[0].action == ACTION_ADMIT
+        assert rows[0].member_ipns == ("IC_LM358",)
+        assert rows[0].proposed_name == "IC-TI-LM358D"
+
+    def test_family_members_sharing_one_url_are_grouped_into_one_row(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        from jbom.services.datasheet_staging import staged_filename_for_url
+
+        url = "https://example.com/docs/0603waj-series.pdf"
+        stem = staged_filename_for_url(url)
+        (staging_dir / f"{stem}.pdf").write_bytes(_PDF_BYTES_A)
+
+        items = [
+            _item(ipn="RES_331", mfgpn="0603WAJ0331T5E", datasheet=url),
+            _item(ipn="RES_332", mfgpn="0603WAJ0332T5E", datasheet=url),
+            _item(ipn="RES_333", mfgpn="0603WAJ0333T5E", datasheet=url),
+        ]
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir,
+            library_dir=tmp_path / "datasheets",
+            inventory_items=items,
+        )
+
+        assert len(rows) == 1
+        assert set(rows[0].member_ipns) == {"RES_331", "RES_332", "RES_333"}
+        assert rows[0].proposed_name.endswith("-series")
+
+    def test_already_admitted_items_are_excluded_from_backlog(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        from jbom.services.datasheet_staging import staged_filename_for_url
+
+        url = "https://example.com/docs/lm358.pdf"
+        stem = staged_filename_for_url(url)
+        (staging_dir / f"{stem}.pdf").write_bytes(_PDF_BYTES_A)
+
+        items = [
+            _item(
+                ipn="IC_LM358",
+                category="IC",
+                mfgpn="LM358D",
+                datasheet=url,
+                datasheet_name="LM358-series",
+            )
+        ]
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir,
+            library_dir=tmp_path / "datasheets",
+            inventory_items=items,
+        )
+
+        assert len(rows) == 1
+        assert rows[0].disposition == DISPOSITION_UNRESOLVABLE
+
+    def test_staged_file_with_no_matching_backlog_url_is_unresolvable(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        (staging_dir / "orphan-abc123.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir,
+            library_dir=tmp_path / "datasheets",
+            inventory_items=[],
+        )
+
+        assert len(rows) == 1
+        assert rows[0].disposition == DISPOSITION_UNRESOLVABLE
+        assert rows[0].action == ACTION_SKIP
+
+    def test_unverified_files_are_never_proposed(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        (staging_dir / "flagged-abc123.unverified").write_bytes(b"<html></html>")
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir,
+            library_dir=tmp_path / "datasheets",
+            inventory_items=[],
+        )
+
+        assert rows == []
+
+    def test_collision_with_existing_different_content_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+
+        from jbom.services.datasheet_staging import staged_filename_for_url
+
+        url = "https://example.com/docs/lm358.pdf"
+        stem = staged_filename_for_url(url)
+        (staging_dir / f"{stem}.pdf").write_bytes(_PDF_BYTES_B)
+        (library_dir / "IC-TI-LM358D.pdf").write_bytes(_PDF_BYTES_A)
+
+        items = [
+            _item(
+                ipn="IC_LM358",
+                category="IC",
+                manufacturer="TI",
+                mfgpn="LM358D",
+                datasheet=url,
+            )
+        ]
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir, library_dir=library_dir, inventory_items=items
+        )
+
+        assert rows[0].disposition == DISPOSITION_COLLISION
+        assert rows[0].action == ACTION_SKIP
+
+    def test_byte_identical_existing_doc_is_dupe_of(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+
+        from jbom.services.datasheet_staging import staged_filename_for_url
+
+        url = "https://example.com/docs/lm358.pdf"
+        stem = staged_filename_for_url(url)
+        (staging_dir / f"{stem}.pdf").write_bytes(_PDF_BYTES_A)
+        (library_dir / "IC-TI-LM358D.pdf").write_bytes(_PDF_BYTES_A)
+
+        items = [
+            _item(
+                ipn="IC_LM358",
+                category="IC",
+                manufacturer="TI",
+                mfgpn="LM358D",
+                datasheet=url,
+            )
+        ]
+
+        rows = propose_admit_manifest(
+            staging_dir=staging_dir, library_dir=library_dir, inventory_items=items
+        )
+
+        assert rows[0].disposition == DISPOSITION_DUPE_OF
+        assert rows[0].dupe_of == "IC-TI-LM358D"
+        assert rows[0].action == ACTION_ADMIT
+
+
+class TestApplyAdmitManifest:
+    def test_admits_new_document_and_moves_file(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        (staging_dir / "stem-abc.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="IC-TI-LM358D",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-abc.pdf",
+                source_url="https://example.com/lm358.pdf",
+                member_ipns=("IC_LM358",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.admitted_count == 1
+        assert result.refused_count == 0
+        assert (library_dir / "IC-TI-LM358D.pdf").is_file()
+        assert not (staging_dir / "stem-abc.pdf").exists()
+        assert result.paste_rows == [("IC_LM358", "IC-TI-LM358D")]
+
+    def test_family_doc_names_every_member(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        (staging_dir / "stem-fam.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="Resistor-Uniroyal-0603WAJ-series",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-fam.pdf",
+                source_url="https://example.com/0603waj-series.pdf",
+                member_ipns=("RES_331", "RES_332", "RES_333"),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert (library_dir / "Resistor-Uniroyal-0603WAJ-series.pdf").is_file()
+        assert result.paste_rows == [
+            ("RES_331", "Resistor-Uniroyal-0603WAJ-series"),
+            ("RES_332", "Resistor-Uniroyal-0603WAJ-series"),
+            ("RES_333", "Resistor-Uniroyal-0603WAJ-series"),
+        ]
+
+    def test_skip_rows_are_left_untouched(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        (staging_dir / "stem-abc.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_SKIP,
+                proposed_name="IC-TI-LM358D",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-abc.pdf",
+                source_url="https://example.com/lm358.pdf",
+                member_ipns=("IC_LM358",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.admitted_count == 0
+        assert (staging_dir / "stem-abc.pdf").is_file()
+        assert not library_dir.exists()
+        assert result.paste_rows == []
+
+    def test_never_rename_guard_refuses_collision_without_mutating_anything(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (staging_dir / "stem-new.pdf").write_bytes(_PDF_BYTES_B)
+        (library_dir / "Published-Name.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                # Case-variant of the published name -- still a collision on
+                # case-insensitive filesystems (macOS/Dropbox), per jBOM#346.
+                proposed_name="published-name",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="stem-new.pdf",
+                source_url="https://example.com/other.pdf",
+                member_ipns=("IC_OTHER",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.refused_count == 1
+        assert result.admitted_count == 0
+        assert result.paste_rows == []
+        # Neither the staged file nor the published file were touched, and
+        # no second file was created (macOS/Dropbox filesystems are
+        # case-insensitive, so "published-name.pdf" and "Published-Name.pdf"
+        # are the same path -- assert via directory listing, not via a
+        # second `.exists()` check that would trivially pass on such
+        # filesystems).
+        assert (staging_dir / "stem-new.pdf").read_bytes() == _PDF_BYTES_B
+        assert (library_dir / "Published-Name.pdf").read_bytes() == _PDF_BYTES_A
+        assert [p.name for p in library_dir.glob("*.pdf")] == ["Published-Name.pdf"]
+
+    def test_reapplying_byte_identical_content_is_idempotent(
+        self, tmp_path: Path
+    ) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+        library_dir.mkdir()
+        (staging_dir / "stem-dupe.pdf").write_bytes(_PDF_BYTES_A)
+        (library_dir / "Existing-Doc.pdf").write_bytes(_PDF_BYTES_A)
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="Existing-Doc",
+                disposition=DISPOSITION_DUPE_OF,
+                dupe_of="Existing-Doc",
+                staged_file="stem-dupe.pdf",
+                source_url="https://example.com/existing.pdf",
+                member_ipns=("IC_DUPE",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.outcomes[0].status == "already-admitted"
+        assert result.admitted_count == 1
+        assert result.refused_count == 0
+        assert result.paste_rows == [("IC_DUPE", "Existing-Doc")]
+
+    def test_missing_staged_file_is_skipped_not_errored(self, tmp_path: Path) -> None:
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        library_dir = tmp_path / "datasheets"
+
+        rows = [
+            AdmitManifestRow(
+                action=ACTION_ADMIT,
+                proposed_name="Ghost-Doc",
+                disposition=DISPOSITION_NEW,
+                dupe_of="",
+                staged_file="does-not-exist.pdf",
+                source_url="https://example.com/ghost.pdf",
+                member_ipns=("IC_GHOST",),
+            )
+        ]
+
+        result = apply_admit_manifest(
+            rows, staging_dir=staging_dir, library_dir=library_dir
+        )
+
+        assert result.outcomes[0].status == "skipped"
+        assert result.admitted_count == 0
+        assert result.refused_count == 0
+
+
+class TestWritePasteFile:
+    def test_writes_ipn_and_datasheet_name_columns(self) -> None:
+        buf = io.StringIO()
+        write_paste_file([("RES_331", "Resistor-Uniroyal-0603WAJ-series")], buf)
+        content = buf.getvalue()
+        assert "IPN" in content and "Datasheet Name" in content
+        assert "RES_331" in content
+        assert "Resistor-Uniroyal-0603WAJ-series" in content
+
+    def test_empty_paste_rows_writes_header_only(self) -> None:
+        buf = io.StringIO()
+        write_paste_file([], buf)
+        lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+        assert len(lines) == 1


### PR DESCRIPTION
## Summary

Implements `jbom inventory admit`, the sole gate into the SPCoast-inventory datasheet library (jBOM#349 decision), via a propose → human edit → apply manifest workflow. Depends on the merged jBOM#355 staging fetch and reuses its `datasheet_staging.staging_dir` profile key exclusively (no hardcoded paths, no env vars).

## Behavior

- **Propose** (`jbom inventory admit --inventory <catalog.csv> [--manifest PATH]`): scans the configured staging directory for verified PDFs, matches each against the inventory backlog (rows with a `Datasheet` URL but no `Datasheet Name`), groups Items sharing one URL (family docs) into a single manifest row, and proposes a best-effort curated name from `Category`/`Manufacturer`/`MFGPN` (bom-datasheets POC convention; `-series` suffix for family docs per jBOM#346). The manifest is a CSV with a human-editable `Action` column (`ADMIT`/`SKIP`).
- **Apply** (`--apply --manifest PATH [-o paste.csv]`): reads the (human-edited) manifest, moves `ADMIT` rows into `datasheets/<name>.pdf`, and writes a full-sheet `Datasheet Name` paste-file proposal (one row per admitted member Item — jBOM never writes to the inventory itself, per jBOM#347/#348).
- **Never-rename guard**: refuses (case-insensitively, since macOS/Dropbox filesystems are case-insensitive) any `ADMIT` row whose proposed name collides with an already-published document of *different* content — no mutation occurs for that row. Re-admitting byte-identical content under its own published name is treated as an idempotent no-op, not a violation.

## Design note for reviewers

Ticket #356's acceptance text says apply "emits a full-sheet paste proposal for the **Datasheet Name column**" (singular). The related #349 map-decision comment describes a richer 2-column (Name + one-URL-per-Name) paste file. This PR implements the single-column form per #356's literal acceptance text — flagged to the orchestrator during implementation; no objection received.

Name proposal is a best-effort heuristic derived only from inventory columns (no PDF content reading, since technology/function tokens like "ThickFilm" or "Schottky" require opening the datasheet — out of scope for automated tooling). The human is expected to review/correct names in the manifest before `--apply`.

## Testing

- New unit tests: `tests/unit/test_inventory_admit.py` (28 tests) — name proposal, manifest CSV round-trip, never-rename guard (including case-insensitive collision and idempotent re-admission), family grouping, dupe-of-by-sha256 detection.
- New behave scenarios: `features/inventory/inventory_admit.feature` (3 scenarios) — propose/apply round-trip, never-rename refusal, family-doc grouping (one doc admitted, many Items named). Follows the hermetic staging-directory harness from jBOM#355/PR#368 (sandboxed `$HOME`, scenario-local `.jbom/common.jbom.yaml`); never touches real SPCoast-inventory artifacts.

### Validation
```
pytest tests/         -> 1559 passed
behave --format progress -> 53 features / 288 scenarios / 1946 steps passed (8 pre-existing skips, unrelated)
pre-commit             -> clean
```

Closes #356
