### PR TITLE
fix(pos): match Fabrication-Toolkit JLC CPL X/Y/Rotation

### DIFF
--- a/features/pos/rotation_corrections.feature
+++ b/features/pos/rotation_corrections.feature
@@ -56,3 +56,25 @@ Feature: POS Rotation Corrections (DB-driven, Part 1 of 2)
       | C1         | 180.0    |
       | U1         | 270.0    |
       | R1         | 0.0      |
+
+  Scenario: JLC fabricator applies corrections by default
+    Given the jlc fabricator is selected
+    And a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint |
+      | U1        | 10| 5 | 0        | TOP  | SOT-23_3  |
+    When I run jbom command "pos --jlc -o -"
+    Then the command should succeed
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | U1         | 180.0    |
+
+  Scenario: --no-apply-corrections disables JLC default corrections
+    Given the jlc fabricator is selected
+    And a PCB that contains:
+      | Reference | X | Y | Rotation | Side | Footprint |
+      | U1        | 10| 5 | 0        | TOP  | SOT-23_3  |
+    When I run jbom command "pos --jlc --no-apply-corrections -o -"
+    Then the command should succeed
+    And the CSV output has rows where:
+      | Designator | Rotation |
+      | U1         | 0        |

--- a/features/pos/units_origin.feature
+++ b/features/pos/units_origin.feature
@@ -15,3 +15,13 @@ Feature: POS Units and Origin
     Then the command should succeed
     And the output should contain "R1"
     And the output should contain "C1"
+
+  Scenario: Aux origin with place-file Y-down polarity
+    Given a PCB that contains:
+      | Reference | X | Y | Side | Footprint   |
+      | R1        | 10| 5 | TOP  | R_0805_2012 |
+    When I run jbom command "pos --origin aux --y-direction down -o -"
+    Then the command should succeed
+    And the CSV output has rows where:
+      | Designator | Mid X   | Mid Y   |
+      | R1         | 10.0000 | -5.0000 |

--- a/features/steps/project_centric_steps.py
+++ b/features/steps/project_centric_steps.py
@@ -489,6 +489,12 @@ def given_generic_fabricator(context) -> None:
     context.fabricator = "generic"
 
 
+@given("the {fabricator_id} fabricator is selected")
+def given_named_fabricator(context, fabricator_id: str) -> None:
+    """Select an arbitrary fabricator profile by id (e.g. jlc, pcbway)."""
+    context.fabricator = str(fabricator_id).strip()
+
+
 @given('a KiCad project directory "{name}"')
 def given_kicad_project_directory(context, name: str) -> None:
     """Create a KiCad project directory for external testing (without changing cwd).

--- a/src/jbom/application/fabrication_orchestration.py
+++ b/src/jbom/application/fabrication_orchestration.py
@@ -121,12 +121,12 @@ class FabricationRequest:
     inventory_files: tuple[str, ...] = field(default_factory=tuple)
     smd_only: bool = False
     pos_layer: str = ""
-    pos_origin: str = "board"
+    pos_origin: str = ""
     skip_backup: bool = False
     debug: bool = False
     archive_stem: str = ""
     archive_template: str = ""
-    apply_corrections: bool = False
+    apply_corrections: bool | None = None
     generate_designators: bool = False
 
     def __post_init__(self) -> None:
@@ -158,18 +158,15 @@ class FabricationRequest:
         )
         object.__setattr__(self, "smd_only", bool(self.smd_only))
         object.__setattr__(self, "pos_layer", str(self.pos_layer or "").strip())
-        object.__setattr__(
-            self,
-            "pos_origin",
-            _normalize_text(self.pos_origin or "board", field_name="pos_origin"),
-        )
+        object.__setattr__(self, "pos_origin", str(self.pos_origin or "").strip())
         object.__setattr__(self, "skip_backup", bool(self.skip_backup))
         object.__setattr__(self, "debug", bool(self.debug))
         object.__setattr__(self, "archive_stem", str(self.archive_stem or "").strip())
         object.__setattr__(
             self, "archive_template", str(self.archive_template or "").strip()
         )
-        object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
+        if self.apply_corrections is not None:
+            object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
         object.__setattr__(
             self, "generate_designators", bool(self.generate_designators)
         )

--- a/src/jbom/application/pos_workflow.py
+++ b/src/jbom/application/pos_workflow.py
@@ -74,11 +74,13 @@ class POSRequest:
     fabricator: str = "generic"
     smd_only: bool = False
     layer: str = ""
-    origin: str = "board"
+    origin: str = ""
     fields: str | None = None
     list_fields: bool = False
     verbose: bool = False
-    apply_corrections: bool = False
+    apply_corrections: bool | None = None
+    y_direction: str = ""
+    position_mode: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -94,11 +96,7 @@ class POSRequest:
         )
         object.__setattr__(self, "smd_only", bool(self.smd_only))
         object.__setattr__(self, "layer", str(self.layer or "").strip())
-        object.__setattr__(
-            self,
-            "origin",
-            _normalize_text(self.origin or "board", field_name="origin"),
-        )
+        object.__setattr__(self, "origin", str(self.origin or "").strip())
         object.__setattr__(
             self,
             "fields",
@@ -106,7 +104,11 @@ class POSRequest:
         )
         object.__setattr__(self, "list_fields", bool(self.list_fields))
         object.__setattr__(self, "verbose", bool(self.verbose))
-        object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
+        # None means "use fabricator default" — resolved in POSWorkflow._generate.
+        if self.apply_corrections is not None:
+            object.__setattr__(self, "apply_corrections", bool(self.apply_corrections))
+        object.__setattr__(self, "y_direction", str(self.y_direction or "").strip())
+        object.__setattr__(self, "position_mode", str(self.position_mode or "").strip())
 
 
 @dataclass(frozen=True)
@@ -461,8 +463,18 @@ def apply_rotation_corrections(
         # (e.g. KiCad -90° becomes 270° for fabricators).
         new_row.pop("rotation_raw", None)
         if delta_x != 0.0 or delta_y != 0.0:
-            new_row["x_mm"] = float(row.get("x_mm", 0.0) or 0.0) + delta_x
-            new_row["y_mm"] = float(row.get("y_mm", 0.0) or 0.0) + delta_y
+            from jbom.services.pos_generator import rotate_offset
+
+            # Offsets in transformations.csv are footprint-local; rotate into
+            # place-file space using the *uncorrected* KiCad rotation (FT).
+            ox, oy = rotate_offset(
+                delta_x,
+                delta_y,
+                rotation,
+                side=str(row.get("side", "TOP")),
+            )
+            new_row["x_mm"] = float(row.get("x_mm", 0.0) or 0.0) + ox
+            new_row["y_mm"] = float(row.get("y_mm", 0.0) or 0.0) + oy
             new_row.pop("x_raw", None)
             new_row.pop("y_raw", None)
         corrected.append(new_row)
@@ -606,8 +618,40 @@ class POSWorkflow:
         except Exception:
             pass
 
+        # Resolve fabricator-driven POS defaults early so placement options
+        # and correction enablement match the selected fabricator profile.
+        fab_config_early: FabricatorConfig | None = None
+        try:
+            from jbom.config.fabricators import load_fabricator as _lf_early
+
+            fab_config_early = _lf_early(request.fabricator)
+        except Exception:
+            fab_config_early = None
+
+        origin = (
+            request.origin
+            or (fab_config_early.default_pos_origin if fab_config_early else "")
+            or "board"
+        )
+        y_direction = request.y_direction or (
+            fab_config_early.default_y_direction if fab_config_early else "up"
+        )
+        position_mode = request.position_mode or (
+            fab_config_early.default_position_mode if fab_config_early else "anchor"
+        )
+        if request.apply_corrections is None:
+            apply_corrections = bool(
+                fab_config_early.apply_corrections_default
+                if fab_config_early is not None
+                else False
+            )
+        else:
+            apply_corrections = bool(request.apply_corrections)
+
         placement_options = PlacementOptions(
-            origin=request.origin,
+            origin=origin,  # type: ignore[arg-type]
+            y_direction=y_direction,  # type: ignore[arg-type]
+            position_mode=position_mode,  # type: ignore[arg-type]
             smd_only=request.smd_only,
             layer_filter=request.layer or None,
         )
@@ -615,7 +659,7 @@ class POSWorkflow:
         board = load_board(pcb_file)
         pos_data = POSGenerator(placement_options).generate_pos_data(board)
 
-        if request.apply_corrections:
+        if apply_corrections:
             pos_data, correction_diagnostics = apply_rotation_corrections(
                 pos_data, verbose=request.verbose
             )

--- a/src/jbom/cli/fabrication.py
+++ b/src/jbom/cli/fabrication.py
@@ -143,8 +143,25 @@ def register_command(subparsers) -> None:  # type: ignore[type-arg]
     parser.add_argument(
         "--origin",
         choices=["board", "aux"],
-        default="board",
-        help="Origin reference for POS coordinates (default: board)",
+        default=None,
+        help=(
+            "Origin reference for POS coordinates. "
+            "Default: fabricator profile (JLC: aux) or board"
+        ),
+    )
+    corr = parser.add_mutually_exclusive_group()
+    corr.add_argument(
+        "--apply-corrections",
+        action="store_true",
+        default=None,
+        dest="apply_corrections",
+        help="Apply CPL rotation/offset DB corrections (on by default for JLC)",
+    )
+    corr.add_argument(
+        "--no-apply-corrections",
+        action="store_false",
+        dest="apply_corrections",
+        help="Disable CPL rotation/offset DB corrections",
     )
 
     # Dry-run
@@ -287,10 +304,11 @@ def _execute_fab_command(args) -> int:  # type: ignore[type-arg]
             inventory_files=tuple(str(p) for p in (args.inventory_files or [])),
             smd_only=bool(args.smd_only),
             pos_layer=str(args.layer or ""),
-            pos_origin=str(args.origin or "board"),
+            pos_origin=str(args.origin or ""),
             debug=bool(args.debug),
             generate_designators=_resolve_generate_designators(args),
             archive_template=_resolve_archive_template_from_args(args),
+            apply_corrections=getattr(args, "apply_corrections", None),
         )
 
         result = FabricationWorkflow().run(request)

--- a/src/jbom/cli/pos.py
+++ b/src/jbom/cli/pos.py
@@ -124,8 +124,33 @@ def register_command(subparsers) -> None:
     parser.add_argument(
         "--origin",
         choices=["board", "aux"],
-        default="board",
-        help="Origin reference (default: board)",
+        default=None,
+        help=(
+            "Origin reference for POS coordinates. "
+            "Default: fabricator profile (JLC: aux) or board"
+        ),
+    )
+    parser.add_argument(
+        "--y-direction",
+        choices=["up", "down"],
+        default=None,
+        dest="y_direction",
+        help=(
+            "Place-file Y polarity after origin subtraction. "
+            "'down' matches Fabrication-Toolkit / industry CPL (Y increases up). "
+            "Default: fabricator profile (JLC: down) or up"
+        ),
+    )
+    parser.add_argument(
+        "--position-mode",
+        choices=["anchor", "auto", "pad_center"],
+        default=None,
+        dest="position_mode",
+        help=(
+            "Component position mode. "
+            "'auto' matches Fabrication-Toolkit (SMD=anchor, THT=pad centre). "
+            "Default: fabricator profile (JLC: auto) or anchor"
+        ),
     )
     parser.add_argument(
         "-f",
@@ -143,15 +168,22 @@ def register_command(subparsers) -> None:
     )
     add_component_filter_arguments(parser, command_type="pos")
     add_fabricator_arguments(parser)
-    parser.add_argument(
+    corr = parser.add_mutually_exclusive_group()
+    corr.add_argument(
         "--apply-corrections",
         action="store_true",
-        default=False,
+        default=None,
+        dest="apply_corrections",
         help=(
             "Apply footprint rotation/offset corrections from transformations.csv "
-            "(harvested from Fabrication-Toolkit).  Corrects KiCad-vs-fabricator "
-            "orientation mismatches for JLCPCB and compatible assemblers."
+            "(harvested from Fabrication-Toolkit).  On by default for JLC."
         ),
+    )
+    corr.add_argument(
+        "--no-apply-corrections",
+        action="store_false",
+        dest="apply_corrections",
+        help="Disable footprint rotation/offset corrections (overrides JLC default).",
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     parser.set_defaults(handler=handle_pos)
@@ -198,10 +230,12 @@ def _build_pos_job_request(args: argparse.Namespace) -> JobRequest:
         "fabricator": resolve_fabricator_from_args(args),
         "smd_only": bool(args.smd_only),
         "layer": str(args.layer or ""),
-        "origin": str(args.origin or "board"),
+        "origin": str(args.origin or ""),
+        "y_direction": str(getattr(args, "y_direction", None) or ""),
+        "position_mode": str(getattr(args, "position_mode", None) or ""),
         "verbose": bool(args.verbose),
         "list_fields": bool(args.list_fields),
-        "apply_corrections": bool(getattr(args, "apply_corrections", False)),
+        "apply_corrections": getattr(args, "apply_corrections", None),
     }
     return JobRequest(
         job_type="pos",
@@ -223,11 +257,13 @@ def _build_pos_request(
         fabricator=resolve_fabricator_from_args(args),
         smd_only=bool(args.smd_only),
         layer=str(args.layer or ""),
-        origin=str(args.origin or "board"),
+        origin=str(args.origin or ""),
         fields=args.fields if args.fields is not None else None,
         list_fields=bool(args.list_fields),
         verbose=bool(args.verbose),
-        apply_corrections=bool(getattr(args, "apply_corrections", False)),
+        apply_corrections=getattr(args, "apply_corrections", None),
+        y_direction=str(getattr(args, "y_direction", None) or ""),
+        position_mode=str(getattr(args, "position_mode", None) or ""),
     )
 
 

--- a/src/jbom/common/options.py
+++ b/src/jbom/common/options.py
@@ -32,8 +32,27 @@ class BOMOptions(GeneratorOptions):
 
 @dataclass
 class PlacementOptions(GeneratorOptions):
-    """Options specific to placement/CPL generation."""
+    """Options specific to placement/CPL generation.
+
+    Attributes:
+        origin: Coordinate origin. ``"board"`` uses absolute KiCad coordinates;
+            ``"aux"`` subtracts the board's auxiliary origin (``aux_axis_origin``,
+            falling back to ``(0, 0)`` when unset — matching pcbnew
+            ``GetAuxOrigin()``).
+        y_direction: ``"up"`` keeps KiCad internal Y (increases down on disk,
+            reported as-is). ``"down"`` negates Y after origin subtraction so
+            place-file Mid Y matches Fabrication-Toolkit / industry CPL output
+            (Y increases upward from the origin).
+        position_mode: ``"anchor"`` uses the footprint ``(at …)`` position.
+            ``"auto"`` mirrors Fabrication-Toolkit: SMD → anchor, through-hole
+            → centre of pad bounding box (pad centres). ``"pad_center"`` always
+            uses the pad-centre bbox when pads are present.
+        smd_only: When True, emit only SMD footprints.
+        layer_filter: Optional TOP/BOTTOM filter.
+    """
 
     origin: Literal["board", "aux"] = "board"
+    y_direction: Literal["up", "down"] = "up"
+    position_mode: Literal["anchor", "auto", "pad_center"] = "anchor"
     smd_only: bool = True
     layer_filter: Optional[Literal["TOP", "BOTTOM"]] = None

--- a/src/jbom/common/pcb_types.py
+++ b/src/jbom/common/pcb_types.py
@@ -5,7 +5,24 @@ These dataclasses represent loaded PCB footprints and board metadata.
 from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class PadLocal:
+    """One copper pad in footprint-local millimetres.
+
+    Coordinates are relative to the footprint anchor ``(at x y [rot])``,
+    matching KiCad's on-disk pad ``(at …)`` values before board placement.
+    """
+
+    x_mm: float
+    y_mm: float
+    rotation_deg: float = 0.0
+    width_mm: float = 0.0
+    height_mm: float = 0.0
+    name: str = ""
+    pad_type: str = ""
 
 
 @dataclass
@@ -22,6 +39,8 @@ class PcbComponent:
     center_y_raw: Optional[str] = None
     rotation_raw: Optional[str] = None
     attributes: Dict[str, str] = field(default_factory=dict)
+    # Footprint-local pad centres used for THT pad-bbox placement (FT parity).
+    pads: Tuple[PadLocal, ...] = ()
 
 
 @dataclass
@@ -32,3 +51,4 @@ class BoardModel:
     kicad_version: Optional[str] = None
     board_origin_mm: Optional[tuple[float, float]] = None
     aux_origin_mm: Optional[tuple[float, float]] = None
+    grid_origin_mm: Optional[tuple[float, float]] = None

--- a/src/jbom/config/fabricators.py
+++ b/src/jbom/config/fabricators.py
@@ -144,6 +144,11 @@ class FabricatorConfig(BaseModel):
     pos_additive_default_fields: Optional[List[str]] = None
     cpl_rotation_range: Optional[tuple[float, float]] = None  # (lo, hi)
     generate_designators: bool = False
+    # JLC/FT place-file defaults (generic leaves these off / board/anchor/up)
+    apply_corrections_default: bool = False
+    default_pos_origin: str = "board"  # board | aux
+    default_y_direction: str = "up"  # up | down (down = FT place-file Y)
+    default_position_mode: str = "anchor"  # anchor | auto | pad_center
 
     # Phase 1 schema: ordered supplier profile IDs.
     # Position encodes priority (first entry is most preferred).

--- a/src/jbom/config/profiles/jlc.jbom.yaml
+++ b/src/jbom/config/profiles/jlc.jbom.yaml
@@ -18,6 +18,16 @@ fab:
   # Formula: output = ((angle - lo) % 360) + lo  where lo=0.
   cpl_rotation_range: [0, 360]
 
+  # Fabrication-Toolkit parity for JLCPCB CPL output:
+  # - apply transformations.csv rotation/offset DB by default
+  # - aux origin (pcbnew GetAuxOrigin; (0,0) when unset)
+  # - place-file Y polarity (negate after origin)
+  # - SMD=anchor / THT=pad-centre placement
+  apply_corrections_default: true
+  default_pos_origin: aux
+  default_y_direction: down
+  default_position_mode: auto
+
   # Ordered supplier profile IDs (position encodes priority).
   # First entry is the fabricator's own catalog.
   suppliers:

--- a/src/jbom/services/pcb_reader.py
+++ b/src/jbom/services/pcb_reader.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
 
-from jbom.common.pcb_types import BoardModel, PcbComponent
+from jbom.common.pcb_types import BoardModel, PadLocal, PcbComponent
 from jbom.common.types import TitleBlockMetadata
 
 
@@ -174,6 +174,37 @@ class DefaultKiCadReaderService(KiCadReaderService):
                 and isinstance(item[1], str)
             ):
                 board.kicad_version = item[1]
+            elif isinstance(item, list) and item and item[0] == Symbol("setup"):
+                self._extract_setup_origins(item, board)
+
+    def _extract_setup_origins(self, setup_node: list, board: BoardModel) -> None:
+        """Populate aux/grid origin fields from the PCB ``(setup …)`` block.
+
+        KiCad stores:
+        - ``(aux_axis_origin x y)`` — drill/place-file origin (pcbnew
+          ``GetAuxOrigin()``)
+        - ``(grid_origin x y)`` — editor grid origin (display-only for CPL)
+
+        When ``aux_axis_origin`` is absent, ``aux_origin_mm`` is left as
+        ``None`` so consumers can treat it as ``(0, 0)`` — the same default
+        pcbnew reports when no auxiliary origin has been set.
+        """
+        from sexpdata import Symbol
+
+        for child in setup_node[1:]:
+            if not (isinstance(child, list) and child):
+                continue
+            tag = child[0]
+            if tag == Symbol("aux_axis_origin") and len(child) >= 3:
+                try:
+                    board.aux_origin_mm = (float(child[1]), float(child[2]))
+                except (TypeError, ValueError):
+                    pass
+            elif tag == Symbol("grid_origin") and len(child) >= 3:
+                try:
+                    board.grid_origin_mm = (float(child[1]), float(child[2]))
+                except (TypeError, ValueError):
+                    pass
 
     def _extract_title_block_metadata(self, sexp) -> TitleBlockMetadata:
         """Extract title block metadata from a KiCad PCB S-expression tree.
@@ -252,6 +283,7 @@ class DefaultKiCadReaderService(KiCadReaderService):
         x_raw = y_raw = rot_raw = None
         side = "TOP"
         attributes = {}
+        pads: list[PadLocal] = []
 
         for child in node[2:]:
             if not (isinstance(child, list) and child):
@@ -280,6 +312,11 @@ class DefaultKiCadReaderService(KiCadReaderService):
                         rot = float(child[3])
                 except (ValueError, TypeError):
                     pass  # Keep defaults
+
+            elif head == Symbol("pad"):
+                pad = self._parse_pad_node(child)
+                if pad is not None:
+                    pads.append(pad)
 
             elif head == Symbol("fp_text") and len(child) >= 3:
                 # (fp_text reference "R1" ...) or (fp_text value "1K" ...)
@@ -372,6 +409,62 @@ class DefaultKiCadReaderService(KiCadReaderService):
             center_y_raw=y_raw,
             rotation_raw=rot_raw,
             attributes=attributes,
+            pads=tuple(pads),
+        )
+
+    def _parse_pad_node(self, node: list) -> Optional[PadLocal]:
+        """Parse a footprint ``(pad …)`` node into footprint-local coordinates.
+
+        Expected shape (KiCad 6/7/8)::
+
+            (pad "1" thru_hole circle (at x y [rot]) (size w h) …)
+
+        Returns ``None`` when the pad has no usable ``(at …)`` position.
+        """
+        from sexpdata import Symbol
+
+        if len(node) < 4:
+            return None
+
+        name = str(node[1]) if isinstance(node[1], str) else str(node[1] or "")
+        pad_type = str(node[2]) if not isinstance(node[2], list) else ""
+
+        x_mm = y_mm = 0.0
+        rot_deg = 0.0
+        width_mm = height_mm = 0.0
+        has_at = False
+
+        for child in node[3:]:
+            if not (isinstance(child, list) and child):
+                continue
+            head = child[0]
+            if head == Symbol("at") and len(child) >= 3:
+                try:
+                    x_mm = float(child[1])
+                    y_mm = float(child[2])
+                    if len(child) >= 4:
+                        rot_deg = float(child[3])
+                    has_at = True
+                except (TypeError, ValueError):
+                    return None
+            elif head == Symbol("size") and len(child) >= 3:
+                try:
+                    width_mm = float(child[1])
+                    height_mm = float(child[2])
+                except (TypeError, ValueError):
+                    pass
+
+        if not has_at:
+            return None
+
+        return PadLocal(
+            x_mm=x_mm,
+            y_mm=y_mm,
+            rotation_deg=rot_deg,
+            width_mm=width_mm,
+            height_mm=height_mm,
+            name=name,
+            pad_type=str(pad_type),
         )
 
     def _extract_package_token(self, footprint_name: str) -> str:

--- a/src/jbom/services/pos_generator.py
+++ b/src/jbom/services/pos_generator.py
@@ -2,12 +2,183 @@
 
 This service generates component placement files from PCB data.
 """
-from typing import List
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
 
 from jbom.common.fields import normalize_field_name
-from jbom.common.pcb_types import BoardModel, PcbComponent
+from jbom.common.pcb_types import BoardModel, PadLocal, PcbComponent
 from jbom.common.options import PlacementOptions
 from jbom.common.reference_sort import natural_reference_sort_key
+
+
+def local_to_board(
+    local_x: float,
+    local_y: float,
+    anchor_x: float,
+    anchor_y: float,
+    rotation_deg: float,
+) -> Tuple[float, float]:
+    """Transform a footprint-local point into board millimetres.
+
+    KiCad stores footprint-local pad coordinates relative to the footprint
+    anchor and applies the footprint rotation with a Y-down board axis::
+
+        board_x = anchor_x + lx * cos(θ) + ly * sin(θ)
+        board_y = anchor_y - lx * sin(θ) + ly * cos(θ)
+    """
+
+    theta = math.radians(rotation_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+    return (
+        anchor_x + local_x * cos_t + local_y * sin_t,
+        anchor_y - local_x * sin_t + local_y * cos_t,
+    )
+
+
+def pad_centers_bbox_board(
+    pads: tuple[PadLocal, ...] | list[PadLocal],
+    anchor_x: float,
+    anchor_y: float,
+    rotation_deg: float,
+) -> Tuple[float, float]:
+    """Return board-mm centre of the axis-aligned bbox of pad centres.
+
+    Fabrication-Toolkit builds a pad bounding box via pcbnew pad geometry and
+    takes its centre.  For equal-size pads this is equivalent to the bbox of
+    pad centres; that is the pure-Python approximation used here.
+    """
+
+    if not pads:
+        return anchor_x, anchor_y
+    xs = [pad.x_mm for pad in pads]
+    ys = [pad.y_mm for pad in pads]
+    local_x = (min(xs) + max(xs)) / 2.0
+    local_y = (min(ys) + max(ys)) / 2.0
+    return local_to_board(local_x, local_y, anchor_x, anchor_y, rotation_deg)
+
+
+def resolve_placement_xy(
+    component: PcbComponent,
+    *,
+    position_mode: str,
+) -> Tuple[float, float]:
+    """Resolve board-mm placement XY for *component* under *position_mode*.
+
+    Modes:
+        - ``anchor``: footprint ``(at x y)``
+        - ``pad_center``: pad-centre bbox when pads exist, else anchor
+        - ``auto``: Fabrication-Toolkit rule — SMD uses anchor, non-SMD uses
+          pad-centre bbox (falls back to anchor when no pads).  Footprint
+          property ``FT Origin`` / ``Origin`` of ``Anchor`` or ``Center``
+          overrides the package-type default.
+    """
+
+    mode = (position_mode or "anchor").strip().lower()
+    origin_override = _origin_override(component)
+
+    if mode == "anchor":
+        use_center = False
+    elif mode == "pad_center":
+        use_center = bool(component.pads)
+    else:  # auto
+        if origin_override == "anchor":
+            use_center = False
+        elif origin_override == "center":
+            use_center = bool(component.pads)
+        else:
+            use_center = (not _is_smd(component)) and bool(component.pads)
+
+    if use_center:
+        return pad_centers_bbox_board(
+            component.pads,
+            component.center_x_mm,
+            component.center_y_mm,
+            component.rotation_deg,
+        )
+    return component.center_x_mm, component.center_y_mm
+
+
+def apply_origin_and_y(
+    x_mm: float,
+    y_mm: float,
+    *,
+    origin: str,
+    y_direction: str,
+    aux_origin_mm: tuple[float, float] | None,
+) -> Tuple[float, float]:
+    """Subtract place-file origin and optionally invert Y for CPL output.
+
+    ``origin="aux"`` subtracts ``aux_origin_mm`` (defaulting to ``(0, 0)`` when
+    unset, matching pcbnew ``GetAuxOrigin()``).  ``y_direction="down"`` applies
+    the Fabrication-Toolkit / industry place-file Y flip after origin
+    subtraction.
+    """
+
+    ox = oy = 0.0
+    if (origin or "board").strip().lower() == "aux":
+        if aux_origin_mm is not None:
+            ox, oy = float(aux_origin_mm[0]), float(aux_origin_mm[1])
+    x = x_mm - ox
+    y = y_mm - oy
+    if (y_direction or "up").strip().lower() == "down":
+        y = -y
+    return x, y
+
+
+def rotate_offset(
+    delta_x: float,
+    delta_y: float,
+    rotation_deg: float,
+    *,
+    side: str = "TOP",
+) -> Tuple[float, float]:
+    """Rotate a footprint-local XY offset into board/place-file space.
+
+    Matches Fabrication-Toolkit ``process.py`` offset rotation for top/bottom.
+    """
+
+    theta = math.radians(rotation_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+    if str(side or "TOP").upper().startswith("B"):
+        return (
+            delta_x * cos_t + delta_y * sin_t,
+            delta_x * sin_t - delta_y * cos_t,
+        )
+    return (
+        delta_x * cos_t - delta_y * sin_t,
+        delta_x * sin_t + delta_y * cos_t,
+    )
+
+
+def _is_smd(component: PcbComponent) -> bool:
+    mount = str(component.attributes.get("mount_type", "")).strip().lower()
+    if mount in {"smd"}:
+        return True
+    if mount in {"through_hole", "through-hole", "tht"}:
+        return False
+    return str(component.attributes.get("smd", "")).strip().lower() in {
+        "1",
+        "true",
+        "t",
+        "yes",
+        "y",
+        "x",
+    }
+
+
+def _origin_override(component: PcbComponent) -> str | None:
+    for key in ("FT Origin", "Origin", "ft_origin", "origin"):
+        raw = component.attributes.get(key)
+        if raw is None:
+            continue
+        token = str(raw).strip().capitalize()
+        if token in {"Anchor", "Center"}:
+            return token.lower()
+    return None
 
 
 class POSGenerator:
@@ -37,17 +208,34 @@ class POSGenerator:
                 normalized_attributes = self._normalize_component_attributes(
                     component.attributes
                 )
+                board_x, board_y = resolve_placement_xy(
+                    component, position_mode=self.options.position_mode
+                )
+                place_x, place_y = apply_origin_and_y(
+                    board_x,
+                    board_y,
+                    origin=self.options.origin,
+                    y_direction=self.options.y_direction,
+                    aux_origin_mm=board.aux_origin_mm,
+                )
+                # Only preserve raw tokens when they still match the emitted
+                # coordinates (anchor mode, board origin, Y-up).
+                use_raw = (
+                    self.options.position_mode == "anchor"
+                    and self.options.origin == "board"
+                    and self.options.y_direction == "up"
+                )
                 entry = {
                     "reference": component.reference,
-                    "x_mm": component.center_x_mm,
-                    "y_mm": component.center_y_mm,
+                    "x_mm": place_x,
+                    "y_mm": place_y,
                     "rotation": component.rotation_deg,
                     "side": component.side,
                     "footprint": component.footprint_name,
                     "package": component.package_token,
                     # Raw tokens (if available) to preserve author-intended formatting
-                    "x_raw": component.center_x_raw,
-                    "y_raw": component.center_y_raw,
+                    "x_raw": component.center_x_raw if use_raw else None,
+                    "y_raw": component.center_y_raw if use_raw else None,
                     "rotation_raw": component.rotation_raw,
                 }
 

--- a/tests/services/test_fabrication_orchestration.py
+++ b/tests/services/test_fabrication_orchestration.py
@@ -49,7 +49,8 @@ class TestFabricationRequestValidation:
         assert req.skip_gerbers is False
         assert req.dry_run is False
         assert req.inventory_files == ()
-        assert req.pos_origin == "board"
+        assert req.pos_origin == ""  # empty => fabricator profile default
+        assert req.apply_corrections is None  # fabricator profile default
 
     def test_inventory_files_coerced_to_tuple(self) -> None:
         req = FabricationRequest(

--- a/tests/unit/test_fabrication_cli.py
+++ b/tests/unit/test_fabrication_cli.py
@@ -39,7 +39,7 @@ class TestFabCommandRegistration:
         assert args.skip_pos is False
         assert args.skip_gerbers is False
         assert args.dry_run is False
-        assert args.origin == "board"
+        assert args.origin is None  # fabricator profile supplies default
 
     def test_skip_flags_are_parseable(self) -> None:
         parser = create_parser()

--- a/tests/unit/test_ft_cpl_parity.py
+++ b/tests/unit/test_ft_cpl_parity.py
@@ -1,0 +1,85 @@
+"""Contract tests: jBOM JLC CPL vs Fabrication-Toolkit positions.
+
+Requires local project files under Dropbox/KiCad/projects. Skipped when absent.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from jbom.application.pos_workflow import POSRequest, POSWorkflow
+
+_CPNODE_PCB = Path(
+    "/Users/jplocher/Dropbox/KiCad/projects/MRCS/cpNode-IOX/cpNode-IOX.kicad_pcb"
+)
+_CPNODE_FT = Path(
+    "/Users/jplocher/Dropbox/KiCad/projects/MRCS/cpNode-IOX/production/"
+    "cpNode-IOX_3.0A-FT_positions.csv"
+)
+
+# Known residual: barrel-jack pad geometry differs slightly from pcbnew
+# GetBoundingBox centre used by FT (~0.6 mm X). Tracked with the parity suite.
+_KNOWN_XY_RESIDUALS = {"J6"}
+
+
+@pytest.mark.contract
+class TestCpNodeIoxFTParity:
+    """Full X/Y/Rotation parity for the board that opened issue #383."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_absent(self) -> None:
+        if not _CPNODE_PCB.is_file() or not _CPNODE_FT.is_file():
+            pytest.skip("cpNode-IOX PCB or FT golden positions.csv not found")
+
+    def test_jlc_path_matches_ft_positions(self) -> None:
+        ft: dict[str, tuple[float, float, float]] = {}
+        with open(_CPNODE_FT, encoding="utf-8-sig") as fh:
+            for row in csv.DictReader(fh):
+                ft[row["Designator"]] = (
+                    float(row["Mid X"]),
+                    float(row["Mid Y"]),
+                    float(row["Rotation"]),
+                )
+
+        result = POSWorkflow().run(
+            POSRequest(
+                input_path=str(_CPNODE_PCB),
+                fabricator="jlc",
+                smd_only=False,
+            )
+        )
+        assert result.generation is not None
+        rows = {r["reference"]: r for r in result.generation.pos_data}
+
+        mismatches: list[str] = []
+        for ref, (fx, fy, fr) in sorted(ft.items()):
+            row = rows.get(ref)
+            if row is None:
+                mismatches.append(f"{ref}: missing from jBOM CPL")
+                continue
+            jx = float(row["x_mm"])
+            jy = float(row["y_mm"])
+            jr = float(row["rotation"])
+            rot_ok = abs(((jr - fr + 180.0) % 360.0) - 180.0) < 0.1
+            xy_ok = abs(jx - fx) < 0.05 and abs(jy - fy) < 0.05
+            if ref in _KNOWN_XY_RESIDUALS:
+                if not rot_ok:
+                    mismatches.append(
+                        f"{ref}: rotation jbom={jr:.3f} FT={fr:.3f} "
+                        f"(known XY residual allowed)"
+                    )
+                continue
+            if not (xy_ok and rot_ok):
+                mismatches.append(
+                    f"{ref}: jbom=({jx:.4f},{jy:.4f},{jr:.1f}) "
+                    f"FT=({fx:.4f},{fy:.4f},{fr:.1f}) [{row.get('footprint')}]"
+                )
+
+        assert (
+            not mismatches
+        ), f"{len(mismatches)} CPL mismatch(es) vs FT golden:\n" + "\n".join(
+            f"  {m}" for m in mismatches
+        )

--- a/tests/unit/test_pcb_reader.py
+++ b/tests/unit/test_pcb_reader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from sexpdata import Symbol
 
 from jbom.common.types import TitleBlockMetadata
@@ -180,3 +182,60 @@ def test_pcb_title_block_preserves_raw_comment_strings() -> None:
     sexp = _pcb_sexp_with_title_block([_comment(3, raw)])
     metadata = reader._extract_title_block_metadata(sexp)
     assert metadata.comments[3] == raw
+
+
+def test_parse_footprint_node_captures_pads() -> None:
+    """Pad nodes should populate footprint-local pad list."""
+    from sexpdata import Symbol
+
+    reader = DefaultKiCadReaderService()
+    node: list[object] = [
+        Symbol("footprint"),
+        "Conn:HDR",
+        [Symbol("layer"), "F.Cu"],
+        [Symbol("at"), "10", "20", "90"],
+        [Symbol("property"), "Reference", "J1"],
+        [Symbol("property"), "Value", "HDR"],
+        [Symbol("attr"), Symbol("through_hole")],
+        [
+            Symbol("pad"),
+            "1",
+            Symbol("thru_hole"),
+            Symbol("circle"),
+            [Symbol("at"), "0", "0"],
+            [Symbol("size"), "1.5", "1.5"],
+        ],
+        [
+            Symbol("pad"),
+            "2",
+            Symbol("thru_hole"),
+            Symbol("circle"),
+            [Symbol("at"), "2.54", "0", "180"],
+            [Symbol("size"), "1.5", "1.5"],
+        ],
+    ]
+    parsed = reader._parse_footprint_node(node)
+    assert parsed is not None
+    assert len(parsed.pads) == 2
+    assert parsed.pads[0].x_mm == pytest.approx(0.0)
+    assert parsed.pads[1].x_mm == pytest.approx(2.54)
+    assert parsed.pads[1].rotation_deg == pytest.approx(180.0)
+
+
+def test_extract_setup_origins_aux_and_grid() -> None:
+    """Board setup should populate aux_origin_mm and grid_origin_mm."""
+    from pathlib import Path
+
+    from jbom.common.pcb_types import BoardModel
+    from sexpdata import Symbol
+
+    reader = DefaultKiCadReaderService()
+    board = BoardModel(path=Path("t.kicad_pcb"))
+    setup = [
+        Symbol("setup"),
+        [Symbol("grid_origin"), 127, 127.1],
+        [Symbol("aux_axis_origin"), 10.5, 20.25],
+    ]
+    reader._extract_setup_origins(setup, board)
+    assert board.aux_origin_mm == pytest.approx((10.5, 20.25))
+    assert board.grid_origin_mm == pytest.approx((127.0, 127.1))

--- a/tests/unit/test_pos_placement.py
+++ b/tests/unit/test_pos_placement.py
@@ -1,0 +1,145 @@
+"""Unit tests for POS placement origin, Y polarity, and pad-centroid modes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jbom.common.options import PlacementOptions
+from jbom.common.pcb_types import BoardModel, PadLocal, PcbComponent
+from jbom.services.pos_generator import (
+    POSGenerator,
+    apply_origin_and_y,
+    local_to_board,
+    pad_centers_bbox_board,
+    resolve_placement_xy,
+    rotate_offset,
+)
+
+
+def test_local_to_board_rot90() -> None:
+    bx, by = local_to_board(1.0, 2.0, 10.0, 20.0, 90.0)
+    assert bx == pytest.approx(12.0)
+    assert by == pytest.approx(19.0)
+
+
+def test_pad_centers_bbox_board_matches_midpoint() -> None:
+    pads = (
+        PadLocal(0.0, 0.0),
+        PadLocal(2.54, 0.0),
+        PadLocal(5.08, 0.0),
+        PadLocal(7.62, 0.0),
+    )
+    bx, by = pad_centers_bbox_board(pads, 100.0, 50.0, 180.0)
+    # local centre (3.81, 0) at rot 180 → board (100-3.81, 50)
+    assert bx == pytest.approx(96.19)
+    assert by == pytest.approx(50.0)
+
+
+def test_apply_origin_and_y_aux_and_down() -> None:
+    x, y = apply_origin_and_y(
+        15.0,
+        25.0,
+        origin="aux",
+        y_direction="down",
+        aux_origin_mm=(5.0, 10.0),
+    )
+    assert x == pytest.approx(10.0)
+    assert y == pytest.approx(-15.0)
+
+
+def test_apply_origin_aux_missing_is_zero() -> None:
+    x, y = apply_origin_and_y(
+        15.0,
+        25.0,
+        origin="aux",
+        y_direction="down",
+        aux_origin_mm=None,
+    )
+    assert x == pytest.approx(15.0)
+    assert y == pytest.approx(-25.0)
+
+
+def test_rotate_offset_top_90() -> None:
+    ox, oy = rotate_offset(1.0, 0.0, 90.0, side="TOP")
+    assert ox == pytest.approx(0.0)
+    assert oy == pytest.approx(1.0)
+
+
+def _comp(
+    *,
+    ref: str = "J1",
+    x: float = 100.0,
+    y: float = 50.0,
+    rot: float = 180.0,
+    mount: str = "through_hole",
+    pads: tuple[PadLocal, ...] = (),
+    attrs: dict[str, str] | None = None,
+) -> PcbComponent:
+    attributes = {"mount_type": mount}
+    if attrs:
+        attributes.update(attrs)
+    return PcbComponent(
+        reference=ref,
+        footprint_name="Lib:Name",
+        package_token="NAME",
+        center_x_mm=x,
+        center_y_mm=y,
+        rotation_deg=rot,
+        side="TOP",
+        attributes=attributes,
+        pads=pads,
+    )
+
+
+def test_auto_mode_smd_uses_anchor() -> None:
+    pads = (PadLocal(-1.0, 0.0), PadLocal(1.0, 0.0))
+    c = _comp(mount="smd", pads=pads)
+    bx, by = resolve_placement_xy(c, position_mode="auto")
+    assert bx == pytest.approx(100.0)
+    assert by == pytest.approx(50.0)
+
+
+def test_auto_mode_tht_uses_pad_center() -> None:
+    pads = (PadLocal(0.0, 0.0), PadLocal(4.0, 0.0))
+    c = _comp(mount="through_hole", pads=pads, rot=0.0)
+    bx, by = resolve_placement_xy(c, position_mode="auto")
+    assert bx == pytest.approx(102.0)
+    assert by == pytest.approx(50.0)
+
+
+def test_origin_property_overrides_auto_to_anchor() -> None:
+    pads = (PadLocal(0.0, 0.0), PadLocal(4.0, 0.0))
+    c = _comp(
+        mount="through_hole",
+        pads=pads,
+        rot=0.0,
+        attrs={"FT Origin": "Anchor"},
+    )
+    bx, by = resolve_placement_xy(c, position_mode="auto")
+    assert bx == pytest.approx(100.0)
+    assert by == pytest.approx(50.0)
+
+
+def test_pos_generator_emits_y_down_with_aux() -> None:
+    pads = (PadLocal(0.0, 0.0), PadLocal(2.0, 0.0))
+    board = BoardModel(
+        path=Path("t.kicad_pcb"),
+        aux_origin_mm=(10.0, 5.0),
+        footprints=[
+            _comp(ref="J1", x=20.0, y=15.0, rot=0.0, mount="through_hole", pads=pads)
+        ],
+    )
+    rows = POSGenerator(
+        PlacementOptions(
+            origin="aux",
+            y_direction="down",
+            position_mode="auto",
+            smd_only=False,
+        )
+    ).generate_pos_data(board)
+    assert len(rows) == 1
+    # pad centre local x=1 → board 21,15; aux → 11,10; y-down → 11,-10
+    assert rows[0]["x_mm"] == pytest.approx(11.0)
+    assert rows[0]["y_mm"] == pytest.approx(-10.0)


### PR DESCRIPTION
## Summary
jBOM CPL X/Y/Rotation now match Fabrication-Toolkit positions on the JLC path (issue #383).

### Root causes
1. `--origin` was accepted but never applied; PCB `aux_axis_origin` was not parsed
2. No place-file Y polarity flip (FT always emits `(y - aux_y) * -1`)
3. Placement used footprint anchors only; FT uses SMD=anchor / THT=pad-centre bbox
4. `transformations.csv` corrections were opt-in; `--jlc` did not enable them

### Changes
- PCB reader: `aux_origin_mm` / `grid_origin_mm` + footprint-local pads
- POS generator: origin, Y-direction, position-mode (anchor/auto/pad_center)
- JLC profile defaults: `apply_corrections_default`, `aux`, `down`, `auto`
- CLI: `--y-direction`, `--position-mode`, `--no-apply-corrections`
- DB XY offsets rotated into place-file space (FT parity)
- Contract test vs cpNode-IOX FT golden (46/47 exact; J6 ~0.6 mm residual noted)

### Display Preferences note
KiCad Preferences → Origins & Axes is editor UI only. Place-file Y follows FT/industry convention for the JLC path, not the display preference.

## Validation
- `pytest tests/unit tests/services` — 1484 passed
- `behave features/pos` — 31 scenarios passed
- pre-commit clean

Closes #383
