### PR TITLE
feat(backup): embed design-source zip in production backup archives

### DIFF
--- a/docs/design/plugin-ux-decisions.md
+++ b/docs/design/plugin-ux-decisions.md
@@ -112,7 +112,8 @@ The plugin's background worker directly sequences four service calls:
 1. `BOMWorkflow().run()` → `BOMWriter` → `production/jbom.csv`
 2. `POSWorkflow().run()` → `POSWriter` → `production/cpl.csv`
 3. `PcbnewGerberGenerator(board).generate()` → `GerberPackager` → `production/{stem}.zip`
-4. `BackupService().backup()` → `production/backups/{stem}_{timestamp}.zip`
+4. `DesignSourcePackager().package()` (temp nested source zip) + `BackupService().backup()`
+   → `production/backups/{stem}_{timestamp}.zip`
 
 `FabricationWorkflow` is intentionally not used from the plugin for two
 reasons. First, its `kicad-cli` subprocess path hangs inside KiCad's

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -804,7 +804,9 @@ production/
   cpl.csv                            ← CPL/placement
   {title}_{revision}.zip             ← Gerber archive for fab upload
   backups/
-    {title}_{revision}_{timestamp}.zip   ← dated snapshot of all artifacts
+    {title}_{revision}_{timestamp}.zip   ← dated snapshot containing
+                                            jbom.csv, cpl.csv, gerber zip,
+                                            and {project}-design-sources.zip
 ```
 `{title}` and `{revision}` are read from the KiCad title block; absent title falls back
 to the `.kicad_pro` basename.

--- a/features/gerbers/fabrication.feature
+++ b/features/gerbers/fabrication.feature
@@ -11,7 +11,10 @@ Feature: jbom fab — complete fabrication pipeline (BOM + CPL + Gerbers + Backu
   #     cpl.csv                               ← CPL/placement
   #     {title}_{revision}.zip                ← Gerber archive
   #     backups/
-  #       {title}_{revision}_{timestamp}.zip  ← snapshot of all three artifacts
+  #       {title}_{revision}_{timestamp}.zip  ← snapshot containing:
+  #                                              jbom.csv, cpl.csv,
+  #                                              gerber zip, and
+  #                                              {project}-design-sources.zip
 
   Background:
     Given a PCB that contains:
@@ -44,11 +47,12 @@ Feature: jbom fab — complete fabrication pipeline (BOM + CPL + Gerbers + Backu
     And the gerber zip should contain a file for layer "B.Cu"
     And the gerber zip should contain a file for layer "Edge.Cuts"
 
-  Scenario: backup contains all three production artifacts
-    # BOM + CPL + gerber zip = 3 entries in the backup archive
+  Scenario: backup contains production artifacts plus design-source archive
+    # BOM + CPL + gerber zip + nested design-source zip = 4 entries
     When I run jbom command "fab ."
     Then the command should succeed
-    And the backup zip should contain 3 files
+    And the backup zip should contain 4 files
+    And the backup zip should contain an entry matching "*-design-sources.zip"
 
   Scenario: --skip-gerbers produces BOM and CPL but no gerber zip
     When I run jbom command "fab . --skip-gerbers"
@@ -58,11 +62,12 @@ Feature: jbom fab — complete fabrication pipeline (BOM + CPL + Gerbers + Backu
     And the production artifact "cpl.csv" should exist
     And no file matching "*.zip" should exist in production/
 
-  Scenario: --skip-gerbers backup contains only BOM and CPL
-    # Without gerbers, only 2 artifacts are in the backup
+  Scenario: --skip-gerbers backup contains BOM/CPL plus design-source archive
+    # Without gerbers, backup still includes nested design-source zip
     When I run jbom command "fab . --skip-gerbers"
     Then the command should succeed
-    And the backup zip should contain 2 files
+    And the backup zip should contain 3 files
+    And the backup zip should contain an entry matching "*-design-sources.zip"
 
   Scenario: --skip-bom skips BOM generation but still creates CPL and gerbers
     When I run jbom command "fab . --skip-bom"

--- a/features/steps/gerbers_steps.py
+++ b/features/steps/gerbers_steps.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 from __future__ import annotations
+from fnmatch import fnmatch
 
 import os
 import shutil
@@ -334,6 +335,24 @@ def step_backup_zip_entry_count(context, count: int) -> None:
         context,
         expected=f"{count} entries",
         actual=f"{len(names)} entries: {sorted(names)}",
+    )
+
+
+@then('the backup zip should contain an entry matching "{glob_pattern}"')
+def step_backup_zip_contains_matching_entry(context, glob_pattern: str) -> None:
+    """Assert the backup zip contains at least one matching entry name."""
+    backups = Path(context.sandbox_root) / "production" / "backups"
+    zips = list(backups.glob("*.zip")) if backups.is_dir() else []
+    assert len(zips) >= 1, "No backup zip found in production/backups/"
+    with zipfile.ZipFile(zips[0]) as zf:
+        names = zf.namelist()
+    matches = [n for n in names if fnmatch(n, glob_pattern)]
+    assert_with_diagnostics(
+        len(matches) > 0,
+        f"Backup zip contains no entry matching '{glob_pattern}'",
+        context,
+        expected=f"entry matching '{glob_pattern}'",
+        actual=f"entries: {sorted(names)}",
     )
 
 

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -801,12 +801,33 @@ class FabricationWorkflow:
 
             backup_service = BackupService()
             backup_dir = production_dir / "backups"
-            backup_archive = backup_service.backup(
-                artifact_paths,
-                backup_dir,
-                archive_stem,
-            )
-            return backup_archive, diagnostics
+            backup_artifacts = [Path(p) for p in artifact_paths]
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                try:
+                    from jbom.services.design_source_packager import (
+                        DesignSourcePackager,
+                    )
+
+                    design_archive = (
+                        Path(temp_dir) / f"{project_dir.name}-design-sources.zip"
+                    )
+                    DesignSourcePackager().package(project_dir, design_archive)
+                    backup_artifacts.append(design_archive)
+                except Exception as exc:
+                    diagnostics.append(
+                        Diagnostic(
+                            "warning",
+                            f"Design-source backup archive skipped: {exc}",
+                        )
+                    )
+
+                backup_archive = backup_service.backup(
+                    backup_artifacts,
+                    backup_dir,
+                    archive_stem,
+                )
+                return backup_archive, diagnostics
 
         except Exception as exc:
             diagnostics.append(Diagnostic("error", f"Backup creation failed: {exc}"))

--- a/src/jbom/plugin/dialog.py
+++ b/src/jbom/plugin/dialog.py
@@ -894,16 +894,39 @@ class JBOMFabricationDialog(wx.Dialog):
                             pass  # Non-fatal
 
                 # ----------------------------------------------------------
-                # Step 4: Backup (all three artifacts in one archive)
+                # Step 4: Backup (production artifacts + design-source archive)
                 # ----------------------------------------------------------
                 _step("backup", "start")
                 if do_backup and not cancelled() and artifact_paths:
                     try:
                         from jbom.services.backup_service import BackupService
 
+                        backup_artifacts = [Path(p) for p in artifact_paths]
+                        with tempfile.TemporaryDirectory() as temp_dir:
+                            try:
+                                from jbom.services.design_source_packager import (
+                                    DesignSourcePackager,
+                                )
+
+                                design_archive = (
+                                    Path(temp_dir)
+                                    / f"{project_dir.name}-design-sources.zip"
+                                )
+                                DesignSourcePackager().package(
+                                    project_dir, design_archive
+                                )
+                                backup_artifacts.append(design_archive)
+                            except Exception as exc:
+                                diagnostics.append(
+                                    _Diag(
+                                        "warning",
+                                        f"Design-source backup archive skipped: {exc}",
+                                    )
+                                )
+
                         backup_dir = production_dir / "backups"
                         BackupService().backup(
-                            artifact_paths,
+                            backup_artifacts,
                             backup_dir,
                             archive_stem,
                         )

--- a/src/jbom/services/design_source_packager.py
+++ b/src/jbom/services/design_source_packager.py
@@ -1,0 +1,86 @@
+"""DesignSourcePackager for archiving KiCad project source files.
+
+Creates a ZIP archive containing design-source files (project, schematic,
+PCB, and related KiCad metadata) from a project directory. Intended for
+embedding into fabrication provenance backups.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+
+class DesignSourcePackager:
+    """Package KiCad design-source files from a project directory."""
+
+    _SOURCE_SUFFIXES: tuple[str, ...] = (
+        ".kicad_pro",
+        ".kicad_prl",
+        ".kicad_sch",
+        ".kicad_pcb",
+        ".kicad_dru",
+    )
+    _OPTIONAL_FILES: tuple[str, ...] = (
+        "fabrication-toolkit-options.json",
+        ".jbom/jbom-options.json",
+    )
+
+    def package(self, project_dir: Path, archive_path: Path) -> Path:
+        """Create a design-source archive from *project_dir*.
+
+        Args:
+            project_dir: KiCad project directory to snapshot.
+            archive_path: Destination path for the ZIP archive.
+
+        Returns:
+            Path to the created archive.
+
+        Raises:
+            ValueError: If project_dir does not exist or no source files found.
+            OSError: If archive creation fails.
+        """
+        project_dir = Path(project_dir).resolve()
+        if not project_dir.is_dir():
+            raise ValueError(f"project_dir is not a directory: {project_dir}")
+
+        source_files = self._collect_source_files(project_dir)
+        if not source_files:
+            raise ValueError(f"No design-source files found in {project_dir}")
+
+        archive_path = Path(archive_path).resolve()
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for file_path in source_files:
+                arcname = str(file_path.relative_to(project_dir))
+                zipf.write(file_path, arcname=arcname)
+
+        return archive_path
+
+    def _collect_source_files(self, project_dir: Path) -> list[Path]:
+        """Collect design-source files to archive from *project_dir*."""
+        collected: list[Path] = []
+        seen: set[Path] = set()
+
+        for file_path in sorted(project_dir.rglob("*")):
+            if not file_path.is_file():
+                continue
+            if file_path.suffix not in self._SOURCE_SUFFIXES:
+                continue
+            resolved = file_path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            collected.append(resolved)
+
+        for relative_name in self._OPTIONAL_FILES:
+            candidate = (project_dir / relative_name).resolve()
+            if candidate.is_file() and candidate not in seen:
+                seen.add(candidate)
+                collected.append(candidate)
+
+        return sorted(collected)
+
+
+__all__ = ["DesignSourcePackager"]

--- a/tests/services/test_fabrication_orchestration.py
+++ b/tests/services/test_fabrication_orchestration.py
@@ -298,3 +298,69 @@ class TestFabricationResultStructure:
         )
         assert isinstance(result.artifacts, tuple)
         assert len(result.artifacts) == 1
+
+
+class TestFabricationBackupComposition:
+    """Backup composition behavior for production + design-source artifacts."""
+
+    def test_create_backup_adds_design_source_archive(self, tmp_path: Path) -> None:
+        """Workflow backup should include nested design-source archive input."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "proj.kicad_pro").write_text("(kicad_project)", encoding="utf-8")
+        (project_dir / "proj.kicad_pcb").write_text("(kicad_pcb)", encoding="utf-8")
+
+        production_dir = project_dir / "production"
+        production_dir.mkdir()
+        bom_path = production_dir / "jbom.csv"
+        bom_path.write_text("bom", encoding="utf-8")
+
+        request = FabricationRequest(
+            input_path=str(project_dir),
+            archive_stem="proj_1.0",
+        )
+        workflow = FabricationWorkflow()
+        captured: dict[str, object] = {}
+
+        def _fake_backup(
+            artifact_paths: list[Path], backup_dir: Path, archive_stem: str
+        ) -> Path:
+            captured["artifact_paths"] = list(artifact_paths)
+            captured["backup_dir"] = backup_dir
+            captured["archive_stem"] = archive_stem
+            result = backup_dir / "proj_1.0_2026-07-16_15-30-38.zip"
+            result.parent.mkdir(parents=True, exist_ok=True)
+            result.write_text("backup", encoding="utf-8")
+            return result
+
+        with (
+            patch(
+                "jbom.services.backup_service.BackupService.backup",
+                side_effect=_fake_backup,
+            ),
+            patch(
+                "jbom.services.design_source_packager.DesignSourcePackager.package"
+            ) as mock_package,
+        ):
+            mock_package.side_effect = (
+                lambda project, archive: archive.write_text("design", encoding="utf-8")
+                or archive
+            )
+            backup_archive, diagnostics = workflow._create_backup(
+                request,
+                [bom_path],
+                production_dir,
+            )
+
+        assert backup_archive is not None
+        assert backup_archive.exists()
+        assert diagnostics == []
+
+        artifact_paths = captured.get("artifact_paths")
+        assert isinstance(artifact_paths, list)
+        assert bom_path in artifact_paths
+        assert any(
+            path.name == "proj-design-sources.zip"
+            for path in artifact_paths
+            if isinstance(path, Path)
+        )

--- a/tests/unit/test_design_source_packager.py
+++ b/tests/unit/test_design_source_packager.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``DesignSourcePackager``."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from jbom.services.design_source_packager import DesignSourcePackager
+
+
+class TestDesignSourcePackager:
+    """Tests for packaging KiCad design-source archives."""
+
+    def test_package_includes_kicad_and_optional_source_files(
+        self, tmp_path: Path
+    ) -> None:
+        """Archive should include KiCad source files and optional JSON configs."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        (project_dir / "project.kicad_pro").write_text("", encoding="utf-8")
+        (project_dir / "project.kicad_prl").write_text("", encoding="utf-8")
+        (project_dir / "project.kicad_pcb").write_text("", encoding="utf-8")
+        (project_dir / "project.kicad_sch").write_text("", encoding="utf-8")
+        (project_dir / "fabrication-toolkit-options.json").write_text(
+            "{}", encoding="utf-8"
+        )
+
+        subdir = project_dir / "sheets"
+        subdir.mkdir()
+        (subdir / "daughter.kicad_sch").write_text("", encoding="utf-8")
+
+        jbom_dir = project_dir / ".jbom"
+        jbom_dir.mkdir()
+        (jbom_dir / "jbom-options.json").write_text("{}", encoding="utf-8")
+
+        archive_path = tmp_path / "design-sources.zip"
+        result = DesignSourcePackager().package(project_dir, archive_path)
+
+        assert result == archive_path
+        assert archive_path.exists()
+
+        with zipfile.ZipFile(archive_path, "r") as zipf:
+            names = set(zipf.namelist())
+
+        assert "project.kicad_pro" in names
+        assert "project.kicad_prl" in names
+        assert "project.kicad_pcb" in names
+        assert "project.kicad_sch" in names
+        assert "sheets/daughter.kicad_sch" in names
+        assert "fabrication-toolkit-options.json" in names
+        assert ".jbom/jbom-options.json" in names
+
+    def test_package_raises_for_missing_project_dir(self, tmp_path: Path) -> None:
+        """Missing project directory should raise ValueError."""
+        project_dir = tmp_path / "missing"
+        archive_path = tmp_path / "design-sources.zip"
+
+        with pytest.raises(ValueError, match="project_dir is not a directory"):
+            DesignSourcePackager().package(project_dir, archive_path)
+
+    def test_package_raises_when_no_design_source_files(self, tmp_path: Path) -> None:
+        """Directories with no supported source files should raise ValueError."""
+        project_dir = tmp_path / "empty_project"
+        project_dir.mkdir()
+        (project_dir / "notes.txt").write_text("not a design file", encoding="utf-8")
+        archive_path = tmp_path / "design-sources.zip"
+
+        with pytest.raises(ValueError, match="No design-source files found"):
+            DesignSourcePackager().package(project_dir, archive_path)


### PR DESCRIPTION
## Problem
Fabrication backups were split/confusing: production artifacts were archived in `production/backups/...`, while design-source backups were handled separately.

## Summary
- add `DesignSourcePackager` to snapshot KiCad project source files into a nested zip
- include nested `*-design-sources.zip` entry in `production/backups/{stem}_{timestamp}.zip` backup composition
- apply the same backup composition in both `FabricationWorkflow` and plugin dialog worker paths
- update docs for the backup artifact contract
- update fabrication BDD scenarios/steps to assert the new backup contents

## Resulting backup contract
- standard run backup zip contains:
  - `jbom.csv`
  - `cpl.csv`
  - gerber upload zip (`{stem}.zip`)
  - nested design-source zip (`{project}-design-sources.zip`)
- `--skip-gerbers` backup still contains design-source zip plus BOM/CPL artifacts

## Files
- `src/jbom/services/design_source_packager.py`
- `src/jbom/application/fabrication_orchestration.py`
- `src/jbom/plugin/dialog.py`
- `features/gerbers/fabrication.feature`
- `features/steps/gerbers_steps.py`
- `tests/unit/test_design_source_packager.py`
- `tests/services/test_fabrication_orchestration.py`
- `docs/reference/cli.md`
- `docs/design/plugin-ux-decisions.md`

## Validation
- `pre-commit`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m pytest tests/ -v`
- `PYTHONPATH=/Users/jplocher/Dropbox/KiCad/jBOM/src python -m behave --format progress`

## Issue
Closes #378
