### PR TITLE
fix(plugin): harden ActionPlugin dialog reinvocation lifecycle

### DIFF
--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -63,6 +63,7 @@ import tempfile
 import threading
 import types
 from pathlib import Path
+from typing import Callable
 
 import wx
 
@@ -95,6 +96,9 @@ class JBOMFabricationDialog(wx.Dialog):
         pcb_path: Filesystem path of the active PCB file, or empty string.
         archive_name: Human-readable archive stem from the project title block
             (e.g. ``"MyProject_1.0"``).  Shown as a read-only label.
+        on_destroy: Optional callback invoked exactly once just before
+            ``Destroy()`` is called, allowing the plugin adapter to clear any
+            retained dialog reference.
     """
 
     def __init__(
@@ -102,6 +106,7 @@ class JBOMFabricationDialog(wx.Dialog):
         *,
         pcb_path: str = "",
         archive_name: str = "",
+        on_destroy: Callable[[], None] | None = None,
     ) -> None:
         super().__init__(
             None,  # parent=None — required for correct KiCad toolbar re-enable
@@ -111,6 +116,7 @@ class JBOMFabricationDialog(wx.Dialog):
 
         self._pcb_path = pcb_path
         self._archive_name = archive_name or "(unknown)"
+        self._on_destroy = on_destroy
         self._cancel_requested = threading.Event()
         self._fab_ids: list[str] = []
         self._gauges: dict[str, wx.Gauge] = {}
@@ -1086,6 +1092,13 @@ class JBOMFabricationDialog(wx.Dialog):
             pcbnew.Refresh()
         except Exception:  # pragma: no cover
             pass  # Non-fatal: Destroy() still runs
+        if self._on_destroy is not None:
+            callback = self._on_destroy
+            self._on_destroy = None
+            try:
+                callback()
+            except Exception:
+                pass
         self.Destroy()
 
     @staticmethod

--- a/src/jbom/plugin/plugin.py
+++ b/src/jbom/plugin/plugin.py
@@ -24,6 +24,11 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
     then calls ``Run()`` each time the user activates the toolbar button.
     """
 
+    def __init__(self) -> None:
+        """Initialise plugin lifecycle state."""
+        super().__init__()
+        self._active_dialog: object | None = None
+
     def defaults(self) -> None:
         """Register plugin metadata with KiCad's plugin manager."""
         self.name = "jBOM Fabrication"
@@ -55,6 +60,8 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
     def _run_impl(self) -> None:
         """Implementation body of Run(); separated for exception tracing."""
+        if self._raise_existing_dialog_if_active():
+            return
         board = pcbnew.GetBoard()
         pcb_path: str = board.GetFileName() if board else ""
 
@@ -76,8 +83,46 @@ class JBOMFabricationPlugin(pcbnew.ActionPlugin):
 
         from .dialog import JBOMFabricationDialog
 
-        dlg = JBOMFabricationDialog(pcb_path=pcb_path, archive_name=archive_name)
+        dlg = JBOMFabricationDialog(
+            pcb_path=pcb_path,
+            archive_name=archive_name,
+            on_destroy=self._clear_active_dialog,
+        )
+        self._active_dialog = dlg
         dlg.Show()
+
+    def _raise_existing_dialog_if_active(self) -> bool:
+        """Raise and focus an existing dialog if one is still active.
+
+        Returns:
+            ``True`` when an existing dialog handled the action and no new
+            dialog should be created; ``False`` when a new dialog should open.
+        """
+        if self._active_dialog is None:
+            return False
+        try:
+            is_visible = False
+            if hasattr(self._active_dialog, "IsShownOnScreen"):
+                is_visible = bool(self._active_dialog.IsShownOnScreen())
+            elif hasattr(self._active_dialog, "IsShown"):
+                is_visible = bool(self._active_dialog.IsShown())
+            if is_visible:
+                if hasattr(self._active_dialog, "Raise"):
+                    self._active_dialog.Raise()
+                if hasattr(self._active_dialog, "RequestUserAttention"):
+                    self._active_dialog.RequestUserAttention()
+                return True
+        except Exception:
+            # Stale or already-destroyed wrapped object; clear and reopen.
+            self._active_dialog = None
+            return False
+        # Dialog reference exists but is no longer visible; clear and reopen.
+        self._active_dialog = None
+        return False
+
+    def _clear_active_dialog(self) -> None:
+        """Clear plugin-held dialog reference on dialog teardown."""
+        self._active_dialog = None
 
     @staticmethod
     def _expand_archive_template_from_file(pcb_path: str, template: str) -> str:

--- a/tests/plugin/test_plugin_reinvoke_lifecycle.py
+++ b/tests/plugin/test_plugin_reinvoke_lifecycle.py
@@ -1,0 +1,168 @@
+"""Lifecycle regression tests for ``JBOMFabricationPlugin`` reinvocation.
+
+These tests validate plugin-side dialog ownership semantics without requiring
+KiCad or wxPython:
+
+- A created dialog is retained by the plugin until dialog teardown callback.
+- Re-clicking while a dialog is still active raises/focuses that dialog instead
+  of creating a second one.
+- A stale wrapped-object reference is tolerated and replaced on next Run().
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import pytest
+
+
+class _FakeActionPlugin:
+    """Minimal stand-in for ``pcbnew.ActionPlugin``."""
+
+    def register(self) -> None:
+        """No-op registration for test-only plugin imports."""
+
+
+class _FakeBoard:
+    """Minimal stand-in for the active PCB board object."""
+
+    def __init__(self, file_name: str = "") -> None:
+        self._file_name = file_name
+
+    def GetFileName(self) -> str:  # noqa: N802 — mirrors KiCad API
+        """Return configured fake board filename."""
+        return self._file_name
+
+
+class _FakeDialog:
+    """Fake dialog capturing lifecycle signals from ``plugin.py``."""
+
+    created_instances: list["_FakeDialog"] = []
+
+    def __init__(
+        self,
+        *,
+        pcb_path: str = "",
+        archive_name: str = "",
+        on_destroy: object | None = None,
+    ) -> None:
+        self.pcb_path = pcb_path
+        self.archive_name = archive_name
+        self.on_destroy = on_destroy
+        self.show_calls = 0
+        self.raise_calls = 0
+        self.user_attention_calls = 0
+        self._shown = True
+        _FakeDialog.created_instances.append(self)
+
+    def Show(self) -> None:
+        """Record modeless Show invocation."""
+        self.show_calls += 1
+
+    def Raise(self) -> None:
+        """Record raise/focus request."""
+        self.raise_calls += 1
+
+    def RequestUserAttention(self) -> None:
+        """Record optional user-attention request."""
+        self.user_attention_calls += 1
+
+    def IsShownOnScreen(self) -> bool:
+        """Report current visibility state."""
+        return self._shown
+
+    def IsShown(self) -> bool:
+        """Fallback visibility API used by plugin guard path."""
+        return self._shown
+
+
+class _StaleDialogRef:
+    """Simulate a stale wx wrapped object that raises on visibility check."""
+
+    def IsShownOnScreen(self) -> bool:
+        """Raise runtime error to emulate dead wrapped C++ dialog object."""
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
+
+def _load_plugin_module_with_fake_pcbnew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> types.ModuleType:
+    """Import ``jbom.plugin.plugin`` with a fake ``pcbnew`` module present."""
+    fake_pcbnew = types.ModuleType("pcbnew")
+    fake_pcbnew.ActionPlugin = _FakeActionPlugin
+    board = _FakeBoard("")
+    fake_pcbnew.GetBoard = lambda: board
+    monkeypatch.setitem(sys.modules, "pcbnew", fake_pcbnew)
+
+    # Force a fresh import path each test so module-level state does not leak.
+    sys.modules.pop("jbom.plugin.dialog", None)
+    sys.modules.pop("jbom.plugin.plugin", None)
+    sys.modules.pop("jbom.plugin", None)
+
+    module = importlib.import_module("jbom.plugin.plugin")
+    return module
+
+
+def _install_fake_dialog_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install fake dialog module consumed by plugin Run() path."""
+    _FakeDialog.created_instances.clear()
+    fake_dialog_module = types.ModuleType("jbom.plugin.dialog")
+    fake_dialog_module.JBOMFabricationDialog = _FakeDialog
+    monkeypatch.setitem(sys.modules, "jbom.plugin.dialog", fake_dialog_module)
+
+
+class TestPluginReinvokeLifecycle:
+    """Regression tests for repeated ActionPlugin invocations."""
+
+    def test_active_dialog_reference_cleared_on_teardown_callback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plugin should clear retained dialog reference when teardown fires."""
+        plugin_module = _load_plugin_module_with_fake_pcbnew(monkeypatch)
+        _install_fake_dialog_module(monkeypatch)
+
+        plugin = plugin_module.JBOMFabricationPlugin()
+        plugin.Run()
+
+        assert len(_FakeDialog.created_instances) == 1
+        first = _FakeDialog.created_instances[0]
+        assert plugin._active_dialog is first
+        assert first.show_calls == 1
+
+        assert callable(first.on_destroy)
+        first.on_destroy()
+        assert plugin._active_dialog is None
+
+        plugin.Run()
+        assert len(_FakeDialog.created_instances) == 2
+        assert plugin._active_dialog is _FakeDialog.created_instances[1]
+
+    def test_second_run_raises_existing_visible_dialog(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Second click should focus the active dialog instead of creating new."""
+        plugin_module = _load_plugin_module_with_fake_pcbnew(monkeypatch)
+        _install_fake_dialog_module(monkeypatch)
+
+        plugin = plugin_module.JBOMFabricationPlugin()
+        plugin.Run()
+        plugin.Run()
+
+        assert len(_FakeDialog.created_instances) == 1
+        assert _FakeDialog.created_instances[0].raise_calls == 1
+        assert plugin._active_dialog is _FakeDialog.created_instances[0]
+
+    def test_stale_dialog_reference_is_replaced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale wrapped-object reference should be cleared and replaced."""
+        plugin_module = _load_plugin_module_with_fake_pcbnew(monkeypatch)
+        _install_fake_dialog_module(monkeypatch)
+
+        plugin = plugin_module.JBOMFabricationPlugin()
+        plugin._active_dialog = _StaleDialogRef()
+        plugin.Run()
+
+        assert len(_FakeDialog.created_instances) == 1
+        assert plugin._active_dialog is _FakeDialog.created_instances[0]


### PR DESCRIPTION
## Problem
The Pcbnew ActionPlugin toolbar button could become effectively one-shot per session (first invocation works, later clicks may do nothing).

## Summary
- retain explicit plugin-owned active dialog reference for modeless ActionPlugin lifecycle
- reuse/focus existing visible dialog on repeated toolbar clicks instead of creating duplicates
- clear retained dialog reference via one-shot teardown callback before dialog destroy
- tolerate stale wrapped-object dialog references and reopen cleanly
- add regression tests for repeated `Run()` behavior and stale wrapped-object recovery

## Files
- `src/jbom/plugin/plugin.py`
- `src/jbom/plugin/dialog.py`
- `tests/plugin/test_plugin_reinvoke_lifecycle.py`

## Validation
- `pre-commit`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m pytest tests/ -v`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress`

## Issue
Closes #377
