### PR TITLE
fix(cli): honor -q/--quiet for bom diagnostics

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,9 +48,13 @@ The BOM workflow keeps designs supplier-neutral: components carry generic values
 ## GLOBAL OPTIONS
 
 **-q, --quiet**
-: Suppress informational diagnostics printed to stderr. Errors are still emitted.
-  Note: this flag operates at the CLI adapter level. Service-layer diagnostics are always
-  collected and available regardless of this flag.
+: Suppress `info` and `warning` severity diagnostics printed to stderr (e.g. `bom`'s
+  "Missing important ... fields" completeness warning, `Selected fields: ...`, and
+  similar guidance). `error` severity diagnostics are always printed regardless of
+  this flag. Stdout is never affected -- `-o -` CSV output stays pure CSV whether or
+  not `-q` is given; diagnostics always go to stderr. This flag operates at the CLI
+  adapter level via the shared `print_diagnostics()` helper; service-layer diagnostics
+  are always collected and available regardless of this flag.
 
 **--version**
 : Print jBOM version and exit.
@@ -318,6 +322,12 @@ Generates a Bill of Materials aggregated by value+package for procurement. Match
 
 **-f, --fields FIELDS**
 : Output columns. Use a preset with `+` prefix (`+standard`, `+jlc`, `+minimal`, `+all`, `+generic`, `+default`), a comma-separated field list, or both: `+jlc,CustomField`.
+: When `-f/--fields` is given, jBOM checks the selection against the active fabricator's
+  (or generic's) default preset and emits a `warning`-severity diagnostic on stderr if
+  important fields (`fabricator_part_number`, `reference`, `quantity`, `value`) are
+  missing, e.g. `Warning: Missing important generic fields: value`. This warning applies
+  regardless of whether a fabricator was explicitly selected. Use `-q/--quiet` to
+  suppress it; stdout CSV output is unaffected either way.
 
 **--list-fields**
 : List available fields and presets, then exit (no project needed).

--- a/features/bom/quiet_diagnostics.feature
+++ b/features/bom/quiet_diagnostics.feature
@@ -1,0 +1,33 @@
+Feature: BOM diagnostics honor -q/--quiet (Issue #375)
+  As a scripting/automation user
+  I want -q/--quiet to actually suppress info/warning diagnostics
+  So that I can pipe jbom bom's stdout without unwanted noise while still seeing real errors
+
+  Background:
+    Given the generic fabricator is selected
+    And a PCB that contains:
+      | Reference | Value | Footprint   |
+      | R1        | 10K   | R_0805_2012 |
+
+  Scenario: Missing-fields warning appears on stderr without -q, stdout stays pure CSV
+    When I run jbom command "bom -f datasheet_name -o -"
+    Then the command should succeed
+    And the stderr output should contain "Warning: Missing important generic fields"
+    And the stdout output should be valid CSV
+    And the stdout output should not contain "Warning: Missing important generic fields"
+
+  Scenario: Missing-fields warning is suppressed with -q
+    When I run jbom command "-q bom -f datasheet_name -o -"
+    Then the command should succeed
+    And the stderr output should not contain "Warning: Missing important generic fields"
+    And the stdout output should be valid CSV
+
+  Scenario: Errors still print with -q
+    When I run jbom command "-q bom --inventory nonexistent.csv -o console"
+    Then the command should fail
+    And the stderr output should contain "Error: Inventory file not found: nonexistent.csv"
+
+  Scenario: Verbose info diagnostics are suppressed with -q
+    When I run jbom command "-q bom -f reference,value -v -o -"
+    Then the command should succeed
+    And the stderr output should not contain "Selected fields:"

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -135,8 +135,13 @@ def step_run_command(context, command):
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(context.src_root)
-    # Suppress noisy informational stderr in tests so CSV parsing is clean
-    env["JBOM_QUIET"] = "1"
+    # Do NOT force JBOM_QUIET here: -q/--quiet is a real, testable CLI
+    # behavior (see features/bom/quiet_diagnostics.feature). Scenarios that
+    # want quiet output pass `-q`/`--quiet` explicitly on the command line,
+    # which sets JBOM_QUIET=1 via jbom.cli.main. Forcing it ambiently for
+    # every subprocess would silence info/warning diagnostics that other
+    # scenarios assert on (e.g. inventory-enhancement verbose messages).
+    env.pop("JBOM_QUIET", None)
     if getattr(context, "trace", False):
         env["JBOM_BEHAVE_TRACE"] = "1"
 
@@ -162,6 +167,8 @@ def step_run_command(context, command):
         )
         context.last_command = command
         context.last_output = result.stdout + result.stderr
+        context.last_stdout = result.stdout
+        context.last_stderr = result.stderr
         context.last_exit_code = result.returncode
         if getattr(context, "trace", False):
             post_tree = _tree(str(context.sandbox_root))
@@ -493,6 +500,53 @@ def step_error_output_should_contain_messages(context):
             expected=content,
             actual=error_output,
         )
+
+
+@then('the stdout output should contain "{text}"')
+def step_stdout_should_contain(context, text):
+    """Assert *text* appears in the process's stdout stream in isolation."""
+    out = getattr(context, "last_stdout", "")
+    assert out and _csv_contains_fields(
+        out, text
+    ), f"Expected text not found in stdout: {text}\nStdout:\n{out}"
+
+
+@then('the stdout output should not contain "{text}"')
+def step_stdout_should_not_contain(context, text):
+    """Assert *text* does NOT appear in the process's stdout stream.
+
+    Used to prove diagnostics never leak into `-o -` CSV stdout, regardless
+    of whether they are visible on stderr.
+    """
+    out = getattr(context, "last_stdout", "")
+    assert text not in out, f"Unexpected text found in stdout: {text}\nStdout:\n{out}"
+
+
+@then("the stdout output should be valid CSV")
+def step_stdout_should_be_valid_csv(context):
+    """Assert stdout parses as CSV with at least a header row.
+
+    Proves stdout stays pure CSV even when diagnostics are emitted on
+    stderr alongside it (see Issue #375).
+    """
+    out = getattr(context, "last_stdout", "")
+    assert out.strip(), "No stdout captured"
+    rows = list(csv.reader(out.splitlines()))
+    assert rows and len(rows[0]) >= 1, f"Stdout does not look like CSV:\n{out}"
+
+
+@then('the stderr output should contain "{text}"')
+def step_stderr_should_contain(context, text):
+    """Assert *text* appears on stderr in isolation."""
+    out = getattr(context, "last_stderr", "")
+    assert text in out, f"Expected text not found in stderr: {text}\nStderr:\n{out}"
+
+
+@then('the stderr output should not contain "{text}"')
+def step_stderr_should_not_contain(context, text):
+    """Assert *text* does NOT appear on stderr."""
+    out = getattr(context, "last_stderr", "")
+    assert text not in out, f"Unexpected text found in stderr: {text}\nStderr:\n{out}"
 
 
 @then("the error output should be empty")

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -16,6 +16,7 @@ from jbom.cli.output import (
     print_diagnostics,
     resolve_output_destination,
 )
+from jbom.common.types import Diagnostic
 from jbom.services.bom_generator import BOMData, BOMEntry
 from jbom.services.fabricator_projection_service import (
     FabricatorProjectionService,
@@ -308,7 +309,7 @@ def _execute_bom_command(args: argparse.Namespace) -> int:
         )
 
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+        print_diagnostics([Diagnostic("error", f"Error: {e}")])
         return 1
 
 

--- a/src/jbom/cli/bom.py
+++ b/src/jbom/cli/bom.py
@@ -13,6 +13,7 @@ from jbom.cli.output import (
     OutputRefusedError,
     add_force_argument,
     open_output_text_file,
+    print_diagnostics,
     resolve_output_destination,
 )
 from jbom.services.bom_generator import BOMData, BOMEntry
@@ -284,8 +285,7 @@ def _execute_bom_command(args: argparse.Namespace) -> int:
             list_fields=bool(args.list_fields),
         )
         result = BOMWorkflow().run(request)
-        for diagnostic in result.diagnostics:
-            print(diagnostic, file=sys.stderr)
+        print_diagnostics(result.diagnostics)
 
         if result.mode == BOMMode.LIST_FIELDS:
             if result.field_listing is None:
@@ -389,8 +389,7 @@ def _enrich_bom_smd_from_project_pcb(
         pcb_file,
         verbose=verbose,
     )
-    for diagnostic in diagnostics:
-        print(diagnostic, file=sys.stderr)
+    print_diagnostics(diagnostics)
     return enriched_bom_data
 
 

--- a/src/jbom/cli/output.py
+++ b/src/jbom/cli/output.py
@@ -105,7 +105,7 @@ def print_diagnostics(
     for diagnostic in diagnostics:
         if quiet and diagnostic.severity != "error":
             continue
-        print(diagnostic, file=destination)
+        print(diagnostic.message, file=destination)
 
 
 class OutputRefusedError(RuntimeError):

--- a/src/jbom/cli/output.py
+++ b/src/jbom/cli/output.py
@@ -12,10 +12,14 @@ Also centralizes overwrite protection via `-F/--force/--Force`.
 from __future__ import annotations
 
 import argparse
+import os
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Callable, TextIO
+from typing import Callable, Iterable, TextIO
+
+from jbom.common.types import Diagnostic
 
 
 class OutputKind(str, Enum):
@@ -75,6 +79,33 @@ def resolve_output_destination(
         return OutputDestination(OutputKind.STDOUT)
 
     return OutputDestination(OutputKind.FILE, path=Path(out))
+
+
+def print_diagnostics(
+    diagnostics: Iterable[Diagnostic],
+    *,
+    file: TextIO | None = None,
+) -> None:
+    """Render diagnostics honoring the global `-q/--quiet` (`JBOM_QUIET`) flag.
+
+    `info` and `warning` severities are suppressed when `JBOM_QUIET` is set
+    (see `-q/--quiet` in `jbom/cli/main.py`). `error` severity is always
+    printed regardless of quiet mode. All diagnostics are written to `file`
+    (stderr by default), never to stdout, preserving stdout CSV purity for
+    `-o -` output.
+
+    Args:
+        diagnostics: Diagnostics to render.
+        file: Stream to write rendered diagnostics to (defaults to the
+            current `sys.stderr`, resolved at call time).
+    """
+
+    destination = file if file is not None else sys.stderr
+    quiet = bool(os.environ.get("JBOM_QUIET"))
+    for diagnostic in diagnostics:
+        if quiet and diagnostic.severity != "error":
+            continue
+        print(diagnostic, file=destination)
 
 
 class OutputRefusedError(RuntimeError):

--- a/tests/unit/test_cli_output_diagnostics.py
+++ b/tests/unit/test_cli_output_diagnostics.py
@@ -1,0 +1,74 @@
+"""Unit tests for jbom.cli.output.print_diagnostics (Issue #375).
+
+Covers the `-q/--quiet` (`JBOM_QUIET`) contract: `info`/`warning`
+severities are suppressed when quiet, `error` severity is always
+printed, and output always goes to the given stream (stderr by
+default), never stdout.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from jbom.cli.output import print_diagnostics
+from jbom.common.types import Diagnostic
+
+
+@pytest.fixture(autouse=True)
+def _clean_jbom_quiet_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure JBOM_QUIET starts unset for every test in this module."""
+    monkeypatch.delenv("JBOM_QUIET", raising=False)
+
+
+def test_info_and_warning_print_when_not_quiet() -> None:
+    diagnostics = [
+        Diagnostic("info", "Selected fields: reference,value"),
+        Diagnostic("warning", "Warning: Missing important generic fields: value"),
+    ]
+    buffer = io.StringIO()
+    print_diagnostics(diagnostics, file=buffer)
+    output = buffer.getvalue()
+    assert "Selected fields" in output
+    assert "Missing important generic fields" in output
+
+
+def test_info_and_warning_suppressed_when_quiet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JBOM_QUIET", "1")
+    diagnostics = [
+        Diagnostic("info", "Selected fields: reference,value"),
+        Diagnostic("warning", "Warning: Missing important generic fields: value"),
+    ]
+    buffer = io.StringIO()
+    print_diagnostics(diagnostics, file=buffer)
+    assert buffer.getvalue() == ""
+
+
+def test_error_always_prints_even_when_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JBOM_QUIET", "1")
+    diagnostics = [
+        Diagnostic("info", "Selected fields: reference,value"),
+        Diagnostic("error", "Inventory file not found: missing.csv"),
+    ]
+    buffer = io.StringIO()
+    print_diagnostics(diagnostics, file=buffer)
+    output = buffer.getvalue()
+    assert "Selected fields" not in output
+    assert "Inventory file not found" in output
+
+
+def test_no_diagnostics_produces_no_output() -> None:
+    buffer = io.StringIO()
+    print_diagnostics([], file=buffer)
+    assert buffer.getvalue() == ""
+
+
+def test_empty_string_jbom_quiet_is_not_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty-string JBOM_QUIET is falsy, matching bool(os.environ.get(...))."""
+    monkeypatch.setenv("JBOM_QUIET", "")
+    diagnostics = [Diagnostic("warning", "Warning: something")]
+    buffer = io.StringIO()
+    print_diagnostics(diagnostics, file=buffer)
+    assert "Warning: something" in buffer.getvalue()


### PR DESCRIPTION
## Summary
The `-q/--quiet` global flag promised to suppress diagnostic guidance output, but the `bom` adapter's diagnostics-printing loop ignored `JBOM_QUIET`, so `check_fabricator_field_completeness()`'s "Missing important ... fields" warning (and other info/warning diagnostics) always printed regardless of `-q`.

- Added a shared `print_diagnostics()` helper in `jbom/cli/output.py` that suppresses `info`/`warning` severities when `JBOM_QUIET` is set, while always printing `error` severity. Wired into `bom.py`'s two diagnostic-rendering loops.
- `check_fabricator_field_completeness()` itself is unchanged (per owner ruling: the warning stays always-armed for every fabricator, including implicit generic — no gating). The fix is purely at the CLI adapter layer honoring `-q`.
- Stdout purity for `-o -` CSV output is preserved either way; diagnostics only ever go to stderr.
- Removed a blanket `JBOM_QUIET=1` override in the behave test harness (`features/steps/common_steps.py`) that was a no-op safety net while the bug existed. Scenarios that want quiet behavior now pass `-q` explicitly, exercising the real code path. This kept all pre-existing scenarios (e.g. `inventory_enhancement.feature`'s verbose-diagnostic assertions) passing unchanged.
- Added `features/bom/quiet_diagnostics.feature` (4 new scenarios): warning visible on stderr without `-q` + pure-CSV stdout; warning suppressed with `-q`; errors still print with `-q`; verbose info suppressed with `-q`.
- Added `tests/unit/test_cli_output_diagnostics.py` (5 new unit tests) for `print_diagnostics`.
- Updated `docs/reference/cli.md` for `-q/--quiet` and the `-f/--fields` completeness-warning behavior.

## Validation
- `PYTHONPATH=src python -m pytest tests/ -q` → **1649 passed** (1644 pre-existing + 5 new)
- `python -m behave --format progress` → **313 scenarios passed, 0 failed, 8 skipped** (309 pre-existing + 4 new); **2099 steps passed, 0 failed, 44 skipped**
- Manual sanity check:
  - `jbom bom <fixture> -f datasheet_name -o -` → warning on stderr, pure CSV on stdout
  - `jbom -q bom <fixture> -f datasheet_name -o -` → no warning, pure CSV on stdout
  - `jbom -q bom --inventory nonexistent.csv -o console` → error still printed, exit code 1

## Deviations from the original ticket
This issue went through three revisions during implementation (visible in the issue comment history): first "remove the check entirely", then "gate on explicit fabricator selection", and finally the owner's authoritative ruling implemented here — keep the warning always-armed and fix the real defect (`-q` not being honored). No gating logic was implemented per the final ruling.

Closes #375